### PR TITLE
Parent block join knn vector query test case.test random

### DIFF
--- a/lucene/join/src/test/org/apache/lucene/search/join/ParentBlockJoinKnnVectorQueryTestCase.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/ParentBlockJoinKnnVectorQueryTestCase.java
@@ -412,12 +412,14 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
       RandomIndexWriter w = new RandomIndexWriter(random(), d);
       for (int i = 0; i < numDocs; i++) {
         Document doc = new Document();
-        if (everyDocHasAVector || random().nextInt(10) != 2) {
-          doc.add(getKnnVectorField("field", randomVector(dimension)));
-        }
         if (random().nextInt(5) == 1) {
           doc.add(new StringField("docType", "_parent", Field.Store.NO));
+        } else if (everyDocHasAVector || random().nextInt(10) != 2) {
+          // NOTE: only child documents are allowed to have a vector!
+          // Otherwise the query's assumptions are invalidated??
+          doc.add(getKnnVectorField("field", randomVector(dimension)));
         }
+
         w.addDocument(doc);
       }
       w.close();

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinByteKnnVectorQuery.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinByteKnnVectorQuery.java
@@ -35,6 +35,8 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
 
 public class TestParentBlockJoinByteKnnVectorQuery extends ParentBlockJoinKnnVectorQueryTestCase {
 
@@ -104,5 +106,24 @@ public class TestParentBlockJoinByteKnnVectorQuery extends ParentBlockJoinKnnVec
       query[i] = (byte) queryVector[i];
     }
     return query;
+  }
+
+  @Override
+  float[] randomVector(int dim) {
+    BytesRef v = TestUtil.randomBinaryTerm(random(), TestUtil.nextInt(random(), 1, 100));
+    // clip at -127 to avoid overflow
+    for (int i = v.offset; i < v.offset + v.length; i++) {
+      if (v.bytes[i] == -128) {
+        v.bytes[i] = -127;
+      }
+    }
+    assert v.offset == 0;
+    byte[] b = v.bytes;
+    float[] v1 = new float[b.length];
+    int vi = 0;
+    for (int i = 0; i < v.length; i++) {
+      v1[vi++] = b[i];
+    }
+    return v1;
   }
 }

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinFloatKnnVectorQuery.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinFloatKnnVectorQuery.java
@@ -22,6 +22,8 @@ import static org.apache.lucene.index.VectorSimilarityFunction.COSINE;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnFloatVectorField;
@@ -136,4 +138,14 @@ public class TestParentBlockJoinFloatKnnVectorQuery extends ParentBlockJoinKnnVe
       String name, float[] vector, VectorSimilarityFunction vectorSimilarityFunction) {
     return new KnnFloatVectorField(name, vector, vectorSimilarityFunction);
   }
+
+  @Override
+  float[] randomVector(int dim) {
+      float[] v = new float[dim];
+      Random random = random();
+      for (int i = 0; i < dim; i++) {
+        v[i] = random.nextFloat();
+      }
+      return v;
+    }
 }


### PR DESCRIPTION
First stab at a unit test to reproduce problem reported in https://github.com/apache/lucene/issues/15005

The test fails with some assertion in `DiversifyingNearestChildrenKnnCollector.collect` right now -- maybe there's something wrong with the setup?  I copied BaseKnnQueryTestCase.testRandom and modified to use a parent join KnnQuery, maybe incorrectly