### PR TITLE
Remove unused delGen() method from FieldTermIterator

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/FieldTermIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldTermIterator.java
@@ -29,9 +29,4 @@ abstract class FieldTermIterator implements BytesRefIterator {
    * may use == to detect a change in field.
    */
   abstract String field();
-
-  /** Del gen of the current term. */
-  // TODO: this is really per-iterator not per term, but when we use MergedPrefixCodedTermsIterator
-  // we need to know which iterator we are on
-  abstract long delGen();
 }

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -500,7 +500,6 @@ final class FrozenBufferedUpdates {
   public void setDelGen(long delGen) {
     assert this.delGen == -1 : "delGen was already previously set to " + this.delGen;
     this.delGen = delGen;
-    deleteTerms.setDelGen(delGen);
   }
 
   public long delGen() {


### PR DESCRIPTION
This was used in the past to correctly order terms in MergedPrefixCodedTermsIterator, 
but that class was removed long ago so the method is no longer needed.


