### PR TITLE
Fix TestLateInteractionField.testInputValidation

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/document/TestLateInteractionField.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLateInteractionField.java
@@ -64,14 +64,16 @@ public class TestLateInteractionField extends LuceneTestCase {
     expectThrows(IllegalArgumentException.class, () -> LateInteractionField.encode(emptyTokens));
 
     final int dim = 128;
-    float[][] value = new float[random().nextInt(20, 30)][];
-    for (int i = 0; i < value.length; i++) {
+    final int numVectors = random().nextInt(3, 12);
+    float[][] value = new float[numVectors][];
+    for (int i = 0; i < numVectors - 1; i++) {
       if (random().nextBoolean()) {
         value[i] = TestVectorUtil.randomVector(dim);
       } else {
         value[i] = TestVectorUtil.randomVector(dim + 1);
       }
     }
+    value[numVectors - 1] = TestVectorUtil.randomVector(dim + 2);
     expectThrows(IllegalArgumentException.class, () -> LateInteractionField.encode(value));
   }
 

--- a/lucene/core/src/test/org/apache/lucene/document/TestLateInteractionField.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLateInteractionField.java
@@ -64,7 +64,7 @@ public class TestLateInteractionField extends LuceneTestCase {
     expectThrows(IllegalArgumentException.class, () -> LateInteractionField.encode(emptyTokens));
 
     final int dim = 128;
-    float[][] value = new float[random().nextInt(3, 12)][];
+    float[][] value = new float[random().nextInt(20, 30)][];
     for (int i = 0; i < value.length; i++) {
       if (random().nextBoolean()) {
         value[i] = TestVectorUtil.randomVector(dim);


### PR DESCRIPTION
### Description

Currently the `value.length` can be very small, and there is a chance that all vector have same dim, thus makes the last Assertion fail, this can be stably reproduced on my machine with `gradlew test --tests TestLateInteractionField.testInputValidation -Dtests.seed=92E678DBD2F6CD0A -Dtests.locale=en-DE -Dtests.timezone=Etc/GMT+7 -Dtests.asserts=true -Dtests.file.encoding=UTF-8`

https://github.com/apache/lucene/blob/c5a802521fe51536da9d951dba782c96608ee03c/lucene/core/src/test/org/apache/lucene/document/TestLateInteractionField.java#L67-L75

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
