### PR TITLE
build: use a faster and more robust source-patterns

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.root-project.setup.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.root-project.setup.gradle
@@ -17,6 +17,7 @@
 
 import com.carrotsearch.gradle.buildinfra.buildoptions.BuildOptionValueSource
 import com.carrotsearch.gradle.buildinfra.buildoptions.BuildOptionsPlugin
+import org.apache.lucene.gradle.plugins.gitgrep.GitGrepPlugin
 import org.apache.lucene.gradle.plugins.gitinfo.GitInfoPlugin
 import org.apache.lucene.gradle.plugins.astgrep.AstGrepPlugin
 import org.apache.lucene.gradle.plugins.eclint.EditorConfigLintPlugin
@@ -44,6 +45,7 @@ plugins.apply(BasePlugin)
 plugins.apply(RegisterBuildGlobalsPlugin)
 
 plugins.apply(GitInfoPlugin)
+plugins.apply(GitGrepPlugin)
 plugins.apply(AstGrepPlugin)
 plugins.apply(EditorConfigLintPlugin)
 

--- a/build-tools/build-infra/src/main/groovy/lucene.validation.source-patterns.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.validation.source-patterns.gradle
@@ -32,31 +32,8 @@ if (project != project.rootProject) {
 }
 
 List<String> extensions = [
-  'adoc',
-  'bat',
-  'cmd',
-  'css',
-  'g4',
-  'gradle',
-  'groovy',
-  'html',
   'java',
-  'jflex',
-  'jj',
-  'js',
-  'json',
-  'md',
-  'mdtext',
-  'pl',
-  'policy',
-  'properties',
-  'py',
-  'sh',
-  'template',
-  'txt',
-  'vm',
   'xml',
-  'xsl',
 ]
 
 // Create source validation task local to each project
@@ -124,16 +101,7 @@ class ValidateSourcePatternsTask extends DefaultTask {
   @TaskAction
   public void check() {
     def invalidPatterns = [
-      (~$/[\u202A-\u202E\u2066-\u2069]/$) : 'misuse of RTL/LTR (https://trojansource.codes)',
       (~$/\Q/**\E((?:\s)|(?:\*))*\Q{@inheritDoc}\E((?:\s)|(?:\*))*\Q*/\E/$) : '{@inheritDoc} on its own is unnecessary',
-      (~$/\$$(?:LastChanged)?Date\b/$) : 'svn keyword',
-      (~$/\$$(?:(?:LastChanged)?Revision|Rev)\b/$) : 'svn keyword',
-      (~$/\$$(?:LastChangedBy|Author)\b/$) : 'svn keyword',
-      (~$/\$$(?:Head)?URL\b/$) : 'svn keyword',
-      (~$/\$$Id\b/$) : 'svn keyword',
-      (~$/\$$Header\b/$) : 'svn keyword',
-      (~$/\$$Source\b/$) : 'svn keyword',
-      (~$/[\u200B\uFEFF]/$) : 'UTF-8 byte order mark or other zero-width codepoints',
     ]
 
     def violations = new TreeSet();

--- a/build-tools/build-infra/src/main/groovy/lucene.validation.source-patterns.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.validation.source-patterns.gradle
@@ -31,10 +31,7 @@ if (project != project.rootProject) {
   throw new GradleException("Applicable to rootProject only: " + project.path)
 }
 
-List<String> extensions = [
-  'java',
-  'xml',
-]
+List<String> extensions = ['java', 'xml',]
 
 // Create source validation task local to each project
 allprojects {

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/gitgrep/GitGrepPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/gitgrep/GitGrepPlugin.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.gradle.plugins.gitgrep;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.tools.ant.taskdefs.condition.Os;
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.Exec;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
+
+/** Uses {@code git-grep(1)} to find text files matching a list of patterns. */
+public class GitGrepPlugin implements Plugin<Project> {
+  @Override
+  public void apply(Project project) {
+    if (project != project.getRootProject()) {
+      throw new GradleException("This plugin can be applied to the root project only.");
+    }
+
+    TaskContainer tasks = project.getTasks();
+
+    // currently configured as basic regular expressions...
+    // extended or even perl-compatible can be configured, but best avoided
+    List<String> invalidPatterns =
+        List.of(
+            // misuse of RTL/LTR (https://trojansource.codes)
+            "\u202A", // LRE
+            "\u202B", // RLE
+            "\u202C", // PDF
+            "\u202D", // LRO
+            "\u202E", // RLO
+            "\u2066", // LRI
+            "\u2067", // RLI
+            "\u2068", // FSI
+            "\u2069", // PDI
+            // unwanted BOM markers
+            "\u200B", // BOM
+            "\uFEFF", // ZWS
+            // svn properties
+            "$Id\\b",
+            "$Header\\b",
+            "$Source\\b",
+            "$HeadURL\\b",
+            "$URL\\b",
+            "$Author\\b",
+            "$LastChangedBy\\b",
+            "$Revision\\b",
+            "$LastChangedRevision\\b",
+            "$Rev\\b");
+
+    TaskProvider<Exec> applyGitGrepRulesTask =
+        tasks.register(
+            "applyGitGrepRules",
+            Exec.class,
+            (Exec task) -> {
+              // we could pass each pattern via '-e', but this feels more comfortable.
+              Path inputFile = task.getTemporaryDir().toPath().resolve("patterns.txt");
+              task.doFirst(
+                  _ -> {
+                    try {
+                      Files.write(inputFile, invalidPatterns);
+                    } catch (IOException e) {
+                      throw new UncheckedIOException(e);
+                    }
+                  });
+              task.setExecutable(Os.isFamily(Os.FAMILY_WINDOWS) ? "git.exe" : "git");
+              task.setWorkingDir(project.getLayout().getProjectDirectory());
+              task.setIgnoreExitValue(true);
+              task.setArgs(
+                  List.of(
+                      "--no-pager",
+                      "grep",
+                      "--untracked", // also check untracked files
+                      "--line-number", // add line numbers to output
+                      "--column", // add col numbers to output
+                      "-I", // don't search binary files
+                      "-f", // read patterns from file
+                      inputFile.toString(),
+                      "--", // exempt ourselves from the check
+                      ":^*GitGrepPlugin.java"));
+              task.doLast(
+                  _ -> {
+                    // only exit status of 1 (no matches) is acceptable
+                    int exitStatus = task.getExecutionResult().get().getExitValue();
+                    if (exitStatus == 0) {
+                      throw new GradleException("Illegal source code patterns were matched");
+                    } else if (exitStatus != 1) {
+                      throw new GradleException("Internal error searching for patterns");
+                    }
+                  });
+            });
+
+    tasks
+        .matching(task -> task.getName().equals("check"))
+        .configureEach(
+            task -> {
+              task.dependsOn(applyGitGrepRulesTask);
+            });
+  }
+}


### PR DESCRIPTION
scans all text files for these patterns. respects .gitignore files so we don't need to configure special exclusions.

uses all cores, scans in like 100ms instead of 20-30 seconds. no need to exclude reuters files or anything like that.

Will take care of the remaining patterns as a separate PR, this gets the majority of them.

