### PR TITLE
Rework off-heap float32 bulk scoring to reduce garbage creation

### DIFF
--- a/lucene/benchmark-jmh/src/test/org/apache/lucene/benchmark/jmh/TestVectorScorerFloat32Benchmark.java
+++ b/lucene/benchmark-jmh/src/test/org/apache/lucene/benchmark/jmh/TestVectorScorerFloat32Benchmark.java
@@ -32,10 +32,12 @@ public class TestVectorScorerFloat32Benchmark extends LuceneTestCase {
   public void setup() throws IOException {
     bench = new VectorScorerFloat32Benchmark();
     bench.size = 1024;
+    bench.pollute = true;
     bench.numVectors = random().nextInt(1, 256);
     bench.numVectorsToScore = random().nextInt(bench.numVectors);
     delta = 1e-3f * bench.size;
     bench.setup();
+    bench.perIterationInit();
   }
 
   @After

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFloatVectorScorer.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFloatVectorScorer.java
@@ -102,15 +102,16 @@ abstract sealed class Lucene99MemorySegmentFloatVectorScorer
     }
 
     @Override
-    public void bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+    public void bulkScore(int[] nodes, float[] scores, int numNodes) {
       int i = 0;
       final int limit = numNodes & ~3;
       for (; i < limit; i += 4) {
-        long addr1 = (long) nodes[i] * vectorByteSize;
-        long addr2 = (long) nodes[i + 1] * vectorByteSize;
-        long addr3 = (long) nodes[i + 2] * vectorByteSize;
-        long addr4 = (long) nodes[i + 3] * vectorByteSize;
-        DOT_OPS.dotProductBulk(seg, scratchScores, query, addr1, addr2, addr3, addr4, query.length);
+        long offset1 = (long) nodes[i] * vectorByteSize;
+        long offset2 = (long) nodes[i + 1] * vectorByteSize;
+        long offset3 = (long) nodes[i + 2] * vectorByteSize;
+        long offset4 = (long) nodes[i + 3] * vectorByteSize;
+        DOT_OPS.dotProductBulk(
+            seg, scratchScores, query, offset1, offset2, offset3, offset4, query.length);
         scores[i + 0] = normalizeToUnitInterval(scratchScores[0]);
         scores[i + 1] = normalizeToUnitInterval(scratchScores[1]);
         scores[i + 2] = normalizeToUnitInterval(scratchScores[2]);

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFloatVectorScorerSupplier.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFloatVectorScorerSupplier.java
@@ -107,17 +107,18 @@ public abstract sealed class Lucene99MemorySegmentFloatVectorScorerSupplier
         }
 
         @Override
-        public void bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+        public void bulkScore(int[] nodes, float[] scores, int numNodes) {
           // TODO checkOrdinal(node1 ....);
           int i = 0;
           long queryAddr = (long) queryOrd * vectorByteSize;
           final int limit = numNodes & ~3;
           for (; i < limit; i += 4) {
-            long addr1 = (long) nodes[i + 0] * vectorByteSize;
-            long addr2 = (long) nodes[i + 1] * vectorByteSize;
-            long addr3 = (long) nodes[i + 2] * vectorByteSize;
-            long addr4 = (long) nodes[i + 3] * vectorByteSize;
-            DOT_OPS.dotProductBulk(seg, scratchScores, queryAddr, addr1, addr2, addr3, addr4, dims);
+            long offset1 = (long) nodes[i + 0] * vectorByteSize;
+            long offset2 = (long) nodes[i + 1] * vectorByteSize;
+            long offset3 = (long) nodes[i + 2] * vectorByteSize;
+            long offset4 = (long) nodes[i + 3] * vectorByteSize;
+            DOT_OPS.dotProductBulk(
+                seg, scratchScores, queryAddr, offset1, offset2, offset3, offset4, dims);
             scores[i + 0] = normalizeToUnitInterval(scratchScores[0]);
             scores[i + 1] = normalizeToUnitInterval(scratchScores[1]);
             scores[i + 2] = normalizeToUnitInterval(scratchScores[2]);

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/MemorySegmentBulkVectorOps.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/MemorySegmentBulkVectorOps.java
@@ -35,7 +35,7 @@ public final class MemorySegmentBulkVectorOps {
   static final ByteOrder LE = ByteOrder.LITTLE_ENDIAN;
   static final ValueLayout.OfFloat LAYOUT_LE_FLOAT = ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(LE);
 
-  public static DotProduct DOT_INSTANCE = new DotProduct();
+  public static final DotProduct DOT_INSTANCE = new DotProduct();
 
   private MemorySegmentBulkVectorOps() {}
 

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/MemorySegmentBulkVectorOps.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/MemorySegmentBulkVectorOps.java
@@ -35,111 +35,66 @@ public final class MemorySegmentBulkVectorOps {
   static final ByteOrder LE = ByteOrder.LITTLE_ENDIAN;
   static final ValueLayout.OfFloat LAYOUT_LE_FLOAT = ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(LE);
 
+  public static DotProduct DOT_INSTANCE = new DotProduct();
+
   private MemorySegmentBulkVectorOps() {}
 
-  sealed interface FloatVectorLoader {
-    /** Returns the number of float elements. */
-    int length();
+  public static final class DotProduct {
 
-    FloatVector load(VectorSpecies<Float> species, int index);
-
-    float tail(int index);
-  }
-
-  record FloatArrayLoader(float[] arr) implements FloatVectorLoader {
-    @Override
-    public int length() {
-      return arr.length;
-    }
-
-    @Override
-    public FloatVector load(VectorSpecies<Float> species, int index) {
-      // assert index + species.length() <= length();
-      return FloatVector.fromArray(species, arr, index);
-    }
-
-    @Override
-    public float tail(int index) {
-      // assert index <= length();
-      return arr[index];
-    }
-  }
-
-  record FloatMemorySegmentLoader(MemorySegment segment) implements FloatVectorLoader {
-    @Override
-    public int length() {
-      return Math.toIntExact(segment.byteSize() / Float.BYTES);
-    }
-
-    @Override
-    public FloatVector load(VectorSpecies<Float> species, int index) {
-      // assert index + species.length() <= length();
-      return FloatVector.fromMemorySegment(species, segment, (long) index * Float.BYTES, LE);
-    }
-
-    @Override
-    public float tail(int index) {
-      // assert index <= length();
-      return segment.get(LAYOUT_LE_FLOAT, (long) index * Float.BYTES);
-    }
-  }
-
-  public static final class DotFromQueryArray extends AbstractDotProduct {
+    private DotProduct() {}
 
     public void dotProductBulk(
+        MemorySegment dataSeg,
         float[] scores,
         float[] q,
-        MemorySegment d1,
-        MemorySegment d2,
-        MemorySegment d3,
-        MemorySegment d4,
+        long d1,
+        long d2,
+        long d3,
+        long d4,
         int elementCount) {
-      super.dotProductBulk(scores, new FloatArrayLoader(q), d1, d2, d3, d4, elementCount);
+      dotProductBulkImpl(dataSeg, scores, q, -1L, d1, d2, d3, d4, elementCount);
     }
-  }
-
-  public static final class DotFromQuerySegment extends AbstractDotProduct {
 
     public void dotProductBulk(
+        MemorySegment seg,
         float[] scores,
-        MemorySegment q,
-        MemorySegment d1,
-        MemorySegment d2,
-        MemorySegment d3,
-        MemorySegment d4,
+        long q,
+        long d1,
+        long d2,
+        long d3,
+        long d4,
         int elementCount) {
-      super.dotProductBulk(scores, new FloatMemorySegmentLoader(q), d1, d2, d3, d4, elementCount);
+      dotProductBulkImpl(seg, scores, null, q, d1, d2, d3, d4, elementCount);
     }
 
-    public float dotProduct(MemorySegment q, MemorySegment d, int elementCount) {
+    public float dotProduct(MemorySegment seg, long q, long d, int elementCount) {
       int i = 0;
       FloatVector sv = FloatVector.zero(FLOAT_SPECIES);
       final int limit = FLOAT_SPECIES.loopBound(elementCount);
       for (; i < limit; i += FLOAT_SPECIES.length()) {
         final long offset = (long) i * Float.BYTES;
-        FloatVector qv = FloatVector.fromMemorySegment(FLOAT_SPECIES, q, offset, LE);
-        FloatVector dv = FloatVector.fromMemorySegment(FLOAT_SPECIES, d, offset, LE);
+        FloatVector qv = FloatVector.fromMemorySegment(FLOAT_SPECIES, seg, q + offset, LE);
+        FloatVector dv = FloatVector.fromMemorySegment(FLOAT_SPECIES, seg, d + offset, LE);
         sv = fma(qv, dv, sv);
       }
       float score = sv.reduceLanes(VectorOperators.ADD);
 
       for (; i < elementCount; i++) {
         final long offset = (long) i * Float.BYTES;
-        score += q.get(LAYOUT_LE_FLOAT, offset) * d.get(LAYOUT_LE_FLOAT, offset);
+        score += seg.get(LAYOUT_LE_FLOAT, q + offset) * seg.get(LAYOUT_LE_FLOAT, d + offset);
       }
       return score;
     }
-  }
 
-  abstract static class AbstractDotProduct {
-
-    protected void dotProductBulk(
+    private void dotProductBulkImpl(
+        MemorySegment seg,
         float[] scores,
-        FloatVectorLoader q,
-        MemorySegment d1,
-        MemorySegment d2,
-        MemorySegment d3,
-        MemorySegment d4,
+        float[] qArray,
+        long qOffset,
+        long d1,
+        long d2,
+        long d3,
+        long d4,
         int elementCount) {
       int i = 0;
       FloatVector sv1 = FloatVector.zero(FLOAT_SPECIES);
@@ -150,11 +105,16 @@ public final class MemorySegmentBulkVectorOps {
       final int limit = FLOAT_SPECIES.loopBound(elementCount);
       for (; i < limit; i += FLOAT_SPECIES.length()) {
         final long offset = (long) i * Float.BYTES;
-        FloatVector dv1 = FloatVector.fromMemorySegment(FLOAT_SPECIES, d1, offset, LE);
-        FloatVector dv2 = FloatVector.fromMemorySegment(FLOAT_SPECIES, d2, offset, LE);
-        FloatVector dv3 = FloatVector.fromMemorySegment(FLOAT_SPECIES, d3, offset, LE);
-        FloatVector dv4 = FloatVector.fromMemorySegment(FLOAT_SPECIES, d4, offset, LE);
-        FloatVector qv = q.load(FLOAT_SPECIES, i);
+        FloatVector dv1 = FloatVector.fromMemorySegment(FLOAT_SPECIES, seg, d1 + offset, LE);
+        FloatVector dv2 = FloatVector.fromMemorySegment(FLOAT_SPECIES, seg, d2 + offset, LE);
+        FloatVector dv3 = FloatVector.fromMemorySegment(FLOAT_SPECIES, seg, d3 + offset, LE);
+        FloatVector dv4 = FloatVector.fromMemorySegment(FLOAT_SPECIES, seg, d4 + offset, LE);
+        FloatVector qv;
+        if (qOffset == -1L) {
+          qv = FloatVector.fromArray(FLOAT_SPECIES, qArray, i);
+        } else {
+          qv = FloatVector.fromMemorySegment(FLOAT_SPECIES, seg, qOffset + offset, LE);
+        }
         sv1 = fma(qv, dv1, sv1);
         sv2 = fma(qv, dv2, sv2);
         sv3 = fma(qv, dv3, sv3);
@@ -167,11 +127,16 @@ public final class MemorySegmentBulkVectorOps {
 
       for (; i < elementCount; i++) {
         final long offset = (long) i * Float.BYTES;
-        final float qValue = q.tail(i);
-        sum1 = fma(qValue, d1.get(LAYOUT_LE_FLOAT, offset), sum1);
-        sum2 = fma(qValue, d2.get(LAYOUT_LE_FLOAT, offset), sum2);
-        sum3 = fma(qValue, d3.get(LAYOUT_LE_FLOAT, offset), sum3);
-        sum4 = fma(qValue, d4.get(LAYOUT_LE_FLOAT, offset), sum4);
+        float qValue;
+        if (qOffset == -1L) {
+          qValue = qArray[i];
+        } else {
+          qValue = seg.get(LAYOUT_LE_FLOAT, qOffset + offset);
+        }
+        sum1 = fma(qValue, seg.get(LAYOUT_LE_FLOAT, d1 + offset), sum1);
+        sum2 = fma(qValue, seg.get(LAYOUT_LE_FLOAT, d2 + offset), sum2);
+        sum3 = fma(qValue, seg.get(LAYOUT_LE_FLOAT, d3 + offset), sum3);
+        sum4 = fma(qValue, seg.get(LAYOUT_LE_FLOAT, d4 + offset), sum4);
       }
       scores[0] = sum1;
       scores[1] = sum2;

--- a/lucene/core/src/test/org/apache/lucene/codecs/hnsw/TestFlatVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/hnsw/TestFlatVectorScorer.java
@@ -77,7 +77,8 @@ public class TestFlatVectorScorer extends BaseVectorizationTestCase {
     var dirs =
         List.<IOSupplier<Directory>>of(
             TestFlatVectorScorer::newDirectory,
-            () -> new MMapDirectory(createTempDir(count.getAndIncrement() + "-")));
+            () -> new MMapDirectory(createTempDir(count.getAndIncrement() + "-")),
+            () -> new MMapDirectory(createTempDir(count.getAndIncrement() + "-"), 1024));
 
     List<Object[]> objs = new ArrayList<>();
     for (var scorer : scorers) {


### PR DESCRIPTION
This commit reworks the off-heap float32 bulk scoring to reduce garbage creation. The JVM fails to optimise things as we'd like, so we can just avoid some of the patterns in the first place!

1. Avoid slicing memory segments: our index input can span over up to 16GB by default, so we can just score a single segment (rather than slicing per scoring operation.
2. The hierarchy to allow scoring against an on-heap and off-heap query does not optimise well, so just flatten this and do the most obvious and straightforward thing - passing and switch on a null array or invalid address offset. 

Before
```
Benchmark                                                               (pollute)  (size)  Mode  Cnt      Score      Error   Units
VectorScorerFloat32Benchmark.dotProductOptBulkScore                         false    1024  avgt   15      3.411 ±    0.262   ms/op
VectorScorerFloat32Benchmark.dotProductOptBulkScore:gc.alloc.rate           false    1024  avgt   15      3.935 ±    0.012  MB/sec
VectorScorerFloat32Benchmark.dotProductOptBulkScore:gc.alloc.rate.norm      false    1024  avgt   15  14120.816 ± 1070.540    B/op
VectorScorerFloat32Benchmark.dotProductOptBulkScore:gc.count                false    1024  avgt   15        ≈ 0             counts
```

After
```
Benchmark                                                               (size)  Mode  Cnt       Score      Error   Units
VectorScorerFloat32Benchmark.dotProductOptBulkScore                       1024  avgt   15       3.557 ±    0.254   ms/op
VectorScorerFloat32Benchmark.dotProductOptBulkScore:gc.alloc.rate         1024  avgt   15     240.211 ±   17.073  MB/sec
VectorScorerFloat32Benchmark.dotProductOptBulkScore:gc.alloc.rate.norm    1024  avgt   15  894804.925 ± 1074.917    B/op
VectorScorerFloat32Benchmark.dotProductOptBulkScore:gc.count              1024  avgt   15       4.000             counts
VectorScorerFloat32Benchmark.dotProductOptBulkScore:gc.time               1024  avgt   15      24.000                 ms
```