### PR TITLE
remove IndexReader.registerParentReader()

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -50,6 +50,10 @@ Improvements
   global queue min-score checking. Improves performance and consistency. (Mike Sokolov, Dzung Bui,
   Ben Trent)
 
+* GITHUB#15002: Remove synchronized WeakHashMap from IndexReader. This was added to help prevent
+  SIGSEGV with the old unsafe "mmap hack", which has been replaced by MemorySegments.
+  (Uwe Schindler, Robert Muir)
+
 Optimizations
 ---------------------
 * GITHUB#14011: Reduce allocation rate in HNSW concurrent merge. (Viliam Durina)

--- a/lucene/core/src/java/org/apache/lucene/index/BaseCompositeReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BaseCompositeReader.java
@@ -84,7 +84,6 @@ public abstract class BaseCompositeReader<R extends IndexReader> extends Composi
       starts[i] = (int) maxDoc;
       final IndexReader r = subReaders[i];
       maxDoc += r.maxDoc(); // compute maxDocs
-      r.registerParentReader(this);
     }
 
     if (maxDoc > IndexWriter.getActualMaxDocs()) {

--- a/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
@@ -334,7 +334,6 @@ public abstract class FilterLeafReader extends LeafReader {
       throw new NullPointerException("incoming LeafReader must not be null");
     }
     this.in = in;
-    in.registerParentReader(this);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
@@ -196,7 +196,6 @@ public class ParallelLeafReader extends LeafReader {
       if (!closeSubReaders) {
         reader.incRef();
       }
-      reader.registerParentReader(this);
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestReaderClosed.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestReaderClosed.java
@@ -81,37 +81,6 @@ public class TestReaderClosed extends LuceneTestCase {
     }
   }
 
-  // LUCENE-3800
-  public void testReaderChaining() throws Exception {
-    assertTrue(reader.getRefCount() > 0);
-    LeafReader wrappedReader = new ParallelLeafReader(getOnlyLeafReader(reader));
-
-    // We wrap with a OwnCacheKeyMultiReader so that closing the underlying reader
-    // does not terminate the threadpool (if that index searcher uses one)
-    IndexSearcher searcher = newSearcher(new OwnCacheKeyMultiReader(wrappedReader));
-
-    TermRangeQuery query = TermRangeQuery.newStringRange("field", "a", "z", true, true);
-    searcher.search(query, 5);
-    reader.close(); // close original child reader
-    try {
-      searcher.search(query, 5);
-    } catch (Exception e) {
-      AlreadyClosedException ace = null;
-      for (Throwable t = e; t != null; t = t.getCause()) {
-        if (t instanceof AlreadyClosedException) {
-          ace = (AlreadyClosedException) t;
-        }
-      }
-      if (ace == null) {
-        throw new AssertionError("Query failed, but not due to an AlreadyClosedException", e);
-      }
-      assertEquals("this IndexReader is closed", ace.getMessage());
-    } finally {
-      // close executor: in case of wrap-wrap-wrapping
-      searcher.getIndexReader().close();
-    }
-  }
-
   @Override
   public void tearDown() throws Exception {
     dir.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestReaderClosed.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestReaderClosed.java
@@ -25,7 +25,6 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.analysis.MockTokenizer;
-import org.apache.lucene.tests.index.OwnCacheKeyMultiReader;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;

--- a/lucene/core/src/test/org/apache/lucene/index/TestReaderClosed.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestReaderClosed.java
@@ -105,9 +105,7 @@ public class TestReaderClosed extends LuceneTestCase {
       if (ace == null) {
         throw new AssertionError("Query failed, but not due to an AlreadyClosedException", e);
       }
-      assertEquals(
-          "this IndexReader cannot be used anymore as one of its child readers was closed",
-          ace.getMessage());
+      assertEquals("this IndexReader is closed", ace.getMessage());
     } finally {
       // close executor: in case of wrap-wrap-wrapping
       searcher.getIndexReader().close();


### PR DESCRIPTION
Remove this function and associated WeakhashMap: it is not needed any more. The tests still pass, user still gets ACE (just slightly different exception message).

Closes #14999
