### PR TITLE
Add the ability to inverse a Sort

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/FeatureSortField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FeatureSortField.java
@@ -45,6 +45,11 @@ final class FeatureSortField extends SortField {
   }
 
   @Override
+  public SortField inverseSort() {
+    throw new UnsupportedOperationException("Inverse sort not supported on FeatureSortField");
+  }
+
+  @Override
   public FieldComparator<?> getComparator(int numHits, Pruning pruning) {
     return new FeatureComparator(numHits, getField(), featureName);
   }

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointSortField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointSortField.java
@@ -39,6 +39,11 @@ final class LatLonPointSortField extends SortField {
   }
 
   @Override
+  public SortField inverseSort() {
+    throw new UnsupportedOperationException("Inverse sort not supported on LatLonPointSortField");
+  }
+
+  @Override
   public FieldComparator<?> getComparator(int numHits, Pruning pruning) {
     return new LatLonPointDistanceComparator(getField(), latitude, longitude, numHits);
   }

--- a/lucene/core/src/java/org/apache/lucene/document/XYPointSortField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/XYPointSortField.java
@@ -36,6 +36,11 @@ final class XYPointSortField extends SortField {
   }
 
   @Override
+  public SortField inverseSort() {
+    throw new UnsupportedOperationException("Inverse sort not supported on XYPointSortField");
+  }
+
+  @Override
   public FieldComparator<?> getComparator(int numHits, Pruning pruning) {
     return new XYPointDistanceComparator(getField(), x, y, numHits);
   }

--- a/lucene/core/src/java/org/apache/lucene/search/DoubleValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DoubleValuesSource.java
@@ -537,6 +537,15 @@ public abstract class DoubleValuesSource implements SegmentCacheable {
     }
 
     @Override
