### PR TITLE
Return the max score from `RandomVectorScorer.bulkScore`

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
@@ -361,10 +361,11 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
           }
           ords[numOrds++] = i;
           if (numOrds == ords.length) {
-            scorer.bulkScore(ords, scores, numOrds);
-            for (int j = 0; j < numOrds; j++) {
-              knnCollector.incVisitedCount(1);
-              knnCollector.collect(scorer.ordToDoc(ords[j]), scores[j]);
+            knnCollector.incVisitedCount(numOrds);
+            if (scorer.bulkScore(ords, scores, numOrds) > knnCollector.minCompetitiveSimilarity()) {
+              for (int j = 0; j < numOrds; j++) {
+                knnCollector.collect(scorer.ordToDoc(ords[j]), scores[j]);
+              }
             }
             numOrds = 0;
           }
@@ -372,10 +373,11 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
       }
 
       if (numOrds > 0) {
-        scorer.bulkScore(ords, scores, numOrds);
-        for (int j = 0; j < numOrds; j++) {
-          knnCollector.incVisitedCount(1);
-          knnCollector.collect(scorer.ordToDoc(ords[j]), scores[j]);
+        knnCollector.incVisitedCount(numOrds);
+        if (scorer.bulkScore(ords, scores, numOrds) > knnCollector.minCompetitiveSimilarity()) {
+          for (int j = 0; j < numOrds; j++) {
+            knnCollector.collect(scorer.ordToDoc(ords[j]), scores[j]);
+          }
         }
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnCollector.java
@@ -47,7 +47,7 @@ public abstract class AbstractKnnCollector implements KnnCollector {
 
   @Override
   public final void incVisitedCount(int count) {
-    assert count > 0;
+    assert count >= 0;
     this.visitedCount += count;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -335,10 +335,11 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
         bulkNodes[numNodes++] = friendOrd;
       }
 
-      if (numNodes > 0) {
-        numNodes = (int) Math.min((long) numNodes, results.visitLimit() - results.visitedCount());
-        scorer.bulkScore(bulkNodes, bulkScores, numNodes);
-        results.incVisitedCount(numNodes);
+      numNodes = (int) Math.min((long) numNodes, results.visitLimit() - results.visitedCount());
+      results.incVisitedCount(numNodes);
+      if (numNodes > 0
+          && scorer.bulkScore(bulkNodes, bulkScores, numNodes)
+              > results.minCompetitiveSimilarity()) {
         for (int i = 0; i < numNodes; i++) {
           int node = bulkNodes[i];
           float score = bulkScores[i];

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/RandomVectorScorer.java
@@ -42,11 +42,15 @@ public interface RandomVectorScorer {
    * @param nodes array of nodes to score.
    * @param scores output array of scores corresponding to each node.
    * @param numNodes number of nodes to score. Must not exceed length of nodes or scores arrays.
+   * @return the maximum scored value of any node, or Float.NEGATIVE_INFINITY if numNodes == 0.
    */
-  default void bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+  default float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+    float max = Float.NEGATIVE_INFINITY;
     for (int i = 0; i < numNodes; i++) {
       scores[i] = score(nodes[i]);
+      max = Math.max(max, scores[i]);
     }
+    return max;
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/codecs/hnsw/TestFlatVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/hnsw/TestFlatVectorScorer.java
@@ -260,11 +260,13 @@ public class TestFlatVectorScorer extends BaseVectorizationTestCase {
             : flatVectorsScorer.getRandomVectorScorer(sim, values, randomFloatVector(dims));
     int[] indices = randomIndices(size);
     float[] expectedScores = new float[size];
+    float expectedMaxScore = Float.NEGATIVE_INFINITY;
     for (int i = 0; i < size; i++) {
       expectedScores[i] = scorer.score(indices[i]);
+      expectedMaxScore = Math.max(expectedMaxScore, expectedScores[i]);
     }
     float[] bulkScores = new float[size];
-    scorer.bulkScore(indices, bulkScores, size);
+    assertEquals(expectedMaxScore, scorer.bulkScore(indices, bulkScores, size), 0.001);
     assertArrayEquals(expectedScores, bulkScores, delta);
     assertNoScoreBeyondNumNodes(scorer, size);
   }
@@ -302,8 +304,10 @@ public class TestFlatVectorScorer extends BaseVectorizationTestCase {
         DefaultFlatVectorScorer.INSTANCE.getRandomVectorScorerSupplier(sim, values).scorer();
     defaultScorer.setScoringOrdinal(targetNode);
     float[] expectedScores = new float[size];
+    float expectedMaxScore = Float.NEGATIVE_INFINITY;
     for (int i = 0; i < size; i++) {
       expectedScores[i] = defaultScorer.score(indices[i]);
+      expectedMaxScore = Math.max(expectedMaxScore, expectedScores[i]);
     }
 
     var supplier = flatVectorsScorer.getRandomVectorScorerSupplier(sim, values);
@@ -311,7 +315,7 @@ public class TestFlatVectorScorer extends BaseVectorizationTestCase {
       var updatableScorer = ss.scorer();
       updatableScorer.setScoringOrdinal(targetNode);
       float[] bulkScores = new float[size];
-      updatableScorer.bulkScore(indices, bulkScores, size);
+      assertEquals(expectedMaxScore, updatableScorer.bulkScore(indices, bulkScores, size), 0.001);
       assertArrayEquals(expectedScores, bulkScores, delta);
     }
   }


### PR DESCRIPTION
Return a little extra information from the `bulkScore()` as this will allow callers to skip results that are
below the minimum similarity needed to appear in the result set. Utilize this in hnsw and exhaustive search
to skip any topN heap manipulation for any bulk scored batches that do not meet the minimum score.

See #14013 
