### PR TITLE
Expose search strategy in KNN query

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -126,6 +126,8 @@ Improvements
 
 * GITHUB#14737: Clean up redundant code and comments in query node classes. (Stefan Vodita)
 
+* GITHUB#14816: Expose search strategy in KNN query
+
 Optimizations
 ---------------------
 * GITHUB#14418: Quick exit on filter query matching no docs when rewriting knn query. (Pan Guixin)

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -675,4 +675,8 @@ abstract class AbstractKnnVectorQuery extends Query {
           classHash(), contextIdentity, Arrays.hashCode(docs), Arrays.hashCode(scores));
     }
   }
+
+  public KnnSearchStrategy getSearchStrategy() {
+    return searchStrategy;
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -49,6 +49,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.knn.KnnCollectorManager;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.search.knn.TopKnnCollectorManager;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
@@ -1218,5 +1219,11 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
       }
       return true;
     }
+  }
+
+  public void testStrategy() {
+    AbstractKnnVectorQuery vector = getKnnVectorQuery("vector", randomVector(10), 3);
+    assertNotNull(vector.getSearchStrategy());
+    assertTrue(vector.getSearchStrategy() instanceof KnnSearchStrategy.Hnsw);
   }
 }


### PR DESCRIPTION
This simply exposes `AbstractKnnQuery#searchStrategy`. 
This might be useful to debug/inspect and perform optimizations based on different such strategies for consumers of KNN queries.