### PR TITLE
build: fix malformed HTML generated by changes2html

### DIFF
--- a/gradle/documentation/changes-to-html/changes2html.pl
+++ b/gradle/documentation/changes-to-html/changes2html.pl
@@ -489,7 +489,7 @@ for my $rel (@releases) {
                   my $prefix = $1;
                   my $code = $2;
                   $code =~ s/\s+$//;
-                  "$prefix<pre><code>$code></code></pre>"
+                  "$prefix<pre><code>$code</code></pre>"
                 }gise;
 
       $item = markup_trailing_attribution($item) unless ($item =~ /\n[ ]*-/);


### PR DESCRIPTION
This `<code>` case causes invalid HTML in two locations of the resulting Changes.html.

