### PR TITLE
build: add eclint to verify editorconfig in CI

### DIFF
--- a/.github/actions/eclint/action.yml
+++ b/.github/actions/eclint/action.yml
@@ -1,0 +1,33 @@
+name: Install eclint
+description: Installs eclint from cache, or builds it
+
+inputs:
+  eclint-version:
+    required: false
+    description: "eclint version to use"
+    default: "v0.5.1"
+
+runs:
+ using: "composite"
+ steps:
+  - name: Cache eclint binary
+    id: cache-eclint
+    uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+    with:
+      path: ~/.local/bin/eclint
+      key: eclint-${{ inputs.eclint-version }}-${{ runner.os }}-${{ runner.arch }}
+  - name: Setup go
+    if: steps.cache-eclint.outputs.cache-hit != 'true'
+    uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+    with:
+      go-version: '1.24'
+      cache: false
+  - name: Install eclint
+    if: steps.cache-eclint.outputs.cache-hit != 'true'
+    run: GOBIN=${HOME}/.local/bin go install gitlab.com/greut/eclint/cmd/eclint@${ECLINT_VERSION}
+    shell: bash
+    env:
+      ECLINT_VERSION: ${{ inputs.eclint-version }}
+  - name: Configure gradle
+    run: echo "lucene.tool.eclint=eclint" >> build-options.local.properties
+    shell: bash

--- a/.github/actions/prepare-for-build/action.yml
+++ b/.github/actions/prepare-for-build/action.yml
@@ -26,14 +26,14 @@ runs:
         java-package: jdk
 
     - name: Cache gradle-wrapper.jar
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: gradle/wrapper/gradle-wrapper.jar
         key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.jar.sha256') }}
 
     # This includes "smart" caching of gradle dependencies.
     - name: Set up Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
       with:
         # increase expiry time for the temp. develocity token.
         # https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#increasing-the-expiry-time-for-develocity-access-tokens

--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -40,6 +40,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/prepare-for-build
 
+      - name: Install eclint
+        if: ${{ ! startsWith(matrix.os, 'windows') }}
+        uses: ./.github/actions/eclint
+
       - name: Install ast-grep
         if: ${{ ! startsWith(matrix.os, 'windows') }}
         run: |

--- a/build-tools/build-infra/src/main/groovy/lucene.root-project.setup.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.root-project.setup.gradle
@@ -19,6 +19,7 @@ import com.carrotsearch.gradle.buildinfra.buildoptions.BuildOptionValueSource
 import com.carrotsearch.gradle.buildinfra.buildoptions.BuildOptionsPlugin
 import org.apache.lucene.gradle.plugins.gitinfo.GitInfoPlugin
 import org.apache.lucene.gradle.plugins.astgrep.AstGrepPlugin
+import org.apache.lucene.gradle.plugins.eclint.EditorConfigLintPlugin
 import com.carrotsearch.randomizedtesting.SeedUtils
 
 import java.time.ZonedDateTime
@@ -40,6 +41,7 @@ allprojects {
 plugins.apply(BasePlugin)
 plugins.apply(GitInfoPlugin)
 plugins.apply(AstGrepPlugin)
+plugins.apply(EditorConfigLintPlugin)
 
 //
 // Figure out project version based on the base version and, suffix (or overrides of these options).

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/eclint/EditorConfigLintPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/eclint/EditorConfigLintPlugin.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.gradle.plugins.eclint;
+
+import com.carrotsearch.gradle.buildinfra.buildoptions.BuildOptionsExtension;
+import java.util.List;
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.Exec;
+
+public class EditorConfigLintPlugin implements Plugin<Project> {
+  @Override
+  public void apply(Project project) {
+    if (project != project.getRootProject()) {
+      throw new GradleException("This plugin can be applied to the root project only.");
+    }
+
+    var optionName = "lucene.tool.eclint";
+    var tasks = project.getTasks();
+
+    var eclintToolOption =
+        project
+            .getExtensions()
+            .getByType(BuildOptionsExtension.class)
+            .addOption(optionName, "External eclint executable (path or name)");
+
+    var applyEcLintTask =
+        tasks.register(
+            "applyEcLint",
+            Exec.class,
+            task -> {
+              if (!eclintToolOption.isPresent()) {
+                task.getLogger()
+                    .warn(
+                        "The eclint tool location is not set ('{}' option), will not apply eclint checks.",
+                        optionName);
+              }
+            });
+
+    // Common configuration.
+    List.of(applyEcLintTask)
+        .forEach(
+            taskProv -> {
+              taskProv.configure(
+                  task -> {
+                    if (!eclintToolOption.isPresent()) {
+                      task.setEnabled(false);
+                    }
+
+                    task.setIgnoreExitValue(false);
+                    if (eclintToolOption.isPresent()) {
+                      task.setExecutable(eclintToolOption.get());
+                    }
+                    task.setWorkingDir(project.getLayout().getProjectDirectory());
+                  });
+            });
+
+    tasks
+        .matching(task -> task.getName().equals("check"))
+        .configureEach(
+            task -> {
+              task.dependsOn(applyEcLintTask);
+            });
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/Version.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Version.java
@@ -58,6 +58,7 @@ public final class Version {
 
   /**
    * Match settings and bugs in Lucene's 10.2.2 release.
+   *
    * @deprecated Use latest
    */
   @Deprecated public static final Version LUCENE_10_2_2 = new Version(10, 2, 2);


### PR DESCRIPTION
You generally shouldn't need the check, as your editor should follow the editorconfig and not introduce the errors checked-for here.

But it helps maintain the .editorconfig itself and ensure that files in the repository actually match whatever is configured there.

If you want to enable the check locally for debugging:
```
GOBIN=${HOME}/.local/bin go install gitlab.com/greut/eclint/cmd/eclint@latest
echo "lucene.tool.eclint=eclint" >> ~/.gradle/gradle.properties
```

The eclint action is not used, as it is not on the apache approved list. Getting the 3MB binary in CI takes 2s (cached) and 9s (uncached, using setup-go).

The check itself runs fast:
```
real	0m3.647s
user	0m6.702s
sys	0m0.474s
```

@dweiss, I imagine you want to keep things a certain way, please feel free to push commits here. I just hack when it comes to the gradle side of things, but the actions part is decent I think.
