### PR TITLE
Reduce memory needed for multi-vector tests

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestLateInteractionFloatValuesSource.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLateInteractionFloatValuesSource.java
@@ -38,7 +38,7 @@ import org.apache.lucene.util.TestVectorUtil;
 
 public class TestLateInteractionFloatValuesSource extends LuceneTestCase {
 
-  private static final int dimension = 128;
+  private static final int DIMENSION = 16;
   private static final String LATE_I_FIELD = "lateIF";
 
   public void testValidations() {
@@ -57,9 +57,9 @@ public class TestLateInteractionFloatValuesSource extends LuceneTestCase {
     float[][] valueBad = new float[random().nextInt(3, 12)][];
     for (int i = 0; i < valueBad.length; i++) {
       if (random().nextBoolean()) {
-        valueBad[i] = TestVectorUtil.randomVector(dimension);
+        valueBad[i] = TestVectorUtil.randomVector(DIMENSION);
       } else {
-        valueBad[i] = TestVectorUtil.randomVector(dimension + 1);
+        valueBad[i] = TestVectorUtil.randomVector(DIMENSION + 1);
       }
     }
   }
@@ -67,7 +67,7 @@ public class TestLateInteractionFloatValuesSource extends LuceneTestCase {
   public void testValues() throws IOException {
     List<float[][]> corpus = new ArrayList<>();
     final int numDocs = atLeast(1000);
-    final int numSegments = random().nextInt(2, 10);
+    final int numSegments = random().nextInt(2, 5);
     final VectorSimilarityFunction vectorSimilarityFunction =
         VectorSimilarityFunction.values()[
             random().nextInt(VectorSimilarityFunction.values().length)];
@@ -150,9 +150,9 @@ public class TestLateInteractionFloatValuesSource extends LuceneTestCase {
   }
 
   private float[][] createMultiVector() {
-    float[][] value = new float[random().nextInt(3, 12)][];
+    float[][] value = new float[random().nextInt(3, 5)][];
     for (int i = 0; i < value.length; i++) {
-      value[i] = TestVectorUtil.randomVector(dimension);
+      value[i] = TestVectorUtil.randomVector(DIMENSION);
     }
     return value;
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestLateInteractionRescorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLateInteractionRescorer.java
@@ -43,7 +43,7 @@ public class TestLateInteractionRescorer extends LuceneTestCase {
 
   private final String LATE_I_FIELD = "li_vector";
   private final String KNN_FIELD = "knn_vector";
-  private final int DIMENSION = 128;
+  private final int DIMENSION = 16;
 
   public void testBasic() throws Exception {
     List<float[][]> corpus = new ArrayList<>();
@@ -131,7 +131,7 @@ public class TestLateInteractionRescorer extends LuceneTestCase {
 
   private void indexMultiVectors(Directory dir, List<float[][]> corpus) throws IOException {
     final int numDocs = atLeast(1000);
-    final int numSegments = random().nextInt(2, 10);
+    final int numSegments = random().nextInt(2, 5);
     int id = 0;
     try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       for (int j = 0; j < numSegments; j++) {
@@ -163,7 +163,7 @@ public class TestLateInteractionRescorer extends LuceneTestCase {
   }
 
   private float[][] createMultiVector(int dimension) {
-    float[][] value = new float[random().nextInt(3, 12)][];
+    float[][] value = new float[random().nextInt(2, 5)][];
     for (int i = 0; i < value.length; i++) {
       value[i] = randomFloatVector(dimension, random());
     }


### PR DESCRIPTION
Tests for late interaction field rescorer have seen some [build failures](https://jenkins.thetaphi.de/job/Lucene-main-Linux/57727/) due to OOM. Looks like they can sometimes exceed 500mb requirements when random tests pick higher values. Updated the tests to keep memory needs low.


 