### PR TITLE
vectorize L2 normalize function

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -63,6 +63,8 @@ Optimizations
 
 * GITHUB#14874: Improve off-heap KNN byte vector query performance in cases where indexing and search are performed by the same process. (Kaival Parikh)
 
+* GITHUB#15043: Vectorize L2 normalize function
+
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -63,7 +63,7 @@ Optimizations
 
 * GITHUB#14874: Improve off-heap KNN byte vector query performance in cases where indexing and search are performed by the same process. (Kaival Parikh)
 
-* GITHUB#15043: Vectorize L2 normalize function
+* GITHUB#15043: Vectorize L2 normalize function. (Ramakrishna Chilaka)
 
 Bug Fixes
 ---------------------

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
@@ -172,11 +172,24 @@ public class VectorUtilBenchmark {
   }
 
   @Benchmark
+  public float[] l2Normalize() {
+    return VectorUtil.l2normalize(floatsA, false);
+  }
+
+  @Benchmark
   @Fork(
       value = 15,
       jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
   public float floatCosineVector() {
     return VectorUtil.cosine(floatsA, floatsB);
+  }
+
+  @Benchmark
+  @Fork(
+      value = 15,
+      jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+  public float[] l2NormalizeVector() {
+    return VectorUtil.l2normalize(floatsA, false);
   }
 
   @Benchmark

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
@@ -17,6 +17,8 @@
 
 package org.apache.lucene.internal.vectorization;
 
+import static org.apache.lucene.util.VectorUtil.EPSILON;
+
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.SuppressForbidden;
@@ -324,5 +326,26 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
       }
     }
     return newSize;
