### PR TITLE
Only score doc first when minCompetitiveScore is zero

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/BlockMaxConjunctionBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BlockMaxConjunctionBulkScorer.java
@@ -84,7 +84,10 @@ final class BlockMaxConjunctionBulkScorer extends BulkScorer {
   public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
     collector.setScorer(scorable);
 
-    int windowMin = scoreDocFirstUntilDynamicPruning(collector, acceptDocs, min, max);
+    int windowMin = Math.max(lead.docID(), min);
+    if (scorable.minCompetitiveScore == 0) {
+      windowMin = scoreDocFirstUntilDynamicPruning(collector, acceptDocs, min, max);
+    }
 
     while (windowMin < max) {
       // Use impacts of the least costly scorer to compute windows


### PR DESCRIPTION
`minCompetitiveScore` could be set when `setScorer` so this proposes only score doc first when minCompetitiveScore is zero. Luceneutil does not show a noticeable improvement but this might be useful in some case.