### PR TITLE
Monitor Stop Relying on Hashcode Across JVMs Fix 2

### DIFF
--- a/lucene/monitor/src/java/org/apache/lucene/monitor/QueryDecomposer.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/QueryDecomposer.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/QueryDecomposer.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/QueryDecomposer.java
@@ -57,7 +57,7 @@ public class QueryDecomposer {
       for (Query subq : ((DisjunctionMaxQuery) q).getDisjuncts()) {
         subqueries.addAll(decompose(subq));
       }
-      return order(subqueries);
+      return groupAndOrder(subqueries);
     }
 
     if (q instanceof BoostQuery) {
@@ -74,7 +74,7 @@ public class QueryDecomposer {
     for (Query subq : decompose(q.getQuery())) {
       boostedDecomposedQueries.add(new BoostQuery(subq, q.getBoost()));
     }
-    return order(boostedDecomposedQueries);
+    return groupAndOrder(boostedDecomposedQueries);
   }
 
   /**
@@ -109,7 +109,7 @@ public class QueryDecomposer {
       subqueries.addAll(decompose(mandatory.iterator().next()));
     }
 
-    if (exclusions.isEmpty()) return order(subqueries);
+    if (exclusions.isEmpty()) return groupAndOrder(subqueries);
 
     // If there are exclusions, then we need to add them to all the decomposed
     // queries
@@ -122,10 +122,10 @@ public class QueryDecomposer {
       }
       rewrittenSubqueries.add(bq.build());
     }
-    return order(rewrittenSubqueries);
+    return groupAndOrder(rewrittenSubqueries);
   }
 
-  private Set<Query> order(Collection<? extends Query> subqueries) {
+  private Set<Query> groupAndOrder(Collection<? extends Query> subqueries) {
     return new LinkedHashSet<>(
         subqueries.stream()
             .map(SortableDisjunction::new)

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/QueryDecomposer.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/QueryDecomposer.java
@@ -148,7 +148,7 @@ public class QueryDecomposer {
     private final Query query;
     private long sortVal;
 
-    public SortableDisjunct(Query query) {
+    SortableDisjunct(Query query) {
       this.query = query;
       query.visit(this);
     }
@@ -156,9 +156,8 @@ public class QueryDecomposer {
     @Override
     public void consumeTerms(Query query, Term... terms) {
       for (Term ter : terms) {
-        BytesRef field = new BytesRef(ter.field());
         if (!seen.contains(ter)) {
-          sortVal += StringHelper.murmurhash3_x86_32(field, FOREVER_SEED);
+          sortVal += StringHelper.murmurhash3_x86_32(new BytesRef(ter.field()), FOREVER_SEED);
           sortVal += StringHelper.murmurhash3_x86_32(ter.bytes(), FOREVER_SEED);
           seen.add(ter);
         }

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/QueryDecomposer.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/QueryDecomposer.java
@@ -145,7 +145,7 @@ public class QueryDecomposer {
   static final class SortableDisjunct extends QueryVisitor {
 
     private static final int FOREVER_SEED = 31;
-    private final Set<List<BytesRef>> seen = new HashSet<>();
+    private final Set<Term> seen = new HashSet<>();
     private final Query query;
     private long sortVal;
 
@@ -158,11 +158,10 @@ public class QueryDecomposer {
     public void consumeTerms(Query query, Term... terms) {
       for (Term ter : terms) {
         BytesRef field = new BytesRef(ter.field());
-        var key = List.of(field, ter.bytes());
-        if (!seen.contains(key)) {
+        if (!seen.contains(ter)) {
           sortVal += StringHelper.murmurhash3_x86_32(field, FOREVER_SEED);
           sortVal += StringHelper.murmurhash3_x86_32(ter.bytes(), FOREVER_SEED);
-          seen.add(key);
+          seen.add(ter);
         }
       }
     }

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/QueryDecomposer.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/QueryDecomposer.java
@@ -128,7 +128,7 @@ public class QueryDecomposer {
   private Set<Query> groupAndOrder(Collection<? extends Query> subqueries) {
     return new LinkedHashSet<>(
         subqueries.stream()
-            .map(SortableDisjunction::new)
+            .map(SortableDisjunct::new)
             .collect(
                 Collectors.toMap(
                     sd -> sd.sortVal,
@@ -142,14 +142,14 @@ public class QueryDecomposer {
             .values());
   }
 
-  static final class SortableDisjunction extends QueryVisitor {
+  static final class SortableDisjunct extends QueryVisitor {
 
     private static final int FOREVER_SEED = 31;
     private final Set<List<BytesRef>> seen = new HashSet<>();
     private final Query query;
     private long sortVal;
 
-    public SortableDisjunction(Query query) {
+    public SortableDisjunct(Query query) {
       this.query = query;
       query.visit(this);
     }

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestMonitorPersistence.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestMonitorPersistence.java
@@ -20,19 +20,32 @@ package org.apache.lucene.monitor;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Objects;
+import java.util.function.Function;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.StringHelper;
 
 public class TestMonitorPersistence extends MonitorTestBase {
 
   private Path indexDirectory = createTempDir();
 
   protected Monitor newMonitorWithPersistence() throws IOException {
+    return newMonitorWithPersistence(MonitorTestBase::parse);
+  }
+
+  protected Monitor newMonitorWithPersistence(Function<String, Query> parser) throws IOException {
     MonitorConfiguration config =
         new MonitorConfiguration()
-            .setIndexPath(
-                indexDirectory, MonitorQuerySerializer.fromParser(MonitorTestBase::parse));
+            .setIndexPath(indexDirectory, MonitorQuerySerializer.fromParser(parser));
 
     return new Monitor(ANALYZER, config);
   }
@@ -94,6 +107,90 @@ public class TestMonitorPersistence extends MonitorTestBase {
           expectThrows(IllegalStateException.class, () -> monitor2.getQuery("query"));
       assertEquals(
           "Cannot get queries from an index with no MonitorQuerySerializer", e.getMessage());
+    }
+  }
+
+  public void testReadingAfterBreakingUpgrade() throws IOException {
+    Document doc = new Document();
+    doc.add(newTextField(FIELD, "test", Field.Store.NO));
+    Function<String, Query> parser =
+        queryStr -> {
+          var query = (BooleanQuery) MonitorTestBase.parse(queryStr);
+          return incompatibleBooleanQuery(query);
+        };
+    try (Monitor monitor = newMonitorWithPersistence(parser)) {
+      StringBuilder queryStr = new StringBuilder();
+      for (int i = 0; i < 100; ++i) {
+        queryStr.append("test").append(i).append(" OR ");
+      }
+      queryStr.append(" test");
+      var mq =
+          new MonitorQuery(
+              "1",
+              incompatibleBooleanQuery((BooleanQuery) parse(queryStr.toString())),
+              queryStr.toString(),
+              Collections.emptyMap());
+      monitor.register(mq);
+      assertEquals(1, monitor.getQueryCount());
+      assertEquals(1, monitor.match(doc, QueryMatch.SIMPLE_MATCHER).getMatchCount());
+    }
+
+    SimulateUpgradeQuery.HASHCODE_FACTOR = ~StringHelper.GOOD_FAST_HASH_SEED;
+
+    try (Monitor monitor2 = newMonitorWithPersistence(parser)) {
+      assertEquals(1, monitor2.getQueryCount());
+      assertEquals(1, monitor2.match(doc, QueryMatch.SIMPLE_MATCHER).getMatchCount());
+    }
+  }
+
+  private static BooleanQuery incompatibleBooleanQuery(BooleanQuery query) {
+    var booleanBuilder = new BooleanQuery.Builder();
+    for (var clause : query) {
+      booleanBuilder.add(new SimulateUpgradeQuery(clause.query()), BooleanClause.Occur.SHOULD);
+    }
+    return booleanBuilder.build();
+  }
+
+  private static final class SimulateUpgradeQuery extends Query {
+
+    private static volatile int HASHCODE_FACTOR = 1;
+
+    private final Query innerQuery;
+
+    private SimulateUpgradeQuery(Query innerQuery) {
+      this.innerQuery = innerQuery;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
+        throws IOException {
+      return innerQuery.createWeight(searcher, scoreMode, boost);
+    }
+
+    @Override
+    public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+      return innerQuery.rewrite(indexSearcher);
+    }
+
+    @Override
+    public String toString(String field) {
+      return innerQuery.toString(field);
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+      innerQuery.visit(visitor);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof SimulateUpgradeQuery that)) return false;
+      return Objects.equals(innerQuery, that.innerQuery);
+    }
+
+    @Override
+    public int hashCode() {
+      return innerQuery.hashCode() * HASHCODE_FACTOR;
     }
   }
 }

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestQueryDecomposer.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestQueryDecomposer.java
@@ -17,9 +17,10 @@
 
 package org.apache.lucene.monitor;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
@@ -40,50 +41,47 @@ public class TestQueryDecomposer extends MonitorTestBase {
 
   public void testSimpleDisjunctions() {
     Query q = parse("hello world");
-    Set<Query> expected = new HashSet<>(Arrays.asList(parse("hello"), parse("world")));
-    assertEquals(expected, decomposer.decompose(q));
+    List<Query> expected = Arrays.asList(parse("world"), parse("hello"));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(q)));
   }
 
   public void testNestedDisjunctions() {
     Query q = parse("(hello goodbye) world");
-    Set<Query> expected =
-        new HashSet<>(Arrays.asList(parse("hello"), parse("goodbye"), parse("world")));
-    assertEquals(expected, decomposer.decompose(q));
+    List<Query> expected = Arrays.asList(parse("world"), parse("hello"), parse("goodbye"));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(q)));
   }
 
   public void testExclusions() {
-    Set<Query> expected =
-        new HashSet<>(Arrays.asList(parse("+hello -goodbye"), parse("+world -goodbye")));
-    assertEquals(expected, decomposer.decompose(parse("hello world -goodbye")));
+    List<Query> expected = Arrays.asList(parse("+world -goodbye"), parse("+hello -goodbye"));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(parse("hello world -goodbye"))));
   }
 
   public void testNestedExclusions() {
-    Set<Query> expected =
-        new HashSet<>(
-            Arrays.asList(
-                parse("+(+hello -goodbye) -greeting"), parse("+(+world -goodbye) -greeting")));
-    assertEquals(expected, decomposer.decompose(parse("((hello world) -goodbye) -greeting")));
+    List<Query> expected =
+        Arrays.asList(parse("+(+world -goodbye) -greeting"), parse("+(+hello -goodbye) -greeting"));
+    assertEquals(
+        expected,
+        new ArrayList<>(decomposer.decompose(parse("((hello world) -goodbye) -greeting"))));
   }
 
   public void testSingleValuedConjunctions() {
-    Set<Query> expected = new HashSet<>(Arrays.asList(parse("hello"), parse("world")));
-    assertEquals(expected, decomposer.decompose(parse("+(hello world)")));
+    List<Query> expected = Arrays.asList(parse("world"), parse("hello"));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(parse("+(hello world)"))));
   }
 
   public void testSingleValuedConjunctWithExclusions() {
-    Set<Query> expected =
-        new HashSet<>(Arrays.asList(parse("+hello -goodbye"), parse("+world -goodbye")));
-    assertEquals(expected, decomposer.decompose(parse("+(hello world) -goodbye")));
+    List<Query> expected = Arrays.asList(parse("+world -goodbye"), parse("+hello -goodbye"));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(parse("+(hello world) -goodbye"))));
   }
 
   public void testBoostsArePreserved() {
-    Set<Query> expected = new HashSet<>(Arrays.asList(parse("hello^0.7"), parse("world^0.7")));
-    assertEquals(expected, decomposer.decompose(parse("+(hello world)^0.7")));
-    expected =
-        new HashSet<>(Arrays.asList(parse("+hello^0.7 -goodbye"), parse("+world^0.7 -goodbye")));
-    assertEquals(expected, decomposer.decompose(parse("+(hello world)^0.7 -goodbye")));
-    expected = new HashSet<>(Arrays.asList(parse("(hello^0.5)^0.8"), parse("world^0.8")));
-    assertEquals(expected, decomposer.decompose(parse("+(hello^0.5 world)^0.8")));
+    List<Query> expected = Arrays.asList(parse("world^0.7"), parse("hello^0.7"));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(parse("+(hello world)^0.7"))));
+    expected = Arrays.asList(parse("+world^0.7 -goodbye"), parse("+hello^0.7 -goodbye"));
+    assertEquals(
+        expected, new ArrayList<>(decomposer.decompose(parse("+(hello world)^0.7 -goodbye"))));
+    expected = Arrays.asList(parse("world^0.8"), parse("(hello^0.5)^0.8"));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(parse("+(hello^0.5 world)^0.8"))));
   }
 
   public void testDisjunctionMaxDecomposition() {
@@ -91,15 +89,14 @@ public class TestQueryDecomposer extends MonitorTestBase {
         new DisjunctionMaxQuery(
             Arrays.asList(new TermQuery(new Term("f", "t1")), new TermQuery(new Term("f", "t2"))),
             0.1f);
-    Set<Query> expected = new HashSet<>(Arrays.asList(parse("f:t1"), parse("f:t2")));
-    assertEquals(expected, decomposer.decompose(q));
+    List<Query> expected = Arrays.asList(parse("f:t1"), parse("f:t2"));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(q)));
   }
 
   public void testNestedDisjunctionMaxDecomposition() {
     Query q = new DisjunctionMaxQuery(Arrays.asList(parse("hello goodbye"), parse("world")), 0.1f);
-    Set<Query> expected =
-        new HashSet<>(Arrays.asList(parse("hello"), parse("goodbye"), parse("world")));
-    assertEquals(expected, decomposer.decompose(q));
+    List<Query> expected = Arrays.asList(parse("world"), parse("hello"), parse("goodbye"));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(q)));
   }
 
   public void testFilterAndShouldClause() {
@@ -112,5 +109,61 @@ public class TestQueryDecomposer extends MonitorTestBase {
             .build();
 
     assertEquals(Collections.singleton(q), decomposer.decompose(q));
+  }
+
+  public void testDisjunctionCollapsesDistinct() {
+    Query q =
+        new DisjunctionMaxQuery(
+            Arrays.asList(parse("hello goodbye"), parse("goodbye hello")), 0.1f);
+    List<Query> expected = Arrays.asList(parse("field:hello"), parse("field:goodbye"));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(q)));
+  }
+
+  public void testDisjunctionWithBoostCollapsesDistinct() {
+    Query q =
+        new DisjunctionMaxQuery(
+            Arrays.asList(parse("hello^0.7 goodbye^0.6"), parse("goodbye^0.6 hello^0.7")), 0.1f);
+    List<Query> expected = Arrays.asList(parse("(field:hello)^0.7"), parse("(field:goodbye)^0.6"));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(q)));
+  }
+
+  public void testDisjunctionWithNoOpBoostCollapsesDistinct() {
+    Query q =
+        new DisjunctionMaxQuery(
+            Arrays.asList(parse("hello^1.0 goodbye^1.0"), parse("goodbye^1.0 hello^1.0")), 0.1f);
+    List<Query> expected = Arrays.asList(parse("field:hello"), parse("field:goodbye"));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(q)));
+  }
+
+  public void testDisjunctionTermEquivalentGroupingOfDistinctQueries() {
+    Query q =
+        new DisjunctionMaxQuery(
+            Arrays.asList(parse("hello^0.7 goodbye^0.6"), parse("goodbye^0.7 hello^0.6")), 0.1f);
+    List<Query> expected =
+        Arrays.asList(
+            parse("(field:hello)^0.7 (field:hello)^0.6"),
+            parse("(field:goodbye)^0.6 (field:goodbye)^0.7"));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(q)));
+  }
+
+  public void testBooleanTermEquivalentGroupingOfDistinctQueries() {
+    Query q = parse("(hello OR (goodbye AND test) OR (world OR (\"test goodbye\")))");
+    List<Query> expected =
+        Arrays.asList(
+            parse("field:world"),
+            parse("field:hello"),
+            parse("(+field:goodbye +field:test) field:\"test goodbye\""));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(q)));
+  }
+
+  public void testBooleanTermEquivalentGroupingRespectsFields() {
+    Query q = parse("(hello OR (goodbye AND test) OR (world OR (f:\"test goodbye\")))");
+    List<Query> expected =
+        Arrays.asList(
+            parse("field:world"),
+            parse("field:hello"),
+            parse("(+field:goodbye +field:test)"),
+            parse("f:\"test goodbye\""));
+    assertEquals(expected, new ArrayList<>(decomposer.decompose(q)));
   }
 }

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestQueryDecomposer.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestQueryDecomposer.java
@@ -20,6 +20,7 @@ package org.apache.lucene.monitor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.lucene.index.Term;
@@ -47,41 +48,44 @@ public class TestQueryDecomposer extends MonitorTestBase {
 
   public void testNestedDisjunctions() {
     Query q = parse("(hello goodbye) world");
-    List<Query> expected = Arrays.asList(parse("world"), parse("hello"), parse("goodbye"));
-    assertEquals(expected, new ArrayList<>(decomposer.decompose(q)));
+    Set<Query> expected =
+        new HashSet<>(Arrays.asList(parse("hello"), parse("goodbye"), parse("world")));
+    assertEquals(expected, decomposer.decompose(q));
   }
 
   public void testExclusions() {
-    List<Query> expected = Arrays.asList(parse("+world -goodbye"), parse("+hello -goodbye"));
-    assertEquals(expected, new ArrayList<>(decomposer.decompose(parse("hello world -goodbye"))));
+    Set<Query> expected =
+        new HashSet<>(Arrays.asList(parse("+hello -goodbye"), parse("+world -goodbye")));
+    assertEquals(expected, decomposer.decompose(parse("hello world -goodbye")));
   }
 
   public void testNestedExclusions() {
-    List<Query> expected =
-        Arrays.asList(parse("+(+world -goodbye) -greeting"), parse("+(+hello -goodbye) -greeting"));
-    assertEquals(
-        expected,
-        new ArrayList<>(decomposer.decompose(parse("((hello world) -goodbye) -greeting"))));
+    Set<Query> expected =
+        new HashSet<>(
+            Arrays.asList(
+                parse("+(+hello -goodbye) -greeting"), parse("+(+world -goodbye) -greeting")));
+    assertEquals(expected, decomposer.decompose(parse("((hello world) -goodbye) -greeting")));
   }
 
   public void testSingleValuedConjunctions() {
-    List<Query> expected = Arrays.asList(parse("world"), parse("hello"));
-    assertEquals(expected, new ArrayList<>(decomposer.decompose(parse("+(hello world)"))));
+    Set<Query> expected = new HashSet<>(Arrays.asList(parse("hello"), parse("world")));
+    assertEquals(expected, decomposer.decompose(parse("+(hello world)")));
   }
 
   public void testSingleValuedConjunctWithExclusions() {
-    List<Query> expected = Arrays.asList(parse("+world -goodbye"), parse("+hello -goodbye"));
-    assertEquals(expected, new ArrayList<>(decomposer.decompose(parse("+(hello world) -goodbye"))));
+    Set<Query> expected =
+        new HashSet<>(Arrays.asList(parse("+hello -goodbye"), parse("+world -goodbye")));
+    assertEquals(expected, decomposer.decompose(parse("+(hello world) -goodbye")));
   }
 
   public void testBoostsArePreserved() {
-    List<Query> expected = Arrays.asList(parse("world^0.7"), parse("hello^0.7"));
-    assertEquals(expected, new ArrayList<>(decomposer.decompose(parse("+(hello world)^0.7"))));
-    expected = Arrays.asList(parse("+world^0.7 -goodbye"), parse("+hello^0.7 -goodbye"));
-    assertEquals(
-        expected, new ArrayList<>(decomposer.decompose(parse("+(hello world)^0.7 -goodbye"))));
-    expected = Arrays.asList(parse("world^0.8"), parse("(hello^0.5)^0.8"));
-    assertEquals(expected, new ArrayList<>(decomposer.decompose(parse("+(hello^0.5 world)^0.8"))));
+    Set<Query> expected = new HashSet<>(Arrays.asList(parse("hello^0.7"), parse("world^0.7")));
+    assertEquals(expected, decomposer.decompose(parse("+(hello world)^0.7")));
+    expected =
+        new HashSet<>(Arrays.asList(parse("+hello^0.7 -goodbye"), parse("+world^0.7 -goodbye")));
+    assertEquals(expected, decomposer.decompose(parse("+(hello world)^0.7 -goodbye")));
+    expected = new HashSet<>(Arrays.asList(parse("(hello^0.5)^0.8"), parse("world^0.8")));
+    assertEquals(expected, decomposer.decompose(parse("+(hello^0.5 world)^0.8")));
   }
 
   public void testDisjunctionMaxDecomposition() {
@@ -89,14 +93,15 @@ public class TestQueryDecomposer extends MonitorTestBase {
         new DisjunctionMaxQuery(
             Arrays.asList(new TermQuery(new Term("f", "t1")), new TermQuery(new Term("f", "t2"))),
             0.1f);
-    List<Query> expected = Arrays.asList(parse("f:t1"), parse("f:t2"));
-    assertEquals(expected, new ArrayList<>(decomposer.decompose(q)));
+    Set<Query> expected = new HashSet<>(Arrays.asList(parse("f:t1"), parse("f:t2")));
+    assertEquals(expected, decomposer.decompose(q));
   }
 
   public void testNestedDisjunctionMaxDecomposition() {
     Query q = new DisjunctionMaxQuery(Arrays.asList(parse("hello goodbye"), parse("world")), 0.1f);
-    List<Query> expected = Arrays.asList(parse("world"), parse("hello"), parse("goodbye"));
-    assertEquals(expected, new ArrayList<>(decomposer.decompose(q)));
+    Set<Query> expected =
+        new HashSet<>(Arrays.asList(parse("hello"), parse("goodbye"), parse("world")));
+    assertEquals(expected, decomposer.decompose(q));
   }
 
   public void testFilterAndShouldClause() {


### PR DESCRIPTION
### Description

The full details can be found https://github.com/apache/lucene/issues/14886. This is an alternative solution to https://github.com/apache/lucene/pull/14885.
