### PR TITLE
source patterns: @author/nocommit/TOOD/tabs

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.validation.source-patterns.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.validation.source-patterns.gradle
@@ -124,10 +124,6 @@ class ValidateSourcePatternsTask extends DefaultTask {
   @TaskAction
   public void check() {
     def invalidPatterns = [
-      (~$/@author\b/$) : '@author javadoc tag',
-      (~$/(?i)\bno(n|)commit\b/$) : 'nocommit',
-      (~$/\bTOOD:/$) : 'TOOD instead TODO',
-      (~$/\t/$) : 'tabs instead spaces',
       (~$/[\u202A-\u202E\u2066-\u2069]/$) : 'misuse of RTL/LTR (https://trojansource.codes)',
       (~$/\Q/**\E((?:\s)|(?:\*))*\Q{@inheritDoc}\E((?:\s)|(?:\*))*\Q*/\E/$) : '{@inheritDoc} on its own is unnecessary',
       (~$/\$$(?:LastChanged)?Date\b/$) : 'svn keyword',

--- a/gradle/validation/ast-grep/rules/java-patterns.yml
+++ b/gradle/validation/ast-grep/rules/java-patterns.yml
@@ -26,8 +26,9 @@ note: add explicit typing on the RHS when using `var`
 id: javadoc-style-license-header
 language: java
 rule:
-  matches: java-license
-  regex: "^/[*][*]"
+  all:
+   - matches: java-license
+   - matches: javadoc
   pattern: $TEXT
 # remove extraneous stars
 transform:
@@ -51,3 +52,42 @@ rule:
     stopBy: end
 severity: error
 message: license should be before `package` declaration
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
+id: javadoc-author-tag
+language: java
+rule:
+  matches: javadoc
+  regex: "@author"
+severity: error
+message: javadoc `@author` tags should not be used
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
+id: nocommit-comment
+language: java
+rule:
+  regex: "nocommit:"
+  any:
+    - kind: line_comment
+    - kind: block_comment
+severity: error
+message: all `nocommit:` comments must be resolved
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
+id: tood-comment
+language: java
+rule:
+  regex: "TOOD:"
+  any:
+    - kind: line_comment
+    - kind: block_comment
+  pattern: $TEXT
+transform:
+  NEWTEXT:
+    replace:
+      replace: "TOOD:"
+      by: "TODO:"
+      source: $TEXT
+fix: $NEWTEXT
+severity: error
+message: please write as `TODO:` instead

--- a/gradle/validation/ast-grep/rules/java-patterns.yml
+++ b/gradle/validation/ast-grep/rules/java-patterns.yml
@@ -27,8 +27,8 @@ id: javadoc-style-license-header
 language: java
 rule:
   all:
-   - matches: java-license
-   - matches: javadoc
+    - matches: java-license
+    - matches: javadoc
   pattern: $TEXT
 # remove extraneous stars
 transform:

--- a/gradle/validation/ast-grep/tests/java-patterns.yml
+++ b/gradle/validation/ast-grep/tests/java-patterns.yml
@@ -41,3 +41,32 @@ valid:
   - |
     /* BLAH BLAH Unless required by applicable law BLAH BLAH */
     package foo;
+---
+id: javadoc-author-tag
+invalid:
+  - |
+    /** @author foo */
+valid:
+  - |
+    // notjavadoc @author
+  - |
+    /* notjavadoc @author */
+---
+id: nocommit-comment
+invalid:
+  - |
+    // nocommit: fix this
+  - |
+    /* nocommit: fix this */
+valid:
+  - boolean nocommit = false;
+---
+id: tood-comment
+invalid:
+  - |
+    // TOOD: fix this
+  - |
+    /* TOOD: fix this */
+valid:
+  - |
+    var foo = "TOOD: whatever";

--- a/gradle/validation/ast-grep/utils/javadoc.yml
+++ b/gradle/validation/ast-grep/utils/javadoc.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
+id: javadoc
+language: java
+rule:
+  # detect javadoc
+  kind: block_comment
+  regex: "^/[*][*]"


### PR DESCRIPTION
The tab rule is handled by eclint for all filetypes. @author/nocommit/TOOD moved to ast-grep rules: they are easier when they only match inside comment nodes to begin with, and can give better feedback from the CLI, editor, and GH actions.

This mornings sudoku puzzles to make more progress on the file.