### PR TITLE
Remove merge instance assertions from AssertingKnnVectorsFormat

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
@@ -137,8 +137,6 @@ public class AssertingKnnVectorsFormat extends KnnVectorsFormat {
 
     @Override
     public FloatVectorValues getFloatVectorValues(String field) throws IOException {
-      assert mergeInstanceCount.get() == finishMergeCount.get() || mergeInstance
-          : "Called on the wrong instance";
       FieldInfo fi = fis.fieldInfo(field);
       assert fi != null
           && fi.getVectorDimension() > 0
@@ -153,8 +151,6 @@ public class AssertingKnnVectorsFormat extends KnnVectorsFormat {
 
     @Override
     public ByteVectorValues getByteVectorValues(String field) throws IOException {
-      assert mergeInstanceCount.get() == finishMergeCount.get() || mergeInstance
-          : "Called on the wrong instance";
       FieldInfo fi = fis.fieldInfo(field);
       assert fi != null
           && fi.getVectorDimension() > 0

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
@@ -114,20 +114,13 @@ public class AssertingKnnVectorsFormat extends KnnVectorsFormat {
       implements HnswGraphProvider {
     public final KnnVectorsReader delegate;
     private final FieldInfos fis;
-    private final boolean mergeInstance;
     private final AtomicInteger mergeInstanceCount = new AtomicInteger();
     private final AtomicInteger finishMergeCount = new AtomicInteger();
 
     private AssertingKnnVectorsReader(KnnVectorsReader delegate, FieldInfos fis) {
-      this(delegate, fis, false);
-    }
-
-    private AssertingKnnVectorsReader(
-        KnnVectorsReader delegate, FieldInfos fis, boolean mergeInstance) {
       assert delegate != null;
       this.delegate = delegate;
       this.fis = fis;
-      this.mergeInstance = mergeInstance;
     }
 
     @Override
@@ -192,8 +185,7 @@ public class AssertingKnnVectorsFormat extends KnnVectorsFormat {
       mergeInstanceCount.incrementAndGet();
       AtomicInteger parentMergeFinishCount = this.finishMergeCount;
 
-      return new AssertingKnnVectorsReader(
-          mergeVectorsReader, AssertingKnnVectorsReader.this.fis, true) {
+      return new AssertingKnnVectorsReader(mergeVectorsReader, AssertingKnnVectorsReader.this.fis) {
         private boolean finished;
 
         @Override


### PR DESCRIPTION
Remove some assertions added by #14844

It turns out that merge instances can be created concurrently to getting byte/float values. This technically breaks the model of ReadAdvice used by MMapDirectory, as whilst a merge instance is open, any other accesses to values from another `KnnVectorsReader` will use the incorrect ReadAdvice. Whilst not bad, this may cause unexpected performance issues.

This PR removes these assertions for now, pending further investigation