### PR TITLE
eclipse: attach javadocs URL for gradle-api.jar

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.ide.eclipse.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.ide.eclipse.gradle
@@ -57,10 +57,15 @@ if (gradle.startParameter.taskNames.contains("eclipse")) {
             return it.kind == "src" || (it.kind == "lib" && it.getPath() ==~ /(.+)lucene-.*\.jar/)
           }
 
-          // I'm not sure what these attributes are supposed to do. Keeping the previous version of having no-attributes.
+          // Wipe attributes which only contain a blank "gradle_used_by_scope" for every single library.
           classpath.entries.each {
             if (it.kind == "lib") {
               it.getEntryAttributes().clear()
+            }
+            // The generated gradle-api.jar has no source attached, attaching source is a PITA
+            // for now just attach a javadocs URL, which improves editor functionality:
+            if (it.getPath() ==~ /(.+)gradle-api-.*\.jar/) {
+              it.getEntryAttributes().put("javadoc_location", "https://docs.gradle.org/${deps.versions.minGradle.get()}/javadoc")
             }
           }
 


### PR DESCRIPTION
This isn't as a great as attaching the sources, yet it enables many basic editor functions that would not otherwise work.

From the perspective of gradle code written in java, it is a big improvement because you can navigate the APIs in your editor, reference documentation, have real parameter names, etc etc.

It is an easy win / incremental improvement from just having bytecode.

Closes #14878

![Screen_Shot_2025-06-30_at_20 22 06](https://github.com/user-attachments/assets/a8a4dde8-d1f8-4094-8024-f34569ae83a4)

