### PR TITLE
Avoid allocations in IndexFileNames.parseGeneration method

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -53,6 +53,8 @@ Optimizations
 * GITHUB#14011: Reduce allocation rate in HNSW concurrent merge. (Viliam Durina)
 * GITHUB#14022: Optimize DFS marking of connected components in HNSW by reducing stack depth, improving performance and reducing allocations. (Viswanath Kuchibhotla)
 
+* GITHUB#14920: Avoid allocations in IndexFileNames.parseGeneration() method. (Dmytro Dumanskiy)
+
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero

--- a/lucene/core/src/java/org/apache/lucene/index/IndexFileNames.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexFileNames.java
@@ -145,14 +145,28 @@ public final class IndexFileNames {
   /** Returns the generation from this file name, or 0 if there is no generation. */
   public static long parseGeneration(String filename) {
     assert filename.startsWith("_");
-    String[] parts = stripExtension(filename).substring(1).split("_");
+    int dot = filename.indexOf('.');
+    int end = (dot != -1) ? dot : filename.length();
+    int start = 1; // skip initial '_'
+
+    int first = filename.indexOf('_', start);
+    if (first == -1 || first >= end) {
+      return 0;
+    }
+
+    int second = filename.indexOf('_', first + 1);
+    int third = (second != -1) ? filename.indexOf('_', second + 1) : -1;
+
+    int parts = (second == -1 || second >= end) ? 2 : (third == -1 || third >= end) ? 3 : 4;
+
     // 4 cases:
     // segment.ext
     // segment_gen.ext
     // segment_codec_suffix.ext
     // segment_gen_codec_suffix.ext
-    if (parts.length == 2 || parts.length == 4) {
-      return Long.parseLong(parts[1], Character.MAX_RADIX);
+    if (parts == 2 || parts == 4) {
+      String gen = filename.substring(first + 1, (second != -1 && second < end) ? second : end);
+      return Long.parseLong(gen, Character.MAX_RADIX);
     } else {
       return 0;
     }


### PR DESCRIPTION
`IndexFileNames.parseGeneration` allocates multiple unnecessary strings (3-6 strings per call) + string[] objects:

![image (17)](https://github.com/user-attachments/assets/2d70c174-7f82-4b4f-ae50-268553ab4c91)

With often reindexing this allocations become notable during profiling. These allocations could be easily eliminated with a manual underscore search. After the fix only 1 string will be allocated in the worst case.