### PR TITLE
Fix too many documents collected when only bool-filter condition is present

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -57,6 +57,8 @@ Bug Fixes
   returns a string which can be parsed back into the original node.
   (Peter Barna, Adam Schwartz)
 
+* GITHUB#14755: Fix too many documents collected when only bool-filter condition is present. (Ke Wei)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14187: The query cache is now disabled by default. (Adrien Grand)

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
@@ -439,6 +439,13 @@ final class BooleanScorerSupplier extends ScorerSupplier {
       required.addAll(requiredScoring);
       required.addAll(requiredNoScoring);
       conjunctionScorer = new ConjunctionScorer(required, requiredScoring);
+      if (this.scoreMode == ScoreMode.TOP_SCORES && requiredScoring.size() == 0) {
+        conjunctionScorer =
+            conjunctionScorer.twoPhaseIterator() != null
+                ? new ConstantScoreScorer(
+                    0.0F, this.scoreMode, conjunctionScorer.twoPhaseIterator())
+                : new ConstantScoreScorer(0.0F, this.scoreMode, conjunctionScorer.iterator());
+      }
     }
     return new DefaultBulkScorer(conjunctionScorer);
   }


### PR DESCRIPTION
### Description

New logic is consistent with the implementation of 9.8
https://github.com/apache/lucene/blob/releases/lucene/9.8.0/lucene/core/src/java/org/apache/lucene/search/Boolean2ScorerSupplier.java#L112

Closes: #14755

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
