### PR TITLE
Add ThreadPoolExecutor without NamedThreadFactory to forbidden-apis

### DIFF
--- a/gradle/validation/forbidden-apis/all/defaults.txt
+++ b/gradle/validation/forbidden-apis/all/defaults.txt
@@ -21,6 +21,8 @@ java.util.concurrent.Executors#newSingleThreadScheduledExecutor()
 java.util.concurrent.Executors#newScheduledThreadPool(int)
 java.util.concurrent.Executors#defaultThreadFactory()
 java.util.concurrent.Executors#privilegedThreadFactory()
+java.util.concurrent.ThreadPoolExecutor#<init>(int, int, long, java.util.concurrent.TimeUnit, java.util.concurrent.BlockingQueue)
+java.util.concurrent.ThreadPoolExecutor#<init>(int, int, long, java.util.concurrent.TimeUnit, java.util.concurrent.BlockingQueue, java.util.concurrent.RejectedExecutionHandler)
 
 @defaultMessage Properties files should be read/written with Reader/Writer, using UTF-8 charset. This allows reading older files with unicode escapes, too.
 java.util.Properties#load(java.io.InputStream)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -40,6 +40,8 @@ New Features
 Improvements
 ---------------------
 
+* Require named thread factory in ThreadPoolExecutor constructors. (Dawid Weiss)
+
 * GITHUB#14597: Rewrite expressions compiler to use Java 24+ Classfile library instead of ASM.
   This avoids clashes with other ASM versions on classpath because it removes the dependency.
   (Uwe Schindler)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -40,7 +40,7 @@ New Features
 Improvements
 ---------------------
 
-* Require named thread factory in ThreadPoolExecutor constructors. (Dawid Weiss)
+* GITHUB#14972: Require named thread factory in ThreadPoolExecutor constructors. (Dawid Weiss)
 
 * GITHUB#14597: Rewrite expressions compiler to use Java 24+ Classfile library instead of ASM.
   This avoids clashes with other ASM versions on classpath because it removes the dependency.

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -37,6 +37,7 @@ import org.apache.lucene.store.RateLimitedIndexOutput;
 import org.apache.lucene.store.RateLimiter;
 import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.NamedThreadFactory;
 import org.apache.lucene.util.ThreadInterruptedException;
 
 /**
@@ -948,7 +949,13 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
 
     public CachedExecutor() {
       this.executor =
-          new ThreadPoolExecutor(0, 1024, 1L, TimeUnit.MINUTES, new SynchronousQueue<>());
+          new ThreadPoolExecutor(
+              0,
+              1024,
+              1L,
+              TimeUnit.MINUTES,
+              new SynchronousQueue<>(),
+              new NamedThreadFactory("CachedExecutor"));
     }
 
     void shutdown() {

--- a/lucene/core/src/test/org/apache/lucene/search/TestTaskExecutor.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTaskExecutor.java
@@ -373,7 +373,13 @@ public class TestTaskExecutor extends LuceneTestCase {
 
   public void testTaskRejectionDoesNotFailExecution() throws Exception {
     try (ThreadPoolExecutor threadPoolExecutor =
-        new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(1))) {
+        new ThreadPoolExecutor(
+            1,
+            1,
+            0L,
+            TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(1),
+            new NamedThreadFactory("TestTaskExecutor"))) {
       final int taskCount = 1000; // enough tasks to cause queuing and rejections on the executor
       final ArrayList<Callable<Void>> callables = new ArrayList<>(taskCount);
       final AtomicInteger executedTasks = new AtomicInteger(0);


### PR DESCRIPTION
Helps in debugging leaked threads.