### PR TITLE
An attempt to use gradle's eclipse plugin to provide us with src paths for libs

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.ide.eclipse.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.ide.eclipse.gradle
@@ -26,6 +26,15 @@ if (project != project.rootProject) {
 Provider<String> eclipseJavaVersionOption = buildOptions.addOption("eclipse.javaVersion", "Set Java version for Eclipse IDE", deps.versions.minJava.get())
 Provider<String> eclipseErrorsOption = buildOptions.addOption("eclipse.errors", "Sets eclipse IDE lint level (ignore/warning/error)", "warning")
 
+configurations {
+  foo
+}
+
+dependencies {
+  foo deps.zstd
+}
+
+
 if (gradle.startParameter.taskNames.contains("eclipse")) {
   project.pluginManager.apply("java-base")
   project.pluginManager.apply("eclipse")
@@ -42,14 +51,28 @@ if (gradle.startParameter.taskNames.contains("eclipse")) {
     classpath {
       defaultOutputDir = file('build/eclipse')
 
-      file {
-        beforeMerged { classpath ->
-          classpath.entries.removeAll {
-            it.kind == "src"
-          }
-        }
+      downloadSources = true
+      downloadJavadoc = false
 
+      plusConfigurations += allprojects.findAll{ prj ->
+        return prj.plugins.hasPlugin(JavaPlugin)
+      }.collectMany {
+        return [ it.configurations.compileClasspath, it.configurations.testCompileClasspath ]
+      }
+
+      file {
         whenMerged { classpath ->
+          classpath.entries.removeAll {
+            return it.kind == "src" || (it.kind == "lib" && it.getPath() ==~ /(.+)lucene-.*\.jar/)
+          }
+
+          // I'm not sure what these attributes are supposed to do. Keeping the previous version of having no-attributes.
+          classpath.entries.each {
+            if (it.kind == "lib") {
+              it.getEntryAttributes().clear()
+            }
+          }
+
           def projects = allprojects.findAll { prj ->
             return prj.plugins.hasPlugin(JavaPlugin)
           }
@@ -62,7 +85,6 @@ if (gradle.startParameter.taskNames.contains("eclipse")) {
             'tools'
           ] as Set
           Set<String> sources = []
-          Set<File> jars = []
           projects.each { prj ->
             prj.sourceSets.each { sourceSet ->
               if (sourceSetNames.contains(sourceSet.name)) {
@@ -70,22 +92,12 @@ if (gradle.startParameter.taskNames.contains("eclipse")) {
                 sources += sourceSet.resources.srcDirs.findAll { dir -> dir.exists() }.collect { dir -> relativize(dir) }
               }
             }
-
-            // This is hacky - we take the resolved compile classpath and just
-            // include JAR files from there. We should probably make it smarter
-            // by looking at real dependencies. But then: this Eclipse configuration
-            // doesn't really separate sources anyway so why bother.
-            jars += prj.configurations.compileClasspath.resolve()
-            jars += prj.configurations.testCompileClasspath.resolve()
           }
 
           classpath.entries += sources.sort().collect { name ->
             def sourceFolder = new SourceFolder(name, "build/eclipse/" + name)
             sourceFolder.setExcludes(["module-info.java"])
             return sourceFolder
-          }
-          classpath.entries += jars.unique().findAll { location -> location.isFile() && !(location.name ==~ /lucene-.*\.jar/) }.collect { location ->
-            new LibEntry(location.toString())
           }
         }
       }
@@ -132,23 +144,3 @@ if (gradle.startParameter.taskNames.contains("eclipse")) {
   }
 }
 
-public class LibEntry implements ClasspathEntry {
-  private String path;
-
-  LibEntry(String path) {
-    this.path = path;
-  }
-
-  @Override
-  String getKind() {
-    return "lib"
-  }
-
-  @Override
-  void appendNode(Node node) {
-    node.appendNode("classpathentry", Map.of(
-        "kind", "lib",
-        "path", path
-        ))
-  }
-}

--- a/build-tools/build-infra/src/main/groovy/lucene.ide.eclipse.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.ide.eclipse.gradle
@@ -26,15 +26,6 @@ if (project != project.rootProject) {
 Provider<String> eclipseJavaVersionOption = buildOptions.addOption("eclipse.javaVersion", "Set Java version for Eclipse IDE", deps.versions.minJava.get())
 Provider<String> eclipseErrorsOption = buildOptions.addOption("eclipse.errors", "Sets eclipse IDE lint level (ignore/warning/error)", "warning")
 
-configurations {
-  foo
-}
-
-dependencies {
-  foo deps.zstd
-}
-
-
 if (gradle.startParameter.taskNames.contains("eclipse")) {
   project.pluginManager.apply("java-base")
   project.pluginManager.apply("eclipse")

--- a/gradle/ide/eclipse/dot.settings/org.eclipse.jdt.core.prefs
+++ b/gradle/ide/eclipse/dot.settings/org.eclipse.jdt.core.prefs
@@ -3,6 +3,8 @@ eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=@eclipseJavaVersion@
 org.eclipse.jdt.core.compiler.compliance=@eclipseJavaVersion@
 org.eclipse.jdt.core.compiler.source=@eclipseJavaVersion@
+# this turns off split package checks, which gradle-api jar contains. https://github.com/gradle/gradle/issues/19577
+org.eclipse.jdt.core.compiler.ignoreUnnamedModuleForSplitPackage=enabled
 # Note: all compiler flags are defined in ECJ linter configuration
 @ecj-lint-config@
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false


### PR DESCRIPTION
This is an alternative take to provide src paths for lib entries in Eclipse. It leverages gradle's build-in utilities -

https://docs.gradle.org/current/dsl/org.gradle.plugins.ide.eclipse.model.EclipseClasspath.html

I'm sure it doesn't follow gradle's conventions (we collect configurations from subprojects) - maybe @breskeby will know how to do it in a nicer way.

I also had to turn off split package checks in eclipse because the generated gradle api jar is full of jdk classes: https://github.com/gradle/gradle/issues/19577

The generated file seems identical to what we used to have and include src refs. When I open the project in eclipse it doesn't compile because of this - I'm not sure how to fix it because it seems like valid code:

![image](https://github.com/user-attachments/assets/a4134cb1-2712-47f6-8f13-a5eb50166c94)
