### PR TITLE
Feat: Add auto formatting bot

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
             --method POST \
-            --field content="eyes"
+            --input - <<< '{"content":"eyes"}'
 
       - name: Get PR details and checkout
         run: |
@@ -172,10 +172,10 @@ jobs:
       - name: Add success reaction
         if: success()
         run: |
-          # Remove eyes reaction and add success reaction
+          # Add success reaction
           gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
             --method POST \
-            --field content="+1"
+            --input - <<< '{"content":"+1"}'
 
       - name: Comment on PR with success (fixes applied)
         if: success() && steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true'
@@ -233,7 +233,7 @@ jobs:
           # Add failure reaction
           gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
             --method POST \
-            --field content="-1"
+            --input - <<< '{"content":"-1"}'
 
       - name: Comment on PR with failure
         if: failure()

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,292 @@
+name: Lucene Auto Format Bot
+
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+
+jobs:
+  format-check:
+    # Only run on pull requests when the bot is mentioned
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/format-fix apply')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Check permissions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const actorPermission = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor
+            });
+
+            const permission = actorPermission.data.permission;
+            const hasPermission = ['admin', 'write'].includes(permission);
+
+            if (!hasPermission) {
+              core.setFailed(`User @${context.actor} does not have permission to run the format bot. Required: admin or write access.`);
+              return;
+            }
+
+      - name: Get PR details
+        id: pr_details
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            return {
+              head_ref: pr.head.ref,
+              head_sha: pr.head.sha,
+              base_ref: pr.base.ref,
+              base_sha: pr.base.sha,
+              clone_url: pr.head.repo.clone_url,
+              ssh_url: pr.head.repo.ssh_url,
+              repo_full_name: pr.head.repo.full_name
+            };
+
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ fromJson(steps.pr_details.outputs.result).repo_full_name }}
+          ref: ${{ fromJson(steps.pr_details.outputs.result).head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: ./.github/actions/prepare-for-build
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: |
+            **/*.java
+            **/*.gradle
+            **/*.groovy
+            **/*.md
+            **/*.properties
+            **/*.xml
+            **/*.py
+            **/*.sh
+            **/*.bat
+            **/*.cmd
+
+      - name: Initial validation
+        id: initial-validation
+        continue-on-error: true
+        run: |
+          echo "Running initial validation..."
+          ./gradlew check -x test
+
+      - name: Fix formatting issues
+        if: steps.initial-validation.outcome == 'failure'
+        run: |
+          echo "Fixing formatting issues..."
+          ./gradlew tidy
+
+      - name: Check if formatting fixes were made
+        if: steps.initial-validation.outcome == 'failure'
+        id: check_changes
+        run: |
+          git add .
+          if git diff --staged --quiet; then
+            echo "No formatting changes were made"
+            echo "changes_made=false" >> $GITHUB_OUTPUT
+          else
+            echo "Formatting changes were made"
+            echo "changes_made=true" >> $GITHUB_OUTPUT
+            echo "Changed files:"
+            git diff --staged --name-only
+          fi
+
+      - name: Create fix branch and commit
+        if: steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true'
+        id: create_fix_branch
+        run: |
+          # Create a new branch for the fixes
+          fix_branch="format-fixes-${{ fromJson(steps.pr_details.outputs.result).head_ref }}-$(date +%s)"
+          echo "fix_branch=$fix_branch" >> $GITHUB_OUTPUT
+
+          git config --local user.email "action@github.com"
+          git config --local user.name "Lucene Format Bot"
+
+          git checkout -b "$fix_branch"
+          git commit -m "Apply automatic formatting fixes
+
+          Fixes applied by @lucene-format-bot in response to:
+          ${{ github.event.comment.html_url }}
+
+          Original PR: #${{ github.event.issue.number }}
+
+          Changes applied:
+          $(git diff --name-only HEAD~1)"
+
+          git push origin "$fix_branch"
+
+      - name: Final validation
+        run: |
+          echo "Running final validation..."
+          ./gradlew check -x test
+
+      - name: Create PR for fixes
+        if: steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true'
+        id: create_pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: fixPr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Apply formatting fixes to #${{ github.event.issue.number }}`,
+              head: '${{ steps.create_fix_branch.outputs.fix_branch }}',
+              base: '${{ fromJson(steps.pr_details.outputs.result).head_ref }}',
+              body: `## Automatic Formatting Fixes
+
+            This PR applies automatic formatting fixes to address validation failures in #${{ github.event.issue.number }}.
+
+            ### 📝 Details
+            - **Triggered by**: ${{ github.event.comment.html_url }}
+            - **Original PR**: #${{ github.event.issue.number }}
+            - **Fix branch**: \`${{ steps.create_fix_branch.outputs.fix_branch }}\`
+            - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
+
+            ### 🚀 Next Steps
+            Review and merge this PR to apply the formatting fixes to the original branch.
+
+            ---
+            *This PR was created automatically by the Auto Format Bot*`
+            });
+
+            return {
+              pr_number: fixPr.number,
+              pr_url: fixPr.html_url
+            };
+
+      - name: Comment on PR with success (fixes applied)
+        if: success() && steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = '${{ fromJson(steps.create_pr.outputs.result).pr_number }}';
+            const comment = `## Formatting Fixes Applied
+
+            The formatting bot has successfully created a PR with formatting fixes!
+
+            ### 📝 Details
+            - **Triggered by**: ${{ github.event.comment.html_url }}
+            - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
+            - **Fix PR**: #${prNumber}
+
+            ### 🚀 Next Steps
+            Review and merge PR #${prNumber} to apply the formatting fixes to this branch.
+
+            ---
+            *This was performed automatically by the Auto Format Bot*`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
+
+      - name: Comment on PR with success (no fixes needed)
+        if: success() && steps.initial-validation.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comment = `## No Formatting Issues Found
+
+            The formatting bot has validated this PR and found no issues!
+
+            ### 📝 Details
+            - **Triggered by**: ${{ github.event.comment.html_url }}
+            - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
+
+            The PR is ready for review!
+
+            ---
+            *This was performed automatically by the Auto Format Bot*`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
+
+      - name: Comment on PR with success (fixes made but no changes)
+        if: success() && steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comment = `## Formatting Issues Detected (No Auto-fixes Available)
+
+            The formatting bot found issues but was unable to automatically fix them.
+
+            ### 📝 Details
+            - **Triggered by**: ${{ github.event.comment.html_url }}
+            - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
+
+            **Recommendation**: Review the validation failures manually and apply fixes as needed.
+
+            ---
+            *This was performed automatically by the Auto Format Bot*`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
+
+      - name: Comment on PR with failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comment = `## Formatting Failed
+
+            The formatting bot encountered issues while processing this PR.
+
+            ### Next Steps:
+            1. Check the workflow logs for specific error details
+            2. Fix any issues manually if needed
+            3. Re-trigger the bot with \`/format-fix apply\`
+
+            ### 📝 Details
+            - **Triggered by**: ${{ github.event.comment.html_url }}
+            - **Files processed**: ${{ steps.changed-files.outputs.all_changed_files || 'None detected' }}
+
+            ---
+            *This was performed automatically by the Auto Format Bot*`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Get PR details and checkout
         run: |
           # Get PR details
