### PR TITLE
ci: enable gh annotations with ast-grep

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/astgrep/AstGrepPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/astgrep/AstGrepPlugin.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.gradle.plugins.astgrep;
 
 import com.carrotsearch.gradle.buildinfra.buildoptions.BuildOptionsExtension;
+import java.util.ArrayList;
 import java.util.List;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
@@ -67,9 +68,15 @@ public class AstGrepPlugin implements Plugin<Project> {
                         optionName);
               }
 
+              var args = new ArrayList<String>();
               // fail on any rule match regardless of severity level
-              task.setArgs(
+              args.addAll(
                   List.of("scan", "-c", "gradle/validation/ast-grep/sgconfig.yml", "--error"));
+              // use the github format when being run as a workflow
+              if (System.getenv("CI") != null && System.getenv("GITHUB_WORKFLOW") != null) {
+                args.addAll(List.of("--format", "github"));
+              }
+              task.setArgs(args);
             });
 
     // Common configuration.


### PR DESCRIPTION
Error is still printed to console, but in a special structured format recognized by actions to highlight and annotate the problem in your PR.

When clicking the build failure, annotations can be seen at the very top of action link (no need to look at logs). Github does highlight the failures in red in the logs as well.

You can see the problems annotated inline in the sources, when reviewing the changes.

Relates: #14835

@dweiss, I know it doesn't solve that issue, nor does it even make use of the autofix I wrote, but I still think it is an improvement to usability.

![Screen_Shot_2025-06-23_at_21 27 33](https://github.com/user-attachments/assets/680d8f4e-f491-49e9-86c7-df77c90e89b5)
