### PR TITLE
Grammar and typo fixes

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ConcatenateGraphFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ConcatenateGraphFilter.java
@@ -39,7 +39,7 @@ import org.apache.lucene.util.fst.Util;
 /**
  * Concatenates/Joins every incoming token with a separator into one output token for every path
  * through the token stream (which is a graph). In simple cases this yields one token, but in the
- * presence of any tokens with a zero positionIncrmeent (e.g. synonyms) it will be more. This filter
+ * presence of any tokens with a zero positionIncrement (e.g. synonyms) it will be more. This filter
  * uses the token bytes, position increment, and position length of the incoming stream. Other
  * attributes are not used or manipulated.
  *

--- a/lucene/core/src/java/org/apache/lucene/analysis/CachingTokenFilter.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/CachingTokenFilter.java
@@ -26,7 +26,7 @@ import org.apache.lucene.util.IgnoreRandomChains;
 /**
  * This class can be used if the token attributes of a TokenStream are intended to be consumed more
  * than once. It caches all token attribute states locally in a List when the first call to {@link
- * #incrementToken()} is called. Subsequent calls will used the cache.
+ * #incrementToken()} is called. Subsequent calls will use the cache.
  *
  * <p><em>Important:</em> Like any proper TokenFilter, {@link #reset()} propagates to the input,
  * although only before {@link #incrementToken()} is called the first time. Prior to Lucene 5, it

--- a/lucene/core/src/java/org/apache/lucene/analysis/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/package-info.java
@@ -104,7 +104,7 @@
  * <p>The relationship between {@link org.apache.lucene.analysis.Analyzer} and {@link
  * org.apache.lucene.analysis.CharFilter}s, {@link org.apache.lucene.analysis.Tokenizer}s, and
  * {@link org.apache.lucene.analysis.TokenFilter}s is sometimes confusing. To ease this confusion,
- * here is some clarifications:
+ * here are some clarifications:
  *
  * <ul>
  *   <li>The {@link org.apache.lucene.analysis.Analyzer} is a <strong>factory</strong> for analysis
@@ -129,7 +129,7 @@
  * </ul>
  *
  * <p>If you want to use a particular combination of <code>CharFilter</code>s, a <code>Tokenizer
- * </code>, and some <code>TokenFilter</code>s, the simplest thing is often an create an anonymous
+ * </code>, and some <code>TokenFilter</code>s, the simplest thing is often to create an anonymous
  * subclass of {@link org.apache.lucene.analysis.Analyzer}, provide {@link
  * org.apache.lucene.analysis.Analyzer#createComponents(String)} and perhaps also {@link
  * org.apache.lucene.analysis.Analyzer#initReader(String, java.io.Reader)}. However, if you need the
@@ -366,8 +366,8 @@
  * <p>Given that position(magenta) = 0 + position(red), they are at the same position, so anything
  * working with analyzers will return the exact same result if you replace "magenta" with "red" in
  * the input. However, multi-word synonyms are more tricky. Let's say that you want to build a
- * TokenStream where "IBM" is a synonym of "Internal Business Machines". Position increments are not
- * enough anymore:
+ * TokenStream where "IBM" is a synonym of "International Business Machines". Position increments
+ * are not enough anymore:
  *
  * <table>
  * <caption>position increments where international is zero</caption>
@@ -377,7 +377,7 @@
  *
  * <p>The problem with this token stream is that "IBM" is at the same position as "International"
  * although it is a synonym with "International Business Machines" as a whole. Setting the position
- * increment of "Business" and "Machines" to 0 wouldn't help as it would mean than "International"
+ * increment of "Business" and "Machines" to 0 wouldn't help as it would mean that "International"
  * is a synonym of "Business". The only way to solve this issue is to make "IBM" span across 3
  * positions, this is where position lengths come to rescue.
  *
@@ -686,7 +686,7 @@
  * API
  * </pre>
  *
- * Now let's take a look how the LengthFilter is implemented:
+ * Now let's take a look at how the LengthFilter is implemented:
  *
  * <pre class="prettyprint">
  * public final class LengthFilter extends FilteringTokenFilter {

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnFieldVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnFieldVectorsWriter.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import org.apache.lucene.util.Accountable;
 
 /**
- * Vectors' writer for a field
+ * Vectors writer for a field.
  *
  * @param <T> an array type; the type of vectors to be written
  */

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsReader.java
@@ -136,7 +136,7 @@ public abstract class KnnVectorsReader implements Closeable {
   public void finishMerge() throws IOException {}
 
   /**
-   * Returns the desired size of off-heap memory the given field. This size can be used to help
+   * Returns the desired size of off-heap memory for the given field. This size can be used to help
    * determine the memory requirements for optimal search performance, which can be greatly affected
    * by page faults when not enough memory is available.
    *
@@ -168,7 +168,7 @@ public abstract class KnnVectorsReader implements Closeable {
   }
 
   /**
-   * Merges the Maps returned by {@link #getOffHeapByteSize(FieldInfo)}.
+   * Merges the maps returned by {@link #getOffHeapByteSize(FieldInfo)}.
    *
    * <p>This method is a convenience for aggregating the desired off-heap memory requirements for
    * several fields. The keys in the returned map are a union of the keys in the given maps. Entries

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsWriter.java
@@ -64,7 +64,7 @@ import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
  */
 public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
 
-  private static final long SHALLLOW_RAM_BYTES_USED =
+  private static final long SHALLOW_RAM_BYTES_USED =
       RamUsageEstimator.shallowSizeOfInstance(Lucene99FlatVectorsWriter.class);
 
   private final SegmentWriteState segmentWriteState;
@@ -146,7 +146,7 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
 
   @Override
   public long ramBytesUsed() {
-    long total = SHALLLOW_RAM_BYTES_USED;
+    long total = SHALLOW_RAM_BYTES_USED;
     for (FieldWriter<?> field : fields) {
       total += field.ramBytesUsed();
     }

--- a/lucene/core/src/java/org/apache/lucene/document/DoublePoint.java
+++ b/lucene/core/src/java/org/apache/lucene/document/DoublePoint.java
@@ -208,7 +208,7 @@ public final class DoublePoint extends Field {
    * {@code lowerValue = Double.NEGATIVE_INFINITY} or {@code upperValue = Double.POSITIVE_INFINITY}.
    *
    * <p>Ranges are inclusive. For exclusive ranges, pass {@link #nextUp(double) nextUp(lowerValue)}
-   * or {@link #nextUp(double) nextDown(upperValue)}.
+   * or {@link #nextDown(double) nextDown(upperValue)}.
    *
    * <p>Range comparisons are consistent with {@link Double#compareTo(Double)}.
    *

--- a/lucene/core/src/java/org/apache/lucene/document/FeatureField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FeatureField.java
@@ -38,7 +38,7 @@ import org.apache.lucene.search.similarities.Similarity.SimScorer;
 
 /**
  * {@link Field} that can be used to store static scoring factors into documents. This is mostly
- * inspired from the work from Nick Craswell, Stephen Robertson, Hugo Zaragoza and Michael Taylor.
+ * inspired by the work of Nick Craswell, Stephen Robertson, Hugo Zaragoza and Michael Taylor:
  * Relevance weighting for query independent evidence. Proceedings of the 28th annual international
  * ACM SIGIR conference on Research and development in information retrieval. August 15-19, 2005,
  * Salvador, Brazil.

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -470,9 +470,9 @@ public class IndexWriter
    * session can be quickly made available for searching without closing the writer nor calling
    * {@link #commit}.
    *
-   * <p>Note that this is functionally equivalent to calling {#flush} and then opening a new reader.
-   * But the turnaround time of this method should be faster since it avoids the potentially costly
-   * {@link #commit}.
+   * <p>Note that this is functionally equivalent to calling {@link #commit} and then opening a new
+   * reader. But the turnaround time of this method should be faster since it avoids the potentially
+   * costly {@link #commit}.
    *
    * <p>You must close the {@link IndexReader} returned by this method once you are done using it.
    *
@@ -501,8 +501,8 @@ public class IndexWriter
    * AlreadyClosedException}.
    *
    * @lucene.experimental
-   * @return IndexReader that covers entire index plus all changes made so far by this IndexWriter
-   *     instance
+   * @return IndexReader that covers the entire index plus all changes made so far by this
+   *     IndexWriter instance
    * @throws IOException If there is a low-level I/O error
    */
   DirectoryReader getReader(boolean applyAllDeletes, boolean writeAllDeletes) throws IOException {
@@ -4063,7 +4063,7 @@ public class IndexWriter
    * Returns true if there may be changes that have not been committed. There are cases where this
    * may return true when there are no actual "real" changes to the index, for example if you've
    * deleted by Term or Query but that Term or Query does not match any documents. Also, if a merge
-   * kicked off as a result of flushing a new segment during {@link #commit}, or a concurrent merged
+   * kicked off as a result of flushing a new segment during {@link #commit}, or a concurrent merge
    * finished, this method may return true right after you had just called {@link #commit}.
    */
   public final boolean hasUncommittedChanges() {
@@ -4476,7 +4476,7 @@ public class IndexWriter
     // if we mix soft and hard deletes we need to make sure that we only carry over deletes
     // that were not deleted before. Otherwise the segDocMap doesn't contain a mapping.
     // yet this is also required if any MergePolicy modifies the liveDocs since this is
-    // what the segDocMap is build on.
+    // what the segDocMap is built on.
     final IntPredicate carryOverDelete =
         docId -> segDocMap.get(docId) != -1 && currentHardLiveDocs.get(docId) == false;
     if (prevHardLiveDocs != null) {
@@ -6091,7 +6091,7 @@ public class IndexWriter
     if (rld != null) {
       numDeletesToMerge = rld.numDeletesToMerge(mergePolicy);
     } else {
-      // if we don't have a  pooled instance lets just return the hard deletes, this is safe!
+      // if we don't have a pooled instance let's just return the hard deletes, this is safe!
       numDeletesToMerge = info.getDelCount();
     }
     assert numDeletesToMerge <= info.info.maxDoc()

--- a/lucene/core/src/java/org/apache/lucene/search/AutomatonQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AutomatonQuery.java
@@ -34,8 +34,8 @@ import org.apache.lucene.util.automaton.CompiledAutomaton;
  * Alternatively, it can be created from a regular expression with {@link RegexpQuery} or from the
  * standard Lucene wildcard syntax with {@link WildcardQuery}.
  *
- * <p>When the query is executed, it will will enumerate the term dictionary in an intelligent way
- * to reduce the number of comparisons. For example: the regular expression of <code>[dl]og?</code>
+ * <p>When the query is executed, it will enumerate the term dictionary in an intelligent way to
+ * reduce the number of comparisons. For example: the regular expression of <code>[dl]og?</code>
  * will make approximately four comparisons: do, dog, lo, and log.
  *
  * @lucene.experimental

--- a/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
@@ -137,7 +137,7 @@ public class FieldExistsQuery extends Query {
       } else if (fieldInfo.getDocValuesType()
           != DocValuesType.NONE) { // the field indexes doc values or points
 
-        // This optimization is possible due to LUCENE-9334 enforcing a field to always uses the
+        // This optimization is possible due to LUCENE-9334 enforcing a field to always use the
         // same data structures (all or nothing). Since there's no index statistic to detect when
         // all documents have doc values for a specific field, FieldExistsQuery can only be
         // rewritten to MatchAllDocsQuery for doc values field, when that same field also indexes

--- a/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -37,7 +37,7 @@ import org.apache.lucene.util.IOConsumer;
 /**
  * Base IndexInput implementation that uses an array of MemorySegments to represent a file.
  *
- * <p>For efficiency, this class requires that the segment size are a power-of-two (<code>
+ * <p>For efficiency, this class requires that the segment size is a power of two (<code>
  * chunkSizePower</code>).
  */
 abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegmentAccessInput {

--- a/lucene/core/src/java/org/apache/lucene/store/NativeAccess.java
+++ b/lucene/core/src/java/org/apache/lucene/store/NativeAccess.java
@@ -35,7 +35,8 @@ abstract class NativeAccess {
   public abstract int getPageSize();
 
   /**
-   * Return the NativeAccess instance for this platform. At moment we only support Linux and MacOS
+   * Return the NativeAccess instance for this platform. At the moment we only support Linux and
+   * MacOS.
    */
   public static Optional<NativeAccess> getImplementation() {
     if (Constants.LINUX || Constants.MAC_OS_X) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -70,7 +70,7 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
    *
    * @param numNodes number of nodes that will be added to this graph, passing in -1 means unbounded
    *     while passing in a non-negative value will lock the whole graph and disable the graph from
-   *     growing itself (you cannot add a node with has id >= numNodes)
+   *     growing itself (you cannot add a node with id >= numNodes)
    */
   OnHeapHnswGraph(int M, int numNodes) {
     this.entryNode = new AtomicReference<>(new EntryNode(-1, 1));

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/CrankyTokenFilter.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/CrankyTokenFilter.java
@@ -22,7 +22,7 @@ import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 
 /**
- * Throws IOException from random Tokenstream methods.
+ * Throws IOException from random TokenStream methods.
  *
  * <p>This can be used to simulate a buggy analyzer in IndexWriter, where we must delete the
  * document but not abort everything in the buffer.


### PR DESCRIPTION
A collection of grammar issues and typo fixes collected over time studying Lucene sources. No code changed, all changes are documentation. 

One change is not a simple error: at `IndexWriter.getReader()` I changed
```
this is functionally equivalent to calling {#flush}
```
to
```
this is functionally equivalent to calling {#commit}
```
A reader opened after `flush()`, if it wasn't opened with this method, won't see the not-yet-committed changes. So this method is an equivalent of committing, not flushing, if I understand it correctly.