### PR TITLE
remove HAS_FAST_INTEGER_VECTORS checks from panama support.

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
@@ -543,20 +543,14 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
     Provider<Boolean> defaultVectorizationOption =
         buildOptions.addBooleanOption(
             "tests.defaultvectorization",
-            "Uses defaults for running tests with correct JVM settings to test Panama vectorization (tests.jvmargs, tests.vectorsize, tests.forceintegervectors).",
+            "Uses defaults for running tests with correct JVM settings to test Panama vectorization (tests.jvmargs, tests.vectorsize).",
             false);
     buildOptions.addOption(
         "tests.vectorsize",
         "Sets preferred vector size in bits.",
         project.provider(() -> defaultVectorizationOption.get() ? "default" : randomVectorSize));
 
-    buildOptions.addBooleanOption(
-        "tests.forceintegervectors",
-        "Forces use of integer vectors even when slow.",
-        project.provider(
-            () -> defaultVectorizationOption.get() ? false : (randomVectorSize != "default")));
-
-    optionsInheritedAsProperties.addAll(List.of("tests.vectorsize", "tests.forceintegervectors"));
+    optionsInheritedAsProperties.add("tests.vectorsize");
 
     return defaultVectorizationOption.get();
   }

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -46,7 +46,6 @@ import org.apache.lucene.util.VectorUtil;
 public abstract class VectorizationProvider {
 
   static final OptionalInt TESTS_VECTOR_SIZE;
-  static final boolean TESTS_FORCE_INTEGER_VECTORS;
   static final int UPPER_JAVA_FEATURE_VERSION = getUpperJavaFeatureVersion();
 
   static {
@@ -63,16 +62,6 @@ public abstract class VectorizationProvider {
       // ignored
     }
     TESTS_VECTOR_SIZE = vs;
-
-    boolean enforce = false;
-    try {
-      enforce = Boolean.getBoolean("tests.forceintegervectors");
-    } catch (
-        @SuppressWarnings("unused")
-        SecurityException se) {
-      // ignored
-    }
-    TESTS_FORCE_INTEGER_VECTORS = enforce;
   }
 
   private static final String UPPER_JAVA_FEATURE_VERSION_SYSPROP =
@@ -157,9 +146,9 @@ public abstract class VectorizationProvider {
       vectorMod.ifPresent(VectorizationProvider.class.getModule()::addReads);
       // check for testMode and otherwise fallback to default if slowness could happen
       if (!testMode) {
-        if (TESTS_VECTOR_SIZE.isPresent() || TESTS_FORCE_INTEGER_VECTORS) {
+        if (TESTS_VECTOR_SIZE.isPresent()) {
           LOG.warning(
-              "Vector bitsize and/or integer vectors enforcement; using default vectorization provider outside of testMode");
+              "Vector bitsize enforcement; using default vectorization provider outside of testMode");
           return new DefaultVectorizationProvider();
         }
         if (Constants.IS_CLIENT_VM) {

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorConstants.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorConstants.java
@@ -42,8 +42,7 @@ final class PanamaVectorConstants {
     // to be fair, they do document this thing only works well with AVX2/AVX3 and Neon
     boolean isAMD64withoutAVX2 =
         Constants.OS_ARCH.equals("amd64") && PREFERRED_VECTOR_BITSIZE < 256;
-    HAS_FAST_INTEGER_VECTORS =
-        VectorizationProvider.TESTS_FORCE_INTEGER_VECTORS || (isAMD64withoutAVX2 == false);
+    HAS_FAST_INTEGER_VECTORS = isAMD64withoutAVX2 == false;
 
     PRERERRED_LONG_SPECIES =
         VectorSpecies.of(long.class, VectorShape.forBitSize(PREFERRED_VECTOR_BITSIZE));

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorConstants.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorConstants.java
@@ -29,7 +29,6 @@ final class PanamaVectorConstants {
   /** Whether integer vectors can be trusted to actually be fast. */
   static final boolean ENABLE_INTEGER_VECTORS;
 
-  static final VectorSpecies<Long> PRERERRED_LONG_SPECIES;
   static final VectorSpecies<Integer> PRERERRED_INT_SPECIES;
 
   static {
@@ -45,8 +44,6 @@ final class PanamaVectorConstants {
     ENABLE_INTEGER_VECTORS =
         (isAMD64withoutAVX2 == false) || VectorizationProvider.TESTS_VECTOR_SIZE.isPresent();
 
-    PRERERRED_LONG_SPECIES =
-        VectorSpecies.of(long.class, VectorShape.forBitSize(PREFERRED_VECTOR_BITSIZE));
     PRERERRED_INT_SPECIES =
         VectorSpecies.of(int.class, VectorShape.forBitSize(PREFERRED_VECTOR_BITSIZE));
   }

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorConstants.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorConstants.java
@@ -27,7 +27,7 @@ final class PanamaVectorConstants {
   static final int PREFERRED_VECTOR_BITSIZE;
 
   /** Whether integer vectors can be trusted to actually be fast. */
-  static final boolean HAS_FAST_INTEGER_VECTORS;
+  static final boolean ENABLE_INTEGER_VECTORS;
 
   static final VectorSpecies<Long> PRERERRED_LONG_SPECIES;
   static final VectorSpecies<Integer> PRERERRED_INT_SPECIES;
@@ -42,7 +42,8 @@ final class PanamaVectorConstants {
     // to be fair, they do document this thing only works well with AVX2/AVX3 and Neon
     boolean isAMD64withoutAVX2 =
         Constants.OS_ARCH.equals("amd64") && PREFERRED_VECTOR_BITSIZE < 256;
-    HAS_FAST_INTEGER_VECTORS = isAMD64withoutAVX2 == false;
+    ENABLE_INTEGER_VECTORS =
+        (isAMD64withoutAVX2 == false) || VectorizationProvider.TESTS_VECTOR_SIZE.isPresent();
 
     PRERERRED_LONG_SPECIES =
         VectorSpecies.of(long.class, VectorShape.forBitSize(PREFERRED_VECTOR_BITSIZE));

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -46,7 +46,6 @@ import org.apache.lucene.util.SuppressForbidden;
  *
  * <ul>
  *   <li>tests.vectorsize (int)
- *   <li>tests.forceintegervectors (boolean)
  * </ul>
  *
  * Setting these properties will make this code run EXTREMELY slow!
@@ -313,9 +312,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     int i = 0;
     int res = 0;
 
-    // only vectorize if we'll at least enter the loop a single time, and we have at least 128-bit
-    // vectors (256-bit on intel to dodge performance landmines)
-    if (a.byteSize() >= 16 && PanamaVectorConstants.HAS_FAST_INTEGER_VECTORS) {
+    // only vectorize if we'll at least enter the loop a single time
+    if (a.byteSize() >= 16) {
       // compute vectorized dot product consistent with VPDPBUSD instruction
       if (VECTOR_BITSIZE >= 512) {
         i += BYTE_SPECIES.loopBound(a.byteSize());
@@ -409,7 +407,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         } else if (VECTOR_BITSIZE == 256) {
           i += ByteVector.SPECIES_128.loopBound(packed.length);
           res += dotProductBody256Int4Packed(unpacked, packed, i);
-        } else if (PanamaVectorConstants.HAS_FAST_INTEGER_VECTORS) {
+        } else {
           i += ByteVector.SPECIES_64.loopBound(packed.length);
           res += dotProductBody128Int4Packed(unpacked, packed, i);
         }
@@ -425,7 +423,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     } else {
       if (VECTOR_BITSIZE >= 512 || VECTOR_BITSIZE == 256) {
         return dotProduct(a, b);
-      } else if (a.length >= 32 && PanamaVectorConstants.HAS_FAST_INTEGER_VECTORS) {
+      } else if (a.length >= 32) {
         i += ByteVector.SPECIES_128.loopBound(a.length);
         res += int4DotProductBody128(a, b, i);
       }
@@ -581,9 +579,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     int norm1 = 0;
     int norm2 = 0;
 
-    // only vectorize if we'll at least enter the loop a single time, and we have at least 128-bit
-    // vectors (256-bit on intel to dodge performance landmines)
-    if (a.byteSize() >= 16 && PanamaVectorConstants.HAS_FAST_INTEGER_VECTORS) {
+    // only vectorize if we'll at least enter the loop a single time
+    if (a.byteSize() >= 16) {
       final float[] ret;
       if (VECTOR_BITSIZE >= 512) {
         i += BYTE_SPECIES.loopBound((int) a.byteSize());
@@ -704,9 +701,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     int i = 0;
     int res = 0;
 
-    // only vectorize if we'll at least enter the loop a single time, and we have at least 128-bit
-    // vectors (256-bit on intel to dodge performance landmines)
-    if (a.byteSize() >= 16 && PanamaVectorConstants.HAS_FAST_INTEGER_VECTORS) {
+    // only vectorize if we'll at least enter the loop a single time
+    if (a.byteSize() >= 16) {
       if (VECTOR_BITSIZE >= 256) {
         i += BYTE_SPECIES.loopBound((int) a.byteSize());
         res += squareDistanceBody256(a, b, i);
@@ -798,7 +794,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   public long int4BitDotProduct(byte[] q, byte[] d) {
     assert q.length == d.length * 4;
     // 128 / 8 == 16
-    if (d.length >= 16 && PanamaVectorConstants.HAS_FAST_INTEGER_VECTORS) {
+    if (d.length >= 16) {
       if (VECTOR_BITSIZE >= 256) {
         return int4BitDotProduct256(q, d);
       } else if (VECTOR_BITSIZE == 128) {

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorizationProvider.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorizationProvider.java
@@ -45,6 +45,10 @@ final class PanamaVectorizationProvider extends VectorizationProvider {
           "Vector bit size is less than 128: " + PanamaVectorConstants.PREFERRED_VECTOR_BITSIZE);
     }
 
+    if (PanamaVectorConstants.HAS_FAST_INTEGER_VECTORS == false) {
+      throw new UnsupportedOperationException("No integer vector support");
+    }
+
     this.vectorUtilSupport = new PanamaVectorUtilSupport();
 
     var log = Logger.getLogger(getClass().getName());
@@ -53,8 +57,7 @@ final class PanamaVectorizationProvider extends VectorizationProvider {
             Locale.ENGLISH,
             "Java vector incubator API enabled; uses preferredBitSize=%d%s%s",
             PanamaVectorConstants.PREFERRED_VECTOR_BITSIZE,
-            Constants.HAS_FAST_VECTOR_FMA ? "; FMA enabled" : "",
-            PanamaVectorConstants.HAS_FAST_INTEGER_VECTORS ? "" : "; floating-point vectors only"));
+            Constants.HAS_FAST_VECTOR_FMA ? "; FMA enabled" : ""));
   }
 
   @Override

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorizationProvider.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorizationProvider.java
@@ -45,8 +45,9 @@ final class PanamaVectorizationProvider extends VectorizationProvider {
           "Vector bit size is less than 128: " + PanamaVectorConstants.PREFERRED_VECTOR_BITSIZE);
     }
 
-    if (PanamaVectorConstants.HAS_FAST_INTEGER_VECTORS == false) {
-      throw new UnsupportedOperationException("No integer vector support");
+    if (PanamaVectorConstants.ENABLE_INTEGER_VECTORS == false) {
+      throw new UnsupportedOperationException(
+          "CPU type or flags do not guarantee support for fast integer vectorization");
     }
 
     this.vectorUtilSupport = new PanamaVectorUtilSupport();
@@ -57,7 +58,8 @@ final class PanamaVectorizationProvider extends VectorizationProvider {
             Locale.ENGLISH,
             "Java vector incubator API enabled; uses preferredBitSize=%d%s%s",
             PanamaVectorConstants.PREFERRED_VECTOR_BITSIZE,
-            Constants.HAS_FAST_VECTOR_FMA ? "; FMA enabled" : ""));
+            Constants.HAS_FAST_VECTOR_FMA ? "; FMA enabled" : "",
+            VectorizationProvider.TESTS_VECTOR_SIZE.isPresent() ? "; testMode enabled" : ""));
   }
 
   @Override
@@ -72,8 +74,7 @@ final class PanamaVectorizationProvider extends VectorizationProvider {
 
   @Override
   public PostingDecodingUtil newPostingDecodingUtil(IndexInput input) throws IOException {
-    if (PanamaVectorConstants.HAS_FAST_INTEGER_VECTORS
-        && input instanceof MemorySegmentAccessInput msai) {
+    if (input instanceof MemorySegmentAccessInput msai) {
       MemorySegment ms = msai.segmentSliceOrNull(0, input.length());
       if (ms != null) {
         return new MemorySegmentPostingDecodingUtil(input, ms);


### PR DESCRIPTION
For any integer vectorization code, the developer must remember to make this check, or suffer a 10x+ slowdown if AVX2 is unavailable. This can happen in virtual environments (default QEMU, virtualbox, etc).

It isn't worth the benefit of supporting floating point vectors on such machines, just remove this trap completely.

