### PR TITLE
fail 'gradle check' on unchecked slow vector api feature usage 

### DIFF
--- a/gradle/validation/ast-grep/rules/vectors.yml
+++ b/gradle/validation/ast-grep/rules/vectors.yml
@@ -1,3 +1,5 @@
+# Special policing of vectorization sources to prevent performance traps!
+---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
 id: illegal-incubator-usage
 language: java
@@ -18,3 +20,19 @@ rule:
 severity: error
 message: Incubator APIs must not be used
 note: Move logic to `PanamaVectorUtilSupport`
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
+id: unchecked-slow-vector-feature
+language: java
+files:
+  - "**/internal/vectorization/**.java"
+rule:
+  all:
+    - matches: slow-vector-feature
+    - not:
+        inside:
+          matches: vector-feature-check
+          stopBy: end
+severity: error
+message: "Vector API feature `$IDENTIFIER` may be slow on some hardware"
+note: guard usage inside `if` with `Constants.HAS_<FEATURE>` check

--- a/gradle/validation/ast-grep/rules/vectors.yml
+++ b/gradle/validation/ast-grep/rules/vectors.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
+id: illegal-incubator-usage
+language: java
+ignores:
+  # the only place vector api code should sit.
+  - "**/internal/vectorization/PanamaVector{Constants,UtilSupport}.java"
+  # TODO: move this vector logic to PanamaVectorUtilSupport!
+  - "**/internal/vectorization/MemorySegmentPostingDecodingUtil.java"
+rule:
+  kind: scoped_identifier
+  all:
+    - has:
+        field: scope
+        pattern: jdk
+    - has:
+        field: name
+        pattern: incubator
+severity: error
+message: Incubator APIs must not be used
+note: Move logic to `PanamaVectorUtilSupport`

--- a/gradle/validation/ast-grep/tests/vectors.yml
+++ b/gradle/validation/ast-grep/tests/vectors.yml
@@ -1,0 +1,8 @@
+# Prevent vector api calls from spreading haphazardly without checks
+---
+id: illegal-incubator-usage
+invalid:
+  - import jdk.incubator.vector.FloatVector
+  - import static jdk.incubator.vector.VectorOperators.ADD
+valid:
+  - import java.util.List

--- a/gradle/validation/ast-grep/tests/vectors.yml
+++ b/gradle/validation/ast-grep/tests/vectors.yml
@@ -6,3 +6,64 @@ invalid:
   - import static jdk.incubator.vector.VectorOperators.ADD
 valid:
   - import java.util.List
+---
+id: unchecked-slow-vector-feature
+invalid:
+  - import static jdk.incubator.vector.VectorOperators.FMA
+    a.lanewise(FMA, b, c)
+  - import static jdk.incubator.vector.VectorOperators.FMA
+    if (other) {
+      a.lanewise(FMA, b, c)
+    }
+  - import static jdk.incubator.vector.VectorOperators.FMA
+    if (Constants.HAS_FAST_VECTOR_FMA || other) {
+      a.lanewise(FMA, b, c)
+    }
+  - import static jdk.incubator.vector.VectorOperators.FMA
+    if (!Constants.HAS_FAST_VECTOR_FMA) {
+      a.lanewise(FMA, b, c)
+    }
+  - import static jdk.incubator.vector.VectorOperators.FMA
+    if (Constants.HAS_FAST_VECTOR_FMA) {
+      somethingElse()
+    } else {
+      a.lanewise(FMA, b, c)
+    }
+  - import jdk.incubator.vector.VectorOperators
+    a.lanewise(VectorOperators.FMA, b, c)
+  # note: doesn't actually chase types yet
+  - import jdk.incubator.vector.ByteVector
+    ByteVector x = ByteVector.fromMemorySegment()
+    x.fma(other, other)
+valid:
+  - |
+    import static jdk.incubator.vector.VectorOperators.FMA
+    if (Constants.HAS_FAST_VECTOR_FMA) {
+      a.lanewise(FMA, b, c)
+    }
+  - |
+    import static jdk.incubator.vector.VectorOperators.FMA
+    if (Constants.HAS_FAST_VECTOR_FMA && other) {
+      a.lanewise(FMA, b, c)
+    }
+  - |
+    import static jdk.incubator.vector.VectorOperators.FMA
+    if (other && Constants.HAS_FAST_VECTOR_FMA) {
+      a.lanewise(FMA, b, c)
+    }
+  - |
+    import static jdk.incubator.vector.VectorOperators.FMA
+    if (other) {
+      somethingSafe()
+    } else if (Constants.HAS_FAST_VECTOR_FMA) {
+      a.lanewise(FMA, b, c)
+    }
+  - |
+    import static jdk.incubator.vector.VectorOperators.FMA
+    if (Constants.HAS_FAST_VECTOR_FMA) {
+      if (somethingElse) {
+        for (var foo : bar) {
+          a.lanewise(FMA, b, c)
+        }
+      }
+    }

