### PR TITLE
Using `BatchScoreBulkScorer` on `CombinedFieldQuery`

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -189,6 +189,8 @@ Optimizations
 
 * GITHUB#14772: Implement ConstantScoreScorer#nextDocsAndScores. (Ge Song)
 
+* GITHUB#14854: Using BatchScoreBulkScorer on CombinedFieldQuery. (Ge Song)
+
 Bug Fixes
 ---------------------
 * GITHUB#14654: ValueSource.fromDoubleValuesSource(dvs).getSortField() would throw errors when

--- a/lucene/core/src/java/org/apache/lucene/search/CombinedFieldQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/CombinedFieldQuery.java
@@ -395,6 +395,11 @@ public final class CombinedFieldQuery extends Query implements Accountable {
         public long cost() {
           return finalCost;
         }
+
+        @Override
+        public BulkScorer bulkScorer() throws IOException {
+          return new BatchScoreBulkScorer(get(Long.MAX_VALUE));
+        }
       };
     }
 


### PR DESCRIPTION
### Description

This is a follow up of #14834 , which utilize `BatchScoreBulkScorer` on `CombinedFieldQuery` as suggested at the [comment](https://github.com/apache/lucene/pull/14834#pullrequestreview-2959423823). So we can speed up `CombinedTermQuery` when score is needed. In theory, maybe there is way we can managed to use the minCompetitive score set with `setMinCompetitiveScore`, but the score calculation of `CombinedFieldQuery` is a little bit complicated (or maybe I missed something), so I give it up, for now.

