### PR TITLE
Make it possible to extend Patience/Seeded knn queries

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -188,7 +188,7 @@ Bug Fixes
 
 * GITHUB#14755: Fix too many documents collected when only bool-filter condition is present. (Ke Wei)
 
-* GITHUB#14838: Make it possible to extend PatienceKnnQuery (Tommaso Teofili)
+* GITHUB#14838: Make it possible to extend Patience/Seeded knn queries (Tommaso Teofili)
 
 Build
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -188,6 +188,8 @@ Bug Fixes
 
 * GITHUB#14755: Fix too many documents collected when only bool-filter condition is present. (Ke Wei)
 
+* GITHUB#14838: Make it possible to extend PatienceKnnQuery (Tommaso Teofili)
+
 Build
 ---------------------
 * Upgrade forbiddenapis to version 3.9.  (Uwe Schindler)

--- a/lucene/core/src/java/org/apache/lucene/search/HnswQueueSaturationCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/HnswQueueSaturationCollector.java
@@ -37,7 +37,7 @@ public class HnswQueueSaturationCollector extends KnnCollector.Decorator {
   private int previousQueueSize;
   private int currentQueueSize;
 
-  HnswQueueSaturationCollector(KnnCollector delegate, double saturationThreshold, int patience) {
+  public HnswQueueSaturationCollector(KnnCollector delegate, double saturationThreshold, int patience) {
     super(delegate);
     this.delegate = delegate;
     this.previousQueueSize = 0;

--- a/lucene/core/src/java/org/apache/lucene/search/HnswQueueSaturationCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/HnswQueueSaturationCollector.java
@@ -37,7 +37,8 @@ public class HnswQueueSaturationCollector extends KnnCollector.Decorator {
   private int previousQueueSize;
   private int currentQueueSize;
 
-  public HnswQueueSaturationCollector(KnnCollector delegate, double saturationThreshold, int patience) {
+  public HnswQueueSaturationCollector(
+      KnnCollector delegate, double saturationThreshold, int patience) {
     super(delegate);
     this.delegate = delegate;
     this.previousQueueSize = 0;

--- a/lucene/core/src/java/org/apache/lucene/search/PatienceKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PatienceKnnVectorQuery.java
@@ -285,7 +285,11 @@ public class PatienceKnnVectorQuery extends AbstractKnnVectorQuery {
           new SeededKnnVectorQuery(
               seededKnnVectorQuery.delegate,
               seededKnnVectorQuery.seed,
-              seededKnnVectorQuery.createSeedWeight(indexSearcher));
+              seededKnnVectorQuery.createSeedWeight(indexSearcher),
+              delegate.field,
+              delegate.k,
+              delegate.filter,
+              delegate.searchStrategy);
     }
     return super.rewrite(indexSearcher);
   }

--- a/lucene/core/src/java/org/apache/lucene/search/PatienceKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PatienceKnnVectorQuery.java
@@ -123,28 +123,54 @@ public class PatienceKnnVectorQuery extends AbstractKnnVectorQuery {
         knnQuery, DEFAULT_SATURATION_THRESHOLD, defaultPatience(knnQuery));
   }
 
-  public PatienceKnnVectorQuery(
-      SeededKnnVectorQuery knnQuery, double saturationThreshold, int patience) {
-    super(knnQuery.field, knnQuery.k, knnQuery.filter, knnQuery.searchStrategy);
+  PatienceKnnVectorQuery(
+      AbstractKnnVectorQuery knnQuery,
+      String field,
+      int k,
+      Query filter,
+      KnnSearchStrategy searchStrategy,
+      double saturationThreshold,
+      int patience) {
+    super(field, k, filter, searchStrategy);
     this.delegate = knnQuery;
     this.saturationThreshold = saturationThreshold;
     this.patience = patience;
+  }
+
+  public PatienceKnnVectorQuery(
+      SeededKnnVectorQuery knnQuery, double saturationThreshold, int patience) {
+    this(
+        knnQuery,
+        knnQuery.field,
+        knnQuery.k,
+        knnQuery.filter,
+        knnQuery.searchStrategy,
+        saturationThreshold,
+        patience);
   }
 
   public PatienceKnnVectorQuery(
       KnnFloatVectorQuery knnQuery, double saturationThreshold, int patience) {
-    super(knnQuery.field, knnQuery.k, knnQuery.filter, knnQuery.searchStrategy);
-    this.delegate = knnQuery;
-    this.saturationThreshold = saturationThreshold;
-    this.patience = patience;
+    this(
+        knnQuery,
+        knnQuery.field,
+        knnQuery.k,
+        knnQuery.filter,
+        knnQuery.searchStrategy,
+        saturationThreshold,
+        patience);
   }
 
   public PatienceKnnVectorQuery(
       KnnByteVectorQuery knnQuery, double saturationThreshold, int patience) {
-    super(knnQuery.field, knnQuery.k, knnQuery.filter, knnQuery.searchStrategy);
-    this.delegate = knnQuery;
-    this.saturationThreshold = saturationThreshold;
-    this.patience = patience;
+    this(
+        knnQuery,
+        knnQuery.field,
+        knnQuery.k,
+        knnQuery.filter,
+        knnQuery.searchStrategy,
+        saturationThreshold,
+        patience);
   }
 
   private static int defaultPatience(AbstractKnnVectorQuery delegate) {

--- a/lucene/core/src/java/org/apache/lucene/search/PatienceKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PatienceKnnVectorQuery.java
@@ -48,7 +48,7 @@ public class PatienceKnnVectorQuery extends AbstractKnnVectorQuery {
   /**
    * Construct a new PatienceKnnVectorQuery instance for a float vector field
    *
-   * @param knnQuery the knn query to be seeded
+   * @param knnQuery the knn query to be wrapped
    * @param saturationThreshold the early exit saturation threshold
    * @param patience the patience parameter
    * @return a new PatienceKnnVectorQuery instance
@@ -62,7 +62,7 @@ public class PatienceKnnVectorQuery extends AbstractKnnVectorQuery {
   /**
    * Construct a new PatienceKnnVectorQuery instance for a float vector field
    *
-   * @param knnQuery the knn query to be seeded
+   * @param knnQuery the knn query to be wrapped
    * @return a new PatienceKnnVectorQuery instance
    * @lucene.experimental
    */
@@ -74,7 +74,7 @@ public class PatienceKnnVectorQuery extends AbstractKnnVectorQuery {
   /**
    * Construct a new PatienceKnnVectorQuery instance for a byte vector field
    *
-   * @param knnQuery the knn query to be seeded
+   * @param knnQuery the knn query to be wrapped
    * @param saturationThreshold the early exit saturation threshold
    * @param patience the patience parameter
    * @return a new PatienceKnnVectorQuery instance
@@ -123,8 +123,24 @@ public class PatienceKnnVectorQuery extends AbstractKnnVectorQuery {
         knnQuery, DEFAULT_SATURATION_THRESHOLD, defaultPatience(knnQuery));
   }
 
-  PatienceKnnVectorQuery(
-      AbstractKnnVectorQuery knnQuery, double saturationThreshold, int patience) {
+  public PatienceKnnVectorQuery(
+      SeededKnnVectorQuery knnQuery, double saturationThreshold, int patience) {
+    super(knnQuery.field, knnQuery.k, knnQuery.filter, knnQuery.searchStrategy);
+    this.delegate = knnQuery;
+    this.saturationThreshold = saturationThreshold;
+    this.patience = patience;
+  }
+
+  public PatienceKnnVectorQuery(
+      KnnFloatVectorQuery knnQuery, double saturationThreshold, int patience) {
+    super(knnQuery.field, knnQuery.k, knnQuery.filter, knnQuery.searchStrategy);
+    this.delegate = knnQuery;
+    this.saturationThreshold = saturationThreshold;
+    this.patience = patience;
+  }
+
+  public PatienceKnnVectorQuery(
+      KnnByteVectorQuery knnQuery, double saturationThreshold, int patience) {
     super(knnQuery.field, knnQuery.k, knnQuery.filter, knnQuery.searchStrategy);
     this.delegate = knnQuery;
     this.saturationThreshold = saturationThreshold;

--- a/lucene/core/src/java/org/apache/lucene/search/SeededKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SeededKnnVectorQuery.java
@@ -69,11 +69,40 @@ public class SeededKnnVectorQuery extends AbstractKnnVectorQuery {
     return new SeededKnnVectorQuery(knnQuery, seed, null);
   }
 
-  SeededKnnVectorQuery(AbstractKnnVectorQuery knnQuery, Query seed, Weight seedWeight) {
-    super(knnQuery.field, knnQuery.k, knnQuery.filter, knnQuery.searchStrategy);
+  SeededKnnVectorQuery(
+      AbstractKnnVectorQuery knnQuery,
+      Query seed,
+      Weight seedWeight,
+      String field,
+      int k,
+      Query filter,
+      KnnSearchStrategy searchStrategy) {
+    super(field, k, filter, searchStrategy);
     this.delegate = knnQuery;
     this.seed = Objects.requireNonNull(seed);
     this.seedWeight = seedWeight;
+  }
+
+  public SeededKnnVectorQuery(KnnFloatVectorQuery knnQuery, Query seed, Weight seedWeight) {
+    this(
+        knnQuery,
+        seed,
+        seedWeight,
+        knnQuery.field,
+        knnQuery.k,
+        knnQuery.filter,
+        knnQuery.searchStrategy);
+  }
+
+  public SeededKnnVectorQuery(KnnByteVectorQuery knnQuery, Query seed, Weight seedWeight) {
+    this(
+        knnQuery,
+        seed,
+        seedWeight,
+        knnQuery.field,
+        knnQuery.k,
+        knnQuery.filter,
+        knnQuery.searchStrategy);
   }
 
   @Override
@@ -94,7 +123,14 @@ public class SeededKnnVectorQuery extends AbstractKnnVectorQuery {
       return super.rewrite(indexSearcher);
     }
     SeededKnnVectorQuery rewritten =
-        new SeededKnnVectorQuery(delegate, seed, createSeedWeight(indexSearcher));
+        new SeededKnnVectorQuery(
+            delegate,
+            seed,
+            createSeedWeight(indexSearcher),
+            delegate.field,
+            delegate.k,
+            delegate.filter,
+            delegate.searchStrategy);
     return rewritten.rewrite(indexSearcher);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestSeededKnnByteVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSeededKnnByteVectorQuery.java
@@ -238,7 +238,7 @@ public class TestSeededKnnByteVectorQuery extends BaseKnnVectorQueryTestCase {
 
     public AssertingSeededKnnVectorQuery(
         AbstractKnnVectorQuery query, Query seed, Weight seedWeight, AtomicInteger seedCalls) {
-      super(query, seed, seedWeight);
+      super(query, seed, seedWeight, query.field, query.k, query.filter, query.searchStrategy);
       this.seedCalls = seedCalls;
     }
 


### PR DESCRIPTION
Currently `PatienceKnnQuery` extends and is constructed by an `AbstractKnnQuery`, which is not public and therefore avoids other classes to extend it (as the related ctor is also package private).
This simply makes `PatienceKnnQuery` constructors public and strict about the type of the wrapped query (float, byte, seeded knn queries),