--- a/gradle/validation/ast-grep/utils/slow-vector-feature.yml
+++ b/gradle/validation/ast-grep/utils/slow-vector-feature.yml
@@ -1,0 +1,70 @@
+# Matches a vector API feature which may be slow on some hardware
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
+id: slow-vector-feature
+language: java
+utils:
+  # imported as $IMPORT from the vector api
+  has-import:
+    pattern: $$$
+    inside:
+      kind: program
+      stopBy: end
+      has:
+        kind: import_declaration
+        any:
+          - pattern: import static $PACKAGE.$IMPORT;
+          - pattern: import $PACKAGE.$IMPORT;
+    # don't match identifiers inside import statements themselves
+    not:
+      inside:
+        kind: import_declaration
+        stopBy: end
+rule:
+  any:
+    # unqualified access (field or method) with matching static import
+    - kind: identifier
+      all:
+        # matches name on bad list
+        - pattern: $IDENTIFIER
+        # also matches vector api import
+        - pattern: $IMPORT
+        - matches: has-import
+    # qualified constant field access with matching import
+    - kind: field_access
+      all:
+        - has:
+            field: field
+            pattern: $IDENTIFIER
+        - has:
+            field: object
+            pattern: $IMPORT
+            matches: has-import
+    # qualified method call (not a helper function with same name)
+    - kind: method_invocation
+      all:
+        # matches name on bad list
+        - has:
+            field: name
+            pattern: $IDENTIFIER
+        # any receiver, but it must have one
+        # TODO: refine if people complain :)
+        - has:
+            field: object
+            pattern: $$$
+constraints:
+  PACKAGE:
+    regex: ^jdk.incubator.vector
+  # slow methods and constants in the vector API
+  # please send a pull request if you find others!
+  IDENTIFIER:
+    any:
+      # falls back to BigInteger
+      - pattern: fma
+      - pattern: FMA
+      # not supported on NEON
+      - pattern: compress
+      - pattern: COMPRESS_BITS
+      # not supported on NEON
+      - pattern: expand
+      - pattern: EXPAND_BITS

--- a/gradle/validation/ast-grep/utils/vector-feature-check.yml
+++ b/gradle/validation/ast-grep/utils/vector-feature-check.yml
@@ -1,0 +1,40 @@
+# Matches a block guarded by a feature check.
+# Note, this rule doesn't do fancy flow analysis.
+# It can be made more complex to support more idioms, or we can keep logic restricted.
+# Remember the constant check will be removed by C2 which is required for vectors to be fast anyway.
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
+id: vector-feature-check
+language: java
+rule:
+  # java block of code, e.g. {}
+  kind: block
+  # inside or nested inside if/elseif
+  inside:
+    field: consequence
+    kind: if_statement
+    stopBy: end
+    # condition contains a Constants.* guard
+    has:
+      field: condition
+      kind: parenthesized_expression
+      has:
+        pattern:
+          selector: field_access
+          context: if (Constants.$FEATURE_CHECK)
+        stopBy: end
+      # unary/binary operations other than && are not allowed in the feature check
+      not:
+        any:
+          - has:
+              kind: binary_expression
+              stopBy: end
+              not:
+                has:
+                  pattern: "&&"
+          - has:
+              kind: unary_expression
+              stopBy: end
+constraints:
+  FEATURE_CHECK:
+    regex: ^HAS[_]

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/MemorySegmentPostingDecodingUtil.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/MemorySegmentPostingDecodingUtil.java
@@ -36,6 +36,8 @@ final class MemorySegmentPostingDecodingUtil extends PostingDecodingUtil {
     this.memorySegment = memorySegment;
   }
 
+  // FIXME: move this logic to PanamaVectorUtilSupport.
+
   private static void shift(
       IntVector vector, int bShift, int dec, int maxIter, int bMask, int[] b, int count, int i) {
     for (int j = 0; j <= maxIter; ++j) {

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorizationProvider.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorizationProvider.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.lang.foreign.MemorySegment;
 import java.util.Locale;
 import java.util.logging.Logger;
-import jdk.incubator.vector.FloatVector;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.MemorySegmentAccessInput;
@@ -37,10 +36,6 @@ final class PanamaVectorizationProvider extends VectorizationProvider {
   private final VectorUtilSupport vectorUtilSupport;
 
   PanamaVectorizationProvider() {
-    // hack to work around for JDK-8309727:
-    FloatVector.fromArray(
-        FloatVector.SPECIES_PREFERRED, new float[FloatVector.SPECIES_PREFERRED.length()], 0);
-
     if (PanamaVectorConstants.PREFERRED_VECTOR_BITSIZE < 128) {
       throw new UnsupportedOperationException(
           "Vector bit size is less than 128: " + PanamaVectorConstants.PREFERRED_VECTOR_BITSIZE);


### PR DESCRIPTION
slow vector features: operations that might be slow on particular hardware. For now the list is `fma`, `compress`, and `expand`.

unchecked: not guarded by a `if (Constants.HAS_XXX)` for use of the potentially slow features.

check is not perfect, because i'm tired. I implemented some of the chasing (e.g. imports) just to make progress though.

I don't want to overly restrict the idioms in use, but use of fancy java features in the vectorization code such as `var` and `import static` equate to more work, if we want to avoid false positives.

I imagine this thing might graduate from incubating at some point, so it'd be nice to run it across all the code without annoying people.