### PR TITLE
Cache high-order bits of hashcode to speed up BytesRefHash

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -128,6 +128,8 @@ Optimizations
 
 * GITHUB#14674: Optimize AbstractKnnVectorQuery#createBitSet with intoBitset. (Guo Feng)
 
+* GITHUB#14720: Cache high-order bits of hashcode to speed up BytesRefHash. (Pan Guixin)
+
 Bug Fixes
 ---------------------
 * GITHUB#14654: ValueSource.fromDoubleValuesSource(dvs).getSortField() would throw errors when

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
@@ -50,6 +50,7 @@ public final class BytesRefHash implements Accountable {
   private int hashSize;
   private int hashHalfSize;
   private int hashMask;
+  private int highMask;
   private int count;
   private int lastCount = -1;
   private int[] ids;
@@ -71,9 +72,13 @@ public final class BytesRefHash implements Accountable {
 
   /** Creates a new {@link BytesRefHash} */
   public BytesRefHash(ByteBlockPool pool, int capacity, BytesStartArray bytesStartArray) {
+    if ((capacity & (capacity - 1)) != 0) {
+      throw new IllegalArgumentException("capacity must be a power of two, got " + capacity);
+    }
     hashSize = capacity;
     hashHalfSize = hashSize >> 1;
     hashMask = hashSize - 1;
+    highMask = ~hashMask;
     this.pool = new BytesRefBlockPool(pool);
     ids = new int[hashSize];
     Arrays.fill(ids, -1);
@@ -124,8 +129,8 @@ public final class BytesRefHash implements Accountable {
     int upto = 0;
     for (int i = 0; i < hashSize; i++) {
       if (ids[i] != -1) {
+        ids[upto] = ids[i] & hashMask;
         if (upto < i) {
-          ids[upto] = ids[i];
           ids[i] = -1;
         }
         upto++;
@@ -232,6 +237,7 @@ public final class BytesRefHash implements Accountable {
       Arrays.fill(ids, -1);
       hashHalfSize = newSize / 2;
       hashMask = newSize - 1;
+      highMask = ~hashMask;
       return true;
     } else {
       return false;
@@ -276,8 +282,9 @@ public final class BytesRefHash implements Accountable {
    */
   public int add(BytesRef bytes) {
     assert bytesStart != null : "Bytesstart is null - not initialized";
+    final int hashcode = doHash(bytes.bytes, bytes.offset, bytes.length);
     // final position
-    final int hashPos = findHash(bytes);
+    final int hashPos = findHash(bytes, hashcode);
     int e = ids[hashPos];
 
     if (e == -1) {
@@ -289,13 +296,14 @@ public final class BytesRefHash implements Accountable {
       bytesStart[count] = pool.addBytesRef(bytes);
       e = count++;
       assert ids[hashPos] == -1;
-      ids[hashPos] = e;
+      ids[hashPos] = e | (hashcode & highMask);
 
       if (count == hashHalfSize) {
         rehash(2 * hashSize, true);
       }
       return e;
     }
+    e = e & hashMask;
     return -(e + 1);
   }
 
@@ -306,25 +314,28 @@ public final class BytesRefHash implements Accountable {
    * @return the id of the given bytes, or {@code -1} if there is no mapping for the given bytes.
    */
   public int find(BytesRef bytes) {
-    return ids[findHash(bytes)];
+    final int hashcode = doHash(bytes.bytes, bytes.offset, bytes.length);
+    final int id = ids[findHash(bytes, hashcode)];
+    return id == -1 ? -1 : id & hashMask;
   }
 
-  private int findHash(BytesRef bytes) {
+  private int findHash(BytesRef bytes, int hashcode) {
     assert bytesStart != null : "bytesStart is null - not initialized";
+    assert hashcode == doHash(bytes.bytes, bytes.offset, bytes.length);
 
-    int code = doHash(bytes.bytes, bytes.offset, bytes.length);
-
+    int code = hashcode;
     // final position
     int hashPos = code & hashMask;
     int e = ids[hashPos];
-    if (e != -1 && pool.equals(bytesStart[e], bytes) == false) {
-      // Conflict; use linear probe to find an open slot
-      // (see LUCENE-5604):
-      do {
-        code++;
-        hashPos = code & hashMask;
-        e = ids[hashPos];
-      } while (e != -1 && pool.equals(bytesStart[e], bytes) == false);
+    final int highBits = hashcode & highMask;
+
+    // Conflict; use linear probe to find an open slot
+    // (see LUCENE-5604):
+    while (e != -1
+        && ((e & highMask) != highBits || pool.equals(bytesStart[e & hashMask], bytes) == false)) {
+      code++;
+      hashPos = code & hashMask;
+      e = ids[hashPos];
     }
 
     return hashPos;
@@ -342,14 +353,13 @@ public final class BytesRefHash implements Accountable {
     int code = offset;
     int hashPos = offset & hashMask;
     int e = ids[hashPos];
-    if (e != -1 && bytesStart[e] != offset) {
-      // Conflict; use linear probe to find an open slot
-      // (see LUCENE-5604):
-      do {
-        code++;
-        hashPos = code & hashMask;
-        e = ids[hashPos];
-      } while (e != -1 && bytesStart[e] != offset);
+
+    // Conflict; use linear probe to find an open slot
+    // (see LUCENE-5604):
+    while (e != -1 && bytesStart[e] != offset) {
+      code++;
+      hashPos = code & hashMask;
+      e = ids[hashPos];
     }
     if (e == -1) {
       // new entry
@@ -375,34 +385,39 @@ public final class BytesRefHash implements Accountable {
    */
   private void rehash(final int newSize, boolean hashOnData) {
     final int newMask = newSize - 1;
+    final int newHighMask = ~newMask;
     bytesUsed.addAndGet(Integer.BYTES * (long) newSize);
     final int[] newHash = new int[newSize];
     Arrays.fill(newHash, -1);
     for (int i = 0; i < hashSize; i++) {
-      final int e0 = ids[i];
+      int e0 = ids[i];
       if (e0 != -1) {
+        e0 &= hashMask;
+        final int hashcode;
         int code;
         if (hashOnData) {
-          code = pool.hash(bytesStart[e0]);
+          hashcode = code = pool.hash(bytesStart[e0]);
         } else {
           code = bytesStart[e0];
+          hashcode = 0;
         }
 
         int hashPos = code & newMask;
         assert hashPos >= 0;
-        if (newHash[hashPos] != -1) {
-          // Conflict; use linear probe to find an open slot
-          // (see LUCENE-5604):
-          do {
-            code++;
-            hashPos = code & newMask;
-          } while (newHash[hashPos] != -1);
+
+        // Conflict; use linear probe to find an open slot
+        // (see LUCENE-5604):
+        while (newHash[hashPos] != -1) {
+          code++;
+          hashPos = code & newMask;
         }
-        newHash[hashPos] = e0;
+
+        newHash[hashPos] = e0 | (hashcode & newHighMask);
       }
     }
 
     hashMask = newMask;
+    highMask = newHighMask;
     bytesUsed.addAndGet(Integer.BYTES * (long) -ids.length);
     ids = newHash;
     hashSize = newSize;

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
@@ -124,7 +124,7 @@ public final class BytesRefHash implements Accountable {
       throw new IllegalArgumentException("capacity must be greater than 0");
     }
 
-    if (BitUtil.isZeroOrPowerOfTwo(capacity)) {
+    if (BitUtil.isZeroOrPowerOfTwo(capacity) == false) {
       throw new IllegalArgumentException("capacity must be a power of two, got " + capacity);
     }
     hashSize = capacity;


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

This PR tries to utilize the unused part of the id to cache the high-order bits of the hashcode to speed up `BytesRefHash`. I used 1 million 16-byte UUIDs to [benchmark this change](https://github.com/bugmakerrrrrr/lucene/commit/43d2945be75acb2464c36ca1eac6067445687fe2), and the results are as follows.
![image](https://github.com/user-attachments/assets/da57ae65-366c-4751-af80-586448278258)

The `baselineXXX` version is the current implementation, the `cachedXXX` version uses a separate array of ints to cache hash codes, and the candidate version is the implementation of this PR.