### PR TITLE
Optimize filtered kNN search with FixedBitSet intersections

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/FixedBits.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBits.java
@@ -17,7 +17,7 @@
 package org.apache.lucene.util;
 
 /** Immutable twin of FixedBitSet. */
-final class FixedBits implements Bits {
+public final class FixedBits implements Bits {
 
   final FixedBitSet bitSet;
 
@@ -38,5 +38,9 @@ final class FixedBits implements Bits {
   @Override
   public int length() {
     return bitSet.length();
+  }
+
+  public FixedBitSet getBitSet() {
+    return bitSet;
   }
 }


### PR DESCRIPTION
### Description
If a filter query in kNN is in query cache, it can be saved as a `BitSetIterator` wrapping a `FixedBitSet`. But we are creating new `FixedBitSet` combined with liveDocs for every query. This is really high cost because it needs to iterate over long BitSet in `applyMask`.
Instead of creating new BitSet by iteration, I will create new BitSet implementing only reading methods. By using this, we don't need to iterate over BitSet. We can leverage `intersectionCount` of FixedBitSet that is super fast.


This is the flamegraph when I ran filtered kNN queries (k=100, num_candidates=100, term filter that filters out about 50% of documents).
![スクリーンショット 2025-06-12 16 21 14](https://github.com/user-attachments/assets/0b50af07-b6ff-44f4-b3ed-5b585c925e84)


After applying this, `applyMask` disappeared completely.
![スクリーンショット 2025-06-12 16 24 43](https://github.com/user-attachments/assets/6a283364-2e33-4201-8bae-a5ab9c76b49f)

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
