### PR TITLE
Discussion: Improve DirectIO Directory for Java 24/25

### DIFF
--- a/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
@@ -21,6 +21,7 @@ import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.foreign.Arena;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -117,7 +118,8 @@ public class DirectIODirectory extends FilterDirectory {
    * Create a new DirectIODirectory for the named location.
    *
    * @param delegate Directory for non-merges, also used as reference to file system path.
-   * @param mergeBufferSize Size of buffer to use for merging.
+   * @param mergeBufferSize Size of buffer to use for merging. The buffer size will be rounded up to
+   *     next multiple of filesystem's block size
    * @param minBytesDirect Merges, or files to be opened for reading, smaller than this will not use
    *     direct IO. See {@link #DEFAULT_MIN_BYTES_DIRECT} and {@link #useDirectIO}.
    * @throws IOException If there is a low-level I/O error
@@ -126,7 +128,9 @@ public class DirectIODirectory extends FilterDirectory {
       throws IOException {
     super(delegate);
     this.blockSize = Math.toIntExact(Files.getFileStore(delegate.getDirectory()).getBlockSize());
-    this.mergeBufferSize = mergeBufferSize;
+    // ensure that the size of mergeBuffer is a multiple of the blockSize:
+    this.mergeBufferSize =
+        ((mergeBufferSize + this.blockSize - 1) / this.blockSize) * this.blockSize;
     this.minBytesDirect = minBytesDirect;
   }
 
@@ -209,6 +213,7 @@ public class DirectIODirectory extends FilterDirectory {
   }
 
   private static final class DirectIOIndexOutput extends IndexOutput {
+    private final Arena arena;
     private final ByteBuffer buffer;
     private final FileChannel channel;
     private final Checksum digest;
@@ -231,7 +236,8 @@ public class DirectIODirectory extends FilterDirectory {
       channel =
           FileChannel.open(
               path, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW, getDirectOpenOption());
-      buffer = ByteBuffer.allocateDirect(bufferSize + blockSize - 1).alignedSlice(blockSize);
+      arena = Arena.ofConfined();
+      buffer = arena.allocate(bufferSize, blockSize).asByteBuffer();
       digest = new BufferedChecksum(new CRC32());
 
       isOpen = true;
@@ -294,7 +300,8 @@ public class DirectIODirectory extends FilterDirectory {
         try {
           dump();
         } finally {
-          try (FileChannel ch = channel) {
+          try (FileChannel ch = channel;
+              Arena _ = arena) {
             ch.truncate(getFilePointer());
           }
         }
@@ -303,6 +310,7 @@ public class DirectIODirectory extends FilterDirectory {
   }
 
   private static final class DirectIOIndexInput extends IndexInput {
+    private final Arena arena;
     private final ByteBuffer buffer;
     private final FileChannel channel;
     private final int blockSize;
@@ -324,7 +332,8 @@ public class DirectIODirectory extends FilterDirectory {
       super("DirectIOIndexInput(path=\"" + path + "\")");
       this.channel = FileChannel.open(path, StandardOpenOption.READ, getDirectOpenOption());
       this.blockSize = blockSize;
-      this.buffer = allocateBuffer(bufferSize, blockSize);
+      this.arena = Arena.ofAuto(); // fix this to be confined
+      this.buffer = allocateBuffer(arena, bufferSize, blockSize);
       this.isOpen = true;
       this.isClosable = true;
       this.length = channel.size();
@@ -339,7 +348,8 @@ public class DirectIODirectory extends FilterDirectory {
       super(description);
       Objects.checkFromIndexSize(offset, length, other.channel.size());
       final int bufferSize = other.buffer.capacity();
-      this.buffer = allocateBuffer(bufferSize, other.blockSize);
+      this.arena = Arena.ofAuto(); // fix this to be confined
+      this.buffer = allocateBuffer(arena, bufferSize, other.blockSize);
       this.blockSize = other.blockSize;
       this.channel = other.channel;
       this.isOpen = true;
@@ -350,16 +360,14 @@ public class DirectIODirectory extends FilterDirectory {
       buffer.limit(0);
     }
 
-    private static ByteBuffer allocateBuffer(int bufferSize, int blockSize) {
-      return ByteBuffer.allocateDirect(bufferSize + blockSize - 1)
-          .alignedSlice(blockSize)
-          .order(LITTLE_ENDIAN);
+    private static ByteBuffer allocateBuffer(Arena arena, int bufferSize, int blockSize) {
+      return arena.allocate(bufferSize, blockSize).asByteBuffer().order(LITTLE_ENDIAN);
     }
 
     @Override
     public void close() throws IOException {
       if (isOpen && isClosable) {
-        channel.close();
+        try (FileChannel _ = channel; /* NOT YET: Arena _ = arena */ ) {}
         isOpen = false;
       }
     }


### PR DESCRIPTION
Currently the DirectIODircetory allocates direct byte buffers outside of heap (because that's needed for direct IO to work). It also needs to align them on the blocksize. The current code may also be wrong if the mergeBufferSize is not a multiple of blockSize. This PR fixes that to have a correct buffer aligned and with correct length.

With MemorySegments we can improve that:
- There is a direct allocator method that takes care that a MemorySegment is allocated with correct alignment. In contrast to ByteBuffers the length is not aligned, so we have to take care (I added code in ctor to have correct multiplies of blockSize).
- We can convert this MemorySegment to a direct buffer with `MemorySegment#asByteBuffer()`. The resulting segment is compatible to direct IO.
- We can free the buffer using an Arena at the correct time, when closing the output or input.

As IndexOutputs are only used by one thread we can use a confined arena and allocate the buffer there.

With IndexInputs it is more complicated: Theoretically they should also only be used from one thread (also RandomAccessInputs as far as I remember), but unfortunately the buffer is allocated at the time of cloning (which is not the thread when it is used). Actually the buffering code is a bit cryptic to me and I had no time to look closely into it: Actually like in BufferedIndexInput the buffer should be lazy initialized on the first real READ access (not on cloning and not on seeking for first time after cloning). To implement this correctly we may need to refactor the buffer code a bit.

Therefore in this mockup I use an AUTO arena which make the buffer freed by garbage collector. A shared arena is too expensive.

If you have an idea how to fix the IndexInput to use a lazy buffer like BufferedIndexInput without mixing everything up, tell me. The buffer should be confined and allocated only from the thread actually using the clone. An alternative is to have a pool of buffers for reuse "per thread" (threadlocal). The JDK internally uses a ThreadLocal for such buffers when implementing java's IO layer.



