### PR TITLE
Only run the labeller on the main branch of the lucene repository

### DIFF
--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -13,10 +13,15 @@ on:
 
 jobs:
   labeler:
+    # only run on the main Lucene repository.
+    if: (github.repository == 'apache/lucene')
+
     permissions:
       contents: read
       pull-requests: write
+
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:


### PR DESCRIPTION
This prevents this action from running on PR against forks, which I couldn't get to work (missing permissions for some reason).