### PR TITLE
Refactor for loop at PointRangeQuery hot path

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -220,6 +220,8 @@ Optimizations
 
 * GITHUB#14970: Further speed up filtering hits by score. (Adrien Grand)
 
+* GITHUB#14991: Refactor for loop at PointRangeQuery hot path. (Ge Song)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14823: Decrease TieredMergePolicy's default number of segments per

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -210,7 +210,7 @@ public abstract class PointRangeQuery extends Query {
 
           @Override
           public void visit(IntsRef ref) {
-            for (int i = ref.offset; i < ref.offset + ref.length; i++) {
+            for (int i = ref.offset, to = ref.offset + ref.length; i < to; i++) {
               result.set(ref.ints[i]);
             }
             cost[0] += ref.length;

--- a/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java
@@ -60,8 +60,8 @@ public final class DocIdSetBuilder {
 
     @Override
     public void add(IntsRef docs) {
-      for (int i = 0; i < docs.length; i++) {
-        bitSet.set(docs.ints[docs.offset + i]);
+      for (int i = docs.offset, to = docs.offset + docs.length; i < to; i++) {
+        bitSet.set(docs.ints[i]);
       }
     }
 


### PR DESCRIPTION
### Description
This is a tiny modification about how to loop through the `IntsRef` during the `PointRangeQuery` visit process, which is a hot path.
I ran the luceneutil on `wikimediumall` with `searchConcurrency=0, taskCountPerCat=5, taskRepeatCount=50`, here is the result after 20 iterations:
```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                 AndHighOrMedMed       14.22      (3.4%)       14.05      (2.8%)   -1.2% (  -7% -    5%) 0.242
                         Prefix3       74.69      (4.2%)       73.87      (3.7%)   -1.1% (  -8% -    7%) 0.383
                       CountTerm     6021.67      (4.7%)     5959.35      (5.5%)   -1.0% ( -10% -    9%) 0.522
            FilteredAndStopWords        8.22      (2.5%)        8.14      (2.8%)   -1.0% (  -6% -    4%) 0.227
                          IntSet      294.24      (5.3%)      291.38      (4.7%)   -1.0% ( -10% -    9%) 0.541
                 FilteredPrefix3       69.88      (4.1%)       69.24      (3.4%)   -0.9% (  -8% -    6%) 0.441
             FilteredAndHighHigh       10.17      (2.6%)       10.08      (2.7%)   -0.9% (  -6% -    4%) 0.283
                        SpanNear        2.50      (3.0%)        2.47      (4.6%)   -0.9% (  -8% -    6%) 0.481
                     CountPhrase        2.66      (2.9%)        2.63      (3.4%)   -0.8% (  -6% -    5%) 0.410
                  FilteredPhrase        9.75      (2.8%)        9.68      (2.8%)   -0.8% (  -6% -    5%) 0.384
                    AndStopWords        9.14      (2.1%)        9.07      (2.2%)   -0.7% (  -4% -    3%) 0.293
                AndMedOrHighHigh       16.93      (2.5%)       16.81      (2.3%)   -0.7% (  -5% -    4%) 0.371
                 DismaxOrHighMed       50.64      (4.2%)       50.31      (4.0%)   -0.7% (  -8% -    7%) 0.611
               FilteredAnd3Terms      100.95      (3.9%)      100.28      (3.4%)   -0.7% (  -7% -    6%) 0.568
                         Respell       36.47      (3.6%)       36.25      (5.0%)   -0.6% (  -8% -    8%) 0.653
                  FilteredOrMany        3.97      (2.9%)        3.95      (2.9%)   -0.6% (  -6% -    5%) 0.520
                IntervalsOrdered        2.43      (2.0%)        2.42      (3.5%)   -0.6% (  -5% -    5%) 0.513
              FilteredAndHighMed       31.57      (2.6%)       31.39      (2.5%)   -0.6% (  -5% -    4%) 0.467
                    SloppyPhrase        1.11      (5.1%)        1.10      (4.1%)   -0.6% (  -9% -    9%) 0.706
                       And3Terms       74.71      (4.4%)       74.32      (4.3%)   -0.5% (  -8% -    8%) 0.703
             FilteredOrStopWords        8.05      (2.3%)        8.01      (2.4%)   -0.5% (  -5% -    4%) 0.489
                          OrMany        4.66      (4.4%)        4.64      (4.8%)   -0.5% (  -9% -    9%) 0.727
                          Fuzzy2       38.17      (4.0%)       37.97      (5.3%)   -0.5% (  -9% -    9%) 0.734
                 CountAndHighMed       74.45      (3.0%)       74.11      (2.9%)   -0.5% (  -6% -    5%) 0.615
                DismaxOrHighHigh       37.52      (3.8%)       37.36      (3.2%)   -0.5% (  -7% -    6%) 0.683
                   TermMonthSort     2148.50      (2.6%)     2139.58      (3.2%)   -0.4% (  -6% -    5%) 0.655
                FilteredOr3Terms       43.11      (3.9%)       42.93      (3.8%)   -0.4% (  -7% -    7%) 0.737
             And2Terms2StopWords       61.27      (7.3%)       61.03      (7.3%)   -0.4% ( -14% -   15%) 0.865
      FilteredOr2Terms2StopWords       49.27      (5.0%)       49.08      (5.1%)   -0.4% ( -10% -   10%) 0.810
                  CountOrHighMed       77.15      (2.9%)       76.88      (2.6%)   -0.4% (  -5% -    5%) 0.680
              Or2Terms2StopWords       63.59      (6.8%)       63.36      (6.6%)   -0.4% ( -12% -   14%) 0.866
     FilteredAnd2Terms2StopWords       60.51      (5.3%)       60.31      (5.3%)   -0.3% ( -10% -   10%) 0.847
                     OrStopWords        9.88      (2.4%)        9.85      (2.4%)   -0.3% (  -4% -    4%) 0.673
              CombinedOrHighHigh        5.60      (3.4%)        5.58      (5.3%)   -0.3% (  -8% -    8%) 0.823
                      AndHighMed       57.66      (3.9%)       57.50      (3.9%)   -0.3% (  -7% -    7%) 0.817
              FilteredOrHighHigh       12.86      (2.9%)       12.82      (3.1%)   -0.3% (  -6% -    5%) 0.763
                          Phrase        7.51      (3.5%)        7.49      (2.6%)   -0.3% (  -6% -    5%) 0.772
               CombinedOrHighMed       20.83      (5.2%)       20.78      (6.3%)   -0.3% ( -11% -   11%) 0.883
             CountFilteredOrMany        4.40      (3.1%)        4.39      (2.9%)   -0.2% (  -6% -    5%) 0.807
                 CountOrHighHigh       49.43      (2.8%)       49.32      (2.4%)   -0.2% (  -5% -    5%) 0.785
                     CountOrMany        4.96      (3.3%)        4.95      (2.9%)   -0.2% (  -6% -    6%) 0.827
                        Or3Terms       68.39      (4.4%)       68.24      (4.5%)   -0.2% (  -8% -    9%) 0.879
               FilteredOrHighMed       38.42      (4.0%)       38.33      (4.0%)   -0.2% (  -7% -    8%) 0.866
                          Fuzzy1       42.60      (4.3%)       42.51      (5.6%)   -0.2% (  -9% -   10%) 0.897
                CountAndHighHigh       48.02      (2.4%)       47.93      (2.4%)   -0.2% (  -4% -    4%) 0.805
                       OrHighMed       73.36      (4.9%)       73.28      (4.9%)   -0.1% (  -9% -   10%) 0.943
         CountFilteredOrHighHigh       15.82      (1.1%)       15.80      (0.9%)   -0.1% (  -2% -    1%) 0.745
             CountFilteredPhrase        9.01      (3.1%)        9.01      (3.5%)   -0.1% (  -6% -    6%) 0.941
                     AndHighHigh       24.76      (2.8%)       24.74      (2.4%)   -0.1% (  -5% -    5%) 0.945
                      OrHighHigh       23.88      (2.8%)       23.87      (2.8%)   -0.1% (  -5% -    5%) 0.953
          CountFilteredOrHighMed       17.90      (0.9%)       17.90      (0.8%)   -0.0% (  -1% -    1%) 0.897
                    FilteredTerm       64.07      (4.3%)       64.08      (4.1%)    0.0% (  -8% -    8%) 0.989
             CombinedAndHighHigh        5.67      (2.4%)        5.68      (2.7%)    0.1% (  -4% -    5%) 0.856
               TermDayOfYearSort      260.32      (2.6%)      260.72      (2.9%)    0.2% (  -5% -    5%) 0.858
                      DismaxTerm      516.56      (4.5%)      517.71      (4.2%)    0.2% (  -8% -    9%) 0.871
                       TermB1M1P      486.46      (5.3%)      487.97      (4.1%)    0.3% (  -8% -   10%) 0.836
              CombinedAndHighMed       21.11      (5.0%)       21.18      (5.5%)    0.3% (  -9% -   11%) 0.846
                          Term1M      486.31      (5.3%)      488.01      (4.0%)    0.3% (  -8% -   10%) 0.813
                            Term      486.88      (5.2%)      488.60      (3.9%)    0.4% (  -8% -   10%) 0.810
                         Term10K      486.28      (5.4%)      488.06      (4.1%)    0.4% (  -8% -   10%) 0.809
                        Wildcard       46.68      (3.5%)       46.86      (3.9%)    0.4% (  -6% -    8%) 0.749
                      TermDTSort      135.05      (2.4%)      135.58      (2.8%)    0.4% (  -4% -    5%) 0.638
                         Term100      486.10      (5.3%)      488.34      (4.0%)    0.5% (  -8% -   10%) 0.755
                   TermTitleSort       49.03      (4.3%)       49.31      (6.3%)    0.6% (  -9% -   11%) 0.740
                         TermB1M      485.85      (5.3%)      488.61      (4.0%)    0.6% (  -8% -   10%) 0.703
             CountFilteredIntNRQ       16.19      (1.2%)       16.31      (1.3%)    0.8% (  -1% -    3%) 0.062
                    CombinedTerm       11.39      (3.6%)       11.48      (4.2%)    0.8% (  -6% -    8%) 0.523
                      OrHighRare       94.52      (6.4%)       96.19      (3.8%)    1.8% (  -7% -   12%) 0.287
                  FilteredIntNRQ       41.34      (2.9%)       42.21      (3.1%)    2.1% (  -3% -    8%) 0.027
                          IntNRQ       41.60      (2.9%)       42.60      (3.0%)    2.4% (  -3% -    8%) 0.009
```

It's not a big speedup, nor is the p-value zero, but it should do no harm and is a easy win I guess?

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
