### PR TITLE
Move isolated-inheritdoc detection to an ast-grep rule

### DIFF
--- a/build-tools/build-infra/src/main/groovy/lucene.validation.source-patterns.gradle
+++ b/build-tools/build-infra/src/main/groovy/lucene.validation.source-patterns.gradle
@@ -97,9 +97,7 @@ class ValidateSourcePatternsTask extends DefaultTask {
 
   @TaskAction
   public void check() {
-    def invalidPatterns = [
-      (~$/\Q/**\E((?:\s)|(?:\*))*\Q{@inheritDoc}\E((?:\s)|(?:\*))*\Q*/\E/$) : '{@inheritDoc} on its own is unnecessary',
-    ]
+    def invalidPatterns = []
 
     def violations = new TreeSet();
     def reportViolation = { f, name ->

--- a/gradle/validation/ast-grep/rules/java-patterns.yml
+++ b/gradle/validation/ast-grep/rules/java-patterns.yml
@@ -140,3 +140,12 @@ rule:
         pattern: incubator
 severity: error
 message: Module dependency on incubator APIs
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/java_rule.json
+id: javadoc-only-inheriting-super
+language: java
+rule:
+  matches: javadoc
+  regex: "^/\\*\\*([ \r\n*])*[{]@inheritDoc[ \r\n]*[}]([ \r\n*])*\\*/$"
+severity: error
+message: "{@inheritDoc} on its own is unnecessary"

--- a/gradle/validation/ast-grep/tests/java-patterns.yml
+++ b/gradle/validation/ast-grep/tests/java-patterns.yml
@@ -115,3 +115,24 @@ valid:
     module org.apache.lucene.foo {
       requires org.apache.lucene.bar;
     }
+---
+id: javadoc-only-inheriting-super
+invalid:
+  - /** {@inheritDoc} */
+  - /** {@inheritDoc } */
+  - |
+    /**
+     * {@inheritDoc}
+     */
+valid:
+  - |
+    /**
+     * {@inheritDoc}
+     *
+     * And something.
+     */
+  - |
+    /**
+     * Something and...
+     * {@inheritDoc}
+     */

--- a/gradle/validation/ast-grep/tests/java-patterns.yml
+++ b/gradle/validation/ast-grep/tests/java-patterns.yml
@@ -120,19 +120,16 @@ id: javadoc-only-inheriting-super
 invalid:
   - /** {@inheritDoc} */
   - /** {@inheritDoc } */
-  - |
-    /**
-     * {@inheritDoc}
-     */
+  - "/**\n * {@inheritDoc}\n */"
 valid:
   - |
     /**
-     * {@inheritDoc}
-     *
-     * And something.
-     */
+    * {@inheritDoc}
+    *
+    * And something.
+    */
   - |
     /**
-     * Something and...
-     * {@inheritDoc}
-     */
+    * Something and...
+    * {@inheritDoc}
+    */


### PR DESCRIPTION
This means the set of patterns in source-patterns validation is empty... easier to port to Java or simplify (?).