### PR TITLE
[bug] Fix Locale usage during lower-casing

### DIFF
--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/builders/PointRangeQueryBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/builders/PointRangeQueryBuilder.java
@@ -76,7 +76,7 @@ public class PointRangeQueryBuilder implements QueryBuilder {
     String field = DOMUtils.getAttributeWithInheritanceOrFail(e, "fieldName");
     final String lowerTerm = DOMUtils.getAttribute(e, "lowerTerm", null);
     final String upperTerm = DOMUtils.getAttribute(e, "upperTerm", null);
-    String type = DOMUtils.getAttribute(e, "type", "int").toLowerCase(Locale.getDefault());
+    String type = DOMUtils.getAttribute(e, "type", "int").toLowerCase(Locale.ROOT);
 
     try {
       return switch (type) {


### PR DESCRIPTION
### Description

Fixes: https://github.com/apache/lucene/pull/15050#discussion_r2277714025
Thanks @msfroh for preventing a bug in future.

Lower-casing using `Locale.ROOT` to make it locale-insensitive instead of `Locale.getDefault()`.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
