### PR TITLE
Refactor computeCommonPrefixLengthAndBuildHistogram

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/MSBRadixSorter.java
@@ -213,16 +213,7 @@ public abstract class MSBRadixSorter extends Sorter {
    *
    * @see #buildHistogram
    */
-  // This method, and its namesakes, have been manually split to work around a JVM crash.
-  // See https://github.com/apache/lucene/issues/12898
   private int computeCommonPrefixLengthAndBuildHistogram(int from, int to, int k, int[] histogram) {
-    int commonPrefixLength = computeInitialCommonPrefixLength(from, k);
-    return computeCommonPrefixLengthAndBuildHistogramPart1(
-        from, to, k, histogram, commonPrefixLength);
-  }
-
-  // This method, and its namesakes, have been manually split to work around a JVM crash.
-  private int computeInitialCommonPrefixLength(int from, int k) {
     final int[] commonPrefix = this.commonPrefix;
     int commonPrefixLength = Math.min(commonPrefix.length, maxLength - k);
     for (int j = 0; j < commonPrefixLength; ++j) {
@@ -233,13 +224,7 @@ public abstract class MSBRadixSorter extends Sorter {
         break;
       }
     }
-    return commonPrefixLength;
-  }
 
-  // This method, and its namesakes, have been manually split to work around a JVM crash.
-  private int computeCommonPrefixLengthAndBuildHistogramPart1(
-      int from, int to, int k, int[] histogram, int commonPrefixLength) {
-    final int[] commonPrefix = this.commonPrefix;
     int i;
     outer:
     for (i = from + 1; i < to; ++i) {
@@ -254,13 +239,7 @@ public abstract class MSBRadixSorter extends Sorter {
         }
       }
     }
-    return computeCommonPrefixLengthAndBuildHistogramPart2(
-        from, to, k, histogram, commonPrefixLength, i);
-  }
 
-  // This method, and its namesakes, have been manually split to work around a JVM crash.
-  private int computeCommonPrefixLengthAndBuildHistogramPart2(
-      int from, int to, int k, int[] histogram, int commonPrefixLength, int i) {
     if (i < to) {
       // the loop got broken because there is no common prefix
       assert commonPrefixLength == 0;

--- a/lucene/core/src/java/org/apache/lucene/util/RadixSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RadixSelector.java
@@ -198,16 +198,7 @@ public abstract class RadixSelector extends Selector {
    *
    * @see #buildHistogram
    */
-  // This method, and its namesakes, have been manually split to work around a JVM crash.
-  // See https://github.com/apache/lucene/issues/12898
   private int computeCommonPrefixLengthAndBuildHistogram(int from, int to, int k, int[] histogram) {
-    int commonPrefixLength = computeInitialCommonPrefixLength(from, k);
-    return computeCommonPrefixLengthAndBuildHistogramPart1(
-        from, to, k, histogram, commonPrefixLength);
-  }
-
-  // This method, and its namesakes, have been manually split to work around a JVM crash.
-  private int computeInitialCommonPrefixLength(int from, int k) {
     final int[] commonPrefix = this.commonPrefix;
     int commonPrefixLength = Math.min(commonPrefix.length, maxLength - k);
     for (int j = 0; j < commonPrefixLength; ++j) {
@@ -218,13 +209,7 @@ public abstract class RadixSelector extends Selector {
         break;
       }
     }
-    return commonPrefixLength;
-  }
 
-  // This method, and its namesakes, have been manually split to work around a JVM crash.
-  private int computeCommonPrefixLengthAndBuildHistogramPart1(
-      int from, int to, int k, int[] histogram, int commonPrefixLength) {
-    final int[] commonPrefix = this.commonPrefix;
     int i;
     outer:
     for (i = from + 1; i < to; ++i) {
@@ -241,13 +226,7 @@ public abstract class RadixSelector extends Selector {
         }
       }
     }
-    return computeCommonPrefixLengthAndBuildHistogramPart2(
-        from, to, k, histogram, commonPrefixLength, i);
-  }
 
-  // This method, and its namesakes, have been manually split to work around a JVM crash.
-  private int computeCommonPrefixLengthAndBuildHistogramPart2(
-      int from, int to, int k, int[] histogram, int commonPrefixLength, int i) {
     if (i < to) {
       // the loop got broken because there is no common prefix
       assert commonPrefixLength == 0;


### PR DESCRIPTION
### Description

Since jdk24 is required (#14533) maybe it's safe to revert #12905, which was introduced to work around a JDK bug.

This pr essentially reverts #12905 (but kept the added crash test), so the related code under `MSBRadixSorter` and 
`RadixSelector` can be more clear

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
