### PR TITLE
build: fix incorrect gradle dependency

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/astgrep/AstGrepPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/astgrep/AstGrepPlugin.java
@@ -92,12 +92,6 @@ public class AstGrepPlugin implements Plugin<Project> {
         .configureEach(
             task -> {
               task.dependsOn(testAstGrepRules);
-            });
-
-    tasks
-        .matching(task -> task.getName().equals("tidy"))
-        .configureEach(
-            task -> {
               task.dependsOn(applyAstGrepRulesTask);
             });
   }

--- a/lucene/core/src/java/org/apache/lucene/util/Version.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Version.java
@@ -58,6 +58,7 @@ public final class Version {
 
   /**
    * Match settings and bugs in Lucene's 10.2.2 release.
+   *
    * @deprecated Use latest
    */
   @Deprecated public static final Version LUCENE_10_2_2 = new Version(10, 2, 2);


### PR DESCRIPTION
applyAstGrep doesn't run in CI, because it is set to depend on "tidy" instead of "check"

