### PR TITLE
Reduce the default RefCountedSharedArena.DEFAULT_MAX_PERMITS to 64 (from 1024)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -253,6 +253,10 @@ Changes in Runtime Behavior
   `dir.setReadAdvice(MMapDirectory.ADVISE_BY_CONTEXT)`, or setting the system property
   `-Dorg.apache.lucene.store.defaultReadAdvice=RANDOM`. (Chris Hegarty)
 
+* GITHUB#15078: Reduce the default RefCountedSharedArena.DEFAULT_MAX_PERMITS to 64. To restore
+  previous behavior set the `-Dorg.apache.lucene.store.MMapDirectory.sharedArenaMaxPermits=1024`.
+  (Chris Hegarty)
+
 Bug Fixes
 ---------------------
 * GITHUB*15025: flush segments in addIndexes, not in addIndexesReaderMerge;

--- a/lucene/core/src/java/org/apache/lucene/store/RefCountedSharedArena.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RefCountedSharedArena.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 final class RefCountedSharedArena implements Arena {
 
   // default maximum permits
-  static final int DEFAULT_MAX_PERMITS = 1024;
+  static final int DEFAULT_MAX_PERMITS = 64;
 
   private static final int CLOSED = 0;
   // minimum value, beyond which permits are exhausted


### PR DESCRIPTION
This commit reduces the default RefCountedSharedArena.DEFAULT_MAX_PERMITS to 64 (from 1024).

relates #15068