### PR TITLE
python: add autofix hint if linter fails

### DIFF
--- a/dev-tools/scripts/Makefile
+++ b/dev-tools/scripts/Makefile
@@ -44,7 +44,7 @@ autofix: ruff-fix reformat
 
 # lints sources
 ruff: env
-	# validate sources with ruff linter
+	# validate sources with ruff linter: if this fails, try "make autofix".
 	$(VENV)/bin/ruff check $(SOURCES)
 
 # fixes (safe) issues that are autofixable such as deprecated/renamed APIs


### PR DESCRIPTION
if the linter fails, often many of the problems can be safely autofixed. That's because many of the rules are opinionated / conventional / cosmetic and can be annoying to deal with manually.

