### PR TITLE
SharedMergeScheduler using shared thread pool for multi-tenant merge scheduling

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/MergeTaskWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeTaskWrapper.java
@@ -2,10 +2,10 @@ package org.apache.lucene.index;
 
 public class MergeTaskWrapper {
     private final Runnable mergeTask;
-    private final Object sourceWriter; // Can be IndexWriter or its ID
+    private final IndexWriter sourceWriter;
     private final long mergeSize;      // For priority-based scheduling
 
-    public MergeTaskWrapper(Runnable mergeTask, Object sourceWriter, long mergeSize) {
+    public MergeTaskWrapper(Runnable mergeTask, IndexWriter sourceWriter, long mergeSize) {
         this.mergeTask = mergeTask;
         this.sourceWriter = sourceWriter;
         this.mergeSize = mergeSize;
@@ -15,7 +15,7 @@ public class MergeTaskWrapper {
         return mergeTask;
     }
 
-    public Object getSourceWriter() {
+    public IndexWriter getSourceWriter() {
         return sourceWriter;
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/MergeTaskWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeTaskWrapper.java
@@ -1,25 +1,59 @@
 package org.apache.lucene.index;
 
-public class MergeTaskWrapper {
-    private final Runnable mergeTask;
-    private final IndexWriter sourceWriter;
-    private final long mergeSize;      // For priority-based scheduling
+import java.util.concurrent.Future;
 
-    public MergeTaskWrapper(Runnable mergeTask, IndexWriter sourceWriter, long mergeSize) {
-        this.mergeTask = mergeTask;
-        this.sourceWriter = sourceWriter;
-        this.mergeSize = mergeSize;
+/**
+ * Package-private wrapper that *is* the Runnable for a single merge.
+ * (Prototype: minimal fields; will be extended later for metrics / priority.)
+ */
+final class MergeTaskWrapper implements Runnable {
+    
+    final SharedMergeScheduler owner;
+    final long mergeSizeBytes;       // size hint (may be used later for prioritization)
+    Runnable delegate;         // calls mergeSource.merge(...)
+    volatile boolean started = false;
+    volatile boolean finished = false;
+    volatile boolean aborted = false;
+    volatile Future<?> future;       // will be set after submission (for possible cancellation later)
+
+    MergeTaskWrapper(SharedMergeScheduler owner, Runnable delegate, long mergeSizeBytes) {
+        this.owner = owner;
+        this.mergeSizeBytes = mergeSizeBytes;
+        this.delegate = delegate;
     }
 
-    public Runnable getMergeTask() {
-        return mergeTask;
+    public void setRunnable(Runnable delegate) {
+        this.delegate = delegate;
     }
 
-    public IndexWriter getSourceWriter() {
-        return sourceWriter;
+    public void setFuture(Future<?> future) {
+        this.future = future;
     }
 
-    public long getMergeSize() {
-        return mergeSize;
+
+    @Override
+    public void run() {
+        started = true;
+        try {
+            delegate.run();
+        } finally {
+            finished = true;
+            owner.onTaskFinished(this);
+        }
+    }
+
+    /** Attempt to cancel if still queued (not started). */
+    boolean cancelIfNotStarted() {
+        Future<?> f = future;
+        return !started && f != null && f.cancel(false);
+    }
+
+    public void markAborted() {
+        this.aborted = true;
+    }
+
+    public boolean isAborted() {
+        return aborted;
     }
 }
+

--- a/lucene/core/src/java/org/apache/lucene/index/MergeTaskWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeTaskWrapper.java
@@ -1,0 +1,25 @@
+package org.apache.lucene.index;
+
+public class MergeTaskWrapper {
+    private final Runnable mergeTask;
+    private final Object sourceWriter; // Can be IndexWriter or its ID
+    private final long mergeSize;      // For priority-based scheduling
+
+    public MergeTaskWrapper(Runnable mergeTask, Object sourceWriter, long mergeSize) {
+        this.mergeTask = mergeTask;
+        this.sourceWriter = sourceWriter;
+        this.mergeSize = mergeSize;
+    }
+
+    public Runnable getMergeTask() {
+        return mergeTask;
+    }
+
+    public Object getSourceWriter() {
+        return sourceWriter;
+    }
+
+    public long getMergeSize() {
+        return mergeSize;
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/index/SharedMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SharedMergeScheduler.java
@@ -11,9 +11,15 @@ import java.util.concurrent.TimeUnit;
  */
 public class SharedMergeScheduler extends MergeScheduler {
 
-  /** Shared thread pool executor used by all IndexWriters using this scheduler. */
-  private static final ExecutorService sharedExecutor =
-      Executors.newFixedThreadPool(4); // Adjust the number of threads as needed
+ /**
+ * Executor service provided externally to handle merge tasks.
+ * Allows sharing a thread pool across IndexWriters if configured that way.
+ */
+  private final ExecutorService sharedExecutor;
+
+  public SharedMergeScheduler(ExecutorService sharedExecutor) {
+      this.sharedExecutor = sharedExecutor;
+  }
 
   /**
    * Retrieves pending merge tasks from the given {@link MergeSource} and submits them to the shared

--- a/lucene/core/src/java/org/apache/lucene/index/SharedMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SharedMergeScheduler.java
@@ -1,0 +1,35 @@
+package org.apache.lucene.index;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * SharedMergeScheduler is an experimental MergeScheduler that submits
+ * merge tasks to a shared thread pool across IndexWriters.
+ */
+public class SharedMergeScheduler extends MergeScheduler {
+
+    private static final ExecutorService sharedExecutor = Executors.newFixedThreadPool(4); // Adjust as needed
+
+    @Override
+    public void merge(MergeSource mergeSource, MergeTrigger trigger) throws IOException {
+        while (true) {
+            final MergePolicy.OneMerge merge = mergeSource.getNextMerge();
+            if (merge == null) break;
+
+            sharedExecutor.submit(() -> {
+                try {
+                    mergeSource.merge(merge);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+    }
+
+    @Override
+    public void close() {
+        // TODO: graceful shutdown logic if needed
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/index/SharedMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SharedMergeScheduler.java
@@ -35,15 +35,17 @@ public class SharedMergeScheduler extends MergeScheduler {
       final MergePolicy.OneMerge merge = mergeSource.getNextMerge();
       if (merge == null) break;
 
-      sharedExecutor.submit(
-          () -> {
-            try {
+      Runnable mergeRunnable = () -> {
+          try {
               mergeSource.merge(merge);
-            } catch (IOException e) {
+          } catch (IOException e) {
               throw new RuntimeException(e);
-            }
-          });
-    }
+          }
+      };
+
+      MergeTaskWrapper wrappedTask = new MergeTaskWrapper(mergeRunnable, mergeSource, merge.totalBytesSize());
+      sharedExecutor.submit(wrappedTask.getMergeTask());
+          }
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/SharedMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SharedMergeScheduler.java
@@ -3,6 +3,7 @@ package org.apache.lucene.index;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * SharedMergeScheduler is an experimental MergeScheduler that submits merge tasks to a shared
@@ -45,6 +46,15 @@ public class SharedMergeScheduler extends MergeScheduler {
    */
   @Override
   public void close() {
-    // no-op for now; in a full version we would shut down the executor
+      sharedExecutor.shutdown();
+      try {
+          if (!sharedExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+              sharedExecutor.shutdownNow();
+          }
+      } catch (InterruptedException e) {
+          sharedExecutor.shutdownNow();
+          Thread.currentThread().interrupt();
+      }
   }
+
 }

--- a/lucene/core/src/java/org/apache/lucene/index/SharedMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SharedMergeScheduler.java
@@ -5,31 +5,46 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 /**
- * SharedMergeScheduler is an experimental MergeScheduler that submits
- * merge tasks to a shared thread pool across IndexWriters.
+ * SharedMergeScheduler is an experimental MergeScheduler that submits merge tasks to a shared
+ * thread pool across IndexWriters.
  */
 public class SharedMergeScheduler extends MergeScheduler {
 
-    private static final ExecutorService sharedExecutor = Executors.newFixedThreadPool(4); // Adjust as needed
+  /** Shared thread pool executor used by all IndexWriters using this scheduler. */
+  private static final ExecutorService sharedExecutor =
+      Executors.newFixedThreadPool(4); // Adjust the number of threads as needed
 
-    @Override
-    public void merge(MergeSource mergeSource, MergeTrigger trigger) throws IOException {
-        while (true) {
-            final MergePolicy.OneMerge merge = mergeSource.getNextMerge();
-            if (merge == null) break;
+  /**
+   * Retrieves pending merge tasks from the given {@link MergeSource} and submits them to the shared
+   * thread pool for execution.
+   *
+   * @param mergeSource the source of merge tasks (typically an IndexWriter)
+   * @param trigger the event that triggered the merge (e.g., SEGMENT_FLUSH, EXPLICIT)
+   * @throws IOException if merging fails
+   */
+  @Override
+  public void merge(MergeSource mergeSource, MergeTrigger trigger) throws IOException {
+    while (true) {
+      final MergePolicy.OneMerge merge = mergeSource.getNextMerge();
+      if (merge == null) break;
 
-            sharedExecutor.submit(() -> {
-                try {
-                    mergeSource.merge(merge);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-        }
+      sharedExecutor.submit(
+          () -> {
+            try {
+              mergeSource.merge(merge);
+            } catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+          });
     }
+  }
 
-    @Override
-    public void close() {
-        // TODO: graceful shutdown logic if needed
-    }
+  /**
+   * Closes the merge scheduler. This implementation is currently a no-op. In a production-ready
+   * version, the shared executor should be properly shut down.
+   */
+  @Override
+  public void close() {
+    // no-op for now; in a full version we would shut down the executor
+  }
 }


### PR DESCRIPTION
# [Draft] SharedMergeScheduler using shared thread pool for multi-tenant merge scheduling

This draft PR introduces a prototype `SharedMergeScheduler`, which extends `MergeScheduler` and routes all merge tasks through a shared thread pool across `IndexWriter` instances.

## Motivation

In multi-tenant environments (e.g., Solr, Elasticsearch), many `IndexWriter`s may coexist in the same JVM. The default Lucene behavior assigns each writer its own `ConcurrentMergeScheduler` and thread pool, which can lead to resource oversubscription and inefficient coordination.

This implementation introduces a new merge scheduler that centralizes merge execution via a shared thread pool. This idea builds on feedback from [GitHub issue #13883](https://github.com/apache/lucene/issues/13883), where contributors suggested exploring a dedicated scheduler based on Java's executor framework, rather than modifying the existing `ConcurrentMergeScheduler`.

## Implementation Highlights

- Adds a new class `SharedMergeScheduler` in `lucene.index`
- Implements the `merge(MergeSource, MergeTrigger)` method using the public `MergeSource` API
- Uses a static `Executors.newFixedThreadPool(4)` as a prototype shared executor
- Keeps `ConcurrentMergeScheduler` unchanged for easier evaluation and iteration

## Next Steps

- Add lifecycle management and graceful shutdown to the executor
- Evaluate fairness or throttling strategies across writers
- Potentially combine with a centralized merge manager
- Seek feedback on architecture fit and maintainability

---

This PR is opened to propose and evaluate a shared-thread-pool merge scheduler design, and to gather feedback for further development.