-          PR_DATA=$(gh pr view ${{ github.event.issue.number }} --json headRefName,headRepository,headRepositoryOwner)
+          PR_DATA=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName,headRepository,headRepositoryOwner)
           HEAD_REF=$(echo "$PR_DATA" | jq -r '.headRefName')
           HEAD_REPO=$(echo "$PR_DATA" | jq -r '.headRepository.name')
           HEAD_OWNER=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login')
@@ -159,6 +159,7 @@ jobs:
           *This PR was created automatically by the Auto Format Bot*"
 
           PR_URL=$(gh pr create \
+            --repo ${{ github.repository }} \
             --title "Apply formatting fixes to #${{ github.event.issue.number }}" \
             --body "$PR_BODY" \
             --base "${{ env.head_ref }}" \
@@ -179,7 +180,7 @@ jobs:
       - name: Comment on PR with success (fixes applied)
         if: success() && steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true'
         run: |
-          gh pr comment ${{ github.event.issue.number }} --body "## Formatting Fixes Applied
+          gh pr comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body "## Formatting Fixes Applied
 
           The formatting bot has successfully created a PR with formatting fixes!
 
@@ -197,7 +198,7 @@ jobs:
       - name: Comment on PR with success (no fixes needed)
         if: success() && steps.initial-validation.outcome == 'success'
         run: |
-          gh pr comment ${{ github.event.issue.number }} --body "## No Formatting Issues Found
+          gh pr comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body "## No Formatting Issues Found
 
           The formatting bot has validated this PR and found no issues!
 
@@ -213,7 +214,7 @@ jobs:
       - name: Comment on PR with success (fixes made but no changes)
         if: success() && steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'false'
         run: |
-          gh pr comment ${{ github.event.issue.number }} --body "## Formatting Issues Detected (No Auto-fixes Available)
+          gh pr comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body "## Formatting Issues Detected (No Auto-fixes Available)
 
           The formatting bot found issues but was unable to automatically fix them.
 
@@ -237,7 +238,7 @@ jobs:
       - name: Comment on PR with failure
         if: failure()
         run: |
-          gh pr comment ${{ github.event.issue.number }} --body "## Formatting Failed
+          gh pr comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body "## Formatting Failed
 
           The formatting bot encountered issues while processing this PR.
 

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
             --method POST \
-            --field content='eyes'
+            --field content="eyes"
 
       - name: Get PR details and checkout
         run: |
@@ -175,7 +175,7 @@ jobs:
           # Remove eyes reaction and add success reaction
           gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
             --method POST \
-            --field content='+1'
+            --field content="+1"
 
       - name: Comment on PR with success (fixes applied)
         if: success() && steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true'
@@ -233,7 +233,7 @@ jobs:
           # Add failure reaction
           gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
             --method POST \
-            --field content='-1'
+            --field content="-1"
 
       - name: Comment on PR with failure
         if: failure()

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -25,9 +25,22 @@ jobs:
     steps:
       - name: Check permissions
         run: |
-          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
-          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
-            echo "Error: User @${{ github.actor }} does not have permission to run the format bot. Required: admin or write access."
+          PR_AUTHOR=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json author --jq '.author.login')
+
+          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission' 2>/dev/null || echo "none")
+
+          # only allow if user is PR author OR has admin/write repository access
+          if [[ "${{ github.actor }}" == "$PR_AUTHOR" ]] || [[ "$PERMISSION" == "admin" ]] || [[ "$PERMISSION" == "write" ]]; then
+            echo "Permission granted: User @${{ github.actor }} can run the format bot"
+            if [[ "${{ github.actor }}" == "$PR_AUTHOR" ]]; then
+              echo "  - Reason: PR author"
+            fi
+            if [[ "$PERMISSION" == "admin" ]] || [[ "$PERMISSION" == "write" ]]; then
+              echo "  - Reason: Repository $PERMISSION access"
+            fi
+          else
+            echo "Error: User @${{ github.actor }} does not have permission to run the format bot."
+            echo "Required: Be the PR author OR have admin/write repository access."
             exit 1
           fi
 

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -90,21 +90,29 @@ jobs:
 
       - uses: ./.github/actions/prepare-for-build
 
