### PR TITLE
Fix deprecated Gradle groovy dsl syntax on property assignments

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.all-projects.conventions.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.all-projects.conventions.gradle
@@ -53,7 +53,7 @@ allprojects {project ->
 
   // Common tasks or meta-tasks.
   tasks.register("tidy", {
-    description "Applies all code formatters and other enforced cleanups to the project."
-    group "verification"
+    description = "Applies all code formatters and other enforced cleanups to the project."
+    group = "verification"
   })
 }

--- a/build-tools/build-infra/src/main/groovy/lucene.datasets.external-datasets.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.datasets.external-datasets.gradle
@@ -47,7 +47,7 @@ configure(project(":lucene:benchmark")) {
       dst = file("${dataDir}/${name}")
     }
 
-    description "Download the ${ext.name} data set."
+    description = "Download the ${ext.name} data set."
 
     outputs.file ext.dst
 
@@ -70,7 +70,7 @@ configure(project(":lucene:benchmark")) {
       dst = file("${dataDir}/${name}")
     }
 
-    description "Download the ${ext.name} data set."
+    description = "Download the ${ext.name} data set."
 
     outputs.file ext.dst
 
@@ -96,7 +96,7 @@ configure(project(":lucene:benchmark")) {
       dst = file("${dataDir}/${name}")
     }
 
-    description "Download the ${ext.name} data set."
+    description = "Download the ${ext.name} data set."
 
     outputs.file ext.dst
 
@@ -119,7 +119,7 @@ configure(project(":lucene:benchmark")) {
       dst = file("${dataDir}/${name}")
     }
 
-    description "Download the ${ext.name} data set."
+    description = "Download the ${ext.name} data set."
 
     outputs.dir ext.dst
 
@@ -145,7 +145,7 @@ configure(project(":lucene:benchmark")) {
       dst = file("${dataDir}/reuters-out")
     }
 
-    description "Download the ${ext.name} data set."
+    description = "Download the ${ext.name} data set."
 
     outputs.dir ext.dst
 

