### PR TITLE
Backport: Remove full integrity check from SortingStoredFieldsConsumer

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -130,6 +130,8 @@ Optimizations
 
 * GITHUB#15010: Improve off-heap KNN byte vector query performance in cases where indexing and search are performed by the same process. (Kaival Parikh)
 
+* GITHUB#15001: Remove full integrity check from SortingStoredFieldsConsumer (Martijn van Groningen)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14823: Decrease TieredMergePolicy's default number of segments per

--- a/lucene/core/src/java/org/apache/lucene/index/SortingStoredFieldsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingStoredFieldsConsumer.java
@@ -103,7 +103,11 @@ final class SortingStoredFieldsConsumer extends StoredFieldsConsumer {
     StoredFieldsWriter sortWriter =
         codec.storedFieldsFormat().fieldsWriter(state.directory, state.segmentInfo, state.context);
     try {
-      reader.checkIntegrity();
+      // Don't perform a full integrity check via reader.checkIntegrity() here,
+      // in order to avoid reading the tmp stored field files twice.
+      // The light-weight integrity check via Lucene90CompressingStoredFieldsReader should be
+      // sufficient
+      // in the context of flushing.
       CopyVisitor visitor = new CopyVisitor(sortWriter);
       for (int docID = 0; docID < state.segmentInfo.maxDoc(); docID++) {
         sortWriter.startDocument();


### PR DESCRIPTION
Backporting #15001 to the 10.x branch.

In write-heavy scenarios with significant stored field usage, the full integrity check that happens during flushing stored fields to disk when index sorting is active can be very expensive. Instead, rely on the light integrity check that happens in `Lucene90CompressingStoredFieldsReader`.

Note that at some point when newly flushed segments are getting merged, a full integrity check will happen.

Closes #14881
