### PR TITLE
Parent block join knn vector query test case test random 10x

### DIFF
--- a/lucene/join/src/test/org/apache/lucene/search/join/ParentBlockJoinKnnVectorQueryTestCase.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/ParentBlockJoinKnnVectorQueryTestCase.java
@@ -409,7 +409,6 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
     int dimension = atLeast(5);
     int numIters = atLeast(10);
     boolean everyDocHasAVector = random().nextBoolean();
-    int numChildren = 0;
     int numParentsWithChildren = 0;
     try (Directory d = newDirectory()) {
       RandomIndexWriter w = new RandomIndexWriter(random(), d);
@@ -419,7 +418,7 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
         if (random().nextInt(5) == 1) {
           if (family.isEmpty() == false) {
             ++numParentsWithChildren;
-            //System.out.println("parent w/children id=" + i);
+            // System.out.println("parent w/children id=" + i);
             doc.add(new StoredField("id", Integer.toString(i)));
           } else {
             doc.add(new StoredField("id", "pnoc" + Integer.toString(i)));
@@ -440,12 +439,13 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
       // trailing children with no parent document are dropped
       try (IndexReader reader = DirectoryReader.open(d)) {
         BitSetProducer parentFilter =
-                new QueryBitSetProducer(new TermQuery(new Term("docType", "_parent")));
+            new QueryBitSetProducer(new TermQuery(new Term("docType", "_parent")));
         IndexSearcher searcher = newSearcher(reader);
         for (int i = 0; i < numIters; i++) {
           int k = random().nextInt(80) + 1;
           // TODO: test with child filter
-          Query query = getParentJoinKnnQuery("field", randomVector(dimension), null, k, parentFilter);
+          Query query =
+              getParentJoinKnnQuery("field", randomVector(dimension), null, k, parentFilter);
           int n = random().nextInt(100) + 1;
           TopDocs results = searcher.search(query, n);
           int expected = Math.min(Math.min(n, k), numParentsWithChildren);
@@ -458,7 +458,7 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
               System.out.println("result id=" + reader.storedFields().document(doc.doc).get("id"));
             }
           }
-           */
+`           */
           assertEquals(expected, results.scoreDocs.length);
           assertTrue(results.totalHits.value() >= results.scoreDocs.length);
           // verify the results are in descending score order

--- a/lucene/join/src/test/org/apache/lucene/search/join/ParentBlockJoinKnnVectorQueryTestCase.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/ParentBlockJoinKnnVectorQueryTestCase.java
@@ -412,12 +412,14 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
       RandomIndexWriter w = new RandomIndexWriter(random(), d);
       for (int i = 0; i < numDocs; i++) {
         Document doc = new Document();
-        if (everyDocHasAVector || random().nextInt(10) != 2) {
-          doc.add(getKnnVectorField("field", randomVector(dimension)));
-        }
         if (random().nextInt(5) == 1) {
           doc.add(new StringField("docType", "_parent", Field.Store.NO));
+        } else if (everyDocHasAVector || random().nextInt(10) != 2) {
+          // NOTE: only child documents are allowed to have a vector!
+          // Otherwise the query's assumptions are invalidated??
+          doc.add(getKnnVectorField("field", randomVector(dimension)));
         }
+
         w.addDocument(doc);
       }
       w.close();

--- a/lucene/join/src/test/org/apache/lucene/search/join/ParentBlockJoinKnnVectorQueryTestCase.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/ParentBlockJoinKnnVectorQueryTestCase.java
@@ -453,12 +453,12 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
           // test that
           assert reader.hasDeletions() == false;
           /*
-          if (expected != results.scoreDocs.length) {
-            for (ScoreDoc doc : results.scoreDocs) {
-              System.out.println("result id=" + reader.storedFields().document(doc.doc).get("id"));
-            }
-          }
-`           */
+                    if (expected != results.scoreDocs.length) {
+                      for (ScoreDoc doc : results.scoreDocs) {
+                        System.out.println("result id=" + reader.storedFields().document(doc.doc).get("id"));
+                      }
+                    }
+          `           */
           assertEquals(expected, results.scoreDocs.length);
           assertTrue(results.totalHits.value() >= results.scoreDocs.length);
           // verify the results are in descending score order

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinByteKnnVectorQuery.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinByteKnnVectorQuery.java
@@ -35,6 +35,8 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
 
 public class TestParentBlockJoinByteKnnVectorQuery extends ParentBlockJoinKnnVectorQueryTestCase {
 
@@ -104,5 +106,24 @@ public class TestParentBlockJoinByteKnnVectorQuery extends ParentBlockJoinKnnVec
       query[i] = (byte) queryVector[i];
     }
     return query;
+  }
+
+  @Override
+  float[] randomVector(int dim) {
+    BytesRef v = TestUtil.randomBinaryTerm(random(), TestUtil.nextInt(random(), 1, 100));
+    // clip at -127 to avoid overflow
+    for (int i = v.offset; i < v.offset + v.length; i++) {
+      if (v.bytes[i] == -128) {
+        v.bytes[i] = -127;
+      }
+    }
+    assert v.offset == 0;
+    byte[] b = v.bytes;
+    float[] v1 = new float[b.length];
+    int vi = 0;
+    for (int i = 0; i < v.length; i++) {
+      v1[vi++] = b[i];
+    }
+    return v1;
   }
 }

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinFloatKnnVectorQuery.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinFloatKnnVectorQuery.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnFloatVectorField;
@@ -141,11 +140,11 @@ public class TestParentBlockJoinFloatKnnVectorQuery extends ParentBlockJoinKnnVe
 
   @Override
   float[] randomVector(int dim) {
-      float[] v = new float[dim];
-      Random random = random();
-      for (int i = 0; i < dim; i++) {
-        v[i] = random.nextFloat();
-      }
-      return v;
+    float[] v = new float[dim];
+    Random random = random();
+    for (int i = 0; i < dim; i++) {
+      v[i] = random.nextFloat();
     }
+    return v;
+  }
 }

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinFloatKnnVectorQuery.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinFloatKnnVectorQuery.java
@@ -22,6 +22,8 @@ import static org.apache.lucene.index.VectorSimilarityFunction.COSINE;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnFloatVectorField;
@@ -136,4 +138,14 @@ public class TestParentBlockJoinFloatKnnVectorQuery extends ParentBlockJoinKnnVe
       String name, float[] vector, VectorSimilarityFunction vectorSimilarityFunction) {
     return new KnnFloatVectorField(name, vector, vectorSimilarityFunction);
   }
+
+  @Override
+  float[] randomVector(int dim) {
+      float[] v = new float[dim];
+      Random random = random();
+      for (int i = 0; i < dim; i++) {
+        v[i] = random.nextFloat();
+      }
+      return v;
+    }
 }


### PR DESCRIPTION
This is a followon from https://github.com/apache/lucene/pull/15013 rebased on branch 10x. I added grouping by block using updateDocuments so that parent/child docs would stay together. I haven't seen any failures?