### PR TITLE
Add logical build option groups for the allOptions task

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.all-projects.conventions.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.all-projects.conventions.gradle
@@ -25,6 +25,9 @@ allprojects {project ->
   // All projects have the base plugin (convention tasks like 'check', etc.)
   apply plugin: 'base'
 
+  // Configure build option groups.
+  project.plugins.apply(org.apache.lucene.gradle.plugins.help.BuildOptionGroupsPlugin)
+
   // Project group and version.
   group = "org.apache.lucene"
   version = rootProject.version

--- a/build-tools/build-infra/src/main/groovy/lucene.help.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.help.gradle
@@ -108,7 +108,8 @@ tasks.named("help").configure {
     }
 
     println ""
-    println "For the impatient, build the project with 'gradlew assemble', run all tests with 'gradlew check'."
+    println "For the impatient, build the project with 'gradlew assemble', run all tests with 'gradlew check', check " +
+        "your current build options with 'gradlew allOptions'."
     throw new StopExecutionException()
   }
 }

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/help/BuildOptionGroupsPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/help/BuildOptionGroupsPlugin.java
@@ -1,0 +1,76 @@
+package org.apache.lucene.gradle.plugins.help;
+
+import com.carrotsearch.gradle.buildinfra.buildoptions.BuildOptionsTask;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+/** Group related Lucene build options into higher level categories. */
+public class BuildOptionGroupsPlugin implements Plugin<Project> {
+  @Override
+  public void apply(Project project) {
+    project
+        .getTasks()
+        .withType(BuildOptionsTask.class)
+        .configureEach(
+            task -> {
+              task.optionGroups(
+                  optionGroups -> {
+                    optionGroups.group("Lucene version strings", "version\\.(.*)");
+
+                    optionGroups.group("IDE-tweaking options", "eclipse\\.(.+)");
+
+                    optionGroups.group(
+                        "Optional testing and test resources",
+                        explicitList(
+                            "tests.hunspell.regressions",
+                            "validation.errorprone",
+                            "hunspell.corpora",
+                            "hunspell.dictionaries",
+                            "hunspell.repo.path",
+                            "validation.owasp",
+                            "validation.owasp.apikey",
+                            "validation.owasp.threshold"));
+
+                    optionGroups.group("Test profiling", "tests\\.profile\\.(.*)");
+
+                    optionGroups.group(
+                        "Test repetition control",
+                        explicitList("tests.iters", "tests.dups", "tests.failfast"));
+
+                    optionGroups.group(
+                        "Test randomization and all test-related options", "tests\\.(.*)");
+
+                    optionGroups.group(
+                        "Local tool paths",
+                        "(lucene\\.tool\\.(.*))|" + explicitList("runtime.java.home"));
+
+                    optionGroups.group(
+                        "Options configuring the :lucene:benchmark:run task",
+                        explicitList("maxHeapSize", "standardOutput", "taskAlg"));
+
+                    optionGroups.group(
+                        "Options useful for release managers",
+                        explicitList("lucene.javadoc.url", "sign", "useGpg"));
+
+                    optionGroups.group(
+                        "Build control and information",
+                        explicitList(
+                            "task.times",
+                            "javac.failOnWarnings",
+                            "tests.slowestSuites",
+                            "tests.slowestSuites.minTime",
+                            "tests.slowestTests",
+                            "tests.slowestTests.minTime"));
+                  });
+            });
+  }
+
+  private static String explicitList(String... explicitOptions) {
+    return Stream.of(explicitOptions)
+        .map(opt -> "(" + Pattern.quote(opt) + ")")
+        .collect(Collectors.joining("|"));
+  }
+}

--- a/help/localSettings.txt
+++ b/help/localSettings.txt
@@ -17,14 +17,14 @@ coverage or profiling).
 
 To see the current values of all these options, run:
 
-./gradlew buildOptions
+./gradlew allOptions
 
-this prints all build options for each module. You can also scope
-this task to just one module, for example:
+this prints all build options for all modules. You can print all options
+for a single module too, for example:
 
 ./gradlew -p lucene/core buildOptions
 
-The output of this task shows all options, their current values
+The output of both tasks shows the options, their current values
 and their current value's "source". All build option values can be
 overridden by, in order of priority:
 


### PR DESCRIPTION
This adds logical (well) build option groups for the 'allOptions' task. Looks like this:

![image](https://github.com/user-attachments/assets/d32873be-ae04-430a-a00a-bbbbac36bf54)
