### PR TITLE
Swap out some functional interfaces for existing parameterized interfaces

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/BitSetDocIdStream.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BitSetDocIdStream.java
@@ -18,6 +18,7 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.IOIntConsumer;
 import org.apache.lucene.util.MathUtil;
 
 final class BitSetDocIdStream extends DocIdStream {
@@ -39,7 +40,7 @@ final class BitSetDocIdStream extends DocIdStream {
   }
 
   @Override
-  public void forEach(int upTo, CheckedIntConsumer<IOException> consumer) throws IOException {
+  public void forEach(int upTo, IOIntConsumer consumer) throws IOException {
     if (upTo > this.upTo) {
       upTo = Math.min(upTo, max);
       bitSet.forEach(this.upTo - offset, upTo - offset, offset, consumer);

--- a/lucene/core/src/java/org/apache/lucene/search/DocIdStream.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocIdStream.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
+import org.apache.lucene.util.IOIntConsumer;
 
 /**
  * A stream of doc IDs. Doc IDs may be consumed at most once.
@@ -30,20 +31,19 @@ public abstract class DocIdStream {
   protected DocIdStream() {}
 
   /**
-   * Iterate over doc IDs contained in this stream in order, calling the given {@link
-   * CheckedIntConsumer} on them. This is a terminal operation.
+   * Iterate over doc IDs contained in this stream in order, calling the given {@link IOIntConsumer}
+   * on them. This is a terminal operation.
    */
-  public void forEach(CheckedIntConsumer<IOException> consumer) throws IOException {
+  public void forEach(IOIntConsumer consumer) throws IOException {
     forEach(DocIdSetIterator.NO_MORE_DOCS, consumer);
   }
 
   /**
    * Iterate over doc IDs contained in this doc ID stream up to the given {@code upTo} exclusive,
-   * calling the given {@link CheckedIntConsumer} on them. It is not possible to iterate these doc
-   * IDs again later on.
+   * calling the given {@link IOIntConsumer} on them. It is not possible to iterate these doc IDs
+   * again later on.
    */
-  public abstract void forEach(int upTo, CheckedIntConsumer<IOException> consumer)
-      throws IOException;
+  public abstract void forEach(int upTo, IOIntConsumer consumer) throws IOException;
 
   /** Count the number of entries in this stream. This is a terminal operation. */
   public int count() throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/search/RangeDocIdStream.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RangeDocIdStream.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
+import org.apache.lucene.util.IOIntConsumer;
 
 final class RangeDocIdStream extends DocIdStream {
 
@@ -37,7 +38,7 @@ final class RangeDocIdStream extends DocIdStream {
   }
 
   @Override
-  public void forEach(int upTo, CheckedIntConsumer<IOException> consumer) throws IOException {
+  public void forEach(int upTo, IOIntConsumer consumer) throws IOException {
     if (upTo > this.upTo) {
       upTo = Math.min(upTo, max);
       for (int doc = this.upTo; doc < upTo; ++doc) {

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -19,7 +19,6 @@ package org.apache.lucene.util;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
-import org.apache.lucene.search.CheckedIntConsumer;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
 
@@ -832,8 +831,7 @@ public final class FixedBitSet extends BitSet {
    * bit index and call {@code consumer} on it. This is internally used by queries that use bit sets
    * as intermediate representations of their matches.
    */
-  public void forEach(int from, int to, int base, CheckedIntConsumer<IOException> consumer)
-      throws IOException {
+  public void forEach(int from, int to, int base, IOIntConsumer consumer) throws IOException {
     Objects.checkFromToIndex(from, to, length());
 
     // First, align `from` with a word start, ie. a multiple of Long.SIZE (64)
@@ -862,8 +860,7 @@ public final class FixedBitSet extends BitSet {
     }
   }
 
-  private static void forEach(long bits, int base, CheckedIntConsumer<IOException> consumer)
-      throws IOException {
+  private static void forEach(long bits, int base, IOIntConsumer consumer) throws IOException {
     while (bits != 0L) {
       int ntz = Long.numberOfTrailingZeros(bits);
       consumer.accept(base + ntz);

--- a/lucene/core/src/java/org/apache/lucene/util/IOIntConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IOIntConsumer.java
@@ -14,18 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.lucene.search;
+package org.apache.lucene.util;
 
-import java.util.function.IntConsumer;
+import java.io.IOException;
 
-/** Like {@link IntConsumer}, but may throw checked exceptions. */
+/**
+ * An IO operation with a single int input that may throw an IOException.
+ *
+ * @see java.util.function.IntConsumer
+ */
 @FunctionalInterface
-public interface CheckedIntConsumer<T extends Exception> {
-
+public interface IOIntConsumer {
   /**
-   * Process the given value.
+   * Performs this operation on the given argument.
    *
-   * @see IntConsumer#accept(int)
+   * @param value the value to accept
+   * @throws IOException if producing the result throws an {@link IOException}
    */
-  void accept(int value) throws T;
+  void accept(int value) throws IOException;
 }

--- a/lucene/core/src/test/org/apache/lucene/codecs/hnsw/TestFlatVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/hnsw/TestFlatVectorScorer.java
@@ -44,6 +44,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.IOSupplier;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 
@@ -51,10 +52,10 @@ public class TestFlatVectorScorer extends LuceneTestCase {
 
   private static final AtomicInteger count = new AtomicInteger();
   private final FlatVectorsScorer flatVectorsScorer;
-  private final ThrowingSupplier<Directory> newDirectory;
+  private final IOSupplier<Directory> newDirectory;
 
   public TestFlatVectorScorer(
-      FlatVectorsScorer flatVectorsScorer, ThrowingSupplier<Directory> newDirectory) {
+      FlatVectorsScorer flatVectorsScorer, IOSupplier<Directory> newDirectory) {
     this.flatVectorsScorer = flatVectorsScorer;
     this.newDirectory = newDirectory;
   }
@@ -67,7 +68,7 @@ public class TestFlatVectorScorer extends LuceneTestCase {
             new Lucene99ScalarQuantizedVectorScorer(new DefaultFlatVectorScorer()),
             FlatVectorScorerUtil.getLucene99FlatVectorsScorer());
     var dirs =
-        List.<ThrowingSupplier<Directory>>of(
+        List.<IOSupplier<Directory>>of(
             TestFlatVectorScorer::newDirectory,
             () -> new MMapDirectory(createTempDir(count.getAndIncrement() + "-")));
 
@@ -222,10 +223,5 @@ public class TestFlatVectorScorer extends LuceneTestCase {
 
   public static <T> void assertThat(T actual, Matcher<? super T> matcher) {
     MatcherAssert.assertThat("", actual, matcher);
-  }
-
-  @FunctionalInterface
-  public interface ThrowingSupplier<T> {
-    T get() throws IOException;
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/store/BaseDataOutputTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/store/BaseDataOutputTestCase.java
@@ -38,8 +38,8 @@ public abstract class BaseDataOutputTestCase<T extends DataOutput> extends Lucen
   protected abstract byte[] toBytes(T instance);
 
   @FunctionalInterface
-  private interface ThrowingBiFunction<T, U, R> {
-    R apply(T t, U u) throws Exception;
+  private interface IOBiFunction<T, U, R> {
+    R apply(T t, U u) throws IOException;
   }
 
   @Test
@@ -68,8 +68,7 @@ public abstract class BaseDataOutputTestCase<T extends DataOutput> extends Lucen
     }
   }
 
-  private static final List<ThrowingBiFunction<DataOutput, Random, IOConsumer<DataInput>>>
-      GENERATORS;
+  private static final List<IOBiFunction<DataOutput, Random, IOConsumer<DataInput>>> GENERATORS;
 
   static {
     GENERATORS = new ArrayList<>();

--- a/lucene/join/src/java/org/apache/lucene/search/join/DocValuesTermsCollector.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DocValuesTermsCollector.java
@@ -23,13 +23,12 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.SimpleCollector;
+import org.apache.lucene.util.IOFunction;
 
 abstract class DocValuesTermsCollector<DV> extends SimpleCollector {
 
   @FunctionalInterface
-  interface Function<R> {
-    R apply(LeafReader t) throws IOException;
-  }
+  interface Function<R> extends IOFunction<LeafReader, R> {}
 
   protected DV docValues;
   private final Function<DV> docValuesCall;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.tests.search;
 
 import java.io.IOException;
-import org.apache.lucene.search.CheckedIntConsumer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.DocIdStream;
 import org.apache.lucene.search.FilterDocIdSetIterator;
@@ -25,6 +24,7 @@ import org.apache.lucene.search.FilterLeafCollector;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.IOIntConsumer;
 
 /** Wraps another Collector and checks that order is respected. */
 class AssertingLeafCollector extends FilterLeafCollector {
@@ -128,7 +128,7 @@ class AssertingLeafCollector extends FilterLeafCollector {
     }
 
     @Override
-    public void forEach(CheckedIntConsumer<IOException> consumer) throws IOException {
+    public void forEach(IOIntConsumer consumer) throws IOException {
       assert lastUpTo != DocIdSetIterator.NO_MORE_DOCS : "exhausted";
       stream.forEach(
           doc -> {
@@ -143,7 +143,7 @@ class AssertingLeafCollector extends FilterLeafCollector {
     }
 
     @Override
-    public void forEach(int upTo, CheckedIntConsumer<IOException> consumer) throws IOException {
+    public void forEach(int upTo, IOIntConsumer consumer) throws IOException {
       assert lastUpTo < upTo : "upTo=" + upTo + " but previous upTo=" + lastUpTo;
       stream.forEach(
           doc -> {


### PR DESCRIPTION
There are several places where custom functional interfaces are used, when instead existing parameterized interfaces can be re-used.

I've not modified or removed interfaces that are part of a public API, as there is utility in keeping custom functional interfaces for descriptive and usability reasons - however those could also be refactored if appropriate (eg `MergeState.DocMap`, `luke.Callable`, `IndexReaderWarmer`)