+      #this replaces ana06/get-changed-files@v2.3.0 since it doesn't support issue comment triggers
       - name: Get changed files
         id: changed-files
-        uses: ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c
-        with:
-          filter: |
-            **/*.java
-            **/*.gradle
-            **/*.groovy
-            **/*.md
-            **/*.properties
-            **/*.xml
-            **/*.py
-            **/*.sh
-            **/*.bat
-            **/*.cmd
+        run: |
+          echo "Getting changed files for PR #${{ github.event.issue.number }}..."
+
+          ALL_FILES=$(gh pr diff ${{ github.event.issue.number }} --name-only --repo ${{ github.repository }})
+
+          FILTERED_FILES=$(echo "$ALL_FILES" | grep -E '\.(java|gradle|groovy|md|properties|xml|py|sh|bat|cmd)$' || true)
+
+          echo "All changed files:"
+          echo "$ALL_FILES"
+          echo
+          echo "Filtered files for formatting check:"
+          echo "$FILTERED_FILES"
+
+          echo "all<<EOF" >> $GITHUB_OUTPUT
+          echo "$ALL_FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          echo "filtered<<EOF" >> $GITHUB_OUTPUT
+          echo "$FILTERED_FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Initial validation
         id: initial-validation

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -82,12 +82,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
       - uses: ./.github/actions/prepare-for-build
 
       #this replaces ana06/get-changed-files@v2.3.0 since it doesn't support issue comment triggers

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   format-check:
@@ -23,61 +24,35 @@ jobs:
 
     steps:
       - name: Check permissions
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const actorPermission = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: context.actor
-            });
-
-            const permission = actorPermission.data.permission;
-            const hasPermission = ['admin', 'write'].includes(permission);
-
-            if (!hasPermission) {
-              core.setFailed(`User @${context.actor} does not have permission to run the format bot. Required: admin or write access.`);
-              return;
-            }
+        run: |
+          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
+            echo "Error: User @${{ github.actor }} does not have permission to run the format bot. Required: admin or write access."
+            exit 1
+          fi
 
       - name: Add workflow started reaction
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes'
-            });
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            --method POST \
+            --field content='eyes'
 
