### PR TITLE
Small enhancements to IndexWriter's InfoStream to support segment tracing

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
@@ -99,13 +99,27 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
     for (FieldInfo fieldInfo : mergeState.mergeFieldInfos) {
       if (fieldInfo.hasVectorValues()) {
         if (mergeState.infoStream.isEnabled("VV")) {
-          mergeState.infoStream.message("VV", "merging " + mergeState.segmentInfo);
+          mergeState.infoStream.message(
+              "VV",
+              "field="
+                  + fieldInfo.name
+                  + " dim="
+                  + fieldInfo.getVectorDimension()
+                  + " merging into "
+                  + mergeState.segmentInfo);
         }
 
         mergeOneField(fieldInfo, mergeState);
 
         if (mergeState.infoStream.isEnabled("VV")) {
-          mergeState.infoStream.message("VV", "merge done " + mergeState.segmentInfo);
+          mergeState.infoStream.message(
+              "VV",
+              "field="
+                  + fieldInfo.name
+                  + " dim="
+                  + fieldInfo.getVectorDimension()
+                  + " merge done into "
+                  + mergeState.segmentInfo);
         }
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
@@ -688,8 +688,7 @@ final class DocumentsWriter implements Closeable, Accountable {
   void finishFullFlush(boolean success) throws IOException {
     try {
       if (infoStream.isEnabled("DW")) {
-        infoStream.message(
-            "DW", Thread.currentThread().getName() + " finishFullFlush success=" + success);
+        infoStream.message("DW", " finishFullFlush success=" + success);
       }
       assert setFlushingDeleteQueue(null);
       if (success) {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3724,7 +3724,7 @@ public class IndexWriter
         maybeCloseOnTragicEvent();
       }
 
-      if (pointInTimeMerges != null && pointInTimeMerges.merges.size() > 0) {
+      if (pointInTimeMerges != null) {
         if (infoStream.isEnabled("IW")) {
           infoStream.message(
               "IW", "now run merges during commit: " + pointInTimeMerges.segString(directory));


### PR DESCRIPTION
Some small fixes to IndexWriter's InfoStream logging, uncovered when working on the new segment tracing tool from luceneutil (example: https://githubsearch.mikemccandless.com/segments_15.html).  I've been sitting on these changes in my main dev area and finally got around to making a PR before I lose track of them, phew!

Details:
  * KNN merging was logging "start/done" multiple times and then I realized it was for a different field each time, so I added field name
  * Thread name was duplicated in a single line at end of full flush
  * Defensive change: don't invoke merge-on-commit logic if merge policy returns empty list of merges
  * I enhanced merge-on-commit logging to state how many merges it will do, and whether all merges completed in the timeout window or not
  * TMP now also logs its deletesPctAllowed and forceMerteDeletesPctAllowed, and more details when it kicks off merge selection