### PR TITLE
style: disable max-line-length in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,8 +12,6 @@ indent_size = 2
 eclint_indent_size = unset
 indent_style = space
 insert_final_newline = true
-max_line_length = 100
-eclint_max_line_length = unset
 trim_trailing_whitespace = true
 ij_continuation_indent_size = 4
 ij_formatter_off_tag = @formatter:off
@@ -619,10 +617,6 @@ ij_properties_align_group_field_declarations = false
 ij_properties_keep_blank_lines = true
 ij_properties_key_value_delimiter = equals
 ij_properties_spaces_around_key_value_delimiter = false
-
-[*.py]
-# must be consistent with ruff formatter settings
-max_line_length = 200
 
 [{*.yaml,*.yml}]
 ij_yaml_align_values_properties = do_not_align


### PR DESCRIPTION
This is set for all files and causes issues where editors will wrap inconsistently with the formatter. It will happen even with java code: because spotless ignores this restriction for comments, as an example.

Best to leave such settings to tools like spotless which are AST-aware.

Relates: #14819

