### PR TITLE
Reapply "Update the IOContext rather than the ReadAdvice on IndexInpu…

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -3,7 +3,6 @@ Lucene Change Log
 For more information on past and future Lucene versions, please see:
 http://s.apache.org/luceneversions
 
-
 ======================= Lucene 10.3.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsReader.java
@@ -124,7 +124,7 @@ public abstract class KnnVectorsReader implements Closeable {
    *
    * <p>The default implementation returns {@code this}
    */
-  public KnnVectorsReader getMergeInstance() {
+  public KnnVectorsReader getMergeInstance() throws IOException {
     return this;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsReader.java
@@ -96,7 +96,7 @@ public abstract class FlatVectorsReader extends KnnVectorsReader implements Acco
    * <p>The default implementation returns {@code this}
    */
   @Override
-  public FlatVectorsReader getMergeInstance() {
+  public FlatVectorsReader getMergeInstance() throws IOException {
     return this;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
@@ -21,7 +21,6 @@ import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.readSi
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.readVectorEncoding;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Map;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
@@ -45,7 +44,6 @@ import org.apache.lucene.store.FileDataHint;
 import org.apache.lucene.store.FileTypeHint;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.ReadAdvice;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
@@ -63,6 +61,7 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
   private final IntObjectHashMap<FieldEntry> fields = new IntObjectHashMap<>();
   private final IndexInput vectorData;
   private final FieldInfos fieldInfos;
+  private final IOContext dataContext;
 
   public Lucene99FlatVectorsReader(SegmentReadState state, FlatVectorsScorer scorer)
       throws IOException {
@@ -70,6 +69,10 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
     int versionMeta = readMetadata(state);
     this.fieldInfos = state.fieldInfos;
     boolean success = false;
+    // Flat formats are used to randomly access vectors from their node ID that is stored
+    // in the HNSW graph.
+    dataContext =
+        state.context.withHints(FileTypeHint.DATA, FileDataHint.KNN_VECTORS, DataAccessHint.RANDOM);
     try {
       vectorData =
           openDataInput(
@@ -77,10 +80,7 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
               versionMeta,
               Lucene99FlatVectorsFormat.VECTOR_DATA_EXTENSION,
               Lucene99FlatVectorsFormat.VECTOR_DATA_CODEC_NAME,
-              // Flat formats are used to randomly access vectors from their node ID that is stored
-              // in the HNSW graph.
-              state.context.withHints(
-                  FileTypeHint.DATA, FileDataHint.KNN_VECTORS, DataAccessHint.RANDOM));
+              dataContext);
       success = true;
     } finally {
       if (success == false) {
@@ -183,14 +183,10 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
   }
 
   @Override
-  public FlatVectorsReader getMergeInstance() {
-    try {
-      // Update the read advice since vectors are guaranteed to be accessed sequentially for merge
-      this.vectorData.updateReadAdvice(ReadAdvice.SEQUENTIAL);
-      return this;
-    } catch (IOException exception) {
-      throw new UncheckedIOException(exception);
-    }
+  public FlatVectorsReader getMergeInstance() throws IOException {
+    // Update the read advice since vectors are guaranteed to be accessed sequentially for merge
+    vectorData.updateIOContext(dataContext.withHints(DataAccessHint.SEQUENTIAL));
+    return this;
   }
 
   private FieldEntry getFieldEntryOrThrow(String field) {
@@ -282,7 +278,7 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
   public void finishMerge() throws IOException {
     // This makes sure that the access pattern hint is reverted back since HNSW implementation
     // needs it
-    this.vectorData.updateReadAdvice(ReadAdvice.RANDOM);
+    vectorData.updateIOContext(dataContext);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
@@ -141,7 +141,7 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
   }
 
   @Override
-  public KnnVectorsReader getMergeInstance() {
+  public KnnVectorsReader getMergeInstance() throws IOException {
     return new Lucene99HnswVectorsReader(this, this.flatVectorsReader.getMergeInstance());
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
@@ -239,7 +239,7 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
       }
     }
 
-    private FieldsReader(final FieldsReader fieldsReader) {
+    private FieldsReader(final FieldsReader fieldsReader) throws IOException {
       this.fieldInfos = fieldsReader.fieldInfos;
       for (FieldInfo fi : this.fieldInfos) {
         if (fi.hasVectorValues() && fieldsReader.fields.containsKey(fi.number)) {
@@ -249,7 +249,7 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
     }
 
     @Override
-    public KnnVectorsReader getMergeInstance() {
+    public KnnVectorsReader getMergeInstance() throws IOException {
       return new FieldsReader(this);
     }
 

--- a/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
@@ -227,12 +227,12 @@ public abstract class IndexInput extends DataInput implements Closeable {
   public void prefetch(long offset, long length) throws IOException {}
 
   /**
-   * Optional method: Give a hint to this input about the change in read access pattern. IndexInput
+   * Optional method: Updates the {@code IOContext} to specify a new read access pattern. IndexInput
    * implementations may take advantage of this hint to optimize reads from storage.
    *
    * <p>The default implementation is a no-op.
    */
-  public void updateReadAdvice(ReadAdvice readAdvice) throws IOException {}
+  public void updateIOContext(IOContext context) throws IOException {}
 
   /**
    * Returns a hint whether all the contents of this input are resident in physical memory. It's a

--- a/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -362,7 +362,11 @@ abstract class MemorySegmentIndexInput extends IndexInput
   }
 
   @Override
-  public void updateReadAdvice(ReadAdvice readAdvice) throws IOException {
+  public void updateIOContext(IOContext context) throws IOException {
+    updateReadAdvice(toReadAdvice.apply(context));
+  }
+
+  private void updateReadAdvice(ReadAdvice readAdvice) throws IOException {
     if (NATIVE_ACCESS.isEmpty()) {
       return;
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockIndexInputWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockIndexInputWrapper.java
@@ -25,7 +25,6 @@ import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.store.FilterIndexInput;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.ReadAdvice;
 
 /**
  * Used by MockDirectoryWrapper to create an input stream that keeps track of when it's been closed.
@@ -186,10 +185,10 @@ public class MockIndexInputWrapper extends FilterIndexInput {
   }
 
   @Override
-  public void updateReadAdvice(ReadAdvice readAdvice) throws IOException {
+  public void updateIOContext(IOContext context) throws IOException {
     ensureOpen();
     ensureAccessible();
-    in.updateReadAdvice(readAdvice);
+    in.updateIOContext(context);
   }
 
   @Override


### PR DESCRIPTION
…t (#14702)" (#14844)

fixes #15071
one question I'm unsure if is whether it's OK to add the `throws IOException` to the method signatures in a minor release? I think it should be?