+  }
+
+  @Override
+  public float[] l2normalize(float[] v, boolean throwOnZero) {
+    double l1norm = this.dotProduct(v, v);
+    if (l1norm == 0) {
+      if (throwOnZero) {
+        throw new IllegalArgumentException("Cannot normalize a zero-length vector");
+      } else {
+        return v;
+      }
+    }
+    if (Math.abs(l1norm - 1.0d) <= EPSILON) {
+      return v;
+    }
+    int dim = v.length;
+    double l2norm = Math.sqrt(l1norm);
+    for (int i = 0; i < dim; i++) {
+      v[i] /= (float) l2norm;
+    }
+    return v;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
@@ -114,4 +114,6 @@ public interface VectorUtilSupport {
    * @return how many pairs left after filter
    */
   int filterByScore(int[] docBuffer, double[] scoreBuffer, double minScoreInclusive, int upTo);
+
+  float[] l2normalize(float[] v, boolean throwOnZero);
 }

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -48,7 +48,7 @@ import org.apache.lucene.internal.vectorization.VectorizationProvider;
  */
 public final class VectorUtil {
 
-  private static final float EPSILON = 1e-4f;
+  public static final float EPSILON = 1e-4f;
 
   private static final VectorUtilSupport IMPL =
       VectorizationProvider.getInstance().getVectorUtilSupport();
@@ -138,23 +138,7 @@ public final class VectorUtil {
    * @throws IllegalArgumentException when the vector is all zero and throwOnZero is true
    */
   public static float[] l2normalize(float[] v, boolean throwOnZero) {
-    double l1norm = IMPL.dotProduct(v, v);
-    if (l1norm == 0) {
-      if (throwOnZero) {
-        throw new IllegalArgumentException("Cannot normalize a zero-length vector");
-      } else {
-        return v;
-      }
-    }
-    if (Math.abs(l1norm - 1.0d) <= EPSILON) {
-      return v;
-    }
-    int dim = v.length;
-    double l2norm = Math.sqrt(l1norm);
-    for (int i = 0; i < dim; i++) {
-      v[i] /= (float) l2norm;
-    }
-    return v;
+    return IMPL.l2normalize(v, throwOnZero);
   }
 
   /**

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -24,6 +24,7 @@ import static jdk.incubator.vector.VectorOperators.B2S;
 import static jdk.incubator.vector.VectorOperators.LSHR;
 import static jdk.incubator.vector.VectorOperators.S2I;
 import static jdk.incubator.vector.VectorOperators.ZERO_EXTEND_B2S;
+import static org.apache.lucene.util.VectorUtil.EPSILON;
 
 import java.lang.foreign.MemorySegment;
 import jdk.incubator.vector.ByteVector;
@@ -1102,5 +1103,56 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       }
     }
     return newUpto;
+  }
+
+  public float[] l2normalize(float[] v, boolean throwOnZero) {
+    double l1norm = this.dotProduct(v, v);
+    if (l1norm == 0) {
+      if (throwOnZero) {
+        throw new IllegalArgumentException("Cannot normalize a zero-length vector");
+      } else {
+        return v;
+      }
+    }
+    if (Math.abs(l1norm - 1.0d) <= EPSILON) {
+      return v;
+    }
+
+    float invNorm = 1.0f / (float) Math.sqrt(l1norm);
+    int i = 0;
+
+    // if the array size is large (> 2x platform vector size), it's worth the overhead to vectorize
+    if (v.length > 2 * FLOAT_SPECIES.length()) {
+      i += FLOAT_SPECIES.loopBound(v.length);
+      l2normalizeBody(v, invNorm, i);
+    }
+
+    for (; i < v.length; i++) {
+      v[i] *= invNorm;
+    }
+    return v;
+  }
+
+  private void l2normalizeBody(float[] v, float invNorm, int limit) {
+    FloatVector invNormVector = FloatVector.broadcast(FLOAT_SPECIES, invNorm);
+    int i = 0;
+    int unrolledLimit = limit - 3 * FLOAT_SPECIES.length();
+
+    for (; i < unrolledLimit; i += 4 * FLOAT_SPECIES.length()) {
+      FloatVector.fromArray(FLOAT_SPECIES, v, i).mul(invNormVector).intoArray(v, i);
+      FloatVector.fromArray(FLOAT_SPECIES, v, i + FLOAT_SPECIES.length())
+          .mul(invNormVector)
+          .intoArray(v, i + FLOAT_SPECIES.length());
+      FloatVector.fromArray(FLOAT_SPECIES, v, i + 2 * FLOAT_SPECIES.length())
+          .mul(invNormVector)
+          .intoArray(v, i + 2 * FLOAT_SPECIES.length());
+      FloatVector.fromArray(FLOAT_SPECIES, v, i + 3 * FLOAT_SPECIES.length())
+          .mul(invNormVector)
+          .intoArray(v, i + 3 * FLOAT_SPECIES.length());
+    }
+
+    for (; i < limit; i += FLOAT_SPECIES.length()) {
+      FloatVector.fromArray(FLOAT_SPECIES, v, i).mul(invNormVector).intoArray(v, i);
+    }
   }
 }


### PR DESCRIPTION
### Description

While reviewing [apache/lucene#14896](https://github.com/apache/lucene/pull/14896) I noticed that the post-dot-product division step in VectorUtil.l2normalize was still scalar.

This PR vectorises only the division loop, leaving the existing fast Panama dot-product untouched.

### Benchmarks on M1 Pro

```
Benchmark                              (size)   Mode  Cnt    Score    Error   Units
VectorUtilBenchmark.l2Normalize             1  thrpt   15  328.829 ± 41.535  ops/us
VectorUtilBenchmark.l2Normalize           128  thrpt   15   24.009 ±  0.603  ops/us
VectorUtilBenchmark.l2Normalize           207  thrpt   15   13.517 ±  0.403  ops/us
VectorUtilBenchmark.l2Normalize           256  thrpt   15   10.178 ±  0.619  ops/us
VectorUtilBenchmark.l2Normalize           300  thrpt   15    9.360 ±  0.450  ops/us
VectorUtilBenchmark.l2Normalize           512  thrpt   15    5.107 ±  0.081  ops/us
VectorUtilBenchmark.l2Normalize           702  thrpt   15    3.528 ±  0.084  ops/us
VectorUtilBenchmark.l2Normalize          1024  thrpt   15    2.365 ±  0.051  ops/us
VectorUtilBenchmark.l2NormalizeVector       1  thrpt   75  350.457 ±  6.117  ops/us
VectorUtilBenchmark.l2NormalizeVector     128  thrpt   75   54.459 ±  3.576  ops/us
VectorUtilBenchmark.l2NormalizeVector     207  thrpt   75   34.701 ±  1.698  ops/us
VectorUtilBenchmark.l2NormalizeVector     256  thrpt   75   35.159 ±  2.050  ops/us
VectorUtilBenchmark.l2NormalizeVector     300  thrpt   75   28.488 ±  1.801  ops/us
VectorUtilBenchmark.l2NormalizeVector     512  thrpt   75   21.058 ±  1.236  ops/us
VectorUtilBenchmark.l2NormalizeVector     702  thrpt   75   15.002 ±  0.688  ops/us
VectorUtilBenchmark.l2NormalizeVector    1024  thrpt   75   11.616 ±  0.394  ops/us
```


Summarising speed-up.

| size | scalar | vector | speed-up |
| ---- | ------ | ------ | -------- |
| 128  | 24.0   | 54.5   | **2.3×** |
| 512  | 5.1    | 21.1   | **4.1×** |
| 1024 | 2.4    | 11.6   | **4.8×** |