-      - name: Get PR details
-        id: pr_details
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = context.issue.number;
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
+      - name: Get PR details and checkout
+        run: |
+          # Get PR details
+          PR_DATA=$(gh pr view ${{ github.event.issue.number }} --json headRefName,headRepository,headRepositoryOwner)
+          HEAD_REF=$(echo "$PR_DATA" | jq -r '.headRefName')
+          HEAD_REPO=$(echo "$PR_DATA" | jq -r '.headRepository.name')
+          HEAD_OWNER=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login')
 
-            return {
-              head_ref: pr.head.ref,
-              head_sha: pr.head.sha,
-              base_ref: pr.base.ref,
-              base_sha: pr.base.sha,
-              clone_url: pr.head.repo.clone_url,
-              ssh_url: pr.head.repo.ssh_url,
-              repo_full_name: pr.head.repo.full_name
-            };
+          echo "head_ref=$HEAD_REF" >> $GITHUB_ENV
+          echo "head_repo_full=$HEAD_OWNER/$HEAD_REPO" >> $GITHUB_ENV
 
       - name: Checkout PR code
         uses: actions/checkout@v4
         with:
-          repository: ${{ fromJson(steps.pr_details.outputs.result).repo_full_name }}
-          ref: ${{ fromJson(steps.pr_details.outputs.result).head_ref }}
+          repository: ${{ env.head_repo_full }}
+          ref: ${{ env.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
@@ -138,8 +113,9 @@ jobs:
         id: create_fix_branch
         run: |
           # Create a new branch for the fixes
-          fix_branch="format-fixes-${{ fromJson(steps.pr_details.outputs.result).head_ref }}-$(date +%s)"
+          fix_branch="format-fixes-${{ env.head_ref }}-$(date +%s)"
           echo "fix_branch=$fix_branch" >> $GITHUB_OUTPUT
+          echo "fix_branch=$fix_branch" >> $GITHUB_ENV
 
           git config --local user.email "action@github.com"
           git config --local user.name "Lucene Format Bot"
@@ -165,195 +141,114 @@ jobs:
       - name: Create PR for fixes
         if: steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true'
         id: create_pr
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { data: fixPr } = await github.rest.pulls.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `Apply formatting fixes to #${{ github.event.issue.number }}`,
-              head: '${{ steps.create_fix_branch.outputs.fix_branch }}',
-              base: '${{ fromJson(steps.pr_details.outputs.result).head_ref }}',
-              body: `## Automatic Formatting Fixes
+        run: |
+          PR_BODY="## Automatic Formatting Fixes
 
-            This PR applies automatic formatting fixes to address validation failures in #${{ github.event.issue.number }}.
+          This PR applies automatic formatting fixes to address validation failures in #${{ github.event.issue.number }}.
 
-            ### 📝 Details
-            - **Triggered by**: ${{ github.event.comment.html_url }}
-            - **Original PR**: #${{ github.event.issue.number }}
-            - **Fix branch**: \`${{ steps.create_fix_branch.outputs.fix_branch }}\`
-            - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
+          ### 📝 Details
+          - **Triggered by**: ${{ github.event.comment.html_url }}
+          - **Original PR**: #${{ github.event.issue.number }}
+          - **Fix branch**: \`${{ env.fix_branch }}\`
+          - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
 
-            ### 🚀 Next Steps
-            Review and merge this PR to apply the formatting fixes to the original branch.
+          ### 🚀 Next Steps
+          Review and merge this PR to apply the formatting fixes to the original branch.
 
-            ---
-            *This PR was created automatically by the Auto Format Bot*`
-            });
+          ---
+          *This PR was created automatically by the Auto Format Bot*"
 
