### PR TITLE
Use switch expression for optimized type checks in PointRangeQueryBuilder

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -63,6 +63,8 @@ Optimizations
 
 * GITHUB#14874: Improve off-heap KNN byte vector query performance in cases where indexing and search are performed by the same process. (Kaival Parikh)
 
+* GITHUB#15050: Use switch expression for optimized type checks in PointRangeQueryBuilder (Sandesh Kumar)
+
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -63,8 +63,6 @@ Optimizations
 
 * GITHUB#14874: Improve off-heap KNN byte vector query performance in cases where indexing and search are performed by the same process. (Kaival Parikh)
 
-* GITHUB#15050: Use switch expression for optimized type checks in PointRangeQueryBuilder (Sandesh Kumar)
-
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
@@ -301,6 +299,8 @@ Other
 * GITHUB#14898: Fix typo in Circle2D.java (Hokuto Joel Ide)
 
 * GITHUB#14839: Add support for sparse SortedDocValues to LuceneTestCase.assertDocValuesEquals (Parker Timmins)
+
+* GITHUB#15050: Use switch expression for optimized type checks in PointRangeQueryBuilder (Sandesh Kumar)
 
 ======================= Lucene 10.2.2 =======================
 

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/builders/PointRangeQueryBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/builders/PointRangeQueryBuilder.java
@@ -75,32 +75,33 @@ public class PointRangeQueryBuilder implements QueryBuilder {
     String field = DOMUtils.getAttributeWithInheritanceOrFail(e, "fieldName");
     final String lowerTerm = DOMUtils.getAttribute(e, "lowerTerm", null);
     final String upperTerm = DOMUtils.getAttribute(e, "upperTerm", null);
+    String type = DOMUtils.getAttribute(e, "type", "int").toLowerCase();
 
-    String type = DOMUtils.getAttribute(e, "type", "int");
     try {
-      if (type.equalsIgnoreCase("int")) {
-        return IntPoint.newRangeQuery(
-            field,
-            (lowerTerm == null ? Integer.MIN_VALUE : Integer.parseInt(lowerTerm)),
-            (upperTerm == null ? Integer.MAX_VALUE : Integer.parseInt(upperTerm)));
-      } else if (type.equalsIgnoreCase("long")) {
-        return LongPoint.newRangeQuery(
-            field,
-            (lowerTerm == null ? Long.MIN_VALUE : Long.parseLong(lowerTerm)),
-            (upperTerm == null ? Long.MAX_VALUE : Long.parseLong(upperTerm)));
-      } else if (type.equalsIgnoreCase("double")) {
-        return DoublePoint.newRangeQuery(
-            field,
-            (lowerTerm == null ? Double.NEGATIVE_INFINITY : Double.parseDouble(lowerTerm)),
-            (upperTerm == null ? Double.POSITIVE_INFINITY : Double.parseDouble(upperTerm)));
-      } else if (type.equalsIgnoreCase("float")) {
-        return FloatPoint.newRangeQuery(
-            field,
-            (lowerTerm == null ? Float.NEGATIVE_INFINITY : Float.parseFloat(lowerTerm)),
-            (upperTerm == null ? Float.POSITIVE_INFINITY : Float.parseFloat(upperTerm)));
-      } else {
-        throw new ParserException("type attribute must be one of: [long, int, double, float]");
-      }
+      return switch (type) {
+        case "int" ->
+            IntPoint.newRangeQuery(
+                field,
+                (lowerTerm == null ? Integer.MIN_VALUE : Integer.parseInt(lowerTerm)),
+                (upperTerm == null ? Integer.MAX_VALUE : Integer.parseInt(upperTerm)));
+        case "long" ->
+            LongPoint.newRangeQuery(
+                field,
+                (lowerTerm == null ? Long.MIN_VALUE : Long.parseLong(lowerTerm)),
+                (upperTerm == null ? Long.MAX_VALUE : Long.parseLong(upperTerm)));
+        case "double" ->
+            DoublePoint.newRangeQuery(
+                field,
+                (lowerTerm == null ? Double.NEGATIVE_INFINITY : Double.parseDouble(lowerTerm)),
+                (upperTerm == null ? Double.POSITIVE_INFINITY : Double.parseDouble(upperTerm)));
+        case "float" ->
+            FloatPoint.newRangeQuery(
+                field,
+                (lowerTerm == null ? Float.NEGATIVE_INFINITY : Float.parseFloat(lowerTerm)),
+                (upperTerm == null ? Float.POSITIVE_INFINITY : Float.parseFloat(upperTerm)));
+        default ->
+            throw new ParserException("type attribute must be one of: [long, int, double, float]");
+      };
     } catch (NumberFormatException nfe) {
       throw new ParserException("Could not parse lowerTerm or upperTerm into a number", nfe);
     }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/builders/PointRangeQueryBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/builders/PointRangeQueryBuilder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.queryparser.xml.builders;
 
+import java.util.Locale;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.IntPoint;
@@ -75,7 +76,7 @@ public class PointRangeQueryBuilder implements QueryBuilder {
     String field = DOMUtils.getAttributeWithInheritanceOrFail(e, "fieldName");
     final String lowerTerm = DOMUtils.getAttribute(e, "lowerTerm", null);
     final String upperTerm = DOMUtils.getAttribute(e, "upperTerm", null);
-    String type = DOMUtils.getAttribute(e, "type", "int").toLowerCase();
+    String type = DOMUtils.getAttribute(e, "type", "int").toLowerCase(Locale.getDefault());
 
     try {
       return switch (type) {


### PR DESCRIPTION
### Description

`PointRangeQueryBuilder` code refactoring:
- Replace multiple `if-else` with `switch` expression
- Store `type` as lowercase to avoid checking with ignore-case later

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