--- a/build-tools/build-infra/src/main/groovy/lucene.documentation.changes-to-html.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.documentation.changes-to-html.gradle
@@ -82,8 +82,8 @@ class ChangesToHtmlTask extends DefaultTask {
     def output = new ByteArrayOutputStream()
     def result = project.exec {
       executable project.externalTool("perl")
-      standardInput changesFile.newInputStream()
-      standardOutput project.file("${targetDir.get().getAsFile()}/Changes.html").newOutputStream()
+      standardInput = changesFile.newInputStream()
+      standardOutput = project.file("${targetDir.get().getAsFile()}/Changes.html").newOutputStream()
       errorOutput = output
       ignoreExitValue = true
 

--- a/build-tools/build-infra/src/main/groovy/lucene.java.modules.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.java.modules.gradle
@@ -334,7 +334,7 @@ class ModularPathsExtension implements Cloneable, Iterable<Object> {
     // otherwise get terribly confused.
     Configuration modulePatchOnly = createModuleConfigurationForConvention(
         SourceSet.isMain(sourceSet) ? "patchOnly" : sourceSet.name + "PatchOnly")
-    modulePatchOnly.canBeResolved(true)
+    modulePatchOnly.canBeResolved = (true)
     moduleImplementation.extendsFrom(modulePatchOnly)
     this.modulePatchOnlyConfiguration = modulePatchOnly
 
@@ -351,8 +351,8 @@ class ModularPathsExtension implements Cloneable, Iterable<Object> {
     Closure<Configuration> createResolvableModuleConfiguration = { String configurationName ->
       Configuration conventionConfiguration = configurations.maybeCreate(configurationName)
       Configuration moduleConfiguration = configurations.maybeCreate(moduleConfigurationNameFor(conventionConfiguration.name))
-      moduleConfiguration.canBeConsumed(false)
-      moduleConfiguration.canBeResolved(true)
+      moduleConfiguration.canBeConsumed = false
+      moduleConfiguration.canBeResolved = true
       ensureJarVariant(moduleConfiguration)
 
       project.logger.info("Created resolvable module configuration for '${conventionConfiguration.name}': ${moduleConfiguration.name}")
@@ -565,8 +565,8 @@ class ModularPathsExtension implements Cloneable, Iterable<Object> {
     ConfigurationContainer configurations = project.configurations
     Configuration conventionConfiguration = configurations.maybeCreate(configurationName)
     Configuration moduleConfiguration = configurations.maybeCreate(moduleConfigurationNameFor(configurationName))
-    moduleConfiguration.canBeConsumed(false)
-    moduleConfiguration.canBeResolved(false)
+    moduleConfiguration.canBeConsumed = false
+    moduleConfiguration.canBeResolved = false
     conventionConfiguration.extendsFrom(moduleConfiguration)
 
     project.logger.info("Created module configuration for '${conventionConfiguration.name}': ${moduleConfiguration.name}")

--- a/build-tools/build-infra/src/main/groovy/lucene.java.tests-and-randomization.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.java.tests-and-randomization.gradle
@@ -282,12 +282,12 @@ tasks.withType(Test).configureEach {
   // Set up logging.
   testLogging {
     events TestLogEvent.FAILED
-    exceptionFormat TestExceptionFormat.FULL
-    showExceptions true
-    showCauses true
-    showStackTraces true
+    exceptionFormat = TestExceptionFormat.FULL
+    showExceptions = true
+    showCauses = true
+    showStackTraces = true
     stackTraceFilters.clear()
-    showStandardStreams false
+    showStandardStreams = false
   }
 
   // Disable automatic test class detection, rely on class names only. This is needed for testing

--- a/build-tools/build-infra/src/main/groovy/lucene.publications.maven-to-nexus-releases.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.publications.maven-to-nexus-releases.gradle
@@ -69,8 +69,8 @@ configure(rootProject.ext.mavenProjects) { Project project ->
           url = apacheNexusReleasesRepository
 
           credentials {
-            username asfNexusUsername.getOrElse(null)
-            password asfNexusPassword.getOrElse(null)
+            username = asfNexusUsername.getOrElse(null)
+            password = asfNexusPassword.getOrElse(null)
           }
         }
       }

--- a/build-tools/build-infra/src/main/groovy/lucene.publications.maven-to-nexus-snapshots.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.publications.maven-to-nexus-snapshots.gradle
@@ -67,8 +67,8 @@ configure(rootProject.ext.mavenProjects) { Project project ->
           url = apacheNexusSnapshotsRepository
 
           credentials {
-            username asfNexusUsername.getOrElse(null)
-            password asfNexusPassword.getOrElse(null)
+            username = asfNexusUsername.getOrElse(null)
+            password = asfNexusPassword.getOrElse(null)
           }
         }
       }

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.antlr.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.antlr.gradle
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import java.nio.file.Files
 
 configure(project(":lucene:expressions")) {
   configurations {
@@ -54,7 +53,7 @@ configure(project(":lucene:expressions")) {
         main = "org.antlr.v4.Tool"
         classpath = configurations.antlr
 
-        ignoreExitValue false
+        ignoreExitValue =  false
         args = [
           "-no-listener",
           "-visitor",

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.antlr.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.antlr.gradle
@@ -53,7 +53,7 @@ configure(project(":lucene:expressions")) {
         main = "org.antlr.v4.Tool"
         classpath = configurations.antlr
 
-        ignoreExitValue =  false
+        ignoreExitValue = false
         args = [
           "-no-listener",
           "-visitor",

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.extract-jdk-apis.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.extract-jdk-apis.gradle
@@ -21,8 +21,8 @@ configure(project(":lucene:core")) {
   plugins.withType(JavaPlugin) {
     mrjarJavaVersions.each { jdkVersion ->
       def task = tasks.create(name: "generateJdkApiJar${jdkVersion}", type: JavaExec) {
-        description "Regenerate the API-only JAR file with public Panama Vector API from JDK ${jdkVersion}"
-        group "generation"
+        description = "Regenerate the API-only JAR file with public Panama Vector API from JDK ${jdkVersion}"
+        group = "generation"
 
         javaLauncher = javaToolchains.launcherFor {
           languageVersion = JavaLanguageVersion.of(jdkVersion)

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.gradle
@@ -254,12 +254,12 @@ configure([
 
       // Copy the description and group from the source task.
       project.afterEvaluate {
-        conditionalTask.group sourceTask.group
-        conditionalTask.description sourceTask.description + " (if sources changed)"
+        conditionalTask.group = sourceTask.group
+        conditionalTask.description = sourceTask.description + " (if sources changed)"
 
         // Hide low-level tasks from help.
         sourceTask.group = null
-        sourceTask.description sourceTask.description + " (low-level)"
+        sourceTask.description = sourceTask.description + " (low-level)"
       }
 
       // Set conditional execution only if checksum mismatch occurred.

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.icu.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.icu.gradle
@@ -96,7 +96,7 @@ configure(project(":lucene:analysis:icu")) {
         main = "org.apache.lucene.analysis.icu.GenerateUTR30DataFiles"
         classpath = sourceSets.tools.runtimeClasspath
 
-        ignoreExitValue =  false
+        ignoreExitValue = false
         workingDir utr30DataDir
         args = [
           "release-${icu4jVersion.replace(".", "-")}"
@@ -146,7 +146,7 @@ configure(project(":lucene:analysis:icu")) {
         main = "org.apache.lucene.analysis.icu.RBBIRuleCompiler"
         classpath = sourceSets.tools.runtimeClasspath
 
-        ignoreExitValue =  false
+        ignoreExitValue = false
         enableAssertions true
         args = [sourceDir, targetDir]
       }
@@ -256,7 +256,7 @@ configure(project(":lucene:analysis:common")) {
     def outputFile = file("src/java/org/apache/lucene/analysis/util/UnicodeProps.java")
 
     description = "Regenerate ${outputFile} (with ${icuConfig.name})"
-    group =  "generation"
+    group = "generation"
 
     dependsOn icuConfig
 
@@ -294,7 +294,7 @@ configure(project(":lucene:core")) {
     def outputFile = file("src/java/org/apache/lucene/util/automaton/CaseFolding.java")
 
     description = "Regenerate ${outputFile} (with ${icuConfig.name})"
-    group =  "generation"
+    group = "generation"
 
     dependsOn icuConfig
 

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.icu.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.icu.gradle
@@ -96,7 +96,7 @@ configure(project(":lucene:analysis:icu")) {
         main = "org.apache.lucene.analysis.icu.GenerateUTR30DataFiles"
         classpath = sourceSets.tools.runtimeClasspath
 
-        ignoreExitValue false
+        ignoreExitValue =  false
         workingDir utr30DataDir
         args = [
           "release-${icu4jVersion.replace(".", "-")}"
@@ -146,7 +146,7 @@ configure(project(":lucene:analysis:icu")) {
         main = "org.apache.lucene.analysis.icu.RBBIRuleCompiler"
         classpath = sourceSets.tools.runtimeClasspath
 
-        ignoreExitValue false
+        ignoreExitValue =  false
         enableAssertions true
         args = [sourceDir, targetDir]
       }
@@ -255,8 +255,8 @@ configure(project(":lucene:analysis:common")) {
     def icuConfig = rootProject.configurations.icu_current
     def outputFile = file("src/java/org/apache/lucene/analysis/util/UnicodeProps.java")
 
-    description "Regenerate ${outputFile} (with ${icuConfig.name})"
-    group "generation"
+    description = "Regenerate ${outputFile} (with ${icuConfig.name})"
+    group =  "generation"
 
     dependsOn icuConfig
 
@@ -293,8 +293,8 @@ configure(project(":lucene:core")) {
     def icuConfig = rootProject.configurations.icu_current
     def outputFile = file("src/java/org/apache/lucene/util/automaton/CaseFolding.java")
 
-    description "Regenerate ${outputFile} (with ${icuConfig.name})"
-    group "generation"
+    description = "Regenerate ${outputFile} (with ${icuConfig.name})"
+    group =  "generation"
 
     dependsOn icuConfig
 

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.jflex.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.jflex.gradle
@@ -35,8 +35,8 @@ def skeletonNoBufferExpansion = file("${resources}/skeleton.disable.buffer.expan
 
 configure(project(":lucene:core")) {
   task generateStandardTokenizerInternal(type: JFlexTask) {
-    description "Regenerate StandardTokenizerImpl.java"
-    group "generation"
+    description = "Regenerate StandardTokenizerImpl.java"
+    group =  "generation"
 
     jflexFile = file('src/java/org/apache/lucene/analysis/standard/StandardTokenizerImpl.jflex')
     skeleton = skeletonNoBufferExpansion
@@ -68,8 +68,8 @@ configure(project(":lucene:analysis:common")) {
     def jflexMacro = file("src/java/org/apache/lucene/analysis/email/ASCIITLD.jflex")
     def tldList = file("src/test/org/apache/lucene/analysis/email/TLDs.txt")
 
-    description "Regenerate top-level domain jflex macros and tests"
-    group "generation"
+    description = "Regenerate top-level domain jflex macros and tests"
+    group =  "generation"
 
     dependsOn { sourceSets.tools.runtimeClasspath }
 
@@ -84,7 +84,7 @@ configure(project(":lucene:analysis:common")) {
         main = "org.apache.lucene.analysis.standard.GenerateJflexTLDMacros"
         classpath = sourceSets.tools.runtimeClasspath
 
-        ignoreExitValue false
+        ignoreExitValue =  false
         args = [
           tldZones,
           tmpJflexMacro,
@@ -115,24 +115,24 @@ configure(project(":lucene:analysis:common")) {
   }
 
   task generateWikipediaTokenizerInternal(type: JFlexTask) {
-    description "Regenerate WikipediaTokenizerImpl.java"
-    group "generation"
+    description = "Regenerate WikipediaTokenizerImpl.java"
+    group =  "generation"
 
     jflexFile = file('src/java/org/apache/lucene/analysis/wikipedia/WikipediaTokenizerImpl.jflex')
     skeleton = skeletonDefault
   }
 
   task generateClassicTokenizerInternal(type: JFlexTask) {
-    description "Regenerate ClassicTokenizerImpl.java"
-    group "generation"
+    description = "Regenerate ClassicTokenizerImpl.java"
+    group =  "generation"
 
     jflexFile = file('src/java/org/apache/lucene/analysis/classic/ClassicTokenizerImpl.jflex')
     skeleton = skeletonDefault
   }
 
   task generateUAX29URLEmailTokenizerInternal(type: JFlexTask) {
-    description "Regenerate UAX29URLEmailTokenizerImpl.java"
-    group "generation"
+    description = "Regenerate UAX29URLEmailTokenizerImpl.java"
+    group =  "generation"
 
     jflexFile = file('src/java/org/apache/lucene/analysis/email/UAX29URLEmailTokenizerImpl.jflex')
     skeleton = skeletonNoBufferExpansion
@@ -201,8 +201,8 @@ configure(project(":lucene:analysis:common")) {
   }
 
   task generateHTMLStripCharFilterInternal(type: JFlexTask) {
-    description "Regenerate HTMLStripCharFilter.java"
-    group "generation"
+    description = "Regenerate HTMLStripCharFilter.java"
+    group =  "generation"
 
     // Add included files as inputs.
     inputs.file file('src/java/org/apache/lucene/analysis/charfilter/HTMLCharacterEntities.jflex')

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.jflex.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.jflex.gradle
@@ -36,7 +36,7 @@ def skeletonNoBufferExpansion = file("${resources}/skeleton.disable.buffer.expan
 configure(project(":lucene:core")) {
   task generateStandardTokenizerInternal(type: JFlexTask) {
     description = "Regenerate StandardTokenizerImpl.java"
-    group =  "generation"
+    group = "generation"
 
     jflexFile = file('src/java/org/apache/lucene/analysis/standard/StandardTokenizerImpl.jflex')
     skeleton = skeletonNoBufferExpansion
@@ -69,7 +69,7 @@ configure(project(":lucene:analysis:common")) {
     def tldList = file("src/test/org/apache/lucene/analysis/email/TLDs.txt")
 
     description = "Regenerate top-level domain jflex macros and tests"
-    group =  "generation"
+    group = "generation"
 
     dependsOn { sourceSets.tools.runtimeClasspath }
 
@@ -84,7 +84,7 @@ configure(project(":lucene:analysis:common")) {
         main = "org.apache.lucene.analysis.standard.GenerateJflexTLDMacros"
         classpath = sourceSets.tools.runtimeClasspath
 
-        ignoreExitValue =  false
+        ignoreExitValue = false
         args = [
           tldZones,
           tmpJflexMacro,
@@ -116,7 +116,7 @@ configure(project(":lucene:analysis:common")) {
 
   task generateWikipediaTokenizerInternal(type: JFlexTask) {
     description = "Regenerate WikipediaTokenizerImpl.java"
-    group =  "generation"
+    group = "generation"
 
     jflexFile = file('src/java/org/apache/lucene/analysis/wikipedia/WikipediaTokenizerImpl.jflex')
     skeleton = skeletonDefault
@@ -124,7 +124,7 @@ configure(project(":lucene:analysis:common")) {
 
   task generateClassicTokenizerInternal(type: JFlexTask) {
     description = "Regenerate ClassicTokenizerImpl.java"
-    group =  "generation"
+    group = "generation"
 
     jflexFile = file('src/java/org/apache/lucene/analysis/classic/ClassicTokenizerImpl.jflex')
     skeleton = skeletonDefault
@@ -132,7 +132,7 @@ configure(project(":lucene:analysis:common")) {
 
   task generateUAX29URLEmailTokenizerInternal(type: JFlexTask) {
     description = "Regenerate UAX29URLEmailTokenizerImpl.java"
-    group =  "generation"
+    group = "generation"
 
     jflexFile = file('src/java/org/apache/lucene/analysis/email/UAX29URLEmailTokenizerImpl.jflex')
     skeleton = skeletonNoBufferExpansion
@@ -202,7 +202,7 @@ configure(project(":lucene:analysis:common")) {
 
   task generateHTMLStripCharFilterInternal(type: JFlexTask) {
     description = "Regenerate HTMLStripCharFilter.java"
-    group =  "generation"
+    group = "generation"
 
     // Add included files as inputs.
     inputs.file file('src/java/org/apache/lucene/analysis/charfilter/HTMLCharacterEntities.jflex')

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.kuromoji.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.kuromoji.gradle
@@ -48,7 +48,7 @@ configure(project(":lucene:analysis:kuromoji")) {
 
     task compileMecab(type: Download) {
       description = "Recompile dictionaries from Mecab data."
-      group =  "generation"
+      group = "generation"
 
       dependsOn deleteDictionaryData
       dependsOn sourceSets.main.runtimeClasspath
@@ -94,7 +94,7 @@ configure(project(":lucene:analysis:kuromoji")) {
 
     task compileNaist(type: Download) {
       description = "Recompile dictionaries from Naist data."
-      group =  "generation"
+      group = "generation"
 
       dependsOn deleteDictionaryData
       dependsOn sourceSets.main.runtimeClasspath

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.kuromoji.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.kuromoji.gradle
@@ -47,8 +47,8 @@ configure(project(":lucene:analysis:kuromoji")) {
     }
 
     task compileMecab(type: Download) {
-      description "Recompile dictionaries from Mecab data."
-      group "generation"
+      description = "Recompile dictionaries from Mecab data."
+      group =  "generation"
 
       dependsOn deleteDictionaryData
       dependsOn sourceSets.main.runtimeClasspath
@@ -93,8 +93,8 @@ configure(project(":lucene:analysis:kuromoji")) {
     }
 
     task compileNaist(type: Download) {
-      description "Recompile dictionaries from Naist data."
-      group "generation"
+      description = "Recompile dictionaries from Naist data."
+      group =  "generation"
 
       dependsOn deleteDictionaryData
       dependsOn sourceSets.main.runtimeClasspath

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.moman.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.moman.gradle
@@ -107,8 +107,8 @@ configure(project(":lucene:core")) {
   }
 
   task moman()  {
-    description "Regenerate Moman-based sources."
-    group "generation"
+    description = "Regenerate Moman-based sources."
+    group =  "generation"
 
     def extraConfig = [
       andThenTasks: [

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.moman.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.moman.gradle
@@ -108,7 +108,7 @@ configure(project(":lucene:core")) {
 
   task moman()  {
     description = "Regenerate Moman-based sources."
-    group =  "generation"
+    group = "generation"
 
     def extraConfig = [
       andThenTasks: [

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.nori.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.nori.gradle
@@ -47,8 +47,8 @@ configure(project(":lucene:analysis:nori")) {
     }
 
     task compileMecabKo(type: Download) {
-      description "Recompile dictionaries from Mecab-Ko data."
-      group "generation"
+      description = "Recompile dictionaries from Mecab-Ko data."
+      group =  "generation"
 
       dependsOn deleteDictionaryData
       dependsOn sourceSets.main.runtimeClasspath

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.nori.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.nori.gradle
@@ -48,7 +48,7 @@ configure(project(":lucene:analysis:nori")) {
 
     task compileMecabKo(type: Download) {
       description = "Recompile dictionaries from Mecab-Ko data."
-      group =  "generation"
+      group = "generation"
 
       dependsOn deleteDictionaryData
       dependsOn sourceSets.main.runtimeClasspath

--- a/build-tools/build-infra/src/main/groovy/lucene.regenerate.unicode-test-classes.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.regenerate.unicode-test-classes.gradle
@@ -25,8 +25,8 @@ configure(project(":lucene:test-framework")) {
     def genScript = file("${genDir}/generateEmojiTokenizationTest.pl")
     def genOutput = file("${genDir}/EmojiTokenizationTestUnicode_${unicodeVersion.replace('.', '_')}.java")
 
-    description "Regenerate ${genOutput}"
-    group "generation"
+    description = "Regenerate ${genOutput}"
+    group = "generation"
 
     inputs.file genScript
     inputs.property "unicodeVersion", unicodeVersion
@@ -59,8 +59,8 @@ configure(project(":lucene:test-framework")) {
     def genScript = file("${genDir}/generateJavaUnicodeWordBreakTest.pl")
     def genOutput = file("${genDir}/WordBreakTestUnicode_${unicodeVersion.replace('.', '_')}.java")
 
-    description "Regenerate ${genOutput}"
-    group "generation"
+    description = "Regenerate ${genOutput}"
+    group = "generation"
 
     inputs.file genScript
     inputs.property "unicodeVersion", unicodeVersion

--- a/build-tools/build-infra/src/main/groovy/lucene.root-project.setup.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.root-project.setup.gradle
@@ -200,7 +200,7 @@ allprojects {
 
           standardOutput = wrapped
           errorOutput = wrapped
-          ignoreExitValue =  true
+          ignoreExitValue = true
         }
       }
 

--- a/build-tools/build-infra/src/main/groovy/lucene.root-project.setup.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.root-project.setup.gradle
@@ -200,7 +200,7 @@ allprojects {
 
           standardOutput = wrapped
           errorOutput = wrapped
-          ignoreExitValue true
+          ignoreExitValue =  true
         }
       }
 

--- a/build-tools/build-infra/src/main/groovy/lucene.validation.ecj-lint.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.validation.ecj-lint.gradle
@@ -179,8 +179,8 @@ def lintTasks = sourceSets.collect { SourceSet sourceSet ->
 }
 
 def ecjLint = tasks.register("ecjLint", {
-  description "Lint Java sources using ECJ."
-  group "Verification"
+  description = "Lint Java sources using ECJ."
+  group =  "Verification"
 
   dependsOn lintTasks
 })

--- a/build-tools/build-infra/src/main/groovy/lucene.validation.ecj-lint.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.validation.ecj-lint.gradle
@@ -180,7 +180,7 @@ def lintTasks = sourceSets.collect { SourceSet sourceSet ->
 
 def ecjLint = tasks.register("ecjLint", {
   description = "Lint Java sources using ECJ."
-  group =  "Verification"
+  group = "Verification"
 
   dependsOn lintTasks
 })

--- a/build-tools/build-infra/src/main/groovy/lucene.validation.owasp.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.validation.owasp.gradle
@@ -48,8 +48,8 @@ if (owaspOption.get() || gradle.startParameter.taskNames.contains("owasp")) {
   }
 
   def owaspTask = tasks.register("owasp", {
-    group "Verification"
-    description "Check project dependencies against OWASP vulnerability database."
+    group = "Verification"
+    description = "Check project dependencies against OWASP vulnerability database."
     dependsOn "dependencyCheckAggregate"
   })
 

--- a/build-tools/build-infra/src/main/groovy/lucene.validation.spotless-java.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.validation.spotless-java.gradle
@@ -29,7 +29,7 @@ configure(allprojects) { prj ->
   plugins.withType(JavaPlugin).configureEach {
     spotless {
       java {
-        lineEndings(LineEnding.UNIX)
+        lineEndings = LineEnding.UNIX
         endWithNewline()
         googleJavaFormat(deps.versions.googleJavaFormat.get())
 

--- a/lucene/analysis/common/build.gradle
+++ b/lucene/analysis/common/build.gradle
@@ -88,7 +88,7 @@ def cloningTasks = dictionaryProjects.collect { repoSpec ->
         logger.lifecycle("Executing git " + cmdArgs.join(" "))
         execOps.exec {
           executable project.externalTool("git")
-          ignoreExitValue false
+          ignoreExitValue =  false
           workingDir dotGitPath.getParent().toString()
           args = cmdArgs
 

--- a/lucene/analysis/common/build.gradle
+++ b/lucene/analysis/common/build.gradle
@@ -88,7 +88,7 @@ def cloningTasks = dictionaryProjects.collect { repoSpec ->
         logger.lifecycle("Executing git " + cmdArgs.join(" "))
         execOps.exec {
           executable project.externalTool("git")
-          ignoreExitValue =  false
+          ignoreExitValue = false
           workingDir dotGitPath.getParent().toString()
           args = cmdArgs
 

--- a/lucene/distribution/binary-release.gradle
+++ b/lucene/distribution/binary-release.gradle
@@ -67,7 +67,7 @@ configure(project(":lucene:distribution")) {
   }
 
   task assembleBinaryTgz(type: Tar) {
-    description "Assemble binary Lucene artifact as a .tgz file."
+    description = "Assemble binary Lucene artifact as a .tgz file."
 
     archiveFileName = packageBaseName + ".tgz"
     destinationDirectory = file(archiveFileName).parentFile
@@ -80,9 +80,9 @@ configure(project(":lucene:distribution")) {
   }
 
   task assembleBinaryDirForTests(type: Sync) {
-    description "Assemble a subset of the binary Lucene distribution as an expanded directory for tests."
+    description = "Assemble a subset of the binary Lucene distribution as an expanded directory for tests."
 
-    destinationDir file("${packageBaseName}-itests")
+    destinationDir = file("${packageBaseName}-itests")
   }
 
   artifacts {

--- a/lucene/distribution/build.gradle
+++ b/lucene/distribution/build.gradle
@@ -39,7 +39,7 @@ Provider<String> gitRev = gitStatus.getting("git.commit")
 // Prepare the "source" distribution artifact. We use raw git export, no additional complexity needed.
 Provider<RegularFile> sourceTgzFile = project.layout.buildDirectory.file("packages/lucene-${version}-src.tgz")
 tasks.register("assembleSourceTgz", {
-  description "Assemble source Lucene artifact as a .tgz file."
+  description = "Assemble source Lucene artifact as a .tgz file."
 
   inputs.property("git-revision", gitRev)
 
@@ -124,7 +124,7 @@ tasks.register("prepareGitRev", {
 
 // Assemble everything needed in the release folder structure.
 tasks.register("assembleRelease", Sync, {
-  description "Assemble all Lucene artifacts for a release."
+  description = "Assemble all Lucene artifacts for a release."
 
   from(configurations.changesHtml, {
     into "changes"


### PR DESCRIPTION
### Description

Replaces usages of deprecated Gradle DSL syntax of using "propName value". This will be removed in future Gradle versions and should not be used anymore.