-            return {
-              pr_number: fixPr.number,
-              pr_url: fixPr.html_url
-            };
+          PR_URL=$(gh pr create \
+            --title "Apply formatting fixes to #${{ github.event.issue.number }}" \
+            --body "$PR_BODY" \
+            --base "${{ env.head_ref }}" \
+            --head "${{ env.fix_branch }}")
 
-      - name: Remove workflow started reaction and add success reaction
+          PR_NUMBER=$(echo "$PR_URL" | grep -o '[0-9]*$')
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+
+      - name: Add success reaction
         if: success()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const reactions = await github.rest.reactions.listForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id
-            });
-
-            const eyesReaction = reactions.data.find(r => r.content === 'eyes' && r.user.type === 'Bot');
-            if (eyesReaction) {
-              await github.rest.reactions.deleteForIssueComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: context.payload.comment.id,
-                reaction_id: eyesReaction.id
-              });
-            }
-
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: '+1'
-            });
+        run: |
+          # Remove eyes reaction and add success reaction
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            --method POST \
+            --field content='+1'
 
       - name: Comment on PR with success (fixes applied)
         if: success() && steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = '${{ fromJson(steps.create_pr.outputs.result).pr_number }}';
-            const comment = `## Formatting Fixes Applied
+        run: |
+          gh pr comment ${{ github.event.issue.number }} --body "## Formatting Fixes Applied
 
-            The formatting bot has successfully created a PR with formatting fixes!
+          The formatting bot has successfully created a PR with formatting fixes!
 
-            ### 📝 Details
-            - **Triggered by**: ${{ github.event.comment.html_url }}
-            - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
-            - **Fix PR**: #${prNumber}
+          ### 📝 Details
+          - **Triggered by**: ${{ github.event.comment.html_url }}
+          - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
+          - **Fix PR**: #${{ steps.create_pr.outputs.pr_number }}
 
-            ### 🚀 Next Steps
-            Review and merge PR #${prNumber} to apply the formatting fixes to this branch.
+          ### 🚀 Next Steps
+          Review and merge PR #${{ steps.create_pr.outputs.pr_number }} to apply the formatting fixes to this branch.
 
-            ---
-            *This was performed automatically by the Auto Format Bot*`;
-
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
+          ---
+          *This was performed automatically by the Auto Format Bot*"
 
       - name: Comment on PR with success (no fixes needed)
         if: success() && steps.initial-validation.outcome == 'success'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const comment = `## No Formatting Issues Found
+        run: |
+          gh pr comment ${{ github.event.issue.number }} --body "## No Formatting Issues Found
 
-            The formatting bot has validated this PR and found no issues!
+          The formatting bot has validated this PR and found no issues!
 
-            ### 📝 Details
-            - **Triggered by**: ${{ github.event.comment.html_url }}
-            - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
+          ### 📝 Details
+          - **Triggered by**: ${{ github.event.comment.html_url }}
+          - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
 
-            The PR is ready for review!
+          The PR is ready for review!
 
-            ---
-            *This was performed automatically by the Auto Format Bot*`;
-
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
+          ---
+          *This was performed automatically by the Auto Format Bot*"
 
       - name: Comment on PR with success (fixes made but no changes)
         if: success() && steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'false'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const comment = `## Formatting Issues Detected (No Auto-fixes Available)
+        run: |
+          gh pr comment ${{ github.event.issue.number }} --body "## Formatting Issues Detected (No Auto-fixes Available)
 
-            The formatting bot found issues but was unable to automatically fix them.
+          The formatting bot found issues but was unable to automatically fix them.
 
-            ### 📝 Details
-            - **Triggered by**: ${{ github.event.comment.html_url }}
-            - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
+          ### 📝 Details
+          - **Triggered by**: ${{ github.event.comment.html_url }}
+          - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
 
-            **Recommendation**: Review the validation failures manually and apply fixes as needed.
+          **Recommendation**: Review the validation failures manually and apply fixes as needed.
 
-            ---
-            *This was performed automatically by the Auto Format Bot*`;
+          ---
+          *This was performed automatically by the Auto Format Bot*"
 
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
-
-      - name: Remove workflow started reaction and add failure reaction
+      - name: Add failure reaction
         if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const reactions = await github.rest.reactions.listForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id
