### PR TITLE
Add code comment about use of Collections#synchronizedMap in LRUQueryCache.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
@@ -131,6 +131,9 @@ public class LRUQueryCache implements QueryCache, Accountable {
     }
     this.skipCacheFactor = skipCacheFactor;
 
+    // Note that reads on this LinkedHashMap trigger modifications on the linked list under the
+    // hood, so reading from multiple threads is not thread-safe. This is why it is wrapped in a
+    // Collections#synchronizedMap.
     uniqueQueries = Collections.synchronizedMap(new LinkedHashMap<>(16, 0.75f, true));
     mostRecentlyUsedQueries = uniqueQueries.keySet();
     cache = new IdentityHashMap<>();


### PR DESCRIPTION
It may not be totally obvious why this map needs to be synchronized since reads and writes are performed under a read-write lock. Except that unlike most other collections, reads are not thread-safe on a `LinkedHashMap`.

Closes #14677