### PR TITLE
Fix usage of deprecated Gradle APIs scheduled to be removed in Gradle 9.0

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.documentation.changes-to-html.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.documentation.changes-to-html.gradle
@@ -68,6 +68,13 @@ class ChangesToHtmlTask extends DefaultTask {
   @InputFile
   def script
 
+  private ExecOperations execOperations;
+
+  @Inject
+  ChangesToHtmlTask(ExecOperations execOperations) {
+    this.execOperations = execOperations
+  }
+
   def loadVersions(File outfile) {
     // load version properties from DOAP RDF
     def prefix = "doap.${productName}".toString()
@@ -80,7 +87,7 @@ class ChangesToHtmlTask extends DefaultTask {
 
   def toHtml(File versionsFile) {
     def output = new ByteArrayOutputStream()
-    def result = project.exec {
+    def result = execOperations.exec {
       executable project.externalTool("perl")
       standardInput changesFile.newInputStream()
       standardOutput project.file("${targetDir.get().getAsFile()}/Changes.html").newOutputStream()

--- a/build-tools/build-infra/src/main/groovy/lucene.java.jar-manifest.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.java.jar-manifest.gradle
@@ -46,6 +46,7 @@ tasks.withType(Jar).configureEach { task ->
     }
   }
 
+  def javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension)
   def manifestAttrs = [
     "Extension-Name"        : implementationTitle,
 
@@ -58,8 +59,8 @@ tasks.withType(Jar).configureEach { task ->
     "Specification-Title"   : title,
 
     // Evaluate these properties lazily so that the defaults are applied properly.
-    "X-Compile-Source-JDK"  : "${-> project.sourceCompatibility}",
-    "X-Compile-Target-JDK"  : "${-> project.targetCompatibility}",
+    "X-Compile-Source-JDK"  : "${-> javaPluginExtension.getSourceCompatibility().toString() }",
+    "X-Compile-Target-JDK"  : "${-> javaPluginExtension.getTargetCompatibility().toString() }",
 
     "X-Build-JDK"           : "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
     "X-Build-OS"            : "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"

--- a/build-tools/build-infra/src/main/groovy/lucene.root-project.setup.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.root-project.setup.gradle
@@ -165,6 +165,11 @@ ext.externalTool = { String name ->
   throw new GradleException("External tool named '${name}' is not defined.")
 }
 
+
+interface InjectedExec {
+  @Inject ExecOperations getOps()
+}
+
 // TODO: These utility methods should be moved somewhere else or removed.
 allprojects {
   ext {
@@ -192,7 +197,8 @@ allprojects {
               }
             }
 
-        result = project.exec { ExecSpec execSpec ->
+        def injected = project.objects.newInstance(InjectedExec)
+        result = injected.ops.exec { ExecSpec execSpec ->
           project.configure(execSpec, closure)
 
           saveIgnoreExitValue = execSpec.ignoreExitValue


### PR DESCRIPTION
### Description

With Gradle 9.0 approaching soon, this fixes incompatibilities with Gradle 9.0 by fixing two types of deprecated api usage in the build logic:

1. The org.gradle.api.plugins.JavaPluginConvention type has been deprecated
2. The Project.exec(Closure) method has been deprecated.