-            });
-
-            const eyesReaction = reactions.data.find(r => r.content === 'eyes' && r.user.type === 'Bot');
-            if (eyesReaction) {
-              await github.rest.reactions.deleteForIssueComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: context.payload.comment.id,
-                reaction_id: eyesReaction.id
-              });
-            }
-
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: '-1'
-            });
+        run: |
+          # Add failure reaction
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            --method POST \
+            --field content='-1'
 
       - name: Comment on PR with failure
         if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const comment = `## Formatting Failed
+        run: |
+          gh pr comment ${{ github.event.issue.number }} --body "## Formatting Failed
 
-            The formatting bot encountered issues while processing this PR.
+          The formatting bot encountered issues while processing this PR.
 
-            ### Next Steps:
-            1. Check the workflow logs for specific error details
-            2. Fix any issues manually if needed
-            3. Re-trigger the bot with \`/format-fix apply\`
+          ### Next Steps:
+          1. Check the workflow logs for specific error details
+          2. Fix any issues manually if needed
+          3. Re-trigger the bot with \`/format-fix apply\`
 
-            ### 📝 Details
-            - **Triggered by**: ${{ github.event.comment.html_url }}
-            - **Files processed**: ${{ steps.changed-files.outputs.all_changed_files || 'None detected' }}
+          ### 📝 Details
+          - **Triggered by**: ${{ github.event.comment.html_url }}
+          - **Files processed**: ${{ steps.changed-files.outputs.all_changed_files || 'None detected' }}
 
-            ---
-            *This was performed automatically by the Auto Format Bot*`;
-
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
+          ---
+          *This was performed automatically by the Auto Format Bot*"

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -40,6 +40,17 @@ jobs:
               return;
             }
 
+      - name: Add workflow started reaction
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
+
       - name: Get PR details
         id: pr_details
         uses: actions/github-script@v7
@@ -185,6 +196,34 @@ jobs:
               pr_url: fixPr.html_url
             };
 
