### PR TITLE
Add non-committer activity to activity report

### DIFF
--- a/.github/workflows/activity-report-known-committers.txt
+++ b/.github/workflows/activity-report-known-committers.txt
@@ -1,0 +1,110 @@
+# a list of known committer names and their aliases, to highlight 
+# commits from non-committers in the activity-report.
+dependabot
+guofeng.my
+gf2121
+Benjamin Trent
+ChrisHegarty
+Andrzej Bialecki
+Alessandro Benedetti
+Armin Braun
+Adriano Crestani Campos
+Ramkumar Aiyengar
+Anshum Gupta
+Alexandre Rafalovitch
+Areek Zillur
+Atri Sharma
+Ben Trent
+William Au
+Benson Margulies
+Bernhard Messer
+Bruno Roustant
+Michael Busch
+Chris Hegarty
+Christopher John Male
+Christian Moen
+Christine Poerschke
+Cassandra Targett
+Doug Cutting
+Cao Mạnh Đạt
+Nhat Nguyen
+Peter Gromov
+Doron Cohen
+Dennis Gove
+Scott Blum
+David Smiley
+Dawid Weiss
+Erik Hatcher
+Shawn Heisey
+Eric Pugh
+Erick Erickson
+Greg Bowyer
+Gregory Chanan
+Jason Gerlowski
+Grant Ingersoll
+Greg Miller
+Guo Feng
+Gus Heck
+Han Jiang
+Hrishikesh Gadre
+Chris M. Hostetter
+Houston Putman
+Ilan Ginzburg
+Ahmet Arslan
+Ishan Chattopadhyaya
+Ignacio Vera
+Ankit Jain
+Jan Høydahl
+Luca Cavanna
+Joel Bernstein
+James Dyer
+Jim Ferenczi
+Adrien Grand
+Julie Tibshirani
+Koji Sekiguchi
+Kevin Risden
+Karl Wright
+Lu Xugang
+Michael Gibney
+Mark Robert Miller
+Mayya Sharipova
+Mike Drob
+Mark Harwood
+Michael McCandless
+Mikhail Khludnev
+Michael Froh
+Munendra S N
+Martijn van Groningen
+Namgyu Kim
+Nick Knize
+Noble Paul
+Otis Gospodnetic
+Patrick Zhai
+Ryan Ernst
+Robert Muir
+Alan Woodward
+Ryan McKinley
+Steven Rowe
+Shai Erera
+Shalin Shekhar Mangar
+Simon Willnauer
+Sami Siren
+Michael Sokolov
+Stanisław Osiński
+Stefan Matheis
+Tim Allison
+Tomas Eduardo Fernandez Lobbe
+Timothy Potter
+Toke Eskildsen
+Tommaso Teofili
+Tomoko Uchida
+Upayavira
+Uwe Schindler
+Andi Vajda
+Varun Thacker
+Vigya Sharma
+Stefan Vodita
+Wolfgang Hoschek
+Yonik Seeley
+Zach Chen
+Chao Zhang

--- a/.github/workflows/activity-report.sh
+++ b/.github/workflows/activity-report.sh
@@ -47,6 +47,12 @@ git log --all --pretty='format:%an' --since="$SINCE" --before="$UNTIL" | sort | 
 echo '```'
 
 echo
+echo "## Top non-committer contributors in the given time period (all commits, any branch)"
+echo '```'
+git log --all --pretty='format:%an | %ae' --since="$SINCE" --before="$UNTIL" | sort | uniq -c | sort -r -n | grep -v -f .github/workflows/activity-report-known-committers.txt
+echo '```'
+
+echo
 echo "## All pull requests:"
 echo '```'
 gh pr list --state all --search "created:$SINCE_TS..$UNTIL_TS" --repo $REPO --limit 1000 \


### PR DESCRIPTION
This adds a section to display non-committer activity in our git repository. This is useful in preparing board reports but also considering committer nominations, I think. Looks something like this:
```
    19 Simon Cooper | simon.cooper@elastic.co
      6 panguixin | panguixin@bytedance.com
      4 zhouhui | vsop_479@163.com
      4 Viliam Durina | viliam-durina@users.noreply.github.com
      4 hanbj | hanbj0707@163.com
      4 guojialiang | guojialiang.2012@bytedance.com
      4 Amos Bird | amosbird@gmail.com
```

I had to add existing committer names (and a few aliases sprinkled in) as this information is not readily available from the ASF roster (committer names are public but not emails or gh aliases). I don't think this is a privacy violation since these names and handles are part of the git commit history anyway.