I did a quick luceneutil benchmark on `wikimediumall` of `taskCountPerCat=1` , `taskRepeatCount=20` after 20 iterations and manully disabled count verification, since this change will reduce the collected docs as `BatchScoreBulkScorer` will filter those docs with score less than `minCompetitiveScore`. The result is as follows:
```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                     AndHighHigh       18.63      (2.5%)       17.67     (13.4%)   -5.1% ( -20% -   11%) 0.092
                      OrHighHigh       28.51      (2.5%)       27.05     (15.9%)   -5.1% ( -22% -   13%) 0.154
                       OrHighMed      113.70      (1.8%)      108.19     (13.4%)   -4.8% ( -19% -   10%) 0.110
                      AndHighMed       63.12      (1.4%)       60.31     (11.8%)   -4.4% ( -17% -    8%) 0.095
                         TermB1M      631.61      (2.3%)      604.98      (9.9%)   -4.2% ( -16% -    8%) 0.064
                     OrStopWords        5.74      (9.2%)        5.51     (14.3%)   -4.0% ( -25% -   21%) 0.287
                        Or3Terms       81.22      (4.7%)       78.04     (11.7%)   -3.9% ( -19% -   13%) 0.164
                            Term      633.71      (3.1%)      609.78      (9.2%)   -3.8% ( -15% -    8%) 0.082
                         Term10K      583.46      (3.1%)      562.66     (10.4%)   -3.6% ( -16% -   10%) 0.142
              FilteredAndHighMed       73.63      (4.3%)       71.02      (9.9%)   -3.5% ( -17% -   11%) 0.144
                       TermB1M1P      582.09      (3.4%)      561.67     (10.3%)   -3.5% ( -16% -   10%) 0.148
                         Term100      648.47      (3.7%)      627.16      (9.8%)   -3.3% ( -16% -   10%) 0.160
                    AndStopWords        5.18      (8.1%)        5.02     (12.0%)   -3.0% ( -21% -   18%) 0.346
                      DismaxTerm      473.19      (2.8%)      459.08      (5.7%)   -3.0% ( -11% -    5%) 0.036
                          Term1M      364.66      (2.4%)      355.07      (8.2%)   -2.6% ( -12% -    8%) 0.170
                 DismaxOrHighMed       58.15      (1.8%)       56.63      (9.0%)   -2.6% ( -13% -    8%) 0.202
                AndMedOrHighHigh       29.79      (1.6%)       29.20      (4.7%)   -2.0% (  -8% -    4%) 0.071
                          Fuzzy2       24.93      (3.0%)       24.57      (5.4%)   -1.4% (  -9% -    7%) 0.300
                          OrMany       10.30      (3.9%)       10.21      (5.6%)   -0.9% ( -10% -    8%) 0.544
                          Fuzzy1       58.49      (3.1%)       58.07      (3.0%)   -0.7% (  -6% -    5%) 0.460
             CountFilteredPhrase       10.49      (4.7%)       10.41      (3.9%)   -0.7% (  -8% -    8%) 0.605
                  FilteredIntNRQ      283.93      (8.6%)      281.97      (8.5%)   -0.7% ( -16% -   17%) 0.798
             And2Terms2StopWords      141.33      (6.7%)      140.45     (11.0%)   -0.6% ( -17% -   18%) 0.830
          CountFilteredOrHighMed       30.48      (1.7%)       30.32      (1.7%)   -0.5% (  -3% -    2%) 0.314
               FilteredAnd3Terms      168.76      (2.8%)      167.86      (3.4%)   -0.5% (  -6% -    5%) 0.586
         CountFilteredOrHighHigh       25.86      (1.4%)       25.72      (2.1%)   -0.5% (  -3% -    2%) 0.342
              Or2Terms2StopWords      158.92      (6.4%)      158.24      (9.8%)   -0.4% ( -15% -   16%) 0.870
             CountFilteredIntNRQ       19.47      (1.6%)       19.40      (2.5%)   -0.4% (  -4% -    3%) 0.559
                  FilteredOrMany        5.08      (1.5%)        5.07      (2.3%)   -0.4% (  -4% -    3%) 0.542
               FilteredOrHighMed       78.30      (1.2%)       78.06      (1.5%)   -0.3% (  -2% -    2%) 0.466
                DismaxOrHighHigh       74.37      (2.1%)       74.16      (3.4%)   -0.3% (  -5% -    5%) 0.751
                          Phrase       24.22      (2.0%)       24.17      (2.0%)   -0.2% (  -4% -    3%) 0.723
                 CountAndHighMed       80.64      (4.6%)       80.54      (4.0%)   -0.1% (  -8% -    8%) 0.925
                          IntNRQ      306.90      (7.3%)      306.54      (8.4%)   -0.1% ( -14% -   16%) 0.963
             CountFilteredOrMany        4.98      (2.0%)        4.98      (2.5%)    0.0% (  -4% -    4%) 0.971
                FilteredOr3Terms       43.21      (1.6%)       43.22      (2.3%)    0.0% (  -3% -    4%) 0.963
                 CountOrHighHigh       67.53      (2.9%)       67.56      (2.4%)    0.0% (  -5% -    5%) 0.960
                CountAndHighHigh       67.56      (2.6%)       67.62      (1.9%)    0.1% (  -4% -    4%) 0.911
                    SloppyPhrase       12.00      (3.2%)       12.02      (3.1%)    0.1% (  -5% -    6%) 0.919
                       And3Terms      278.44      (2.9%)      279.25      (3.1%)    0.3% (  -5% -    6%) 0.758
              FilteredOrHighHigh       18.17      (1.6%)       18.22      (1.4%)    0.3% (  -2% -    3%) 0.544
                 AndHighOrMedMed       11.66      (3.0%)       11.70      (2.8%)    0.3% (  -5% -    6%) 0.744
                        Wildcard       73.74      (4.0%)       74.02      (4.2%)    0.4% (  -7% -    9%) 0.771
                        SpanNear        3.67      (2.5%)        3.69      (2.2%)    0.5% (  -4% -    5%) 0.499
             FilteredAndHighHigh       14.35      (1.3%)       14.43      (1.8%)    0.5% (  -2% -    3%) 0.274
                IntervalsOrdered        3.66      (3.2%)        3.68      (3.2%)    0.6% (  -5% -    7%) 0.584
            FilteredAndStopWords        9.57      (1.9%)        9.63      (2.0%)    0.6% (  -3% -    4%) 0.353
             FilteredOrStopWords       15.00      (1.1%)       15.09      (1.9%)    0.6% (  -2% -    3%) 0.237
                         Respell       43.86      (2.9%)       44.15      (2.8%)    0.6% (  -4% -    6%) 0.472
             CombinedAndHighHigh        5.97      (2.4%)        6.00      (1.6%)    0.7% (  -3% -    4%) 0.308
                     CountOrMany        6.12      (3.1%)        6.16      (3.3%)    0.7% (  -5% -    7%) 0.497
                  CountOrHighMed      102.70      (3.3%)      103.57      (2.8%)    0.8% (  -5% -    7%) 0.375
                         Prefix3       36.50      (4.8%)       36.82      (4.1%)    0.9% (  -7% -   10%) 0.542
               CombinedOrHighMed       11.20      (4.6%)       11.30      (5.0%)    0.9% (  -8% -   11%) 0.568
                    FilteredTerm      123.35      (2.1%)      124.43      (2.2%)    0.9% (  -3% -    5%) 0.191
                          IntSet      333.62      (4.7%)      336.62      (5.2%)    0.9% (  -8% -   11%) 0.565
              CombinedOrHighHigh        8.28      (4.3%)        8.37      (5.0%)    1.1% (  -7% -   10%) 0.449
                      OrHighRare       54.67      (4.1%)       55.34      (4.0%)    1.2% (  -6% -    9%) 0.337
                 FilteredPrefix3      342.24      (3.4%)      346.79      (2.3%)    1.3% (  -4% -    7%) 0.147
                   TermTitleSort       72.12      (8.3%)       73.09      (8.2%)    1.4% ( -14% -   19%) 0.605
                  FilteredPhrase       30.36      (2.9%)       30.78      (3.3%)    1.4% (  -4% -    7%) 0.149
                      TermDTSort      187.48      (3.0%)      190.31      (2.8%)    1.5% (  -4% -    7%) 0.100
      FilteredOr2Terms2StopWords      127.12      (4.1%)      129.14      (4.4%)    1.6% (  -6% -   10%) 0.234
               TermDayOfYearSort      253.23      (5.0%)      258.00      (4.2%)    1.9% (  -6% -   11%) 0.198
     FilteredAnd2Terms2StopWords       98.61      (5.2%)      100.62      (5.5%)    2.0% (  -8% -   13%) 0.226
                   TermMonthSort     1553.97      (7.1%)     1590.31      (7.6%)    2.3% ( -11% -   18%) 0.314
              CombinedAndHighMed       44.57      (2.8%)       45.70      (3.0%)    2.5% (  -3% -    8%) 0.006
                     CountPhrase        7.47      (4.8%)        7.67      (3.4%)    2.7% (  -5% -   11%) 0.039
                       CountTerm     3875.14      (7.8%)     3994.37     (10.4%)    3.1% ( -13% -   23%) 0.288
                    CombinedTerm       17.81      (3.2%)       18.66      (2.6%)    4.8% (  -1% -   10%) 0.000
WARNING: cat=CombinedTerm: hit counts differ: 1392120+ vs 1759+
```

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
