### PR TITLE
Fix intermittent failure of TestDoubleValuesSourceRescorer

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesSourceRescorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesSourceRescorer.java
@@ -78,7 +78,7 @@ public class TestDoubleValuesSourceRescorer extends LuceneTestCase {
 
   public void testBasic() throws Exception {
     try (Directory dir = newDirectory()) {
-      publishDocs( random().nextInt(50, 100), "title", true, dir);
+      publishDocs(random().nextInt(50, 100), "title", true, dir);
       try (IndexReader r = DirectoryReader.open(dir)) {
         IndexSearcher s = new IndexSearcher(r);
         TermQuery query =

--- a/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesSourceRescorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesSourceRescorer.java
@@ -78,7 +78,7 @@ public class TestDoubleValuesSourceRescorer extends LuceneTestCase {
 
   public void testBasic() throws Exception {
     try (Directory dir = newDirectory()) {
-      publishDocs(random().nextInt(100), "title", true, dir);
+      publishDocs( random().nextInt(50, 100), "title", true, dir);
       try (IndexReader r = DirectoryReader.open(dir)) {
         IndexSearcher s = new IndexSearcher(r);
         TermQuery query =


### PR DESCRIPTION
This commit fixes an intermittent failure of TestDoubleValuesSourceRescorer, where the test sometimes randomly selects too few documents to index leading to no matches in the search. Failure example:

```
org.apache.lucene.search.TestDoubleValuesSourceRescorer > test suite's output saved to /../lucene/core/build/test-results/test/outputs/OUTPUT-org.apache.lucene.search.TestDoubleValuesSourceRescorer.txt, copied below:
   >     java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
   >         at __randomizedtesting.SeedInfo.seed([86E2E915B8727B0:A3943384845BA19E]:0)
   >         at org.apache.lucene.search.TestDoubleValuesSourceRescorer.testBasic(TestDoubleValuesSourceRescorer.java:99)
   >         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
   >         at java.base/java.lang.reflect.Method.invoke(Method.java:580)
...
```

I think that bumping the number of docs to index should be sufficient, as I see no failures even after several hundreds of thousands runs.

relates #14776