### PR TITLE
Fix: Include tests.jvmargs in "Reproduce with" output

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/RunListenerPrintReproduceInfo.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/RunListenerPrintReproduceInfo.java
@@ -188,6 +188,8 @@ public final class RunListenerPrintReproduceInfo extends RunListener {
     // Pass the master seed.
     addVmOpt(b, "tests.seed", RandomizedContext.current().getRunnerSeedAsString());
 
+    addVmOpt(b, "tests.jvmargs", System.getProperty("tests.jvmargs"));
+
     // Test groups and multipliers.
     if (RANDOM_MULTIPLIER != LuceneTestCase.defaultRandomMultiplier())
       addVmOpt(b, "tests.multiplier", RANDOM_MULTIPLIER);


### PR DESCRIPTION
Appended tests.jvmargs from system properties to support accurate reproduction lines.

### Description

This patch fixes an issue where the "Reproduce with" line generated by the test runner omits `tests.jvmargs`. This leads to loss of custom JVM flags (e.g., `-XX:+UseParallelGC`, `-XX:ActiveProcessorCount=1`) when attempting to reproduce test failures.

The fix appends the system property `tests.jvmargs` using `addVmOpt`, ensuring the JVM args used during test execution are preserved in the reproduction line.

Fix for #14741.


<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