+    public SortField inverseSort() {
+      DoubleValuesSortField inverse = new DoubleValuesSortField(producer, !reverse);
+      if (missingValue != null) {
+        inverse.setMissingValue(missingValue);
+      }
+      return inverse;
+    }
+
+    @Override
     public void setMissingValue(Object missingValue) {
       if (missingValue instanceof Number) {
         this.missingValue = missingValue;

--- a/lucene/core/src/java/org/apache/lucene/search/LongValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LongValuesSource.java
@@ -281,6 +281,15 @@ public abstract class LongValuesSource implements SegmentCacheable {
     }
 
     @Override
+    public SortField inverseSort() {
+      LongValuesSortField inverse = new LongValuesSortField(producer, !reverse);
+      if (missingValue != null) {
+        inverse.setMissingValue(missingValue);
+      }
+      return inverse;
+    }
+
+    @Override
     public void setMissingValue(Object missingValue) {
       if (missingValue instanceof Number) {
         this.missingValue = missingValue;

--- a/lucene/core/src/java/org/apache/lucene/search/Sort.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Sort.java
@@ -75,6 +75,19 @@ public final class Sort {
   }
 
   /**
+   * Creates a new Sort that represents the inverse ordering of this Sort
+   *
+   * @return this Sort in inverse order
+   */
+  public Sort inverse() {
+    SortField[] reversedFields = new SortField[fields.length];
+    for (int i = 0; i < fields.length; i++) {
+      reversedFields[i] = fields[i].inverseSort();
+    }
+    return new Sort(reversedFields);
+  }
+
+  /**
    * Rewrites the SortFields in this Sort, returning a new Sort if any of the fields changes during
    * their rewriting.
    *

--- a/lucene/core/src/java/org/apache/lucene/search/SortField.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SortField.java
@@ -359,11 +359,16 @@ public class SortField {
    * @return An identical sort, but with reverse flipped.
    */
   public SortField inverseSort() {
+    SortField inverse;
     if (type == Type.CUSTOM) {
-      return new SortField(field, comparatorSource, !reverse);
+      inverse = new SortField(field, comparatorSource, !reverse);
     } else {
-      return new SortField(field, type, !reverse);
+      inverse = new SortField(field, type, !reverse);
     }
+    if (missingValue != null) {
+      inverse.setMissingValue(missingValue);
+    }
+    return inverse;
   }
 
   // Sets field & type, and ensures field is not NULL unless

--- a/lucene/core/src/java/org/apache/lucene/search/SortField.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SortField.java
@@ -352,6 +352,20 @@ public class SortField {
     this.comparatorSource = comparator;
   }
 
+  /**
+   * Duplicates this SortField, but with the inverse ordering. So reverse if this sort is
+   * non-reverse, and non-reverse if this sort is reverse.
+   *
+   * @return An identical sort, but with reverse flipped.
+   */
+  public SortField inverseSort() {
+    if (type == Type.CUSTOM) {
+      return new SortField(field, comparatorSource, !reverse);
+    } else {
+      return new SortField(field, type, !reverse);
+    }
+  }
+
   // Sets field & type, and ensures field is not NULL unless
   // type is SCORE or DOC
   private void initFieldType(String field, Type type) {

--- a/lucene/core/src/java/org/apache/lucene/search/SortedNumericSortField.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SortedNumericSortField.java
@@ -94,6 +94,16 @@ public class SortedNumericSortField extends SortField {
     this.type = type;
   }
 
+  @Override
+  public SortField inverseSort() {
+    SortedNumericSortField inverse =
+        new SortedNumericSortField(getField(), type, !reverse, selector);
+    if (missingValue != null) {
+      inverse.setMissingValue(missingValue);
+    }
+    return inverse;
+  }
+
   /** A SortFieldProvider for this sort field */
   public static final class Provider extends SortFieldProvider {
 

--- a/lucene/core/src/java/org/apache/lucene/search/SortedSetSortField.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SortedSetSortField.java
@@ -75,6 +75,15 @@ public class SortedSetSortField extends SortField {
     this.selector = selector;
   }
 
+  @Override
+  public SortField inverseSort() {
+    SortedSetSortField inverse = new SortedSetSortField(getField(), !reverse, selector);
+    if (missingValue != null) {
+      inverse.setMissingValue(missingValue);
+    }
+    return inverse;
+  }
+
   /** A SortFieldProvider for this sort */
   public static final class Provider extends SortFieldProvider {
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesSource.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesSource.java
@@ -112,6 +112,10 @@ public class TestDoubleValuesSource extends LuceneTestCase {
     FieldDoc first = (FieldDoc) results.scoreDocs[0];
     assertEquals(LEAST_DOUBLE_VALUE, first.fields[0]);
 
+    results = searcher.search(new MatchAllDocsQuery(), 1, new Sort(oneFieldSort).inverse());
+    first = (FieldDoc) results.scoreDocs[0];
+    assertEquals(Double.MIN_VALUE, first.fields[0]);
+
     // sort increasing, missing last
     oneFieldSort = onefield.getSortField(false);
     oneFieldSort.setMissingValue(Double.MAX_VALUE);
@@ -119,6 +123,10 @@ public class TestDoubleValuesSource extends LuceneTestCase {
     results = searcher.search(new MatchAllDocsQuery(), 1, new Sort(oneFieldSort));
     first = (FieldDoc) results.scoreDocs[0];
     assertEquals(LEAST_DOUBLE_VALUE, first.fields[0]);
+
+    results = searcher.search(new MatchAllDocsQuery(), 1, new Sort(oneFieldSort).inverse());
+    first = (FieldDoc) results.scoreDocs[0];
+    assertEquals(Double.MAX_VALUE, first.fields[0]);
   }
 
   public void testSimpleFieldEquivalences() throws Exception {
@@ -225,6 +233,12 @@ public class TestDoubleValuesSource extends LuceneTestCase {
     TopDocs actual = searcher.search(query, size, mutatedSort, random().nextBoolean());
 
     CheckHits.checkEqual(query, expected.scoreDocs, actual.scoreDocs);
+
+    TopDocs actualInverse =
+        searcher.search(query, size, mutatedSort.inverse(), random().nextBoolean());
+    TopDocs expectedInverse = searcher.search(query, size, sort.inverse(), random().nextBoolean());
+
+    CheckHits.checkEqual(query, expectedInverse.scoreDocs, actualInverse.scoreDocs);
 
     if (size < actual.totalHits.value()) {
       expected = searcher.searchAfter(expected.scoreDocs[size - 1], query, size, sort);

--- a/lucene/core/src/test/org/apache/lucene/search/TestLongValuesSource.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLongValuesSource.java
@@ -97,6 +97,10 @@ public class TestLongValuesSource extends LuceneTestCase {
     FieldDoc first = (FieldDoc) results.scoreDocs[0];
     assertEquals(LEAST_LONG_VALUE, first.fields[0]);
 
+    results = searcher.search(new MatchAllDocsQuery(), 1, new Sort(oneFieldSort).inverse());
+    first = (FieldDoc) results.scoreDocs[0];
+    assertEquals(Long.MIN_VALUE, first.fields[0]);
+
     // sort increasing, missing last
     oneFieldSort = onefield.getSortField(false);
     oneFieldSort.setMissingValue(Long.MAX_VALUE);
@@ -104,6 +108,10 @@ public class TestLongValuesSource extends LuceneTestCase {
     results = searcher.search(new MatchAllDocsQuery(), 1, new Sort(oneFieldSort));
     first = (FieldDoc) results.scoreDocs[0];
     assertEquals(LEAST_LONG_VALUE, first.fields[0]);
+
+    results = searcher.search(new MatchAllDocsQuery(), 1, new Sort(oneFieldSort).inverse());
+    first = (FieldDoc) results.scoreDocs[0];
+    assertEquals(Long.MAX_VALUE, first.fields[0]);
   }
 
   public void testSimpleFieldEquivalences() throws Exception {
@@ -191,6 +199,12 @@ public class TestLongValuesSource extends LuceneTestCase {
     TopDocs expected = searcher.search(query, size, sort, random().nextBoolean());
 
     CheckHits.checkEqual(query, expected.scoreDocs, actual.scoreDocs);
+
+    TopDocs actualInverse =
+        searcher.search(query, size, mutatedSort.inverse(), random().nextBoolean());
+    TopDocs expectedInverse = searcher.search(query, size, sort.inverse(), random().nextBoolean());
+
+    CheckHits.checkEqual(query, expectedInverse.scoreDocs, actualInverse.scoreDocs);
 
     if (size < actual.totalHits.value()) {
       expected = searcher.searchAfter(expected.scoreDocs[size - 1], query, size, sort);

--- a/lucene/core/src/test/org/apache/lucene/search/TestSort.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSort.java
@@ -170,6 +170,12 @@ public class TestSort extends LuceneTestCase {
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
 
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(2, td.totalHits.value());
+    // inverse of normal order is reverse
+    assertEquals("foo", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("bar", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+
     ir.close();
     dir.close();
   }
@@ -197,6 +203,12 @@ public class TestSort extends LuceneTestCase {
     // 'foo' comes after 'bar' in reverse order
     assertEquals("foo", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(2, td.totalHits.value());
+    // inverse of reverse order is normal ordering
+    assertEquals("bar", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
 
     ir.close();
     dir.close();
@@ -231,6 +243,13 @@ public class TestSort extends LuceneTestCase {
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
     assertEquals("300000", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
 
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(3, td.totalHits.value());
+    // inverse of normal numeric order is reverse
+    assertEquals("300000", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+
     ir.close();
     dir.close();
   }
@@ -264,6 +283,13 @@ public class TestSort extends LuceneTestCase {
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
 
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(3, td.totalHits.value());
+    // inverse of reverse is normal numeric order
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("300000", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+
     ir.close();
     dir.close();
   }
@@ -294,6 +320,13 @@ public class TestSort extends LuceneTestCase {
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(3, td.totalHits.value());
+    // make sure the missing value is kept during the inverse generation
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertNull(searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
 
     ir.close();
     dir.close();
@@ -329,6 +362,13 @@ public class TestSort extends LuceneTestCase {
     assertEquals("-1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
     assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
     assertNull(searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
+
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(3, td.totalHits.value());
+    // make sure the missing last is reversed during the inverse generation
+    assertNull(searcher.storedFields().document(td.scoreDocs[0].doc).get("value"));
+    assertEquals("4", searcher.storedFields().document(td.scoreDocs[1].doc).get("value"));
+    assertEquals("-1", searcher.storedFields().document(td.scoreDocs[2].doc).get("value"));
 
     ir.close();
     dir.close();
@@ -843,6 +883,26 @@ public class TestSort extends LuceneTestCase {
     assertEquals(4, td.totalHits.value());
     assertEquals("bar", searcher.storedFields().document(td.scoreDocs[0].doc).get("value1"));
     assertEquals("0", searcher.storedFields().document(td.scoreDocs[0].doc).get("value2"));
+
+    // Inverse the sort and make sure that each sortField is inversed
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(4, td.totalHits.value());
+    // 'foo' comes before 'bar'
+    assertEquals("foo", searcher.storedFields().document(td.scoreDocs[0].doc).get("value1"));
+    assertEquals("foo", searcher.storedFields().document(td.scoreDocs[1].doc).get("value1"));
+    assertEquals("bar", searcher.storedFields().document(td.scoreDocs[2].doc).get("value1"));
+    assertEquals("bar", searcher.storedFields().document(td.scoreDocs[3].doc).get("value1"));
+    // 1 comes before 0
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value2"));
+    assertEquals("0", searcher.storedFields().document(td.scoreDocs[1].doc).get("value2"));
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[2].doc).get("value2"));
+    assertEquals("0", searcher.storedFields().document(td.scoreDocs[3].doc).get("value2"));
+
+    // Now with overflow
+    td = searcher.search(new MatchAllDocsQuery(), 1, sort.inverse());
+    assertEquals(4, td.totalHits.value());
+    assertEquals("foo", searcher.storedFields().document(td.scoreDocs[0].doc).get("value1"));
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[0].doc).get("value2"));
 
     ir.close();
     dir.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortedNumericSortField.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortedNumericSortField.java
@@ -101,6 +101,12 @@ public class TestSortedNumericSortField extends LuceneTestCase {
     assertEquals("1", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
     assertEquals("2", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
 
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(2, td.totalHits.value());
+    // inverse of normal order is reverse order
+    assertEquals("2", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
+
     ir.close();
     dir.close();
   }
@@ -129,6 +135,12 @@ public class TestSortedNumericSortField extends LuceneTestCase {
     // 'bar' comes before 'baz'
     assertEquals("2", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
     assertEquals("1", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
+
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(2, td.totalHits.value());
+    // inverse of reverse order is normal order
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
+    assertEquals("2", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
 
     ir.close();
     dir.close();
@@ -165,6 +177,15 @@ public class TestSortedNumericSortField extends LuceneTestCase {
     assertEquals("1", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
     assertEquals("2", searcher.storedFields().document(td.scoreDocs[2].doc).get("id"));
 
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(3, td.totalHits.value());
+    // When the sort is in inverse order:
+    // 5 comes before 3
+    // null comes last
+    assertEquals("2", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
+    assertEquals("3", searcher.storedFields().document(td.scoreDocs[2].doc).get("id"));
+
     ir.close();
     dir.close();
   }
@@ -200,6 +221,15 @@ public class TestSortedNumericSortField extends LuceneTestCase {
     // null comes last
     assertEquals("3", searcher.storedFields().document(td.scoreDocs[2].doc).get("id"));
 
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(3, td.totalHits.value());
+    // When the sort is in inverse order:
+    // 5 comes before 3
+    // null comes first
+    assertEquals("3", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
+    assertEquals("2", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[2].doc).get("id"));
+
     ir.close();
     dir.close();
   }
@@ -226,6 +256,12 @@ public class TestSortedNumericSortField extends LuceneTestCase {
     // 3 comes before 5
     assertEquals("1", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
     assertEquals("2", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
+
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(2, td.totalHits.value());
+    // inverse order
+    assertEquals("2", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
 
     ir.close();
     dir.close();
@@ -255,6 +291,11 @@ public class TestSortedNumericSortField extends LuceneTestCase {
     assertEquals("1", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
     assertEquals("2", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
 
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(2, td.totalHits.value());
+    assertEquals("2", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
+
     ir.close();
     dir.close();
   }
@@ -282,6 +323,11 @@ public class TestSortedNumericSortField extends LuceneTestCase {
     // -5 comes before -3
     assertEquals("1", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
     assertEquals("2", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
+
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(2, td.totalHits.value());
+    assertEquals("2", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
 
     ir.close();
     dir.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortedSetSortField.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortedSetSortField.java
@@ -84,6 +84,12 @@ public class TestSortedSetSortField extends LuceneTestCase {
     assertEquals("1", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
     assertEquals("2", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
 
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(2, td.totalHits.value());
+    // inverse of normal order is reverse order
+    assertEquals("2", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
+
     ir.close();
     dir.close();
   }
@@ -112,6 +118,12 @@ public class TestSortedSetSortField extends LuceneTestCase {
     // 'bar' comes before 'baz'
     assertEquals("2", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
     assertEquals("1", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
+
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(2, td.totalHits.value());
+    // inverse of reverse order is normal order
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
+    assertEquals("2", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
 
     ir.close();
     dir.close();
@@ -148,6 +160,15 @@ public class TestSortedSetSortField extends LuceneTestCase {
     assertEquals("1", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
     assertEquals("2", searcher.storedFields().document(td.scoreDocs[2].doc).get("id"));
 
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(3, td.totalHits.value());
+    // When the sort is in inverse order:
+    // 'baz' comes before 'bar'
+    // null comes last
+    assertEquals("2", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
+    assertEquals("3", searcher.storedFields().document(td.scoreDocs[2].doc).get("id"));
+
     ir.close();
     dir.close();
   }
@@ -183,6 +204,15 @@ public class TestSortedSetSortField extends LuceneTestCase {
     // null comes last
     assertEquals("3", searcher.storedFields().document(td.scoreDocs[2].doc).get("id"));
 
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(3, td.totalHits.value());
+    // When the sort is in inverse order:
+    // 'baz' comes before 'bar'
+    // null comes first
+    assertEquals("3", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
+    assertEquals("2", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[2].doc).get("id"));
+
     ir.close();
     dir.close();
   }
@@ -209,6 +239,12 @@ public class TestSortedSetSortField extends LuceneTestCase {
     // 'bar' comes before 'baz'
     assertEquals("1", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
     assertEquals("2", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
+
+    td = searcher.search(new MatchAllDocsQuery(), 10, sort.inverse());
+    assertEquals(2, td.totalHits.value());
+    // inverse order
+    assertEquals("2", searcher.storedFields().document(td.scoreDocs[0].doc).get("id"));
+    assertEquals("1", searcher.storedFields().document(td.scoreDocs[1].doc).get("id"));
 
     ir.close();
     dir.close();

--- a/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinSortField.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/ToParentBlockJoinSortField.java
@@ -113,6 +113,17 @@ public class ToParentBlockJoinSortField extends SortField {
   }
 
   @Override
+  public SortField inverseSort() {
+    ToParentBlockJoinSortField inverse =
+        new ToParentBlockJoinSortField(
+            getField(), getType(), !getReverse(), !order, parentFilter, childFilter);
+    if (missingValue != null) {
+      inverse.setMissingValue(missingValue);
+    }
+    return inverse;
+  }
+
+  @Override
   public FieldComparator<?> getComparator(int numHits, Pruning pruning) {
     switch (getType()) {
       case STRING:

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/ValueSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/ValueSource.java
@@ -372,6 +372,11 @@ public abstract class ValueSource {
       createWeight(context, searcher);
       return new SortField(getField(), new ValueSourceComparatorSource(context), getReverse());
     }
+
+    @Override
+    public SortField inverseSort() {
+      return new ValueSourceSortField(!getReverse());
+    }
   }
 
   class ValueSourceComparatorSource extends FieldComparatorSource {

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestValueSources.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestValueSources.java
@@ -899,6 +899,16 @@ public class TestValueSources extends LuceneTestCase {
     for (int i = 0; i < originalScoreDocs.length; i++) {
       assertEquals(originalScoreDocs[i].doc, sortedScoreDocs[i].doc);
     }
+
+    // Search with the inverse sort.
+    sortedDocs = searcher.search(query, documents.size(), sort.inverse());
+    sortedScoreDocs = sortedDocs.scoreDocs;
+
+    // Verify we got the same docs in-order but don't check the scores
+    assertEquals(originalScoreDocs.length, sortedScoreDocs.length);
+    for (int i = 0; i < originalScoreDocs.length; i++) {
+      assertEquals(originalScoreDocs[originalScoreDocs.length - i - 1].doc, sortedScoreDocs[i].doc);
+    }
   }
 
   /**

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/Geo3DPointOutsideSortField.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/Geo3DPointOutsideSortField.java
@@ -42,6 +42,12 @@ final class Geo3DPointOutsideSortField extends SortField {
   }
 
   @Override
+  public SortField inverseSort() {
+    throw new UnsupportedOperationException(
+        "Inverse sort not supported on Geo3DPointOutsideSortField");
+  }
+
+  @Override
   public FieldComparator<?> getComparator(int numHits, Pruning pruning) {
     return new Geo3DPointOutsideDistanceComparator(getField(), planetModel, distanceShape, numHits);
   }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/Geo3DPointSortField.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/Geo3DPointSortField.java
@@ -42,6 +42,11 @@ final class Geo3DPointSortField extends SortField {
   }
 
   @Override
+  public SortField inverseSort() {
+    throw new UnsupportedOperationException("Inverse sort not supported on Geo3DPointSortField");
+  }
+
+  @Override
   public FieldComparator<?> getComparator(int numHits, Pruning pruning) {
     return new Geo3DPointDistanceComparator(getField(), planetModel, distanceShape, numHits);
   }


### PR DESCRIPTION
### Description

Currently there is no easy way to reverse a Sort unless you know how that sort was created. Adding an `inverse` option gives users an easy way to reverse a given sort.

In Solr, I plan on using this to implement reverse pagination (cursorMark).