### PR TITLE
vscode: improve setup

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+  "recommendations": [
+    "redhat.java",
+    "editorconfig.editorconfig",
+    "ast-grep.ast-grep-vscode"
+  ],
+  "unwantedRecommendations": [
+    "vscjava.vscode-java-pack",
+    "vscjava.vscode-gradle"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "java.import.gradle.enabled": false,
+  "java.import.maven.enabled": false,
+  "java.jdt.ls.lombokSupport.enabled": false,
+  "java.compile.nullAnalysis.mode": "disabled",
+  "java.completion.maxResults": 500,
+  "java.inlayHints.parameterNames.enabled": "all",
+  "astGrep.configPath": "gradle/validation/ast-grep/sgconfig.yml"
+}

--- a/help/IDEs.txt
+++ b/help/IDEs.txt
@@ -29,15 +29,6 @@ Run the following to set up Eclipse project files:
 
 Open the lucene checkout in VSCode.
 
-Install the recommended "Extension Pack for Java" if asked.
-
-View -> Command Palette -> Preferences: Open Settings UI
-Type 'java.import.gradle.enabled' and uncheck it.
-Type 'java.import.maven.enabled' and uncheck it.
-
-Restart VSCode.
-
-
 Neovim
 ======
 


### PR DESCRIPTION
I don't use this editor, but popularity-wise, it dominates: https://survey.stackoverflow.co/2024/technology#1-integrated-development-environment

Simplify the configuration so things "just work". This is a minimal setup: it will work if the user doesn't even have java installed on their computer. If the user wants to do more serious stuff and configure debuggers/test-runners, they'll need to install appropriate JRE, additional extensions, etc.

Configuration doesn't require maintenance such as classpaths as it leans on `gradle eclipse`, it is just two small json files.

specify extensions (redhat language server, editorconfig, ast-grep) to be recommended to the user so that the sources work correctly.

disable automatic gradle/maven importing: causes false errors and we configure this via `gradle eclipse`

disable the default lombok support: it isn't used by the project and causes false compiler errors in some large sources such as HTMLStripCharFilter.

disable the default prompt for null analysis, we don't want this: we configure such things via `gradle eclipse` exactly the way we want.

put an upperbound on completions: otherwise eclipse jdt.ls can be overwhelmed.

configure ast-grep for our non-standard configuration path. This way it works out of box if user tries to add wildcard import, @author tag, TOOD, etc.

![Screen_Shot_2025-07-01_at_06 13 58](https://github.com/user-attachments/assets/e933fe73-21a6-450b-beff-65751f57776e)

There's only one error reported with the configuration out of box, but we know about it, same one as eclipse:

![Screen_Shot_2025-07-01_at_06 15 20](https://github.com/user-attachments/assets/3db1347d-a812-4957-ae94-4ba3979ca47c)
