### PR TITLE
build: fix some eclipse errors in build-infra

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/hacks/WipeGradleTempPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/hacks/WipeGradleTempPlugin.java
@@ -60,7 +60,7 @@ public abstract class WipeGradleTempPlugin extends LuceneGradlePlugin {
                   .getPlugins()
                   .withType(JavaPlugin.class)
                   .configureEach(
-                      unused -> {
+                      _ -> {
                         wipeAfterTests(project);
                       });
             });
@@ -97,7 +97,7 @@ public abstract class WipeGradleTempPlugin extends LuceneGradlePlugin {
     rootProject
         .getGradle()
         .buildFinished(
-            unused -> {
+            _ -> {
               cleanUpRedirectedTmpDir(rootProject);
               cleanUpGradlesTempDir(rootProject);
             });

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/misc/CheckEnvironmentPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/misc/CheckEnvironmentPlugin.java
@@ -109,7 +109,7 @@ public class CheckEnvironmentPlugin extends LuceneGradlePlugin {
             CHECK_JDK_INTERNALS_EXPOSED_TO_GRADLE_TASK,
             task -> {
               task.doFirst(
-                  t -> {
+                  _ -> {
                     var jdkCompilerModule =
                         ModuleLayer.boot().findModule("jdk.compiler").orElseThrow();
                     var gradleModule = getClass().getModule();

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/misc/HelpPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/misc/HelpPlugin.java
@@ -73,7 +73,7 @@ public class HelpPlugin extends LuceneGradlePlugin {
             task.setGroup("Help (developer guides and hints)");
             task.setDescription(helpEntry.description);
             task.doFirst(
-                t -> {
+                _ -> {
                   try {
                     println("\n" + Files.readString(rootProject.file(helpEntry.path).toPath()));
                   } catch (IOException e) {
@@ -89,7 +89,7 @@ public class HelpPlugin extends LuceneGradlePlugin {
         .configure(
             task -> {
               task.doFirst(
-                  t -> {
+                  _ -> {
                     printf("");
                     printf(
                         "This is Lucene %s build file (gradle %s). See some guidelines in files",
@@ -118,7 +118,7 @@ public class HelpPlugin extends LuceneGradlePlugin {
             "checkAllHelpFilesExist",
             task -> {
               task.doFirst(
-                  t -> {
+                  _ -> {
                     helpFiles.forEach(
                         helpFile -> {
                           if (!rootProject.file(helpFile.path).exists()) {

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/misc/QuietExec.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/misc/QuietExec.java
@@ -41,6 +41,7 @@ public class QuietExec extends Exec {
   }
 
   @TaskAction
+  @Override
   protected void exec() {
     try {
       // TODO: maybe add an output stream that spills to disk only when necessary here?


### PR DESCRIPTION
I don't think we are running ecj on these sources yet, but just clearing out the problems from my editor: very minor stuff such as missing @override and use of unnamed variables when lambda parameter is not used

