### PR TITLE
Add cleaner asserts to track unreleased RefCountedSharedArenas.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/RefCountedSharedArena.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RefCountedSharedArena.java
@@ -57,9 +57,7 @@ final class RefCountedSharedArena implements Arena {
   private static final Cleaner CLEANER;
 
   static {
-    boolean ae = false;
-    assert (ae = true); // sets to true only when -ea is used
-    ASSERTS_ENABLED = ae;
+    ASSERTS_ENABLED = RefCountedSharedArena.class.desiredAssertionStatus();
     CLEANER = ASSERTS_ENABLED ? Cleaner.create() : null;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/store/RefCountedSharedArena.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RefCountedSharedArena.java
@@ -20,6 +20,7 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.ref.Cleaner;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.lucene.util.SuppressForbidden;
 
 /**
  * A reference counted shared Arena.
@@ -183,6 +184,7 @@ final class RefCountedSharedArena implements Arena {
     }
 
     @Override
+    @SuppressForbidden(reason = "Uses system.out to print out the leak source.")
     public void run() {
       // Runs on Cleaner thread when the internal Arena becomes phantom-reachable.
       final int v = state.get();


### PR DESCRIPTION
This is not supposed to be merged. Should help with #15068 