### PR TITLE
Use LessThan here rather than Comparator for some key PriorityQueues

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorer.java
@@ -18,7 +18,6 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Comparator;
 import org.apache.lucene.internal.hppc.LongArrayList;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
@@ -73,10 +72,8 @@ final class BooleanScorer extends BulkScorer {
     }
     this.leads = new DisiWrapper[scorers.size()];
     this.head =
-        PriorityQueue.usingComparator(
-            scorers.size() - minShouldMatch + 1, Comparator.comparingInt(d -> d.doc));
-    this.tail =
-        PriorityQueue.usingComparator(minShouldMatch - 1, Comparator.comparingLong(d -> d.cost));
+        PriorityQueue.usingLessThan(scorers.size() - minShouldMatch + 1, (a, b) -> a.doc < b.doc);
+    this.tail = PriorityQueue.usingLessThan(minShouldMatch - 1, (a, b) -> a.cost < b.cost);
     this.minShouldMatch = minShouldMatch;
     this.needsScores = needsScores;
     LongArrayList costs = new LongArrayList(scorers.size());

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
@@ -18,7 +18,6 @@ package org.apache.lucene.search.comparators;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
-import java.util.Comparator;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexOptions;
@@ -596,7 +595,7 @@ public class TermOrdValComparator extends FieldComparator<BytesRef> {
         }
       }
       disjunction =
-          PriorityQueue.usingComparator(size, Comparator.comparingInt(p -> p.postings.docID()));
+          PriorityQueue.usingLessThan(size, (a, b) -> a.postings.docID() < b.postings.docID());
       disjunction.addAll(postings);
     }
   }


### PR DESCRIPTION
Following from the regression identified in https://github.com/apache/lucene/pull/14705#issuecomment-3014284037, use `LessThan` rather than `Comparator` (which involves less function calls) for these key queues