### PR TITLE
flush segments in addIndexes, not in addIndexesReaderMerge; fixes #14994

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -237,6 +237,9 @@ Changes in Runtime Behavior
 
 Bug Fixes
 ---------------------
+* GITHUB*15025: flush segments in addIndexes, not in addIndexesReaderMerge;
+  reduces extra needless merge activity
+
 * GITHUB#14880: NPE exception could occur in Luke on Windows when using network shares (wuth)
 
 * GITHUB#14654: ValueSource.fromDoubleValuesSource(dvs).getSortField() would throw errors when

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3156,6 +3156,11 @@ public class IndexWriter
     long seqNo;
 
     try {
+      if (infoStream.isEnabled("IW")) {
+        infoStream.message("IW", "flush at addIndexes(CodecReader...)");
+      }
+      flush(false, true);
+
       // Best effort up front validations
       for (CodecReader leaf : readers) {
         validateMergeReader(leaf);
@@ -3354,11 +3359,6 @@ public class IndexWriter
 
     // long so we can detect int overflow:
     long numDocs = 0;
-    if (infoStream.isEnabled("IW")) {
-      infoStream.message("IW", "flush at addIndexes(CodecReader...)");
-    }
-    flush(false, true);
-
     String mergedName = newSegmentName();
     Directory mergeDirectory = mergeScheduler.wrapForMerge(merge, directory);
     int numSoftDeleted = 0;


### PR DESCRIPTION
Just monkey-coding based on @mikemccand 's comment in the issue. It makes sense to me and seems to pass unit tests.

Restores this logic to the way it was before 698f40ad51af0c42b0a4a8321ab89968e8d0860b -- CC: @vigyasharma 