### PR TITLE
build: include overview.html into javadocs again

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.documentation.render-javadoc.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.documentation.render-javadoc.gradle
@@ -364,13 +364,11 @@ abstract class RenderJavadocTask extends RenderJavadocTaskBase {
         .collect {  dir -> project.file("${dir}/overview.html") }
         .findAll { overviewFile -> overviewFile.exists() }
 
-    if (!overviewFiles.isEmpty()) {
-      assert overviewFiles.size() == 1 : "More than one overview file?: " + overviewFiles
-      opts << [
-        '-overview',
-        project.file("${overviewFiles.getFirst()}/overview.html")
-      ]
-    }
+    assert overviewFiles.size() == 1 : "Must be exactly one overview.html file: " + overviewFiles
+    opts << [
+      '-overview',
+      project.file(overviewFiles.getFirst())
+    ]
 
     opts << ['-d', outputDir]
     opts << '-protected'

--- a/build-tools/missing-doclet/src/java/overview.html
+++ b/build-tools/missing-doclet/src/java/overview.html
@@ -1,0 +1,26 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<html>
+  <head>
+    <title>
+      MissingDoclet
+    </title>
+  </head>
+  <body>
+    Doclet that allows for gradual improvements, validating specific options with per-package rules.
+  </body>
+</html>


### PR DESCRIPTION
Previously invalid filepaths were being passed to `javadoc` tool:

```
-overview /home/rmuir/workspace/lucene/lucene/core/src/java/overview.html/overview.html
```

Fix the paths so that overview.html content is included. This also means the content is being validated by the build again.

