### PR TITLE
Address test failure #14948 TestLateInteractionRescorer.testBasic

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestLateInteractionRescorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLateInteractionRescorer.java
@@ -77,7 +77,7 @@ public class TestLateInteractionRescorer extends LuceneTestCase {
           float[][] docVector = corpus.get(idValue);
           float expected =
               scoreFunction.compare(lateIQueryVector, docVector, vectorSimilarityFunction);
-          assertEquals(expected, rerankedHits.scoreDocs[i].score, 1e-5);
+          assertEquals(expected, rerankedHits.scoreDocs[i].score, 1e-4f);
           if (i > 0) {
             assertTrue(rerankedHits.scoreDocs[i].score <= rerankedHits.scoreDocs[i - 1].score);
           }


### PR DESCRIPTION
Seems to fail regularly on the ubuntu github runner. Switch to `1e-4f` epsilon on score equality check

closes: https://github.com/apache/lucene/issues/14948