### PR TITLE
Correct tests.seed to be reported on failures

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.java.show-failed-tests-at-end.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.java.show-failed-tests-at-end.gradle
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import java.util.regex.Pattern
 import org.apache.lucene.gradle.ErrorReportingTestListener
 
 // Display all failed tests at the end of the build.
@@ -33,11 +34,28 @@ allprojects {
 
       afterTest { desc, result ->
         if (result.resultType == TestResult.ResultType.FAILURE) {
+          // check if it's a constructor or a before/after class hook that failed.
+          def qTestName
+          if (desc.name == "classMethod") {
+            qTestName = desc.className
+          } else {
+            qTestName = "${desc.className}.${desc.name}"
+          }
+
+          def randomizationParameters = ""
+          def p = Pattern.compile(/.+ (?<params>[{].*[}])$/)
+          def matcher = p.matcher(qTestName)
+          if (matcher.matches()) {
+            randomizationParameters = matcher.group("params")
+            qTestName = qTestName.replace(randomizationParameters, "").trim()
+          }
+
           failedTests << [
-            "name"     : "${desc.className}.${desc.name}",
+            "name"     : qTestName,
+            "randomizationParameters": randomizationParameters,
             "project"  : "${test.project.path}",
             "output"   : file("${testOutputsDir}/${ErrorReportingTestListener.getOutputLogName(desc.parent)}"),
-            "reproduce": "gradlew ${project.path}:test --tests \"${desc.className}.${desc.name}\" ${reproLine}"
+            "reproduce": "gradlew ${project.path}:test --tests \"${qTestName}\" ${reproLine}"
           ]
         }
       }
@@ -62,11 +80,14 @@ gradle.buildFinished { result ->
         .sort { a, b -> b.project.compareTo(a.project) }
         .collect { e ->
           String.format(Locale.ROOT,
-              "  - %s (%s)\n    Test output: %s\n    Reproduce with: %s\n",
-              e.name, e.project, e.output, e.reproduce)
+              "  - %s (%s)%s\n    Test output: %s\n    Reproduce with: %s\n",
+              e.name, e.project,
+              e.containsKey("randomizationParameters") &&
+              !e.randomizationParameters.isBlank() ? "\n    Context parameters: ${e.randomizationParameters}" : "",
+              e.output, e.reproduce)
         }
         .join("\n")
 
-    logger.error("\nERROR: The following test(s) have failed:\n${formatted}")
+    logger.error("\nERROR: The following {} failed:\n\n{}", failedTests.size() == 1 ? "test has" : "tests have", formatted)
   }
 }

--- a/build-tools/build-infra/src/main/groovy/lucene.java.tests-and-randomization.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.java.tests-and-randomization.gradle
@@ -20,6 +20,7 @@ import org.apache.tools.ant.types.Commandline
 import org.gradle.api.tasks.testing.logging.*
 import com.carrotsearch.randomizedtesting.generators.RandomPicks
 import org.apache.lucene.gradle.ErrorReportingTestListener
+import com.carrotsearch.gradle.buildinfra.buildoptions.BuildOptionsExtension
 
 def loggingConfigFile = rootProject.layout.projectDirectory.file("gradle/testing/logging.properties")
 def verboseModeHookInstalled = false
@@ -82,6 +83,13 @@ Provider<Integer> upperJavaFeatureVersionOption = buildOptions.addIntOption(
     "tests.upperJavaFeatureVersion", "Min JDK feature version to configure the Panama Vectorization provider")
 
 // Test reiteration, filtering and component randomization options.
+
+// Propagate root seed so that it is visible and reported as an option in subprojects.
+if (project != project.rootProject) {
+  buildOptions.addOption("tests.seed", "The \"root\" randomization seed for options and test parameters.",
+      rootProject.getExtensions().getByType(BuildOptionsExtension).getOption("tests.seed").asStringProvider())
+}
+
 buildOptions.addIntOption("tests.iters", "Duplicate (re-run) each test case N times.")
 optionsInheritedAsProperties += ["tests.iters"]
 

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/ErrorReportingTestListener.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/ErrorReportingTestListener.java
@@ -165,7 +165,6 @@ public class ErrorReportingTestListener implements TestOutputListener, TestListe
   public static String getReproLineOptions(Test testTask) {
     var buildOptions = testTask.getProject().getExtensions().getByType(BuildOptionsExtension.class);
     var internalOptions = Set.of("tests.workDir", "tests.tmpDir");
-    var alwaysIncludeOptions = Set.of("tests.seed");
 
     return buildOptions.getAllOptions().stream()
         .filter(


### PR DESCRIPTION
Correct tests.seed to be reported on failures, do not write '.classMethod' for failures in static contexts. Extract and present randomization context parameters separately from test name. Fixes #14846