### PR TITLE
Revert unneccessary cms change

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -583,6 +583,7 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
         // OK to spawn a new merge thread to handle this
         // merge:
         final MergeThread newMergeThread = getMergeThread(mergeSource, merge);
+        mergeThreads.add(newMergeThread);
 
         updateIOThrottle(newMergeThread.merge, newMergeThread.rateLimiter);
 
@@ -670,7 +671,6 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
     final MergeThread thread = new MergeThread(mergeSource, merge);
     thread.setDaemon(true);
     thread.setName("Lucene Merge Thread #" + mergeThreadCounter++);
-    mergeThreads.add(thread);
     return thread;
   }
 


### PR DESCRIPTION
Unnecessary CMS change was made in this PR: https://github.com/apache/lucene/issues/15051

This commit just reverts that particular change

closes: https://github.com/apache/lucene/issues/15051