### PR TITLE
add illegal-incubator-usage lint check

### DIFF
--- a/gradle/validation/ast-grep/rules/vectors.yml
+++ b/gradle/validation/ast-grep/rules/vectors.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
+id: illegal-incubator-usage
+language: java
+ignores:
+  # the only place vector api code should sit.
+  - "**/internal/vectorization/PanamaVector{Constants,UtilSupport}.java"
+  # TODO: move this vector logic to PanamaVectorUtilSupport!
+  - "**/internal/vectorization/MemorySegmentPostingDecodingUtil.java"
+rule:
+  kind: scoped_identifier
+  all:
+    - has:
+        field: scope
+        pattern: jdk
+    - has:
+        field: name
+        pattern: incubator
+severity: error
+message: Incubator APIs must not be used
+note: Move logic to `PanamaVectorUtilSupport`

--- a/gradle/validation/ast-grep/tests/vectors.yml
+++ b/gradle/validation/ast-grep/tests/vectors.yml
@@ -1,0 +1,8 @@
+# Prevent vector api calls from spreading haphazardly without checks
+---
+id: illegal-incubator-usage
+invalid:
+  - import jdk.incubator.vector.FloatVector
+  - import static jdk.incubator.vector.VectorOperators.ADD
+valid:
+  - import java.util.List

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/MemorySegmentPostingDecodingUtil.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/MemorySegmentPostingDecodingUtil.java
@@ -36,6 +36,8 @@ final class MemorySegmentPostingDecodingUtil extends PostingDecodingUtil {
     this.memorySegment = memorySegment;
   }
 
+  // FIXME: move this logic to PanamaVectorUtilSupport.
+
   private static void shift(
       IntVector vector, int bShift, int dec, int maxIter, int bMask, int[] b, int count, int i) {
     for (int j = 0; j <= maxIter; ++j) {

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorizationProvider.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorizationProvider.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.lang.foreign.MemorySegment;
 import java.util.Locale;
 import java.util.logging.Logger;
-import jdk.incubator.vector.FloatVector;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.MemorySegmentAccessInput;
@@ -37,10 +36,6 @@ final class PanamaVectorizationProvider extends VectorizationProvider {
   private final VectorUtilSupport vectorUtilSupport;
 
   PanamaVectorizationProvider() {
-    // hack to work around for JDK-8309727:
-    FloatVector.fromArray(
-        FloatVector.SPECIES_PREFERRED, new float[FloatVector.SPECIES_PREFERRED.length()], 0);
-
     if (PanamaVectorConstants.PREFERRED_VECTOR_BITSIZE < 128) {
       throw new UnsupportedOperationException(
           "Vector bit size is less than 128: " + PanamaVectorConstants.PREFERRED_VECTOR_BITSIZE);


### PR DESCRIPTION
Prevent proliferation of vectors api code outside of PanamaVectorUtilSupport.

It is already happening: example is the memory segment abstraction, which I've left as a TODO to fix.

Let's keep all vectors code into a single file for easy static analysis: we can add simple rules to prevent performance traps instead of constantly staring at assembly, looking at openjdk sources, debugging 10x slowdowns.

But we can't do it, if kernels spread via complex java abstractions, because it makes the analysis too difficult.

Closes #14937

This is just the first step. We may have to adopt some different patterns and so on with our vectors code to help prevent the traps. But I think we must use automation and not do it manually on every PR.