### PR TITLE
Add minor utility method VectorUtil::normalizeToUnitInterval

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
@@ -19,6 +19,7 @@ package org.apache.lucene.index;
 import static org.apache.lucene.util.VectorUtil.cosine;
 import static org.apache.lucene.util.VectorUtil.dotProduct;
 import static org.apache.lucene.util.VectorUtil.dotProductScore;
+import static org.apache.lucene.util.VectorUtil.normalizeToUnitInterval;
 import static org.apache.lucene.util.VectorUtil.scaleMaxInnerProductScore;
 import static org.apache.lucene.util.VectorUtil.squareDistance;
 
@@ -52,7 +53,7 @@ public enum VectorSimilarityFunction {
   DOT_PRODUCT {
     @Override
     public float compare(float[] v1, float[] v2) {
-      return Math.max((1 + dotProduct(v1, v2)) / 2, 0);
+      return normalizeToUnitInterval(dotProduct(v1, v2));
     }
 
     @Override
@@ -70,7 +71,7 @@ public enum VectorSimilarityFunction {
   COSINE {
     @Override
     public float compare(float[] v1, float[] v2) {
-      return Math.max((1 + cosine(v1, v2)) / 2, 0);
+      return normalizeToUnitInterval(cosine(v1, v2));
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -309,6 +309,20 @@ public final class VectorUtil {
   }
 
   /**
+   * Converts a dot product or cosine similarity value to a normalized score in the [0, 1] range.
+   *
+   * <p>This transformation is necessary when consistent non-negative scores are required. It maps
+   * input values from [-1, 1] to [0, 1] using the formula: (1 + value) / 2. Any result below 0 is
+   * clamped to 0 for numerical safety.
+   *
+   * @param value the similarity value (dot product or cosine), typically in the range [-1, 1]
+   * @return a normalized score between 0 and 1
+   */
+  public static float normalizeToUnitInterval(float value) {
+    return Math.max((1 + value) / 2, 0);
+  }
+
+  /**
    * Checks if a float vector only has finite components.
    *
    * @param v bytes containing a vector

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -122,6 +122,17 @@ public class TestVectorUtil extends LuceneTestCase {
     expectThrows(IllegalArgumentException.class, () -> VectorUtil.l2normalize(v));
   }
 
+  public void testNormalizeToUnitInterval() {
+    for (int i = 0; i < 100; i++) {
+      // Generates a float in the range [-1.0, 1.0)
+      float f = random().nextFloat() * 2 - 1;
+      float v = VectorUtil.normalizeToUnitInterval(f);
+      assertTrue(v >= 0);
+      assertTrue(v <= 1);
+      assertEquals(Math.max((1 + f) / 2, 0), v, 0.0f);
+    }
+  }
+
   public void testExtremeNumerics() {
     float[] v1 = new float[1536];
     float[] v2 = new float[1536];


### PR DESCRIPTION
This commit adds a minor utility method, `VectorUtil::normalizeToUnitInterval`, to avoid copying and pasting the normalising logic for dot product and cosine, as we allow more customisable scorers.