### PR TITLE
tighten java-lang-import to avoid false-positive on subpackage wildcard

### DIFF
--- a/gradle/validation/ast-grep/rules/java-patterns.yml
+++ b/gradle/validation/ast-grep/rules/java-patterns.yml
@@ -5,7 +5,7 @@
 id: java-lang-import
 language: java
 rule:
-  pattern: import java.lang.$REF
+  pattern: import java.lang.$REF;
   kind: import_declaration
 fix: ""
 severity: error

--- a/gradle/validation/ast-grep/tests/java-patterns.yml
+++ b/gradle/validation/ast-grep/tests/java-patterns.yml
@@ -5,6 +5,8 @@ invalid:
 valid:
   - import java.lang.foo.bar;
   - import static java.lang.Foo.bar;
+  - import java.lang.foo.*;
+  - import static java.lang.Foo.*;
 ---
 id: confusing-type-inference
 invalid:


### PR DESCRIPTION
This is being a bit anal, but this rule shouldn't emit a false positive if you do a wildcard import from a subpackage of java.lang, e.g.

    import java.lang.classfile.*;

The issue is, it can be a bit confusing as you get two errors instead of just the `WildcardImport` error. Anchor it.

Found by testing rules on openjdk sources.

