### PR TITLE
error-prone: implement BanClassLoader with forbidden-apis instead

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.validation.error-prone.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.validation.error-prone.gradle
@@ -153,7 +153,7 @@ allprojects { prj ->
           // '-Xep:AutoValueConstructorOrderChecker:OFF', // we don't use autovalue
           '-Xep:BadAnnotationImplementation:ERROR',
           '-Xep:BadShiftAmount:ERROR',
-          '-Xep:BanClassLoader:ERROR',
+          // '-Xep:BanClassLoader:OFF', // implemented with forbidden APIs instead
           // '-Xep:BanJNDI:OFF', // implemented with forbidden APIs instead
           // '-Xep:BoxedPrimitiveEquality:OFF', // TODO: there are problems
           // '-Xep:BundleDeserializationCast:OFF', // we don't use android

--- a/gradle/validation/forbidden-apis/defaults.all.txt
+++ b/gradle/validation/forbidden-apis/defaults.all.txt
@@ -77,8 +77,10 @@ java.lang.Math#fma(double,double,double)
 
 java.lang.Thread#sleep(**) @ Thread.sleep makes inefficient use of resources, introduces weird race conditions and slows down the code/tests. Not a scalable and good practice so we should prevent it creeping into lucene code
 
+# rules to prevent defining new code from bytes
 @defaultMessage Using dangerous ClassLoader APIs may deserialize untrusted user input into bytecode, leading to remote code execution vulnerabilities
 java.lang.ClassLoader#defineClass(**)
 java.lang.invoke.MethodHandles$Lookup#defineClass(**)
+java.lang.invoke.MethodHandles$Lookup#defineHiddenClass(**)
+java.lang.invoke.MethodHandles$Lookup#defineHiddenClassWithClassData(**)
 java.rmi.server.RMIClassLoader
-java.net.URLClassLoader#<init>(**)

--- a/gradle/validation/forbidden-apis/defaults.all.txt
+++ b/gradle/validation/forbidden-apis/defaults.all.txt
@@ -76,3 +76,15 @@ java.lang.Math#fma(float,float,float)
 java.lang.Math#fma(double,double,double)
 
 java.lang.Thread#sleep(**) @ Thread.sleep makes inefficient use of resources, introduces weird race conditions and slows down the code/tests. Not a scalable and good practice so we should prevent it creeping into lucene code
+
+@defaultMessage Using dangerous ClassLoader APIs may deserialize untrusted user input into bytecode, leading to remote code execution vulnerabilities
+java.lang.ClassLoader#defineClass(**)
+jdk.internal.misc.Unsafe#defineClass(**)
+jdk.internal.access.JavaLangAccess#defineClass(**)
+# forbidden complains it can't find this enclosed class
+# java.lang.invoke.MethodHandles.Lookup#defineClass(**)
+java.rmi.server.RMIClassLoader#loadClass(**)
+java.rmi.server.RMIClassLoader#loadProxyClass(**)
+java.rmi.server.RMIClassLoaderSpi#loadClass(**)
+java.rmi.server.RMIClassLoaderSpi#loadProxyClass(**)
+java.net.URLClassLoader#<init>(**)

--- a/gradle/validation/forbidden-apis/defaults.all.txt
+++ b/gradle/validation/forbidden-apis/defaults.all.txt
@@ -79,12 +79,6 @@ java.lang.Thread#sleep(**) @ Thread.sleep makes inefficient use of resources, in
 
 @defaultMessage Using dangerous ClassLoader APIs may deserialize untrusted user input into bytecode, leading to remote code execution vulnerabilities
 java.lang.ClassLoader#defineClass(**)
-jdk.internal.misc.Unsafe#defineClass(**)
-jdk.internal.access.JavaLangAccess#defineClass(**)
-# forbidden complains it can't find this enclosed class
-# java.lang.invoke.MethodHandles.Lookup#defineClass(**)
-java.rmi.server.RMIClassLoader#loadClass(**)
-java.rmi.server.RMIClassLoader#loadProxyClass(**)
-java.rmi.server.RMIClassLoaderSpi#loadClass(**)
-java.rmi.server.RMIClassLoaderSpi#loadProxyClass(**)
+java.lang.invoke.MethodHandles$Lookup#defineClass(**)
+java.rmi.server.RMIClassLoader
 java.net.URLClassLoader#<init>(**)

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/js/JavascriptCompiler.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/js/JavascriptCompiler.java
@@ -66,6 +66,7 @@ import org.apache.lucene.expressions.Expression;
 import org.apache.lucene.expressions.js.JavascriptParser.ExpressionContext;
 import org.apache.lucene.search.DoubleValues;
 import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.SuppressForbidden;
 
 /**
  * An expression compiler for javascript expressions.
@@ -199,6 +200,7 @@ public final class JavascriptCompiler {
    * @return A new compiled expression
    * @throws ParseException on failure to compile
    */
+  @SuppressForbidden(reason = "defines new bytecode on purpose, carefully")
   private Expression compileExpression() throws ParseException {
     final Map<String, Integer> externalsMap = new LinkedHashMap<>(),
         constantsMap = new LinkedHashMap<>();

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
@@ -45,6 +45,7 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.luke.models.LukeException;
 import org.apache.lucene.util.AttributeImpl;
 import org.apache.lucene.util.AttributeSource;
+import org.apache.lucene.util.SuppressForbidden;
 import org.apache.lucene.util.IOUtils;
 
 /** Default implementation of {@link AnalysisImpl} */
@@ -52,7 +53,7 @@ public final class AnalysisImpl implements Analysis {
 
   private Analyzer analyzer = defaultAnalyzer();
 
-  @SuppressWarnings("BanClassLoader")
+  @SuppressForbidden(reason = "adds external jars to classloader")
   @Override
   public void addExternalJars(List<String> jarFiles) {
     List<URL> urls = new ArrayList<>();

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
@@ -45,8 +45,8 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.luke.models.LukeException;
 import org.apache.lucene.util.AttributeImpl;
 import org.apache.lucene.util.AttributeSource;
-import org.apache.lucene.util.SuppressForbidden;
 import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.SuppressForbidden;
 
 /** Default implementation of {@link AnalysisImpl} */
 public final class AnalysisImpl implements Analysis {

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
@@ -46,14 +46,12 @@ import org.apache.lucene.luke.models.LukeException;
 import org.apache.lucene.util.AttributeImpl;
 import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.IOUtils;
-import org.apache.lucene.util.SuppressForbidden;
 
 /** Default implementation of {@link AnalysisImpl} */
 public final class AnalysisImpl implements Analysis {
 
   private Analyzer analyzer = defaultAnalyzer();
 
-  @SuppressForbidden(reason = "adds external jars to classloader")
   @Override
   public void addExternalJars(List<String> jarFiles) {
     List<URL> urls = new ArrayList<>();


### PR DESCRIPTION
This rule is attempting to ban dangerous usages of ClassLoader which could be security hazard (IMO a good idea). forbidden APIs is a good tool for banning, just like we use forbidden-apis to ban JNDI and other things.

