### PR TITLE
eliminate more redundant errorprone checks

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.validation.error-prone.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.validation.error-prone.gradle
@@ -162,7 +162,7 @@ allprojects { prj ->
           // '-Xep:CheckReturnValue:OFF', // we don't use these annotations
           '-Xep:CollectionToArraySafeParameter:ERROR',
           // '-Xep:ComparableType:OFF',
-          // '-Xep:ComparingThisWithNull:ERROR', // we use ast-grep for this check
+          // '-Xep:ComparingThisWithNull:OFF', // we use ast-grep for this check
           '-Xep:ComparisonOutOfRange:ERROR',
           // '-Xep:CompatibleWithAnnotationMisuse:OFF', // we don't use this annotation
           // '-Xep:CompileTimeConstant:OFF', // we don't use this annotation
@@ -395,7 +395,7 @@ allprojects { prj ->
           // '-Xep:DoNotMockAutoValue:OFF', // we don't use autovalue
           // '-Xep:DoubleCheckedLocking:OFF', // TODO: there are problems
           '-Xep:DuplicateDateFormatField:WARN',
-          '-Xep:EmptyBlockTag:WARN',
+          // '-Xep:EmptyBlockTag:OFF', // ECJ takes care
           // '-Xep:EmptyCatch:OFF', // ECJ takes care
           // '-Xep:EmptySetMultibindingContributions:OFF', // we don't use this annotation
           // '-Xep:EnumOrdinal:OFF', // noisy
@@ -570,11 +570,11 @@ allprojects { prj ->
           // '-Xep:StreamResourceLeak:OFF', // TODO: there are problems
           '-Xep:StreamToIterable:WARN',
           // '-Xep:StringCaseLocaleUsage:OFF', // noisy, can use forbidden-apis for this
-          '-Xep:StringCharset:WARN',
+          // '-Xep:StringCharset:OFF', // we use ast-grep for this
           '-Xep:StringFormatWithLiteral:WARN',
           // '-Xep:StringSplitter:OFF', // noisy, can use forbidden-apis for this
           '-Xep:SystemConsoleNull:WARN',
-          '-Xep:SunApi:WARN',
+          // '-Xep:SunApi:OFF', // we use forbidden-apis for this
           '-Xep:SuperCallToObjectMethod:WARN',
           // '-Xep:SwigMemoryLeak:OFF', // we don't use swig
           // '-Xep:SynchronizeOnNonFinalField:OFF', // noisy
@@ -582,7 +582,7 @@ allprojects { prj ->
           // '-Xep:ThreadLocalUsage:OFF', // noisy
           // '-Xep:ThreadPriorityCheck:OFF', // noisy, forbidden APIs can do this
           // '-Xep:ThrowIfUncheckedKnownUnchecked:OFF', // we don't use these google libraries
-          '-Xep:ThreeLetterTimeZoneID:WARN',
+          // '-Xep:ThreeLetterTimeZoneID:OFF', // we use ast-grep for this
           '-Xep:TimeUnitConversionChecker:WARN',
           // '-Xep:ToStringReturnsNull:OFF', // TODO: there are problems
           // '-Xep:TruthAssertExpected:OFF', // we don't use truth

--- a/gradle/validation/ast-grep/rules/errorprone.yml
+++ b/gradle/validation/ast-grep/rules/errorprone.yml
@@ -149,3 +149,35 @@ severity: error
 message: |
   `main` methods must be `public`, `static`, and `void`
 url: https://errorprone.info/bugpattern/IncorrectMainMethod
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
+id: ThreeLetterTimeZoneID
+language: java
+rule:
+  pattern: $$$.getTimeZone("$ZONE")
+severity: error
+constraints:
+  ZONE:
+    # three-letter zone
+    regex: "^[A-Z][A-Z][A-Z]$"
+    # exempt UTC/GMT
+    not:
+      regex: "(UTC|GMT)"
+message: Three-letter time zone identifiers are deprecated, may be ambiguous, and might not do what you intend
+note: The full IANA time zone ID should be used instead.
+url: https://errorprone.info/bugpattern/ThreeLetterTimeZoneID
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
+id: StringCharset
+language: java
+rule:
+  any:
+    - pattern: new String($ARG, "$CHARSET")
+    - pattern: $$$.getBytes("$CHARSET")
+constraints:
+  CHARSET:
+    # these are available in StandardCharsets
+    regex: "(US-ASCII|UTF-16|UTF-8)"
+severity: error
+message: Prefer StandardCharsets over using string names for charsets
+url: https://errorprone.info/bugpattern/StringCharset

--- a/gradle/validation/ast-grep/tests/errorprone.yml
+++ b/gradle/validation/ast-grep/tests/errorprone.yml
@@ -103,3 +103,22 @@ invalid:
     public void main() {}
   - |
     public static int main() {}
+---
+id: ThreeLetterTimeZoneID
+invalid:
+  - TimeZone.getTimeZone("EST")
+valid:
+  - TimeZone.getTimeZone("UTC")
+  - TimeZone.getTimeZone("America/New_York")
+---
+id: StringCharset
+invalid:
+  - |
+    new String(bytes, "UTF-8")
+  - |
+    "abc".getBytes("UTF-16LE")
+valid:
+  - |
+    new String(bytes, "GB2312")
+  - |
+    new String(bytes, StandardCharsets.UTF_8)


### PR DESCRIPTION
* EmptyBlockTag: ecj linter detects missing descriptions for all these.
* StringCharset: ast-grep rule
* SunApi: forbidden-apis takes care
* ThreeLetterTimeZoneID: ast-grep rule

