### PR TITLE
build: specify GH format for run-checks-python

### DIFF
--- a/.github/workflows/run-checks-python.yml
+++ b/.github/workflows/run-checks-python.yml
@@ -34,3 +34,5 @@ jobs:
 
       - name: Lint Python
         run: "cd dev-tools/scripts && make"
+        env:
+          RUFF_OUTPUT_FORMAT: github


### PR DESCRIPTION
the typechecker will automatically do this, for the linter we need to set an environment variable.

![Screen_Shot_2025-06-29_at_09 26 45](https://github.com/user-attachments/assets/34d689cd-2bca-4992-97aa-76bdfa6e6445)
