### PR TITLE
build: enable error-prone's FormatString check

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.validation.error-prone.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.validation.error-prone.gradle
@@ -199,7 +199,7 @@ allprojects { prj ->
           // '-Xep:FloggerLogVarargs:OFF', // we don't use flogger
           // '-Xep:FloggerSplitLogStatement:OFF', // we don't use flogger
           // '-Xep:ForOverride:OFF', // we don't use this annotation
-          // '-Xep:FormatString:OFF',
+          '-Xep:FormatString:ERROR',
           // '-Xep:FormatStringAnnotation:OFF', // we don't use this annotation
           // '-Xep:FromTemporalAccessor:OFF', // we don't use .from(LocalDate) etc
           '-Xep:FunctionalInterfaceMethodChanged:ERROR',


### PR DESCRIPTION
This check will find some printf-style format problems at compile-time instead of runtime: enable it.

Please note: this won't find my original bug yet on #14901, maybe because the file is in `src/java24`. But I tested it works by adding an extra `%s` to a format string in IndexWriter.java and it properly fails the build. I will dig on the `src/java24` issue separately... I suspect we're not running error-prone on these sources.

We have hundreds of such format strings in the codebase, many of which might not have perfect test coverage (they are printing), so it is a good check to have.
