### PR TITLE
Move srcdir redirection for build-infra-shadow earlier in the build

### DIFF
--- a/build-tools/build-infra-shadow/build.gradle
+++ b/build-tools/build-infra-shadow/build.gradle
@@ -69,11 +69,3 @@ tasks.matching {
 }.configureEach {
   enabled = false
 }
-
-// make certain tasks think their sources are from build-infra.
-if (!buildGlobals.intellijIdea.get().isIdea) {
-  plugins.withType(JavaPlugin).configureEach {
-    SourceSet main = sourceSets.main
-    main.java.srcDirs = rootProject.files("build-tools/build-infra/src/main/java")
-  }
-}

--- a/build-tools/build-infra/src/main/groovy/lucene.java.modules.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.java.modules.gradle
@@ -152,7 +152,7 @@ allprojects {
           }
         } else {
           // This combination simply does not make any sense (in my opinion).
-          throw GradleException("Test source set is modular and main source set is class-based, this makes no sense: " + project.path)
+          throw new GradleException("Test source set is modular and main source set is class-based, this makes no sense: " + project.path)
         }
       } else {
         if (mainIsModular) {

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/JavaFolderLayoutPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/JavaFolderLayoutPlugin.java
@@ -40,6 +40,20 @@ public class JavaFolderLayoutPlugin extends LuceneGradlePlugin {
     mainSrcSet.java(srcSetDir -> srcSetDir.setSrcDirs(List.of("src/java")));
     mainSrcSet.resources(resources -> resources.setSrcDirs(List.of("src/resources")));
 
+    // point build-infra-shadow's main sources at build-infra sources so that we can
+    // reapply the build to ourselves.
+    if (project.getPath().equals(":lucene:build-tools:build-infra-shadow")
+        && !getLuceneBuildGlobals(project).getIntellijIdea().get().isIdea()) {
+      mainSrcSet.java(
+          srcSetDir -> {
+            srcSetDir.setSrcDirs(
+                List.of(
+                    getProjectRootPath(project)
+                        .resolve("build-tools/build-infra/src/main/java")
+                        .toFile()));
+          });
+    }
+
     SourceSet testSrcSet = sourceSets.named("test").get();
     testSrcSet.java(srcSetDir -> srcSetDir.setSrcDirs(List.of("src/test")));
     testSrcSet.resources(resources -> resources.setSrcDirs(List.of("src/test-files")));


### PR DESCRIPTION
So that tasks that eagerly do something with the sourceset have a chance to work with the redirected path.

This makes ecj-lint run properly.
