### PR TITLE
build: download eclipse source jars and specify in .classpath

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.ide.eclipse.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.ide.eclipse.gradle
@@ -27,6 +27,11 @@ Provider<String> eclipseJavaVersionOption = buildOptions.addOption("eclipse.java
 Provider<String> eclipseErrorsOption = buildOptions.addOption("eclipse.errors", "Sets eclipse IDE lint level (ignore/warning/error)", "warning")
 
 if (gradle.startParameter.taskNames.contains("eclipse")) {
+  // force it to download source jars
+  subprojects {
+    apply plugin: 'eclipse'
+  }
+
   project.pluginManager.apply("java-base")
   project.pluginManager.apply("eclipse")
 
@@ -143,11 +148,30 @@ public class LibEntry implements ClasspathEntry {
     return "lib"
   }
 
+  // hackishly locates a source jar in your gradle cache!
+  static String findSourceJar(String byteCodeJar) {
+    def location = new File(byteCodeJar);
+    def sourceJar = location.getName().replaceFirst('.jar$', '-sources.jar');
+    def dependency = location.getParentFile().getParentFile();
+    for (subdir in dependency.listFiles()) {
+      def candidate = new File(subdir, sourceJar);
+      if (candidate.exists()) {
+        return candidate.toString();
+      }
+    }
+    return null;
+  }
+
   @Override
   void appendNode(Node node) {
-    node.appendNode("classpathentry", Map.of(
-        "kind", "lib",
-        "path", path
-        ))
+    def attributes = new HashMap();
+    attributes.put('kind', 'lib');
+    attributes.put('path', path);
+    // look for -sources.jar of dependency to see if eclipse plugin downloaded it
+    def sourceJar = LibEntry.findSourceJar(path);
+    if (sourceJar != null) {
+      attributes.put('sourcepath', sourceJar);
+    }
+    node.appendNode('classpathentry', attributes);
   }
 }

--- a/gradlew
+++ b/gradlew
@@ -243,6 +243,8 @@ if [ ! -e "$APP_HOME/gradle.properties" ]; then
         exit $GENERATOR_STATUS
     fi
 fi
+# hack
+buildarg="$1"
 # END OF LUCENE CUSTOMIZATION
 
 # Collect all arguments for the java command:
@@ -289,4 +291,12 @@ eval "set -- $(
         tr '\n' ' '
     )" '"$@"'
 
-exec "$JAVACMD" "$@"
+if [[ "$buildarg" == "eclipse" ]]; then
+  "$JAVACMD" "$@"
+  # clean up unwanted .classpath/.project/.settings in subprojects
+  # i'm sure there's a better way, but various functionality of gradle such as doLast doesnt work
+  # use what works.
+  git clean -df
+else
+  exec "$JAVACMD" "$@"
+fi


### PR DESCRIPTION
hackishly applies "eclipse" plugin to all subprojects. this forces it to download the source jars, which doesn't happen today.

pokes around in the gradle cache to find corresponding source jars and specifies them in the .classpath properly.

Still needs to remove .classpath/.project/.settings that is being generated in each subproject as a side-effect.

Closes #14865

I need help as I spent hours trying to remove .classpath/.project/.settings from the subprojects, but can't figure it out. But if you run `gradlew eclipse` from this branch and then run `git clean -df` afterwards, it will take care of them and you will see that it works:

![Screen_Shot_2025-06-29_at_11 37 15](https://github.com/user-attachments/assets/2644d353-6744-495f-a39d-55504f2602e2)

