### PR TITLE
IndexOrDocValuesQuery and IndexSortSortedNumericDocValuesRangeQuery should only be counted once when computing maxClauseCount

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
@@ -130,8 +130,9 @@ public final class IndexOrDocValuesQuery extends Query {
   @Override
   public void visit(QueryVisitor visitor) {
     QueryVisitor v = visitor.getSubVisitor(BooleanClause.Occur.MUST, this);
+    // we cannot register this query in the visitor, since we don't have the field name,
+    // so we just visit one of the subqueries.
     indexQuery.visit(v);
-    dvQuery.visit(v);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -113,7 +113,6 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
   public void visit(QueryVisitor visitor) {
     if (visitor.acceptField(field)) {
       visitor.visitLeaf(this);
-      fallbackQuery.visit(visitor);
     }
   }
 


### PR DESCRIPTION
see https://github.com/apache/lucene/issues/14756

The idea proposed here is that both queries are just leaf queries and should only call once the method QueryVisitor#visitLeaf. For IndexOrDocValuesQuery is a bit more complicated because the query does not contain the field that is being queried, therefore it delegates the registration of the query to the visitor to the index query.

closes https://github.com/apache/lucene/issues/14756


