### PR TITLE
Use DocValuesSkipper for count() in SortedNumericDocValuesRangeQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -241,6 +241,8 @@ Optimizations
 
 * GITHUB#15004: Wraps all iterator with likelyImpactsEnum under BlockMaxConjunctionBulkScorer. (Ge Song)
 
+* GITHUB#15080: Use DocValuesSkippers in SortedNumericDocValuesRangeQuery#count(). (Alan Woodward)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14823: Decrease TieredMergePolicy's default number of segments per

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -195,11 +195,10 @@ final class SortedNumericDocValuesRangeQuery extends Query {
           return 0;
         }
         if (skipper.docCount() == context.reader().maxDoc()
-            && context.reader().hasDeletions() == false
             && skipper.minValue() >= lowerValue
             && skipper.maxValue() <= upperValue) {
 
-          return context.reader().maxDoc();
+          return context.reader().numDocs();
         }
         return -1;
       }

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -184,6 +184,25 @@ final class SortedNumericDocValuesRangeQuery extends Query {
         return ConstantScoreScorerSupplier.fromIterator(
             TwoPhaseIterator.asDocIdSetIterator(iterator), score(), scoreMode, maxDoc);
       }
+
+      @Override
+      public int count(LeafReaderContext context) throws IOException {
+        DocValuesSkipper skipper = context.reader().getDocValuesSkipper(field);
+        if (skipper == null) {
+          return -1;
+        }
+        if (skipper.minValue() > upperValue || skipper.maxValue() < lowerValue) {
+          return 0;
+        }
+        if (skipper.docCount() == context.reader().maxDoc()
+            && context.reader().hasDeletions() == false
+            && skipper.minValue() >= lowerValue
+            && skipper.maxValue() <= upperValue) {
+
+          return context.reader().maxDoc();
+        }
+        return -1;
+      }
     };
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
@@ -580,4 +580,72 @@ public class TestDocValuesQueries extends LuceneTestCase {
       dir.close();
     }
   }
+
+  public void testSortedNumericDocValuesRangeQueryCount() throws Exception {
+    try (Directory dir = newDirectory();
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+      for (int i = 0; i < 100; i++) {
+        Document doc = new Document();
+        doc.add(SortedNumericDocValuesField.indexedField("with_index", 100 + i));
+        doc.add(new SortedNumericDocValuesField("without_index", 100 + i));
+        if (i != 55) {
+          doc.add(SortedNumericDocValuesField.indexedField("sparse", 100 + i));
+        }
+        iw.addDocument(doc);
+      }
+      iw.commit();
+      iw.forceMerge(1);
+
+      try (IndexReader reader = iw.getReader()) {
+        IndexSearcher searcher = new IndexSearcher(reader);
+
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 0, 50), 0);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("without_index", 0, 50), -1);
+        assertCount(searcher, SortedNumericDocValuesField.newSlowRangeQuery("sparse", 0, 50), 0);
+
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 50, 250), 100);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("without_index", 50, 250), -1);
+        assertCount(searcher, SortedNumericDocValuesField.newSlowRangeQuery("sparse", 50, 250), -1);
+
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 150, 250), -1);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("without_index", 150, 250), -1);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("sparse", 150, 250), -1);
+
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 250, 350), 0);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("without_index", 250, 350), -1);
+        assertCount(searcher, SortedNumericDocValuesField.newSlowRangeQuery("sparse", 250, 350), 0);
+      }
+
+      iw.deleteDocuments(SortedNumericDocValuesField.newSlowRangeQuery("with_index", 102, 103));
+      iw.commit();
+
+      try (IndexReader reader = iw.getReader()) {
+        IndexSearcher searcher = new IndexSearcher(reader);
+
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 0, 50), 0);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 50, 250), -1);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 150, 250), -1);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 250, 350), 0);
+      }
+    }
+  }
+
+  private void assertCount(IndexSearcher searcher, Query query, int expectedCount)
+      throws IOException {
+    Weight w = searcher.createWeight(query, ScoreMode.COMPLETE, 1.0f);
+    assertEquals(expectedCount, w.count(searcher.reader.leaves().getFirst()));
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
@@ -634,7 +634,7 @@ public class TestDocValuesQueries extends LuceneTestCase {
         assertCount(
             searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 0, 50), 0);
         assertCount(
-            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 50, 250), -1);
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 50, 250), 98);
         assertCount(
             searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 150, 250), -1);
         assertCount(


### PR DESCRIPTION
If a field has a skipper enabled then we can shortcut range queries where the 
requested range is entirely outside of the skipper, or if the skipper is fully included 
within the requested range and there are no deleted documents or documents with 
no value in the field.