### PR TITLE
Change default ReadAdvice from RANDOM to NORMAL

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -241,6 +241,12 @@ Changes in Runtime Behavior
   tier from 10 to 8. This is expected to result in slightly faster search and
   slightly slower indexing. (Adrien Grand)
 
+* GITHUB#15040: The default ReadAdvice has been changed from RANDOM to NORMAL. MMapDirectory
+  will no longer set any specific read advice out-of-the-box. Rather there is a straightforward
+  way to enable previous behaviour (in 10.2), either by setting:
+  `dir.setReadAdvice(MMapDirectory.ADVISE_BY_CONTEXT)`, or setting the system property
+  `-Dorg.apache.lucene.store.defaultReadAdvice=RANDOM`. (Chris Hegarty)
+
 Bug Fixes
 ---------------------
 * GITHUB*15025: flush segments in addIndexes, not in addIndexesReaderMerge;

--- a/lucene/core/src/java/org/apache/lucene/util/Constants.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Constants.java
@@ -176,13 +176,13 @@ public final class Constants {
 
   /**
    * The default {@link ReadAdvice} used for opening index files. It will be {@link
-   * ReadAdvice#RANDOM} by default, unless set by system property {@code
+   * ReadAdvice#NORMAL} by default, unless set by system property {@code
    * org.apache.lucene.store.defaultReadAdvice}.
    */
   public static final ReadAdvice DEFAULT_READADVICE =
       Optional.ofNullable(getSysProp("org.apache.lucene.store.defaultReadAdvice"))
           .map(a -> ReadAdvice.valueOf(a.toUpperCase(Locale.ROOT)))
-          .orElse(ReadAdvice.RANDOM);
+          .orElse(ReadAdvice.NORMAL);
 
   private static String getSysProp(String property) {
     return System.getProperty(property);


### PR DESCRIPTION
This commit changes the default ReadAdvice from RANDOM to NORMAL. 

After this change MMapDirectory will not set any specific read advice out-of-the-box. Rather there is a straightforward way to enable either previous behaviour ( in 10.2 ), by setting either:
1.  `dir.setReadAdvice(MMapDirectory.ADVISE_BY_CONTEXT)`, or
2. setting the system property `-Dorg.apache.lucene.store.defaultReadAdvice=RANDOM`.

closes #14408