### PR TITLE
Enable tests.haltonfailure (regression on main)

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
@@ -168,9 +168,10 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
             false);
     Provider<Boolean> haltOnFailureOption =
         buildOptions.addBooleanOption(
-            "tests.haltonfailure", "Halt processing early on test failure.", true);
+            "tests.haltonfailure", "Stop processing on test failures.", true);
     Provider<Boolean> failFastOption =
-        buildOptions.addBooleanOption("tests.failfast", "Stop the build early on failure.", false);
+        buildOptions.addBooleanOption(
+            "tests.failfast", "Stop the build on the first failed test.", false);
     Provider<Boolean> rerunOption =
         buildOptions.addBooleanOption(
             "tests.rerun",

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
@@ -168,7 +168,7 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
             false);
     Provider<Boolean> haltOnFailureOption =
         buildOptions.addBooleanOption(
-            "tests.haltonfailure", "Halt processing early on test failure.", false);
+            "tests.haltonfailure", "Halt processing early on test failure.", true);
     Provider<Boolean> failFastOption =
         buildOptions.addBooleanOption("tests.failfast", "Stop the build early on failure.", false);
     Provider<Boolean> rerunOption =


### PR DESCRIPTION
There are two confusing options that the gradle test task has: failfast and ignorefailures. One stops the build as soon as the first test failed (failfast), the other causes the test task to not fail the build, even if tests failed. I introduced a regression where the second was set to true, causing tests to never failed the build.

I don't see the benefit of having these two options. Rather, it should be that you fail the build early or you fail the build at the very end of processing if any test failed. I may clean this up later - for now, re-enabling failures on failed tests.