### PR TITLE
build: replace invalidJavaOnlyPatterns source-patterns with ast-grep

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.validation.source-patterns.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.validation.source-patterns.gradle
@@ -138,13 +138,6 @@ class ValidateSourcePatternsTask extends DefaultTask {
       (~$/\$$Header\b/$) : 'svn keyword',
       (~$/\$$Source\b/$) : 'svn keyword',
       (~$/[\u200B\uFEFF]/$) : 'UTF-8 byte order mark or other zero-width codepoints',
-      (~$/import java\.lang\.\w+;/$) : 'java.lang import is unnecessary',
-    ]
-
-    // Python and others merrily use var declarations, this is a problem _only_ in Java at least for 8x where we're forbidding var declarations
-    def invalidJavaOnlyPatterns = [
-      (~$/\n\s*var\s+.*=.*<>.*/$) : 'Diamond operators should not be used with var',
-      (~$/import\s+\w+(\.\w+)\.\*;/$) : 'Expand wildcard imports into explicit imports'
     ]
 
     def violations = new TreeSet();
@@ -236,13 +229,6 @@ class ValidateSourcePatternsTask extends DefaultTask {
             }
           }
           checkLicenseHeaderPrecedes(f, 'package', packagePattern, javaCommentPattern, text, ratDocument);
-
-          invalidJavaOnlyPatterns.each { pattern, name ->
-            def matcher = pattern.matcher(text);
-            if (matcher.find()) {
-              reportViolation(f, String.format(Locale.ROOT, '%s [start=%d, end=%d]', name, matcher.start(), matcher.end()));
-            }
-          }
         }
         if (f.name.endsWith('.xml')) {
           checkLicenseHeaderPrecedes(f, '<tag>', xmlTagPattern, xmlCommentPattern, text, ratDocument);

--- a/gradle/validation/ast-grep/rules/java-patterns.yml
+++ b/gradle/validation/ast-grep/rules/java-patterns.yml
@@ -13,12 +13,11 @@ message: unnecessary import of `$REF` from java.lang
 note: classes in java.lang are implicitly imported
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
-id: impossible-type-inference
+id: confusing-type-inference
 language: java
-# does the javac compiler allow this? did it ever?
 rule:
   pattern: var $$$ = new $$$<>($$$)
   kind: local_variable_declaration
 severity: error
 message: illegal use of `var` keyword with generic instance creation
-note: type inference cannot happen in both directions
+note: add explicit typing on the RHS when using `var`

--- a/gradle/validation/ast-grep/rules/java-patterns.yml
+++ b/gradle/validation/ast-grep/rules/java-patterns.yml
@@ -1,0 +1,24 @@
+# Banned Lucene source patterns
+# Historically implemented as regexes which are more difficult
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
+id: java-lang-import
+language: java
+rule:
+  pattern: import java.lang.$REF
+  kind: import_declaration
+fix: ""
+severity: error
+message: unnecessary import of `$REF` from java.lang
+note: classes in java.lang are implicitly imported
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
+id: impossible-type-inference
+language: java
+# does the javac compiler allow this? did it ever?
+rule:
+  pattern: var $$$ = new $$$<>($$$)
+  kind: local_variable_declaration
+severity: error
+message: illegal use of `var` keyword with generic instance creation
+note: type inference cannot happen in both directions

--- a/gradle/validation/ast-grep/tests/java-patterns.yml
+++ b/gradle/validation/ast-grep/tests/java-patterns.yml
@@ -6,7 +6,7 @@ valid:
   - import java.lang.foo.bar;
   - import static java.lang.Foo.bar;
 ---
-id: impossible-type-inference
+id: confusing-type-inference
 invalid:
   - var x = new HashSet<>();
   - var x = new HashSet<>(foo);

--- a/gradle/validation/ast-grep/tests/java-patterns.yml
+++ b/gradle/validation/ast-grep/tests/java-patterns.yml
@@ -1,0 +1,14 @@
+---
+id: java-lang-import
+invalid:
+  - import java.lang.Foo;
+valid:
+  - import java.lang.foo.bar;
+  - import static java.lang.Foo.bar;
+---
+id: impossible-type-inference
+invalid:
+  - var x = new HashSet<>();
+  - var x = new HashSet<>(foo);
+valid:
+  - HashSet<String> x = new HashSet<>();

--- a/gradle/validation/ast-grep/tests/java-patterns.yml
+++ b/gradle/validation/ast-grep/tests/java-patterns.yml
@@ -12,3 +12,4 @@ invalid:
   - var x = new HashSet<>(foo);
 valid:
   - HashSet<String> x = new HashSet<>();
+  - var list = new ArrayList<String>();


### PR DESCRIPTION
The validation.source-patterns.gradle is intimidating, there's a lot going on here. Many of the rules are doing regex matches, which is tricky to maintain and can't give good error messages, autofixes in IDE, relevant explanations/URLs, etc.

Start with the 'invalidJavaOnlyPatterns' because it is one of many special cases, and better to just implement as ast-grep java rules.
