### PR TITLE
feat: add automated backport workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,7 +5,8 @@ self-hosted-runner:
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.
 # Empty array means no configuration variable is allowed.
-config-variables: []
+config-variables:
+  - BACKPORT_DRY_RUN
 
 # Configuration for file paths. The keys are glob patterns to match to file
 # paths relative to the repository root. The values are the configurations for

--- a/.github/workflows/backport.sh
+++ b/.github/workflows/backport.sh
@@ -87,24 +87,23 @@ echo "🌿 Caching branch information..."
 ALL_BRANCHES=$(git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin | grep -v '^HEAD$' | sort)
 declare -ra TARGET_BRANCH_TEMPLATES=(
   "branch_{{major}}x"
-  "branch_{{version_us}}"
-  "release/{{version}}"
-  "v{{version}}"
-  "{{version}}"
-  "{{version}}-stable"
+  "branch_{{major}}_{{minor}}"
 )
 
 find_target_branch() {
   local version="$1"
   local major
-  local version_us="${version//\./_}"
+  local minor=""
 
   major=$(echo "$version" | sed -E 's/^([0-9]+).*/\1/')
+  if [[ "$version" =~ ^[0-9]+\.([0-9]+) ]]; then
+    minor="${BASH_REMATCH[1]}"
+  fi
 
   for template in "${TARGET_BRANCH_TEMPLATES[@]}"; do
     local candidate="${template//\{\{version\}\}/$version}"
-    candidate="${candidate//\{\{version_us\}\}/$version_us}"
     candidate="${candidate//\{\{major\}\}/$major}"
+    candidate="${candidate//\{\{minor\}\}/$minor}"
 
     local target
     target=$(echo "$ALL_BRANCHES" | grep -Fx "$candidate" | head -1 || true)
@@ -113,8 +112,6 @@ find_target_branch() {
       return 0
     fi
   done
-
-  echo "$ALL_BRANCHES" | awk -v v="$version" 'index($0, v) > 0 { print; exit }'
 }
 
 declare -a requested_versions=()
@@ -168,8 +165,12 @@ if [ ${#failed_versions[@]} -gt 0 ]; then
   for version in "${failed_versions[@]}"; do
     failed_list="${failed_list}- \`${version}\`"$'\n'
     major=$(echo "$version" | sed -E 's/^([0-9]+).*/\1/')
-    version_us="${version//\./_}"
-    attempted_patterns="${attempted_patterns}- \`branch_${major}x\`, \`branch_${version_us}\`, \`release/${version}\`, \`v${version}\`, \`${version}\`, \`${version}-stable\`"$'\n'
+    if [[ "$version" =~ ^[0-9]+\.([0-9]+) ]]; then
+      minor="${BASH_REMATCH[1]}"
+      attempted_patterns="${attempted_patterns}- \`branch_${major}x\`, \`branch_${major}_${minor}\`"$'\n'
+    else
+      attempted_patterns="${attempted_patterns}- \`branch_${major}x\`"$'\n'
+    fi
   done
 
   create_comment "❌ **Backport failed for some versions - Missing target branches**
@@ -181,9 +182,7 @@ $failed_list
 
 **Expected patterns:**
 - \`branch_{major}x\` (Lucene style)
-- \`branch_{version_with_underscores}\`
-- \`release/{version}\`
-- \`v{version}\`
+- \`branch_{major}_{minor}\` (Lucene release branch style)
 
 **Attempted branch names per missing version:**
 $attempted_patterns

--- a/.github/workflows/backport.sh
+++ b/.github/workflows/backport.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "📊 Fetching PR data..."
+PR_DATA=$(gh pr view "$PR_NUMBER" --json labels,milestone,title)
+PR_LABELS=$(echo "$PR_DATA" | jq -r '.labels[].name | select(test("^backport/"; "i"))')
+PR_MILESTONE=$(echo "$PR_DATA" | jq -r '.milestone.title // ""')
+PR_TITLE=$(echo "$PR_DATA" | jq -r '.title // "Unknown title"')
+PR_MERGE_COMMIT_SHA="${PR_MERGE_COMMIT_SHA:-unknown}"
+DRY_RUN="${BACKPORT_DRY_RUN:-true}"
+
+normalize_version() {
+  local raw="$1"
+  local trimmed
+  local normalized=""
+  trimmed=$(echo "$raw" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')
+  if [[ $trimmed =~ ([0-9]+(\.[0-9]+)*) ]]; then
+    normalized="${BASH_REMATCH[1]}"
+  fi
+  echo "$normalized"
+}
+
+is_valid_sha() {
+  local sha="$1"
+  [[ "$sha" =~ ^[0-9a-f]{7,40}$ ]]
+}
+
+create_comment() {
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[dry-run] Would comment on PR #$PR_NUMBER:"
+    echo "$1"
+    return 0
+  fi
+  gh pr comment "$PR_NUMBER" --body "$1"
+}
+
+add_label() {
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[dry-run] Would add label '$1' on PR #$PR_NUMBER"
+    return 0
+  fi
+  gh pr edit "$PR_NUMBER" --add-label "$1" 2>/dev/null || true
+}
+
+publish_outputs() {
+  local has_targets="$1"
+  local targets_json="$2"
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      echo "dry_run=$DRY_RUN"
+      echo "has_targets=$has_targets"
+      echo "targets<<EOF"
+      echo "$targets_json"
+      echo "EOF"
+    } >> "$GITHUB_OUTPUT"
+  fi
+}
+
+if [ -z "$PR_LABELS" ] && [ -z "$PR_MILESTONE" ]; then
+  echo "ℹ️ No backport labels or milestone found. Nothing to do."
+  publish_outputs "false" "[]"
+  exit 0
+fi
+
+if [ "$DRY_RUN" != "true" ] && ! is_valid_sha "$PR_MERGE_COMMIT_SHA"; then
+  create_comment "❌ **Automatic backports skipped**
+
+Invalid merge commit SHA was provided by workflow context: \`$PR_MERGE_COMMIT_SHA\`.
+
+Backports are skipped for safety."
+  add_label "backport-failed"
+  publish_outputs "false" "[]"
+  exit 0
+fi
+
+echo "🏷️ Ensuring backport labels exist..."
+if [ "$DRY_RUN" = "true" ]; then
+  echo "[dry-run] Skipping label creation"
+else
+  gh label create "backport" --description "Automated backport workflow" --color "0366d6" 2>/dev/null || true
+  gh label create "backport-failed" --description "Backport failed" --color "d73a49" 2>/dev/null || true
+fi
+
+echo "🌿 Caching branch information..."
+ALL_BRANCHES=$(git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin | grep -v '^HEAD$' | sort)
+declare -ra TARGET_BRANCH_TEMPLATES=(
+  "branch_{{major}}x"
+  "branch_{{version_us}}"
+  "release/{{version}}"
+  "v{{version}}"
+  "{{version}}"
+  "{{version}}-stable"
+)
+
+find_target_branch() {
+  local version="$1"
+  local major
+  local version_us="${version//\./_}"
+
+  major=$(echo "$version" | sed -E 's/^([0-9]+).*/\1/')
+
+  for template in "${TARGET_BRANCH_TEMPLATES[@]}"; do
+    local candidate="${template//\{\{version\}\}/$version}"
+    candidate="${candidate//\{\{version_us\}\}/$version_us}"
+    candidate="${candidate//\{\{major\}\}/$major}"
+
+    local target
+    target=$(echo "$ALL_BRANCHES" | grep -Fx "$candidate" | head -1 || true)
+    if [ -n "$target" ]; then
+      echo "$target"
+      return 0
+    fi
+  done
+
+  echo "$ALL_BRANCHES" | awk -v v="$version" 'index($0, v) > 0 { print; exit }'
+}
+
+declare -a requested_versions=()
+if [ -n "$PR_MILESTONE" ]; then
+  normalized_milestone=$(normalize_version "$PR_MILESTONE")
+  if [ -n "$normalized_milestone" ]; then
+    requested_versions+=("$normalized_milestone")
+  fi
+fi
+
+while IFS= read -r label; do
+  [ -z "$label" ] && continue
+  normalized_label=$(normalize_version "${label#*/}")
+  if [ -n "$normalized_label" ]; then
+    requested_versions+=("$normalized_label")
+  fi
+done <<< "$PR_LABELS"
+
+declare -a deduped_requested_versions=()
+declare -A seen_versions=()
+for version in "${requested_versions[@]}"; do
+  [ -n "$version" ] || continue
+  if [ -z "${seen_versions[$version]:-}" ]; then
+    seen_versions[$version]=1
+    deduped_requested_versions+=("$version")
+  fi
+done
+
+echo "📋 Requested versions: ${deduped_requested_versions[*]}"
+
+declare -a valid_backports=()
+declare -a failed_versions=()
+
+echo "🔍 Pre-validating target branches..."
+for version in "${deduped_requested_versions[@]}"; do
+  target=$(find_target_branch "$version")
+
+  if [ -n "$target" ]; then
+    valid_backports+=("$version:$target")
+    echo "✅ $version -> $target"
+  else
+    failed_versions+=("$version")
+    echo "❌ $version -> NOT FOUND"
+  fi
+done
+
+if [ ${#failed_versions[@]} -gt 0 ]; then
+  available_sample=$(echo "$ALL_BRANCHES" | head -5 | tr '\n' ', ' | sed 's/,$//')
+  failed_list=""
+  attempted_patterns=""
+  for version in "${failed_versions[@]}"; do
+    failed_list="${failed_list}- \`${version}\`"$'\n'
+    major=$(echo "$version" | sed -E 's/^([0-9]+).*/\1/')
+    version_us="${version//\./_}"
+    attempted_patterns="${attempted_patterns}- \`branch_${major}x\`, \`branch_${version_us}\`, \`release/${version}\`, \`v${version}\`, \`${version}\`, \`${version}-stable\`"$'\n'
+  done
+
+  create_comment "❌ **Backport failed for some versions - Missing target branches**
+
+Could not find target branches for:
+$failed_list
+
+**Sample available branches:** $available_sample
+
+**Expected patterns:**
+- \`branch_{major}x\` (Lucene style)
+- \`branch_{version_with_underscores}\`
+- \`release/{version}\`
+- \`v{version}\`
+
+**Attempted branch names per missing version:**
+$attempted_patterns
+
+Please create the missing branches or update the backport labels/milestone.
+
+**Note:** Valid backports will still be processed."
+  add_label "backport-failed"
+fi
+
+if [ ${#valid_backports[@]} -eq 0 ]; then
+  echo "❌ No valid backports found."
+  publish_outputs "false" "[]"
+  exit 0
+fi
+
+targets_json=$(printf '%s\n' "${valid_backports[@]}" \
+  | jq -R 'select(length > 0) | split(":") | {version: .[0], target: .[1]}' \
+  | jq -cs '.')
+
+echo "✅ Prepared ${#valid_backports[@]} valid backport target(s)."
+  if [ "$DRY_RUN" = "true" ]; then
+  echo "[dry-run] Planned targets: $targets_json"
+  for backport in "${valid_backports[@]}"; do
+    IFS=':' read -r version target <<< "$backport"
+    backport_branch="backport-${PR_NUMBER}-to-${target}"
+    echo "[dry-run] -----------------------------------------------------------------"
+    echo "[dry-run] target_branch=${target}, version=${version}, merge_commit=${PR_MERGE_COMMIT_SHA}"
+    echo "[dry-run] Would run equivalent git operations:"
+    echo "[dry-run]   git checkout -b ${backport_branch} origin/${target}"
+    echo "[dry-run]   git cherry-pick -x ${PR_MERGE_COMMIT_SHA}"
+    echo "[dry-run]   git push origin ${backport_branch}"
+    echo "[dry-run] Would run equivalent PR creation:"
+    echo "[dry-run]   gh pr create --base ${target} --head ${backport_branch} --title \"[Backport ${target}] ${PR_TITLE}\" --label backport"
+    echo "[dry-run]   PR body payload:"
+    echo "[dry-run]     ## 🔄 Automatic Backport"
+    echo "[dry-run]     Backport of #${PR_NUMBER} to \`${target}\`."
+    echo "[dry-run]     **Target:** \`${target}\`"
+    echo "[dry-run]     **Version:** \`${version}\`"
+  done
+fi
+
+publish_outputs "true" "$targets_json"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,305 @@
+name: Backport PR
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: read
+      checks: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Backport
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -e
+          
+          # Cache PR data early
+          echo "📊 Fetching PR data..."
+          PR_DATA=$(gh pr view "$PR_NUMBER" --json title,body,labels,statusCheckRollup,commits)
+          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
+          PR_BODY=$(echo "$PR_DATA" | jq -r '.body // "No description provided."')
+          PR_LABELS=$(echo "$PR_DATA" | jq -r '.labels[].name | select(test("^[Bb]ackport/"; "i"))')
+          
+          # Function to create GitHub comment
+          create_comment() {
+            gh pr comment "$PR_NUMBER" --body "$1"
+          }
+          
+          # Function to add label safely  
+          add_label() {
+            gh pr edit "$PR_NUMBER" --add-label "$1" 2>/dev/null || true
+          }
+          
+          # Check status checks once
+          echo "🔍 Checking PR status checks..."
+          FAILED_CHECKS=$(echo "$PR_DATA" | jq -r '.statusCheckRollup[]? | select(.isRequired == true and (.state == "FAILURE" or .state == "ERROR")) | .state' 2>/dev/null || echo "")
+          
+          if [ -n "$FAILED_CHECKS" ]; then
+            echo "❌ Required status checks failed"
+            create_comment "⚠️ **Automatic backports skipped**
+          
+          Some required status checks failed on this PR. Backports will not be created automatically.
+          
+          **Action required:**
+          1. Fix failing tests or checks
+          2. Manually create backport PRs after verification
+          3. Or re-run this workflow after fixes are merged"
+            add_label "backport-failed"
+            exit 0
+          fi
+          
+          # Early exit if no backport labels
+          if [ -z "$PR_LABELS" ]; then
+            echo "ℹ️ No backport labels found. Nothing to do."
+            exit 0
+          fi
+          
+          echo "📋 Found backport labels: $(echo "$PR_LABELS" | tr '\n' ' ')"
+          
+          # Batch create labels
+          echo "🏷️ Ensuring backport labels exist..."
+          gh label create "backport" --description "Automated backport workflow" --color "0366d6" 2>/dev/null || true &
+          gh label create "backport-conflict" --description "Backport had conflicts" --color "d73a49" 2>/dev/null || true &
+          gh label create "backport-failed" --description "Backport failed" --color "d73a49" 2>/dev/null || true &
+          wait # Wait for background label creation
+          
+          # Cache all remote branches once
+          echo "🌿 Caching branch information..."
+          ALL_BRANCHES=$(git branch -r | grep -v HEAD | sed 's|.*origin/||' | sort)
+          
+          # Define templates in order of preference
+          declare -a target_branch_templates=(
+            "branch_{{version_us}}"
+            "release/{{version}}"
+            "v{{version}}"
+            "{{version}}"
+            "{{version}}-stable"
+          )
+          
+          # Optimized branch finder with caching
+          find_target_branch() {
+            local version="$1"
+            local version_us="${version//\./_}"
+          
+            for template in "${target_branch_templates[@]}"; do
+              local pattern="${template//\{\{version\}\}/$version}"
+              pattern="${pattern//\{\{version_us\}\}/$version_us}"
+          
+              # Use cached branches instead of repeated git calls
+              local target=$(echo "$ALL_BRANCHES" | grep -E "^${pattern}$" | head -1)
+              if [ -n "$target" ]; then
+                echo "$target"
+                return 0
+              fi
+            done
+          
+            # Fallback with cached data
+            echo "$ALL_BRANCHES" | grep -E "${version}([^0-9]|$)" | head -1 || echo ""
+          }
+          
+          # Pre-check all target branches exist before processing
+          declare -a valid_backports=()
+          declare -a failed_versions=()
+          
+          echo "🔍 Pre-validating target branches..."
+          while IFS= read -r label; do
+            [ -z "$label" ] && continue
+            version=${label#[Bb]ackport/}
+            target=$(find_target_branch "$version")
+          
+            if [ -n "$target" ]; then
+              valid_backports+=("$version:$target")
+              echo "✅ $version -> $target"
+            else
+              failed_versions+=("$version")
+              echo "❌ $version -> NOT FOUND"
+            fi
+          done <<< "$PR_LABELS"
+          
+          # Report all missing branches at once
+          if [ ${#failed_versions[@]} -gt 0 ]; then
+            available_sample=$(echo "$ALL_BRANCHES" | head -5 | tr '\n' ', ' | sed 's/,$//')
+            failed_list=""
+            for version in "${failed_versions[@]}"; do
+              failed_list="${failed_list}- \`${version}\`"$'\n'
+            done
+          
+            create_comment "❌ **Backport failed for some versions - Missing target branches**
+          
+          Could not find target branches for:
+          $failed_list
+          
+          **Sample available branches:** $available_sample
+          
+          **Expected patterns:**
+          - \`branch_{version_with_underscores}\` (Lucene style)
+          - \`release/{version}\`
+          - \`v{version}\`
+          
+          Please create the missing branches or update the backport labels.
+          
+          **Note:** Valid backports will still be processed."
+          
+            add_label "backport-failed"
+          fi
+          
+          # Only exit if NO valid backports exist
+          if [ ${#valid_backports[@]} -eq 0 ]; then
+            echo "❌ No valid backports found. Exiting."
+            exit 1
+          fi
+          
+          echo "✅ Processing ${#valid_backports[@]} valid backport(s)..."
+          
+          # Process valid backports
+          success_count=0
+          failure_count=${#failed_versions[@]}
+          
+          for backport in "${valid_backports[@]}"; do
+            IFS=':' read -r version target <<< "$backport"
+            echo "🔄 Processing backport: $version -> $target"
+          
+            branch="backport-${PR_NUMBER}-to-${target}"
+          
+            # Clean checkout with error handling
+            git checkout "$DEFAULT_BRANCH" >/dev/null 2>&1
+            git branch -D "$branch" 2>/dev/null || true
+          
+            if ! git checkout -b "$branch" "origin/$target" >/dev/null 2>&1; then
+              echo "❌ Failed to checkout origin/$target"
+              create_comment "❌ **Backport to \`$target\` failed**
+          
+              Could not create branch from \`origin/$target\`. Branch may have been deleted or is unreachable."
+              add_label "backport-failed"
+              failure_count=$((failure_count + 1))
+              continue
+            fi
+          
+            # Check if PR already exists (early check)
+            existing_pr=$(gh pr list --head "$branch" --base "$target" --json number -q '.[0].number' 2>/dev/null || echo "")
+            if [ -n "$existing_pr" ]; then
+              echo "ℹ️ Backport PR already exists: #$existing_pr"
+              success_count=$((success_count + 1))
+              continue
+            fi
+          
+            # Get individual commits from the PR instead of merge commit
+            echo "🔍 Getting PR commits..."
+            PR_COMMITS=$(echo "$PR_DATA" | jq -r '.commits[].oid' | tr '\n' ' ')
+            echo "📝 PR commits: $PR_COMMITS"
+
+            if [ -z "$PR_COMMITS" ]; then
+              echo "❌ No commits found in PR"
+              create_comment "❌ **Backport to \`$target\` failed**
+          
+              Could not find individual commits in PR #${PR_NUMBER}."
+              add_label "backport-failed"
+              failure_count=$((failure_count + 1))
+              continue
+            fi
+
+            # Cherry-pick each commit individually
+            cherry_pick_success=true
+            for commit in $PR_COMMITS; do
+              echo "🍒 Cherry-picking commit: $commit"
+              if ! git cherry-pick -x "$commit" 2>&1; then
+                echo "❌ Failed to cherry-pick $commit"
+                cherry_pick_success=false
+                break
+              fi
+            done
+
+            if [ "$cherry_pick_success" = true ]; then
+              echo "✅ All commits cherry-picked successfully"
+              if git push origin "$branch" >/dev/null 2>&1; then
+                # Create PR with cached data
+                new_pr_url=$(gh pr create \
+                  --title "[Backport $target] $PR_TITLE" \
+                  --body "## 🔄 Automatic Backport
+          
+          Backport of #${PR_NUMBER} to \`$target\` branch.
+          
+          **Original PR:** #${PR_NUMBER}  
+          **Target:** \`$target\`
+          **Label:** \`backport/$version\`
+          
+          ---
+          
+          $PR_BODY" \
+                  --base "$target" \
+                  --head "$branch" \
+                  --label "backport")
+          
+          
+                echo "✅ Created: $new_pr_url"
+                success_count=$((success_count + 1))
+              else
+                echo "❌ Push failed for $branch"
+                create_comment "❌ **Backport to \`$target\` failed**
+          
+          Cherry-pick succeeded but push failed. This might be a permissions issue."
+                add_label "backport-failed"
+                failure_count=$((failure_count + 1))
+              fi
+            else
+              # Handle cherry-pick failure
+              git cherry-pick --abort 2>/dev/null || true
+          
+              create_comment "❌ **Backport to \`$target\` has conflicts**
+          
+          **Manual resolution required:**
+          \`\`\`bash
+          git checkout $target && git pull
+          git checkout -b backport-${PR_NUMBER}-to-${target}-manual
+          # Cherry-pick commits individually:
+          $(echo "$PR_COMMITS" | tr ' ' '\n' | sed 's/^/git cherry-pick -x /')
+          # Resolve conflicts, then:
+          git add . && git cherry-pick --continue
+          git push origin backport-${PR_NUMBER}-to-${target}-manual
+          \`\`\`"
+          
+              add_label "backport-conflict"
+              failure_count=$((failure_count + 1))
+            fi
+          
+            # Cleanup
+            git checkout "$DEFAULT_BRANCH" >/dev/null 2>&1
+            git branch -D "$branch" 2>/dev/null || true
+          done
+          
+          echo "🏁 Completed: $success_count successes, $failure_count failures"
+          
+          # Set appropriate exit code based on results
+          if [ $success_count -eq 0 ]; then
+            echo "❌ All backports failed"
+            exit 1
+          elif [ $failure_count -gt 0 ]; then
+            echo "⚠️ Some backports failed, but at least one succeeded"
+            exit 0
+          else
+            echo "✅ All backports completed successfully"
+            exit 0
+          fi

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,302 +4,103 @@ on:
   pull_request:
     types: [closed]
 
+permissions: {}
+
 jobs:
-  backport:
+  prepare:
+    name: Prepare Backport Targets
     if: github.event.pull_request.merged == true
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
-      statuses: read
-      checks: read
-      actions: read
+      contents: read # Reads repository workflow script and remote branch refs.
+      pull-requests: write # Adds comments/labels to the source pull request.
+    outputs:
+      dry_run: ${{ steps.plan.outputs.dry_run }}
+      has_targets: ${{ steps.plan.outputs.has_targets }}
+      targets: ${{ steps.plan.outputs.targets }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
-      - name: Setup Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Backport
+      - name: Plan backports
+        id: plan
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PR_MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          BACKPORT_DRY_RUN: ${{ vars.BACKPORT_DRY_RUN || 'true' }}
+        run: ./.github/workflows/backport.sh
+
+  backport:
+    name: Create Backport Pull Requests
+    needs: prepare
+    if: needs.prepare.outputs.has_targets == 'true' && needs.prepare.outputs.dry_run != 'true'
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Pushes generated backport branches.
+      pull-requests: write # Creates backport pull requests and comments on failures.
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.prepare.outputs.targets) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Cherry-pick with approved action
+        id: cherry_pick
+        continue-on-error: true
+        uses: carloscastrojumo/github-cherry-pick-action@503773289f4a459069c832dc628826685b75b4b3 # v1.0.10
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ matrix.target }}
+          cherry-pick-branch: backport-${{ github.event.pull_request.number }}-to-${{ matrix.target }}
+          title: '[Backport ${{ matrix.target }}] {old_title}'
+          body: |
+            ## 🔄 Automatic Backport
+
+            Backport of #{old_pull_request_id} to `${{ matrix.target }}`.
+
+            **Target:** `${{ matrix.target }}`
+            **Version:** `${{ matrix.version }}`
+          labels: |
+            backport
+          inherit_labels: 'false'
+
+      - name: Handle failed action backport
+        if: steps.cherry_pick.outcome != 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARGET_BRANCH: ${{ matrix.target }}
         run: |
-          set -e
-          
-          # Cache PR data early
-          echo "📊 Fetching PR data..."
-          PR_DATA=$(gh pr view "$PR_NUMBER" --json title,body,labels,statusCheckRollup,commits)
-          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
-          PR_BODY=$(echo "$PR_DATA" | jq -r '.body // "No description provided."')
-          PR_LABELS=$(echo "$PR_DATA" | jq -r '.labels[].name | select(test("^[Bb]ackport/"; "i"))')
-          
-          # Function to create GitHub comment
-          create_comment() {
-            gh pr comment "$PR_NUMBER" --body "$1"
-          }
-          
-          # Function to add label safely  
-          add_label() {
-            gh pr edit "$PR_NUMBER" --add-label "$1" 2>/dev/null || true
-          }
-          
-          # Check status checks once
-          echo "🔍 Checking PR status checks..."
-          FAILED_CHECKS=$(echo "$PR_DATA" | jq -r '.statusCheckRollup[]? | select(.isRequired == true and (.state == "FAILURE" or .state == "ERROR")) | .state' 2>/dev/null || echo "")
-          
-          if [ -n "$FAILED_CHECKS" ]; then
-            echo "❌ Required status checks failed"
-            create_comment "⚠️ **Automatic backports skipped**
-          
-          Some required status checks failed on this PR. Backports will not be created automatically.
-          
-          **Action required:**
-          1. Fix failing tests or checks
-          2. Manually create backport PRs after verification
-          3. Or re-run this workflow after fixes are merged"
-            add_label "backport-failed"
-            exit 0
-          fi
-          
-          # Early exit if no backport labels
-          if [ -z "$PR_LABELS" ]; then
-            echo "ℹ️ No backport labels found. Nothing to do."
-            exit 0
-          fi
-          
-          echo "📋 Found backport labels: $(echo "$PR_LABELS" | tr '\n' ' ')"
-          
-          # Batch create labels
-          echo "🏷️ Ensuring backport labels exist..."
-          gh label create "backport" --description "Automated backport workflow" --color "0366d6" 2>/dev/null || true &
-          gh label create "backport-conflict" --description "Backport had conflicts" --color "d73a49" 2>/dev/null || true &
-          gh label create "backport-failed" --description "Backport failed" --color "d73a49" 2>/dev/null || true &
-          wait # Wait for background label creation
-          
-          # Cache all remote branches once
-          echo "🌿 Caching branch information..."
-          ALL_BRANCHES=$(git branch -r | grep -v HEAD | sed 's|.*origin/||' | sort)
-          
-          # Define templates in order of preference
-          declare -a target_branch_templates=(
-            "branch_{{version_us}}"
-            "release/{{version}}"
-            "v{{version}}"
-            "{{version}}"
-            "{{version}}-stable"
-          )
-          
-          # Optimized branch finder with caching
-          find_target_branch() {
-            local version="$1"
-            local version_us="${version//\./_}"
-          
-            for template in "${target_branch_templates[@]}"; do
-              local pattern="${template//\{\{version\}\}/$version}"
-              pattern="${pattern//\{\{version_us\}\}/$version_us}"
-          
-              # Use cached branches instead of repeated git calls
-              local target=$(echo "$ALL_BRANCHES" | grep -E "^${pattern}$" | head -1)
-              if [ -n "$target" ]; then
-                echo "$target"
-                return 0
-              fi
-            done
-          
-            # Fallback with cached data
-            echo "$ALL_BRANCHES" | grep -E "${version}([^0-9]|$)" | head -1 || echo ""
-          }
-          
-          # Pre-check all target branches exist before processing
-          declare -a valid_backports=()
-          declare -a failed_versions=()
-          
-          echo "🔍 Pre-validating target branches..."
-          while IFS= read -r label; do
-            [ -z "$label" ] && continue
-            version=${label#[Bb]ackport/}
-            target=$(find_target_branch "$version")
-          
-            if [ -n "$target" ]; then
-              valid_backports+=("$version:$target")
-              echo "✅ $version -> $target"
-            else
-              failed_versions+=("$version")
-              echo "❌ $version -> NOT FOUND"
-            fi
-          done <<< "$PR_LABELS"
-          
-          # Report all missing branches at once
-          if [ ${#failed_versions[@]} -gt 0 ]; then
-            available_sample=$(echo "$ALL_BRANCHES" | head -5 | tr '\n' ', ' | sed 's/,$//')
-            failed_list=""
-            for version in "${failed_versions[@]}"; do
-              failed_list="${failed_list}- \`${version}\`"$'\n'
-            done
-          
-            create_comment "❌ **Backport failed for some versions - Missing target branches**
-          
-          Could not find target branches for:
-          $failed_list
-          
-          **Sample available branches:** $available_sample
-          
-          **Expected patterns:**
-          - \`branch_{version_with_underscores}\` (Lucene style)
-          - \`release/{version}\`
-          - \`v{version}\`
-          
-          Please create the missing branches or update the backport labels.
-          
-          **Note:** Valid backports will still be processed."
-          
-            add_label "backport-failed"
-          fi
-          
-          # Only exit if NO valid backports exist
-          if [ ${#valid_backports[@]} -eq 0 ]; then
-            echo "❌ No valid backports found. Exiting."
-            exit 1
-          fi
-          
-          echo "✅ Processing ${#valid_backports[@]} valid backport(s)..."
-          
-          # Process valid backports
-          success_count=0
-          failure_count=${#failed_versions[@]}
-          
-          for backport in "${valid_backports[@]}"; do
-            IFS=':' read -r version target <<< "$backport"
-            echo "🔄 Processing backport: $version -> $target"
-          
-            branch="backport-${PR_NUMBER}-to-${target}"
-          
-            # Clean checkout with error handling
-            git checkout "$DEFAULT_BRANCH" >/dev/null 2>&1
-            git branch -D "$branch" 2>/dev/null || true
-          
-            if ! git checkout -b "$branch" "origin/$target" >/dev/null 2>&1; then
-              echo "❌ Failed to checkout origin/$target"
-              create_comment "❌ **Backport to \`$target\` failed**
-          
-              Could not create branch from \`origin/$target\`. Branch may have been deleted or is unreachable."
-              add_label "backport-failed"
-              failure_count=$((failure_count + 1))
-              continue
-            fi
-          
-            # Check if PR already exists (early check)
-            existing_pr=$(gh pr list --head "$branch" --base "$target" --json number -q '.[0].number' 2>/dev/null || echo "")
-            if [ -n "$existing_pr" ]; then
-              echo "ℹ️ Backport PR already exists: #$existing_pr"
-              success_count=$((success_count + 1))
-              continue
-            fi
-          
-            # Get individual commits from the PR instead of merge commit
-            echo "🔍 Getting PR commits..."
-            PR_COMMITS=$(echo "$PR_DATA" | jq -r '.commits[].oid' | tr '\n' ' ')
-            echo "📝 PR commits: $PR_COMMITS"
+          body="❌ **Backport to \`${TARGET_BRANCH}\` failed**"$'\n\n'"Automatic cherry-pick action failed for this target. Please inspect workflow logs and backport manually if needed."
+          gh pr comment "$PR_NUMBER" --body "$body"
+          gh pr edit "$PR_NUMBER" --add-label "backport-failed" 2>/dev/null || true
 
-            if [ -z "$PR_COMMITS" ]; then
-              echo "❌ No commits found in PR"
-              create_comment "❌ **Backport to \`$target\` failed**
-          
-              Could not find individual commits in PR #${PR_NUMBER}."
-              add_label "backport-failed"
-              failure_count=$((failure_count + 1))
-              continue
-            fi
-
-            # Cherry-pick each commit individually
-            cherry_pick_success=true
-            for commit in $PR_COMMITS; do
-              echo "🍒 Cherry-picking commit: $commit"
-              if ! git cherry-pick -x "$commit" 2>&1; then
-                echo "❌ Failed to cherry-pick $commit"
-                cherry_pick_success=false
-                break
-              fi
-            done
-
-            if [ "$cherry_pick_success" = true ]; then
-              echo "✅ All commits cherry-picked successfully"
-              if git push origin "$branch" >/dev/null 2>&1; then
-                # Create PR with cached data
-                new_pr_url=$(gh pr create \
-                  --title "[Backport $target] $PR_TITLE" \
-                  --body "## 🔄 Automatic Backport
-          
-          Backport of #${PR_NUMBER} to \`$target\` branch.
-          
-          **Original PR:** #${PR_NUMBER}  
-          **Target:** \`$target\`
-          **Label:** \`backport/$version\`
-          
-          ---
-          
-          $PR_BODY" \
-                  --base "$target" \
-                  --head "$branch" \
-                  --label "backport")
-          
-          
-                echo "✅ Created: $new_pr_url"
-                success_count=$((success_count + 1))
-              else
-                echo "❌ Push failed for $branch"
-                create_comment "❌ **Backport to \`$target\` failed**
-          
-          Cherry-pick succeeded but push failed. This might be a permissions issue."
-                add_label "backport-failed"
-                failure_count=$((failure_count + 1))
-              fi
-            else
-              # Handle cherry-pick failure
-              git cherry-pick --abort 2>/dev/null || true
-          
-              create_comment "❌ **Backport to \`$target\` has conflicts**
-          
-          **Manual resolution required:**
-          \`\`\`bash
-          git checkout $target && git pull
-          git checkout -b backport-${PR_NUMBER}-to-${target}-manual
-          # Cherry-pick commits individually:
-          $(echo "$PR_COMMITS" | tr ' ' '\n' | sed 's/^/git cherry-pick -x /')
-          # Resolve conflicts, then:
-          git add . && git cherry-pick --continue
-          git push origin backport-${PR_NUMBER}-to-${target}-manual
-          \`\`\`"
-          
-              add_label "backport-conflict"
-              failure_count=$((failure_count + 1))
-            fi
-          
-            # Cleanup
-            git checkout "$DEFAULT_BRANCH" >/dev/null 2>&1
-            git branch -D "$branch" 2>/dev/null || true
-          done
-          
-          echo "🏁 Completed: $success_count successes, $failure_count failures"
-          
-          # Set appropriate exit code based on results
-          if [ $success_count -eq 0 ]; then
-            echo "❌ All backports failed"
-            exit 1
-          elif [ $failure_count -gt 0 ]; then
-            echo "⚠️ Some backports failed, but at least one succeeded"
-            exit 0
-          else
-            echo "✅ All backports completed successfully"
-            exit 0
-          fi
+  dry-run-report:
+    name: Report Dry-Run Plan
+    needs: prepare
+    if: needs.prepare.outputs.has_targets == 'true' && needs.prepare.outputs.dry_run == 'true'
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Report dry-run targets
+        env:
+          PLANNED_TARGETS: ${{ needs.prepare.outputs.targets }}
+        run: |
+          echo "Backport dry-run mode is enabled."
+          printf 'Planned targets: %s\n' "$PLANNED_TARGETS"


### PR DESCRIPTION
Fixes #14496

## Summary
This PR adds an automated backport workflow for merged pull requests.

The implementation now:
- uses a dedicated script file for planning: `.github/workflows/backport.sh`
- keeps workflow orchestration in `.github/workflows/backport.yml`
- resolves target branches from both milestone and `backport/<version>` labels
- supports Lucene branch naming (`branch_<major>x`) and other common patterns
- normalizes version text from labels/milestones (e.g., extracts `10.3.0` from `Release 10.3.0`)
- produces explicit planning output in dry-run mode, including the commands and payloads that would be used
- validates merge commit SHA before non-dry-run execution
- reports missing target branches on the source PR and applies `backport-failed`

## Backport execution
For actual backport creation, the workflow uses the approved action:
- `carloscastrojumo/github-cherry-pick-action`

The workflow is structured as:
- `prepare` job: computes/validates targets and publishes outputs
- `backport` matrix job: creates backport PRs for valid targets

## Configuration
Dry-run is controlled via repository variable:
- `BACKPORT_DRY_RUN=true` (default/fallback):
- `BACKPORT_DRY_RUN=false`: create backport PRs

## Notes
- Backport attempt decisions are based on merge event + resolved target branches.
- If action-based cherry-pick fails, the workflow comments on the source PR and adds `backport-failed`.

## Testing
<img width="1676" height="1042" alt="image" src="https://github.com/user-attachments/assets/02eb4c8e-d2c8-459f-a98f-b8b0f00b980f" />

<img width="1654" height="661" alt="image" src="https://github.com/user-attachments/assets/cea5d625-817b-40ee-b945-f639ec3ba016" />
