### PR TITLE
Optimize bitset to array

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -208,6 +208,8 @@ Optimizations
 
 * GITHUB#14906: Use branchless way to speedup filterCompetitiveHits. (Adrien Grand, Ge Song)
 
+* GITHUB#14935: Speed up PostingsEnum#nextPostings when block is encoded as bitset. (Guo Feng)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14823: Decrease TieredMergePolicy's default number of segments per

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BitsetToArrayBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BitsetToArrayBenchmark.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.benchmark.jmh;
 
 import java.util.concurrent.TimeUnit;

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BitsetToArrayBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BitsetToArrayBenchmark.java
@@ -36,8 +36,8 @@ import org.openjdk.jmh.annotations.Warmup;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
-@Warmup(iterations = 2, time = 1)
-@Measurement(iterations = 3, time = 1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
 @Fork(
     value = 1,
     jvmArgsAppend = {

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BitsetToArrayBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BitsetToArrayBenchmark.java
@@ -342,23 +342,17 @@ public class BitsetToArrayBenchmark {
 
   private static int _denseBranchLessParallel(
       long word, int[] resultArray, int offset, int base, int[] scratch) {
-    int lWord = (int) word;
-    int hWord = (int) (word >>> 32);
+    final int lWord = (int) word;
+    final int hWord = (int) (word >>> 32);
 
-    // manual unrolling the loop to help CPU parallel
-    for (int i = 0, i16 = i + 16; i < 16; i++, i16++) {
+    for (int i = 0; i < 32; i++) {
       scratch[i] = (lWord >>> i) & 1;
-      scratch[i16] = (lWord >>> i16) & 1;
       scratch[i + 32] = (hWord >>> i) & 1;
-      scratch[i + 48] = (hWord >>> i16) & 1;
     }
-    // like above, manual unrolling the loop to help CPU parallel
-    int offset32 = offset + Integer.bitCount(lWord);
-    for (int i = 0, i32 = i + 32; i < 32; i++, i32++) {
+
+    for (int i = 0; i < 64; i++) {
       resultArray[offset] = base + i;
-      resultArray[offset32] = base + i32;
       offset += scratch[i];
-      offset32 += scratch[i32];
     }
 
     return offset;

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BitsetToArrayBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BitsetToArrayBenchmark.java
@@ -16,10 +16,9 @@
  */
 package org.apache.lucene.benchmark.jmh;
 
-import java.util.concurrent.TimeUnit;
 import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
-
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -40,11 +39,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 5, time = 1)
 @Fork(
     value = 1,
-    jvmArgsAppend = {
-        "-Xmx1g",
-        "-Xms1g",
-        "-XX:+AlwaysPreTouch"
-    })
+    jvmArgsAppend = {"-Xmx1g", "-Xms1g", "-XX:+AlwaysPreTouch"})
 public class BitsetToArrayBenchmark {
 
   private final SplittableRandom R = new SplittableRandom(4314123142L);
@@ -329,7 +324,8 @@ public class BitsetToArrayBenchmark {
 
   static int[] IDENTITY = IntStream.range(0, 32).toArray();
 
-  private static int _denseBranchLessVectorized(long word, int[] resultArray, int offset, int base, int[] scratch) {
+  private static int _denseBranchLessVectorized(
+      long word, int[] resultArray, int offset, int base, int[] scratch) {
     int lWord = (int) word;
     int hWord = (int) (word >>> 32);
 
@@ -381,5 +377,3 @@ public class BitsetToArrayBenchmark {
     return to;
   }
 }
-
-

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BitsetToArrayBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BitsetToArrayBenchmark.java
@@ -54,7 +54,7 @@ public class BitsetToArrayBenchmark {
   @Setup(Level.Trial)
   public void setup() {
     base = R.nextInt(1000);
-    resultArray = new int[bitCount + Long.SIZE];
+    resultArray = new int[bitCount + 64];
   }
 
   @Setup(Level.Invocation)

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BitsetToArrayBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BitsetToArrayBenchmark.java
@@ -1,0 +1,369 @@
+package org.apache.lucene.benchmark.jmh;
+
+import java.util.concurrent.TimeUnit;
+import java.util.SplittableRandom;
+import java.util.stream.IntStream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 3, time = 1)
+@Fork(
+    value = 1,
+    jvmArgsAppend = {
+        "-Xmx1g",
+        "-Xms1g",
+        "-XX:+AlwaysPreTouch"
+    })
+public class BitsetToArrayBenchmark {
+
+  private final SplittableRandom R = new SplittableRandom(4314123142L);
+
+  @Param({"5", "10", "20", "30", "40", "50", "60"})
+  int bitCount;
+
+  private final int[] scratch = new int[64];
+  private long word;
+  private int[] resultArray;
+  private int base;
+  private int offset;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    base = R.nextInt(1000);
+    resultArray = new int[bitCount + Long.SIZE];
+  }
+
+  @Setup(Level.Invocation)
+  public void setupInvocation() {
+    word = 0L;
+    while (Long.bitCount(word) < bitCount) {
+      word |= 1L << R.nextInt(64);
+    }
+    offset = R.nextInt(64);
+  }
+
+  @Benchmark
+  public int whileLoop() {
+    return _whileLoop(word, resultArray, offset, base);
+  }
+
+  @Benchmark
+  public int forLoop() {
+    return _forLoop(word, resultArray, offset, base);
+  }
+
+  @Benchmark
+  public int forLoopManualUnrolling() {
+    return _forLoopManualUnrolling(word, resultArray, offset, base);
+  }
+
+  @Benchmark
+  public int dense() {
+    return _dense(word, resultArray, offset, base);
+  }
+
+  @Benchmark
+  public int denseBranchLess() {
+    return _denseBranchLess(word, resultArray, offset, base);
+  }
+
+  @Benchmark
+  public int denseBranchLessUnrolling() {
+    return _denseBranchLessUnrolling(word, resultArray, offset, base);
+  }
+
+  @Benchmark
+  public int denseBranchLessVectorized() {
+    return _denseBranchLessVectorized(word, resultArray, offset, base, scratch);
+  }
+
+  @Benchmark
+  public int denseInvert() {
+    return _denseInvert(word, resultArray, offset, base);
+  }
+
+  @Benchmark
+  public int hybrid() {
+    return _hybrid(word, resultArray, offset, base, scratch);
+  }
+
+  private static int _whileLoop(long word, int[] resultArray, int offset, int base) {
+    while (word != 0) {
+      int bit = Long.numberOfTrailingZeros(word);
+      resultArray[offset++] = base + bit;
+      word ^= 1L << bit;
+    }
+    return offset;
+  }
+
+  private static int _forLoop(long word, int[] resultArray, int offset, int base) {
+    int to = offset + Long.bitCount(word);
+    for (int i = offset; i < to; i++) {
+      int bit = Long.numberOfTrailingZeros(word);
+      resultArray[i] = base + bit;
+      word ^= 1L << bit;
+    }
+    return to;
+  }
+
+  private static int _forLoopManualUnrolling(long word, int[] resultArray, int offset, int base) {
+    int to = offset + Long.bitCount(word);
+    int i = offset;
+
+    for (; i < to - 3; i += 4) {
+      int ntz = Long.numberOfTrailingZeros(word);
+      resultArray[i] = base + ntz;
+      word ^= 1L << ntz;
+      ntz = Long.numberOfTrailingZeros(word);
+      resultArray[i] = base + ntz;
+      word ^= 1L << ntz;
+      ntz = Long.numberOfTrailingZeros(word);
+      resultArray[i] = base + ntz;
+      word ^= 1L << ntz;
+      ntz = Long.numberOfTrailingZeros(word);
+      resultArray[i] = base + ntz;
+      word ^= 1L << ntz;
+    }
+
+    for (; i < to; i++) {
+      int ntz = Long.numberOfTrailingZeros(word);
+      resultArray[i] = base + ntz;
+      word ^= 1L << ntz;
+    }
+
+    return to;
+  }
+
+  private static int _dense(long word, int[] resultArray, int offset, int base) {
+    for (int i = 0; i < Long.SIZE; i++) {
+      if ((word & (1L << i)) != 0) {
+        resultArray[offset++] = base + i;
+      }
+    }
+    return offset;
+  }
+
+  private static int _denseBranchLess(long word, int[] resultArray, int offset, int base) {
+    int lWord = (int) word;
+    int hWord = (int) (word >>> 32);
+    for (int i = 0; i < Integer.SIZE; i++) {
+      resultArray[offset] = base + i;
+      offset += lWord & 1;
+      lWord >>>= 1;
+    }
+    for (int i = Integer.SIZE; i < Long.SIZE; i++) {
+      resultArray[offset] = base + i;
+      offset += hWord & 1;
+      hWord >>>= 1;
+    }
+    return offset;
+  }
+
+  private static int _denseBranchLessUnrolling(long word, int[] resultArray, int offset, int base) {
+    int lWord = (int) word;
+    int hWord = (int) (word >>> 32);
+
+    resultArray[offset] = base + 0;
+    offset += (lWord >>> 0) & 1;
+    resultArray[offset] = base + 1;
+    offset += (lWord >>> 1) & 1;
+    resultArray[offset] = base + 2;
+    offset += (lWord >>> 2) & 1;
+    resultArray[offset] = base + 3;
+    offset += (lWord >>> 3) & 1;
+    resultArray[offset] = base + 4;
+    offset += (lWord >>> 4) & 1;
+    resultArray[offset] = base + 5;
+    offset += (lWord >>> 5) & 1;
+    resultArray[offset] = base + 6;
+    offset += (lWord >>> 6) & 1;
+    resultArray[offset] = base + 7;
+    offset += (lWord >>> 7) & 1;
+    resultArray[offset] = base + 8;
+    offset += (lWord >>> 8) & 1;
+    resultArray[offset] = base + 9;
+    offset += (lWord >>> 9) & 1;
+    resultArray[offset] = base + 10;
+    offset += (lWord >>> 10) & 1;
+    resultArray[offset] = base + 11;
+    offset += (lWord >>> 11) & 1;
+    resultArray[offset] = base + 12;
+    offset += (lWord >>> 12) & 1;
+    resultArray[offset] = base + 13;
+    offset += (lWord >>> 13) & 1;
+    resultArray[offset] = base + 14;
+    offset += (lWord >>> 14) & 1;
+    resultArray[offset] = base + 15;
+    offset += (lWord >>> 15) & 1;
+    resultArray[offset] = base + 16;
+    offset += (lWord >>> 16) & 1;
+    resultArray[offset] = base + 17;
+    offset += (lWord >>> 17) & 1;
+    resultArray[offset] = base + 18;
+    offset += (lWord >>> 18) & 1;
+    resultArray[offset] = base + 19;
+    offset += (lWord >>> 19) & 1;
+    resultArray[offset] = base + 20;
+    offset += (lWord >>> 20) & 1;
+    resultArray[offset] = base + 21;
+    offset += (lWord >>> 21) & 1;
+    resultArray[offset] = base + 22;
+    offset += (lWord >>> 22) & 1;
+    resultArray[offset] = base + 23;
+    offset += (lWord >>> 23) & 1;
+    resultArray[offset] = base + 24;
+    offset += (lWord >>> 24) & 1;
+    resultArray[offset] = base + 25;
+    offset += (lWord >>> 25) & 1;
+    resultArray[offset] = base + 26;
+    offset += (lWord >>> 26) & 1;
+    resultArray[offset] = base + 27;
+    offset += (lWord >>> 27) & 1;
+    resultArray[offset] = base + 28;
+    offset += (lWord >>> 28) & 1;
+    resultArray[offset] = base + 29;
+    offset += (lWord >>> 29) & 1;
+    resultArray[offset] = base + 30;
+    offset += (lWord >>> 30) & 1;
+    resultArray[offset] = base + 31;
+    offset += (lWord >>> 31) & 1;
+
+    resultArray[offset] = base + 32;
+    offset += (hWord >>> 0) & 1;
+    resultArray[offset] = base + 33;
+    offset += (hWord >>> 1) & 1;
+    resultArray[offset] = base + 34;
+    offset += (hWord >>> 2) & 1;
+    resultArray[offset] = base + 35;
+    offset += (hWord >>> 3) & 1;
+    resultArray[offset] = base + 36;
+    offset += (hWord >>> 4) & 1;
+    resultArray[offset] = base + 37;
+    offset += (hWord >>> 5) & 1;
+    resultArray[offset] = base + 38;
+    offset += (hWord >>> 6) & 1;
+    resultArray[offset] = base + 39;
+    offset += (hWord >>> 7) & 1;
+    resultArray[offset] = base + 40;
+    offset += (hWord >>> 8) & 1;
+    resultArray[offset] = base + 41;
+    offset += (hWord >>> 9) & 1;
+    resultArray[offset] = base + 42;
+    offset += (hWord >>> 10) & 1;
+    resultArray[offset] = base + 43;
+    offset += (hWord >>> 11) & 1;
+    resultArray[offset] = base + 44;
+    offset += (hWord >>> 12) & 1;
+    resultArray[offset] = base + 45;
+    offset += (hWord >>> 13) & 1;
+    resultArray[offset] = base + 46;
+    offset += (hWord >>> 14) & 1;
+    resultArray[offset] = base + 47;
+    offset += (hWord >>> 15) & 1;
+    resultArray[offset] = base + 48;
+    offset += (hWord >>> 16) & 1;
+    resultArray[offset] = base + 49;
+    offset += (hWord >>> 17) & 1;
+    resultArray[offset] = base + 50;
+    offset += (hWord >>> 18) & 1;
+    resultArray[offset] = base + 51;
+    offset += (hWord >>> 19) & 1;
+    resultArray[offset] = base + 52;
+    offset += (hWord >>> 20) & 1;
+    resultArray[offset] = base + 53;
+    offset += (hWord >>> 21) & 1;
+    resultArray[offset] = base + 54;
+    offset += (hWord >>> 22) & 1;
+    resultArray[offset] = base + 55;
+    offset += (hWord >>> 23) & 1;
+    resultArray[offset] = base + 56;
+    offset += (hWord >>> 24) & 1;
+    resultArray[offset] = base + 57;
+    offset += (hWord >>> 25) & 1;
+    resultArray[offset] = base + 58;
+    offset += (hWord >>> 26) & 1;
+    resultArray[offset] = base + 59;
+    offset += (hWord >>> 27) & 1;
+    resultArray[offset] = base + 60;
+    offset += (hWord >>> 28) & 1;
+    resultArray[offset] = base + 61;
+    offset += (hWord >>> 29) & 1;
+    resultArray[offset] = base + 62;
+    offset += (hWord >>> 30) & 1;
+    resultArray[offset] = base + 63;
+    offset += (hWord >>> 31) & 1;
+
+    return offset;
+  }
+
+  static int[] IDENTITY = IntStream.range(0, 32).toArray();
+
+  private static int _denseBranchLessVectorized(long word, int[] resultArray, int offset, int base, int[] scratch) {
+    int lWord = (int) word;
+    int hWord = (int) (word >>> 32);
+
+    // vectorized loop
+    for (int i = 0; i < 32; i++) {
+      scratch[i] = (lWord >>> IDENTITY[i]) & 1;
+      scratch[i + 32] = (hWord >>> IDENTITY[i]) & 1;
+    }
+
+    for (int i = 0; i < 64; i++) {
+      resultArray[offset] = base + i;
+      offset += scratch[i];
+    }
+
+    return offset;
+  }
+
+  private static int _denseInvert(long word, int[] resultArray, int offset, int base) {
+    int bit = 0;
+    while (word != 0L) {
+      int zeros = Long.numberOfTrailingZeros(word);
+      word >>>= zeros;
+      bit += zeros;
+
+      int ones = Long.numberOfTrailingZeros(~word);
+      word >>>= ones;
+      for (; bit < ones; bit++) {
+        resultArray[offset++] = base + bit;
+      }
+    }
+
+    return offset;
+  }
+
+  private static int _hybrid(long word, int[] resultArray, int offset, int base, int[] scratch) {
+    int bitCount = Long.bitCount(word);
+    if (bitCount > 32) {
+      return _denseBranchLessVectorized(word, resultArray, offset, base, scratch);
+    }
+
+    int to = offset + Long.bitCount(word);
+
+    for (int i = offset; i < to; i++) {
+      int ntz = Long.numberOfTrailingZeros(word);
+      resultArray[i] = base + ntz;
+      word ^= 1L << ntz;
+    }
+
+    return to;
+  }
+}
+
+

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BitsetToArrayBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/BitsetToArrayBenchmark.java
@@ -354,7 +354,7 @@ public class BitsetToArrayBenchmark {
 
     resultArray[offset32] = base + 32 + Integer.numberOfTrailingZeros(hWord);
 
-    return offset;
+    return hOffset;
   }
 
   private static int _denseInvert(long word, int[] resultArray, int offset, int base) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/BitSetUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/BitSetUtil.java
@@ -1,0 +1,100 @@
+// This file has been automatically generated, DO NOT EDIT
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene103;
+
+import java.util.Objects;
+import org.apache.lucene.util.FixedBitSet;
+
+class BitSetUtil {
+
+  private final int[] scratch = new int[64];
+
+  final int denseBitsetToArray(FixedBitSet bitSet, int from, int to, int base, int[] array) {
+    Objects.checkFromToIndex(from, to, bitSet.length());
+
+    int offset = 0;
+    long[] bits = bitSet.getBits();
+    // First, align `from` with a word start, ie. a multiple of Long.SIZE (64)
+    if ((from & 0x3F) != 0) {
+      long word = bits[from >> 6] >>> from;
+      int numBitsTilNextWord = -from & 0x3F;
+      if (to - from < numBitsTilNextWord) {
+        // All bits are in a single word
+        word &= (1L << (to - from)) - 1L;
+        return word2Array(word, from + base, array, offset);
+      }
+      offset = word2Array(word, from + base, array, offset);
+      from += numBitsTilNextWord;
+      assert (from & 0x3F) == 0;
+    }
+
+    for (int i = from >> 6, end = to >> 6; i < end; ++i) {
+      long word = bits[i];
+      offset = word2Array(word, base + (i << 6), array, offset);
+    }
+
+    // Now handle remaining bits in the last partial word
+    if ((to & 0x3F) != 0) {
+      long word = bits[to >> 6] & ((1L << to) - 1);
+      offset = word2Array(word, base + (to & ~0x3F), array, offset);
+    }
+
+    return offset;
+  }
+
+  private int word2Array(long word, int base, int[] docs, int offset) {
+    final int bitCount = Long.bitCount(word);
+
+    if (bitCount >= 32) {
+      return denseWord2Array(word, base, docs, offset);
+    }
+
+    for (int i = 0; i < bitCount; i++) {
+      int ntz = Long.numberOfTrailingZeros(word);
+      docs[offset++] = base + ntz;
+      word ^= 1L << ntz;
+    }
+
+    return offset;
+  }
+
+  private int denseWord2Array(long word, int base, int[] docs, int offset) {
+    final int lWord = (int) word;
+    final int hWord = (int) (word >>> 32);
+    final int[] scratch = this.scratch;
+
+    // manual unrolling to help CPU parallel
+    for (int i = 0, i16 = i + 16; i < 16; i++, i16++) {
+      scratch[i] = (lWord >>> i) & 1;
+      scratch[i16] = (lWord >>> i16) & 1;
+      scratch[i + 32] = (hWord >>> i) & 1;
+      scratch[i + 48] = (hWord >>> i16) & 1;
+    }
+    // like above, manual unrolling to help CPU parallel
+    int offset32 = offset + Integer.bitCount(lWord);
+    for (int i = 0, i32 = i + 32; i < 32; i++, i32++) {
+      docs[offset] = base + i;
+      docs[offset32] = base + i32;
+      offset += scratch[i];
+      offset32 += scratch[i32];
+    }
+
+    return offset32;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/BitSetUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/BitSetUtil.java
@@ -21,7 +21,21 @@ import org.apache.lucene.util.FixedBitSet;
 
 class BitSetUtil {
 
-  final int denseBitsetToArray(FixedBitSet bitSet, int from, int to, int base, int[] array) {
+  /**
+   * Converts set bits in the given bitset to an array of document IDs. Only processes bits from
+   * index {@code from} (inclusive) to {@code to} (exclusive) and returns the number of bits set in
+   * this range.
+   *
+   * <p>Each set bit's position is converted to a document ID by adding the {@code base} value and
+   * stored in the provided {@code array}.
+   *
+   * <p>NOTE: Caller need to ensure the {@code array} has a length greater than or equal to {@code
+   * bitSet.cardinality(from, to) + 1}.
+   */
+  static int denseBitsetToArray(FixedBitSet bitSet, int from, int to, int base, int[] array) {
+    assert bitSet.cardinality(from, to) + 1 <= array.length
+        : "Array length must be at least bitSet.cardinality(from, to) + 1";
+
     Objects.checkFromToIndex(from, to, bitSet.length());
 
     int offset = 0;
@@ -54,7 +68,7 @@ class BitSetUtil {
     return offset;
   }
 
-  private int word2Array(long word, int base, int[] docs, int offset) {
+  private static int word2Array(long word, int base, int[] docs, int offset) {
     final int bitCount = Long.bitCount(word);
 
     if (bitCount >= 32) {
@@ -70,7 +84,7 @@ class BitSetUtil {
     return offset;
   }
 
-  private int denseWord2Array(long word, int base, int[] docs, int offset) {
+  private static int denseWord2Array(long word, int base, int[] docs, int offset) {
     final int lWord = (int) word;
     final int hWord = (int) (word >>> 32);
     final int offset32 = offset + Integer.bitCount(lWord);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/BitSetUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/BitSetUtil.java
@@ -21,8 +21,6 @@ import org.apache.lucene.util.FixedBitSet;
 
 class BitSetUtil {
 
-  private final int[] scratch = new int[64];
-
   final int denseBitsetToArray(FixedBitSet bitSet, int from, int to, int base, int[] array) {
     Objects.checkFromToIndex(from, to, bitSet.length());
 
@@ -75,18 +73,18 @@ class BitSetUtil {
   private int denseWord2Array(long word, int base, int[] docs, int offset) {
     final int lWord = (int) word;
     final int hWord = (int) (word >>> 32);
-    final int[] scratch = this.scratch;
+    final int offset32 = offset + Integer.bitCount(lWord);
+    int hOffset = offset32;
 
     for (int i = 0; i < 32; i++) {
-      scratch[i] = (lWord >>> i) & 1;
-      scratch[i + 32] = (hWord >>> i) & 1;
-    }
-
-    for (int i = 0; i < 64; i++) {
       docs[offset] = base + i;
-      offset += scratch[i];
+      docs[hOffset] = base + i + 32;
+      offset += (lWord >>> i) & 1;
+      hOffset += (hWord >>> i) & 1;
     }
 
-    return offset;
+    docs[offset32] = base + 32 + Integer.numberOfTrailingZeros(hWord);
+
+    return hOffset;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/BitSetUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/BitSetUtil.java
@@ -1,5 +1,3 @@
-// This file has been automatically generated, DO NOT EDIT
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -79,22 +77,16 @@ class BitSetUtil {
     final int hWord = (int) (word >>> 32);
     final int[] scratch = this.scratch;
 
-    // manual unrolling to help CPU parallel
-    for (int i = 0, i16 = i + 16; i < 16; i++, i16++) {
+    for (int i = 0; i < 32; i++) {
       scratch[i] = (lWord >>> i) & 1;
-      scratch[i16] = (lWord >>> i16) & 1;
       scratch[i + 32] = (hWord >>> i) & 1;
-      scratch[i + 48] = (hWord >>> i16) & 1;
-    }
-    // like above, manual unrolling to help CPU parallel
-    int offset32 = offset + Integer.bitCount(lWord);
-    for (int i = 0, i32 = i + 32; i < 32; i++, i32++) {
-      docs[offset] = base + i;
-      docs[offset32] = base + i32;
-      offset += scratch[i];
-      offset32 += scratch[i32];
     }
 
-    return offset32;
+    for (int i = 0; i < 64; i++) {
+      docs[offset] = base + i;
+      offset += scratch[i];
+    }
+
+    return offset;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
@@ -303,7 +303,6 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
       UNARY
     }
 
-    private final BitSetUtil bitSetUtil = new BitSetUtil();
     private ForDeltaUtil forDeltaUtil;
     private PForUtil pforUtil;
 
@@ -1051,7 +1050,8 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
       }
 
       // Only return docs from the current block
-      buffer.growNoCopy(BLOCK_SIZE);
+      // +1 to make BitSetUtil#denseBitsetToArray work, see its java doc.
+      buffer.growNoCopy(BLOCK_SIZE + 1);
       upTo = (int) Math.min(upTo, level0LastDocID + 1L);
 
       // Frequencies are decoded lazily, calling freq() makes sure that the freq block is decoded
@@ -1066,7 +1066,7 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
           break;
         case UNARY:
           buffer.size =
-              bitSetUtil.denseBitsetToArray(
+              BitSetUtil.denseBitsetToArray(
                   docBitSet, doc - docBitSetBase, upTo - docBitSetBase, docBitSetBase, buffer.docs);
           break;
       }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
@@ -1070,14 +1070,14 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
           System.arraycopy(docBuffer, start, buffer.docs, 0, buffer.size);
           break;
         case UNARY:
-          buffer.size = denseBitsetToArray(
-              docBitSet,
-              doc - docBitSetBase,
-              upTo - docBitSetBase,
-              docBitSetBase,
-              buffer.docs,
-              scratch
-          );
+          buffer.size =
+              denseBitsetToArray(
+                  docBitSet,
+                  doc - docBitSetBase,
+                  upTo - docBitSetBase,
+                  docBitSetBase,
+                  buffer.docs,
+                  scratch);
           break;
       }
 
@@ -1089,7 +1089,8 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
       advance(upTo);
     }
 
-    private static int denseBitsetToArray(FixedBitSet bitSet, int from, int to, int base, int[] array, int[] scratch) {
+    private static int denseBitsetToArray(
+        FixedBitSet bitSet, int from, int to, int base, int[] array, int[] scratch) {
       Objects.checkFromToIndex(from, to, bitSet.length());
 
       int offset = 0;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
@@ -31,9 +31,7 @@ import java.util.AbstractList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.RandomAccess;
-import java.util.stream.IntStream;
 import org.apache.lucene.codecs.BlockTermState;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.PostingsReaderBase;
@@ -80,8 +78,6 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
   // We stopped storing a placeholder impact with freq=1 for fields with DOCS after 9.12.0
   private static final List<Impact> DUMMY_IMPACTS_NO_FREQS =
       Collections.singletonList(new Impact(1, 1L));
-
-  private static final int[] IDENTITY = IntStream.range(0, 32).toArray();
 
   private final IndexInput docIn;
   private final IndexInput posIn;
@@ -307,6 +303,7 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
       UNARY
     }
 
+    private final BitSetUtil bitSetUtil = new BitSetUtil();
     private ForDeltaUtil forDeltaUtil;
     private PForUtil pforUtil;
 
@@ -1039,8 +1036,6 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
       }
     }
 
-    private final int[] scratch = new int[64];
-
     @Override
     public void nextPostings(int upTo, DocAndFloatFeatureBuffer buffer) throws IOException {
       assert needsRefilling == false;
@@ -1071,13 +1066,8 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
           break;
         case UNARY:
           buffer.size =
-              denseBitsetToArray(
-                  docBitSet,
-                  doc - docBitSetBase,
-                  upTo - docBitSetBase,
-                  docBitSetBase,
-                  buffer.docs,
-                  scratch);
+              bitSetUtil.denseBitsetToArray(
+                  docBitSet, doc - docBitSetBase, upTo - docBitSetBase, docBitSetBase, buffer.docs);
           break;
       }
 
@@ -1087,66 +1077,6 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
       }
 
       advance(upTo);
-    }
-
-    private static int denseBitsetToArray(
-        FixedBitSet bitSet, int from, int to, int base, int[] array, int[] scratch) {
-      Objects.checkFromToIndex(from, to, bitSet.length());
-
-      int offset = 0;
-      long[] bits = bitSet.getBits();
-      // First, align `from` with a word start, ie. a multiple of Long.SIZE (64)
-      if ((from & 0x3F) != 0) {
-        long word = bits[from >> 6] >>> from;
-        int numBitsTilNextWord = -from & 0x3F;
-        if (to - from < numBitsTilNextWord) {
-          // All bits are in a single word
-          word &= (1L << (to - from)) - 1L;
-          return word2Array(word, from + base, array, offset, scratch);
-        }
-        offset = word2Array(word, from + base, array, offset, scratch);
-        from += numBitsTilNextWord;
-        assert (from & 0x3F) == 0;
-      }
-
-      for (int i = from >> 6, end = to >> 6; i < end; ++i) {
-        long word = bits[i];
-        offset = word2Array(word, base + (i << 6), array, offset, scratch);
-      }
-
-      // Now handle remaining bits in the last partial word
-      if ((to & 0x3F) != 0) {
-        long word = bits[to >> 6] & ((1L << to) - 1);
-        offset = word2Array(word, base + (to & ~0x3F), array, offset, scratch);
-      }
-
-      return offset;
-    }
-
-    private static int word2Array(long word, int base, int[] docs, int offset, int[] scratch) {
-      final int bitCount = Long.bitCount(word);
-
-      if (bitCount >= 32) {
-        final int lWord = (int) word;
-        final int hWord = (int) (word >>> 32);
-        // vectorized loop
-        for (int i = 0; i < 32; i++) {
-          scratch[i] = (lWord >>> IDENTITY[i]) & 1;
-          scratch[i + 32] = (hWord >>> IDENTITY[i]) & 1;
-        }
-        for (int i = 0; i < 64; i++) {
-          docs[offset] = base + i;
-          offset += scratch[i];
-        }
-      } else {
-        for (int i = 0; i < bitCount; i++) {
-          int ntz = Long.numberOfTrailingZeros(word);
-          docs[offset++] = base + ntz;
-          word ^= 1L << ntz;
-        }
-      }
-
-      return offset;
     }
 
     private int computeBufferEndBoundary(int upTo) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
@@ -303,7 +303,7 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
       UNARY
     }
 
-    private final BitSetUtil bitSetUtil = new BitSetUtil();
+    private BitSetUtil bitSetUtil;
     private ForDeltaUtil forDeltaUtil;
     private PForUtil pforUtil;
 
@@ -518,6 +518,8 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
 
       if (forDeltaUtil == null && docFreq >= BLOCK_SIZE) {
         forDeltaUtil = new ForDeltaUtil();
+        assert bitSetUtil == null;
+        bitSetUtil = new BitSetUtil();
       }
       totalTermFreq = indexHasFreq ? termState.totalTermFreq : termState.docFreq;
       if (needsFreq && pforUtil == null && totalTermFreq >= BLOCK_SIZE) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
@@ -303,7 +303,7 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
       UNARY
     }
 
-    private BitSetUtil bitSetUtil;
+    private final BitSetUtil bitSetUtil = new BitSetUtil();
     private ForDeltaUtil forDeltaUtil;
     private PForUtil pforUtil;
 
@@ -518,8 +518,6 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
 
       if (forDeltaUtil == null && docFreq >= BLOCK_SIZE) {
         forDeltaUtil = new ForDeltaUtil();
-        assert bitSetUtil == null;
-        bitSetUtil = new BitSetUtil();
       }
       totalTermFreq = indexHasFreq ? termState.totalTermFreq : termState.docFreq;
       if (needsFreq && pforUtil == null && totalTermFreq >= BLOCK_SIZE) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
@@ -80,7 +80,8 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
   // We stopped storing a placeholder impact with freq=1 for fields with DOCS after 9.12.0
   private static final List<Impact> DUMMY_IMPACTS_NO_FREQS =
       Collections.singletonList(new Impact(1, 1L));
-  private static int[] IDENTITY = IntStream.range(0, 32).toArray();
+
+  private static final int[] IDENTITY = IntStream.range(0, 32).toArray();
 
   private final IndexInput docIn;
   private final IndexInput posIn;

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene103/TestBitSetUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene103/TestBitSetUtil.java
@@ -1,0 +1,37 @@
+package org.apache.lucene.codecs.lucene103;
+
+import static org.apache.lucene.codecs.lucene103.Lucene103PostingsFormat.BLOCK_SIZE;
+
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.FixedBitSet;
+
+public class TestBitSetUtil extends LuceneTestCase {
+
+  public void testDenseBitsetToArray() throws Exception {
+    for (int iter = 0; iter < 1000; iter++) {
+      FixedBitSet bitSet = new FixedBitSet(BLOCK_SIZE + random().nextInt(200));
+      while (bitSet.cardinality() < BLOCK_SIZE) {
+        bitSet.set(random().nextInt(bitSet.length()));
+      }
+
+      int[] array = new int[BLOCK_SIZE + 1];
+      int from, to, size;
+      if (random().nextBoolean()) {
+        from = 0;
+        to = bitSet.length();
+      } else {
+        from = random().nextInt(bitSet.length());
+        to = from + random().nextInt(bitSet.length() - from);
+      }
+
+      int base = random().nextInt(1000);
+      size = BitSetUtil.denseBitsetToArray(bitSet, from, to, base, array);
+
+      assertEquals(bitSet.cardinality(from, to), size);
+
+      int[] index = new int[] {0};
+      bitSet.forEach(from, to, base, bit -> assertEquals(bit, array[index[0]++]));
+      assertEquals(size, index[0]);
+    }
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene103/TestBitSetUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene103/TestBitSetUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.lucene.codecs.lucene103;
 
 import static org.apache.lucene.codecs.lucene103.Lucene103PostingsFormat.BLOCK_SIZE;


### PR DESCRIPTION
This comes from https://github.com/apache/lucene/pull/14910#issuecomment-3059176116.

JMH shows:

1. `whileLoop`, `forloop`, `forLoopManualUnrolling` are having even performance, `whileLoop` is even slightly better. So in #14910, the speed-up i see (when vector module disabled or at mac m2) may come from some where else, like the consumer abstraction? JMH results can sometimes be not consistent with luceneutil as well. So it is hard to say.

```
BitsetToArrayBenchmark.whileLoop                           5  thrpt    5  29.180 ± 0.568  ops/us
BitsetToArrayBenchmark.whileLoop                          10  thrpt    5  23.460 ± 0.120  ops/us
BitsetToArrayBenchmark.whileLoop                          20  thrpt    5  16.722 ± 0.330  ops/us
BitsetToArrayBenchmark.whileLoop                          30  thrpt    5  13.006 ± 0.292  ops/us
BitsetToArrayBenchmark.whileLoop                          40  thrpt    5  10.678 ± 0.195  ops/us
BitsetToArrayBenchmark.whileLoop                          50  thrpt    5   9.035 ± 0.179  ops/us
BitsetToArrayBenchmark.whileLoop                          60  thrpt    5   7.834 ± 0.060  ops/us
BitsetToArrayBenchmark.forLoop                             5  thrpt    5  26.207 ± 0.642  ops/us
BitsetToArrayBenchmark.forLoop                            10  thrpt    5  21.541 ± 0.281  ops/us
BitsetToArrayBenchmark.forLoop                            20  thrpt    5  15.884 ± 0.310  ops/us
BitsetToArrayBenchmark.forLoop                            30  thrpt    5  12.666 ± 0.013  ops/us
BitsetToArrayBenchmark.forLoop                            40  thrpt    5  10.412 ± 0.180  ops/us
BitsetToArrayBenchmark.forLoop                            50  thrpt    5   8.881 ± 0.091  ops/us
BitsetToArrayBenchmark.forLoop                            60  thrpt    5   7.709 ± 0.222  ops/us
BitsetToArrayBenchmark.forLoopManualUnrolling              5  thrpt    5  25.848 ± 0.492  ops/us
BitsetToArrayBenchmark.forLoopManualUnrolling             10  thrpt    5  21.263 ± 0.354  ops/us
BitsetToArrayBenchmark.forLoopManualUnrolling             20  thrpt    5  15.842 ± 0.315  ops/us
BitsetToArrayBenchmark.forLoopManualUnrolling             30  thrpt    5  12.641 ± 0.053  ops/us
BitsetToArrayBenchmark.forLoopManualUnrolling             40  thrpt    5  10.489 ± 0.073  ops/us
BitsetToArrayBenchmark.forLoopManualUnrolling             50  thrpt    5   8.930 ± 0.178  ops/us
BitsetToArrayBenchmark.forLoopManualUnrolling             60  thrpt    5   7.816 ± 0.018  ops/us
```

2. 
> By the way, we may want to look into other approaches for the scalar case. Since we only use bit sets in postings when many bits would be set, a linear scan should perform quite efficiently?

Inspired by this comment, i tried some dense optimization ways, as you can see `denseXXX` in jmh. The fastest is `denseBranchlessUnrolling` but i liked `denseBranchlessVectorized` better since it has less code.

```
Benchmark                                         (bitCount)   Mode  Cnt   Score   Error   Units
BitsetToArrayBenchmark.dense                               5  thrpt    5   9.668 ± 0.054  ops/us
BitsetToArrayBenchmark.dense                              10  thrpt    5   6.949 ± 0.068  ops/us
BitsetToArrayBenchmark.dense                              20  thrpt    5   4.607 ± 0.057  ops/us
BitsetToArrayBenchmark.dense                              30  thrpt    5   3.432 ± 0.037  ops/us
BitsetToArrayBenchmark.dense                              40  thrpt    5   3.759 ± 0.036  ops/us
BitsetToArrayBenchmark.dense                              50  thrpt    5   5.310 ± 0.016  ops/us
BitsetToArrayBenchmark.dense                              60  thrpt    5   9.039 ± 0.240  ops/us
BitsetToArrayBenchmark.denseBranchLess                     5  thrpt    5  13.464 ± 0.446  ops/us
BitsetToArrayBenchmark.denseBranchLess                    10  thrpt    5  13.547 ± 0.250  ops/us
BitsetToArrayBenchmark.denseBranchLess                    20  thrpt    5  13.531 ± 0.209  ops/us
BitsetToArrayBenchmark.denseBranchLess                    30  thrpt    5  13.534 ± 0.336  ops/us
BitsetToArrayBenchmark.denseBranchLess                    40  thrpt    5  13.530 ± 0.319  ops/us
BitsetToArrayBenchmark.denseBranchLess                    50  thrpt    5  13.515 ± 0.330  ops/us
BitsetToArrayBenchmark.denseBranchLess                    60  thrpt    5  13.526 ± 0.067  ops/us
BitsetToArrayBenchmark.denseBranchLessUnrolling            5  thrpt    5  15.753 ± 0.262  ops/us
BitsetToArrayBenchmark.denseBranchLessUnrolling           10  thrpt    5  15.709 ± 0.214  ops/us
BitsetToArrayBenchmark.denseBranchLessUnrolling           20  thrpt    5  15.811 ± 0.334  ops/us
BitsetToArrayBenchmark.denseBranchLessUnrolling           30  thrpt    5  15.752 ± 0.444  ops/us
BitsetToArrayBenchmark.denseBranchLessUnrolling           40  thrpt    5  15.861 ± 0.074  ops/us
BitsetToArrayBenchmark.denseBranchLessUnrolling           50  thrpt    5  15.630 ± 0.052  ops/us
BitsetToArrayBenchmark.denseBranchLessUnrolling           60  thrpt    5  15.789 ± 0.682  ops/us
BitsetToArrayBenchmark.denseBranchLessVectorized           5  thrpt    5  14.884 ± 0.212  ops/us
BitsetToArrayBenchmark.denseBranchLessVectorized          10  thrpt    5  14.931 ± 0.328  ops/us
BitsetToArrayBenchmark.denseBranchLessVectorized          20  thrpt    5  14.953 ± 0.050  ops/us
BitsetToArrayBenchmark.denseBranchLessVectorized          30  thrpt    5  15.011 ± 0.328  ops/us
BitsetToArrayBenchmark.denseBranchLessVectorized          40  thrpt    5  14.961 ± 0.394  ops/us
BitsetToArrayBenchmark.denseBranchLessVectorized          50  thrpt    5  14.927 ± 0.323  ops/us
BitsetToArrayBenchmark.denseBranchLessVectorized          60  thrpt    5  14.924 ± 0.286  ops/us
BitsetToArrayBenchmark.denseInvert                         5  thrpt    5  22.539 ± 0.523  ops/us
BitsetToArrayBenchmark.denseInvert                        10  thrpt    5  16.538 ± 0.298  ops/us
BitsetToArrayBenchmark.denseInvert                        20  thrpt    5  12.110 ± 0.228  ops/us
BitsetToArrayBenchmark.denseInvert                        30  thrpt    5  10.344 ± 0.195  ops/us
BitsetToArrayBenchmark.denseInvert                        40  thrpt    5   9.934 ± 0.201  ops/us
BitsetToArrayBenchmark.denseInvert                        50  thrpt    5  10.192 ± 0.309  ops/us
BitsetToArrayBenchmark.denseInvert                        60  thrpt    5  11.114 ± 0.387  ops/us
BitsetToArrayBenchmark.hybrid                              5  thrpt    5  25.812 ± 0.503  ops/us
BitsetToArrayBenchmark.hybrid                             10  thrpt    5  21.618 ± 0.062  ops/us
BitsetToArrayBenchmark.hybrid                             20  thrpt    5  15.988 ± 0.018  ops/us
BitsetToArrayBenchmark.hybrid                             30  thrpt    5  12.660 ± 0.027  ops/us
BitsetToArrayBenchmark.hybrid                             40  thrpt    5  14.960 ± 0.201  ops/us
BitsetToArrayBenchmark.hybrid                             50  thrpt    5  14.907 ± 0.407  ops/us
BitsetToArrayBenchmark.hybrid                             60  thrpt    5  14.933 ± 0.364  ops/us
```

And luceneutil result: (This one is not correct, see https://github.com/apache/lucene/pull/14935#issuecomment-3065989475)

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                   TermTitleSort       56.43      (3.2%)       54.92      (3.3%)   -2.7% (  -8% -    3%) 0.030
                 AndHighOrMedMed       21.09      (1.7%)       20.91      (1.3%)   -0.9% (  -3% -    2%) 0.140
                 CountAndHighMed       63.47      (2.6%)       63.16      (3.5%)   -0.5% (  -6% -    5%) 0.672
               TermDayOfYearSort      302.92      (1.2%)      301.46      (4.3%)   -0.5% (  -5% -    5%) 0.685
                        PKLookup       76.25      (2.4%)       76.01      (1.4%)   -0.3% (  -3% -    3%) 0.671
                          Fuzzy1       32.73      (2.4%)       32.66      (3.3%)   -0.2% (  -5% -    5%) 0.849
                          Fuzzy2       30.22      (1.7%)       30.20      (2.7%)   -0.1% (  -4% -    4%) 0.929
                    CombinedTerm       16.35      (2.1%)       16.34      (1.3%)   -0.0% (  -3% -    3%) 0.976
                         Respell       27.75      (1.9%)       27.77      (2.7%)    0.1% (  -4% -    4%) 0.947
                    FilteredTerm       64.97      (1.9%)       65.02      (2.5%)    0.1% (  -4% -    4%) 0.920
             CountFilteredPhrase       11.49      (1.1%)       11.51      (1.2%)    0.1% (  -2% -    2%) 0.820
                        Wildcard       48.76      (3.1%)       48.81      (3.1%)    0.1% (  -5% -    6%) 0.923
         CountFilteredOrHighHigh       25.92      (0.8%)       25.96      (1.1%)    0.1% (  -1% -    2%) 0.685
                            Term      396.14      (5.7%)      396.74      (5.4%)    0.2% ( -10% -   11%) 0.943
                          IntNRQ       55.37      (2.1%)       55.48      (2.4%)    0.2% (  -4% -    4%) 0.815
                   TermMonthSort     1158.39      (3.1%)     1160.79      (5.3%)    0.2% (  -7% -    8%) 0.899
                CountAndHighHigh       54.59      (1.5%)       54.72      (1.9%)    0.2% (  -3% -    3%) 0.713
              FilteredOrHighHigh       16.18      (1.8%)       16.23      (2.9%)    0.3% (  -4% -    5%) 0.735
                          IntSet      149.94      (4.3%)      150.42      (4.7%)    0.3% (  -8% -    9%) 0.851
          CountFilteredOrHighMed       31.52      (0.9%)       31.62      (1.3%)    0.3% (  -1% -    2%) 0.462
            FilteredAndStopWords       12.58      (1.9%)       12.62      (1.9%)    0.4% (  -3% -    4%) 0.602
                  FilteredIntNRQ       54.87      (1.1%)       55.09      (1.9%)    0.4% (  -2% -    3%) 0.503
             CountFilteredIntNRQ       24.33      (1.2%)       24.44      (1.5%)    0.4% (  -2% -    3%) 0.403
             FilteredAndHighHigh       14.57      (1.8%)       14.64      (2.0%)    0.5% (  -3% -    4%) 0.513
                  FilteredPhrase       11.89      (2.4%)       11.95      (3.0%)    0.5% (  -4% -    6%) 0.624
                         Prefix3       79.10      (3.9%)       79.51      (4.5%)    0.5% (  -7% -    9%) 0.743
               FilteredOrHighMed       49.42      (1.8%)       49.69      (3.2%)    0.5% (  -4% -    5%) 0.586
              CombinedAndHighMed       28.15      (1.8%)       28.31      (2.7%)    0.6% (  -3% -    5%) 0.514
      FilteredOr2Terms2StopWords       57.94      (1.9%)       58.27      (2.8%)    0.6% (  -3% -    5%) 0.520
                 FilteredPrefix3       73.30      (4.3%)       73.76      (4.8%)    0.6% (  -8% -   10%) 0.720
                          Phrase        9.22      (2.2%)        9.28      (2.9%)    0.6% (  -4% -    5%) 0.517
                  CountOrHighMed       83.12      (2.1%)       83.68      (2.4%)    0.7% (  -3% -    5%) 0.431
                 CountOrHighHigh       55.51      (0.9%)       55.89      (1.7%)    0.7% (  -1% -    3%) 0.173
             FilteredOrStopWords       11.10      (2.1%)       11.18      (2.7%)    0.7% (  -3% -    5%) 0.426
               FilteredAnd3Terms       80.17      (1.4%)       80.77      (2.9%)    0.7% (  -3% -    5%) 0.383
                AndMedOrHighHigh       19.29      (3.1%)       19.43      (3.5%)    0.8% (  -5% -    7%) 0.545
                       CountTerm     2854.29      (2.9%)     2876.79      (3.9%)    0.8% (  -5% -    7%) 0.545
                      DismaxTerm      321.50      (4.0%)      324.09      (3.6%)    0.8% (  -6% -    8%) 0.575
                FilteredOr3Terms       50.89      (1.3%)       51.31      (2.9%)    0.8% (  -3% -    5%) 0.327
               CombinedOrHighMed       27.67      (1.7%)       27.93      (2.4%)    0.9% (  -3% -    5%) 0.238
                       OrHighMed       78.17      (8.1%)       78.97      (8.1%)    1.0% ( -13% -   18%) 0.737
                 DismaxOrHighMed       52.90      (4.7%)       53.87      (5.0%)    1.8% (  -7% -   12%) 0.317
                      TermDTSort      184.12      (1.8%)      187.60      (4.0%)    1.9% (  -3% -    7%) 0.109
              FilteredAndHighMed       42.42      (2.3%)       43.24      (3.4%)    1.9% (  -3% -    7%) 0.084
                      AndHighMed       59.49      (6.4%)       60.73      (8.2%)    2.1% ( -11% -   17%) 0.452
                      OrHighRare      113.84      (5.1%)      116.29      (5.9%)    2.1% (  -8% -   13%) 0.303
             And2Terms2StopWords       60.52      (4.4%)       62.04      (4.9%)    2.5% (  -6% -   12%) 0.154
                DismaxOrHighHigh       37.38      (5.3%)       38.37      (5.7%)    2.7% (  -7% -   14%) 0.201
     FilteredAnd2Terms2StopWords       61.89      (2.5%)       63.59      (3.8%)    2.7% (  -3% -    9%) 0.025
             CombinedAndHighHigh        7.77      (1.9%)        7.99      (2.0%)    2.8% (  -1% -    6%) 0.000
              CombinedOrHighHigh        7.66      (1.9%)        7.90      (2.3%)    3.1% (  -1% -    7%) 0.000
              Or2Terms2StopWords       62.35      (4.3%)       64.34      (5.4%)    3.2% (  -6% -   13%) 0.086
                     AndHighHigh       26.50      (9.3%)       28.10     (10.7%)    6.0% ( -12% -   28%) 0.112
                      OrHighHigh       26.64      (8.6%)       28.27     (10.4%)    6.1% ( -11% -   27%) 0.089
                        Or3Terms       64.65      (4.8%)       68.88      (6.5%)    6.5% (  -4% -   18%) 0.002
                       And3Terms       69.90      (4.6%)       74.59      (6.7%)    6.7% (  -4% -   18%) 0.002
                    AndStopWords       10.30      (5.8%)       11.89      (9.2%)   15.4% (   0% -   32%) 0.000
                     OrStopWords       10.83      (7.6%)       12.57     (10.1%)   16.0% (  -1% -   36%) 0.000
```

Another thing makes me not happy is the duplicate word-level code with `FixedBitSet#forEach`, but i have not had a good idea to reuse it for now.