+      - name: Remove workflow started reaction and add success reaction
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const reactions = await github.rest.reactions.listForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id
+            });
+
+            const eyesReaction = reactions.data.find(r => r.content === 'eyes' && r.user.type === 'Bot');
+            if (eyesReaction) {
+              await github.rest.reactions.deleteForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                reaction_id: eyesReaction.id
+              });
+            }
+
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1'
+            });
+
       - name: Comment on PR with success (fixes applied)
         if: success() && steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true'
         uses: actions/github-script@v7
@@ -261,6 +300,34 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: comment
+            });
+
+      - name: Remove workflow started reaction and add failure reaction
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const reactions = await github.rest.reactions.listForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id
+            });
+
+            const eyesReaction = reactions.data.find(r => r.content === 'eyes' && r.user.type === 'Bot');
+            if (eyesReaction) {
+              await github.rest.reactions.deleteForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                reaction_id: eyesReaction.id
+              });
+            }
+
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '-1'
             });
 
       - name: Comment on PR with failure

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -79,9 +79,9 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c
         with:
-          files: |
+          filter: |
             **/*.java
             **/*.gradle
             **/*.groovy
@@ -163,7 +163,6 @@ jobs:
           - **Triggered by**: ${{ github.event.comment.html_url }}
           - **Original PR**: #${{ github.event.issue.number }}
           - **Fix branch**: \`${{ env.fix_branch }}\`
-          - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
 
           ### 🚀 Next Steps
           Review and merge this PR to apply the formatting fixes to the original branch.
@@ -199,7 +198,6 @@ jobs:
 
           ### 📝 Details
           - **Triggered by**: ${{ github.event.comment.html_url }}
-          - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
           - **Fix PR**: #${{ steps.create_pr.outputs.pr_number }}
 
           ### 🚀 Next Steps
@@ -217,7 +215,6 @@ jobs:
 
           ### 📝 Details
           - **Triggered by**: ${{ github.event.comment.html_url }}
-          - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
 
           The PR is ready for review!
 
@@ -233,7 +230,6 @@ jobs:
 
           ### 📝 Details
           - **Triggered by**: ${{ github.event.comment.html_url }}
-          - **Files checked**: ${{ steps.changed-files.outputs.all_changed_files_count || '0' }} files
 
           **Recommendation**: Review the validation failures manually and apply fixes as needed.
 
@@ -262,7 +258,7 @@ jobs:
 
           ### 📝 Details
           - **Triggered by**: ${{ github.event.comment.html_url }}
-          - **Files processed**: ${{ steps.changed-files.outputs.all_changed_files || 'None detected' }}
+          - **Files processed**: ${{ steps.changed-files.outputs.all || 'None detected' }}
 
           ---
           *This was performed automatically by the Auto Format Bot*"

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,4 +1,4 @@
-name: Lucene Auto Format Bot
+name: Auto Format Bot
 
 on:
   issue_comment:
@@ -61,6 +61,19 @@ jobs:
           echo "head_ref=$HEAD_REF" >> $GITHUB_ENV
           echo "head_repo_full=$HEAD_OWNER/$HEAD_REPO" >> $GITHUB_ENV
 
+      - name: Detect if PR is from fork
+        run: |
+          HEAD_OWNER=$(echo "${{ env.head_repo_full }}" | cut -d'/' -f1)
+          REPO_OWNER="${{ github.repository_owner }}"
+
+          if [[ "$HEAD_OWNER" != "$REPO_OWNER" ]]; then
+            echo "is_fork=true" >> $GITHUB_ENV
+            echo "PR is from fork: ${{ env.head_repo_full }}"
+          else
+            echo "is_fork=false" >> $GITHUB_ENV
+            echo "PR is from same repository"
+          fi
+
       - name: Checkout PR code
         uses: actions/checkout@v4
         with:
@@ -121,8 +134,8 @@ jobs:
             git diff --staged --name-only
           fi
 
-      - name: Create fix branch and commit
-        if: steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true'
+      - name: Create fix branch and commit (same-repo)
+        if: steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true' && env.is_fork == 'false'
         id: create_fix_branch
         run: |
           # Create a new branch for the fixes
@@ -131,12 +144,12 @@ jobs:
           echo "fix_branch=$fix_branch" >> $GITHUB_ENV
 
           git config --local user.email "action@github.com"
-          git config --local user.name "Lucene Format Bot"
+          git config --local user.name "Auto Format Bot"
 
           git checkout -b "$fix_branch"
           git commit -m "Apply automatic formatting fixes
 
-          Fixes applied by @lucene-format-bot in response to:
+          Fixes applied by @auto-format-bot in response to:
           ${{ github.event.comment.html_url }}
 
           Original PR: #${{ github.event.issue.number }}
@@ -146,13 +159,32 @@ jobs:
 
           git push origin "$fix_branch"
 
+      - name: Commit directly to fork PR
+        if: steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true' && env.is_fork == 'true'
+        id: commit_to_fork
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "Auto Format Bot"
+
+          git commit -m "Apply automatic formatting fixes
+
+          Fixes applied by @auto-format-bot in response to:
+          ${{ github.event.comment.html_url }}
+
+          Original PR: #${{ github.event.issue.number }}
+
+          Changes applied:
+          $(git diff --name-only HEAD~1)"
+
+          git push origin "${{ env.head_ref }}"
+
       - name: Final validation
         run: |
           echo "Running final validation..."
           ./gradlew check -x test
 
-      - name: Create PR for fixes
-        if: steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true'
+      - name: Create PR for fixes (same-repo only)
+        if: steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true' && env.is_fork == 'false'
         id: create_pr
         run: |
           PR_BODY="## Automatic Formatting Fixes
@@ -189,8 +221,8 @@ jobs:
             --method POST \
             --input - <<< '{"content":"+1"}'
 
-      - name: Comment on PR with success (fixes applied)
-        if: success() && steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true'
+      - name: Comment on PR with success (fixes applied to same-repo)
+        if: success() && steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true' && env.is_fork == 'false'
         run: |
           gh pr comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body "## Formatting Fixes Applied
 
@@ -202,6 +234,20 @@ jobs:
 
           ### 🚀 Next Steps
           Review and merge PR #${{ steps.create_pr.outputs.pr_number }} to apply the formatting fixes to this branch.
+
+          ---
+          *This was performed automatically by the Auto Format Bot*"
+
+      - name: Comment on PR with success (fixes applied to fork)
+        if: success() && steps.initial-validation.outcome == 'failure' && steps.check_changes.outputs.changes_made == 'true' && env.is_fork == 'true'
+        run: |
+          gh pr comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body "## Formatting Fixes Applied
+
+          The formatting bot has commited the formatting fixes to this PR!
+
+          ### 📝 Details
+          - **Triggered by**: ${{ github.event.comment.html_url }}
+          - **Action taken**: Direct commit to this PR branch
 
           ---
           *This was performed automatically by the Auto Format Bot*"


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

Added a workflow bot that automatically formats a PR's file changes and raises a separate PR against that PR

### How it works :
When someone comments ```/format-fix apply``` on a PR, the bot will:
- Check your code using ./gradlew check -x test to find any formatting/style issues
- Fix what it can by running ./gradlew tidy (which includes Google Java Format, EditorConfig fixes, and other style tools)
- Verify everything looks good by running the checks again
- Create a separate PR with just the formatting fixes, so you can review and merge them without mixing formatting changes with your actual code changes

### Supported files:
Java, Gradle, Groovy, Markdown, properties, XML, Python, shell scripts, and batch files.
Just comment "/format-fix apply" on any PR to trigger it

Closes: [Issue #14835](https://github.com/apache/lucene/issues/14835) 

Test Run : [Test PR](https://github.com/georgereuben/lucene/pull/2)