### PR TITLE
Make calls to BM25Scorer#score inlinable.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/CombinedFieldQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/CombinedFieldQuery.java
@@ -289,8 +289,8 @@ public final class CombinedFieldQuery extends Query implements Accountable {
         CollectionStatistics pseudoCollectionStats = mergeCollectionStatistics(searcher);
         TermStatistics pseudoTermStatistics =
             new TermStatistics(new BytesRef("pseudo_term"), docFreq, Math.max(1, totalTermFreq));
-        this.simWeight =
-            searcher.getSimilarity().scorer(boost, pseudoCollectionStats, pseudoTermStatistics);
+        Similarity similarity = ScorerUtil.likelyBM25Similarity(searcher.getSimilarity());
+        this.simWeight = similarity.scorer(boost, pseudoCollectionStats, pseudoTermStatistics);
       } else {
         this.simWeight = null;
       }

--- a/lucene/core/src/java/org/apache/lucene/search/TermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermQuery.java
@@ -56,7 +56,7 @@ public class TermQuery extends Query {
       }
       this.scoreMode = scoreMode;
       this.termStates = termStates;
-      this.similarity = ScorerUtil.likelyBM25Similarity(searcher.getSimilarity());
+      this.similarity = searcher.getSimilarity();
 
       final CollectionStatistics collectionStats;
       final TermStatistics termStats;
@@ -79,7 +79,8 @@ public class TermQuery extends Query {
         // allocations in case default BM25Scorer is used.
         // See: https://github.com/apache/lucene/issues/12297
         if (scoreMode.needsScores()) {
-          this.simScorer = similarity.scorer(boost, collectionStats, termStats);
+          this.simScorer =
+              ScorerUtil.likelyBM25Similarity(similarity).scorer(boost, collectionStats, termStats);
         } else {
           // Assigning a dummy scorer as this is not expected to be called since scores are not
           // needed.

--- a/lucene/core/src/java/org/apache/lucene/search/TermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TermQuery.java
@@ -56,7 +56,7 @@ public class TermQuery extends Query {
       }
       this.scoreMode = scoreMode;
       this.termStates = termStates;
-      this.similarity = searcher.getSimilarity();
+      this.similarity = ScorerUtil.likelyBM25Similarity(searcher.getSimilarity());
 
       final CollectionStatistics collectionStats;
       final TermStatistics termStats;


### PR DESCRIPTION
I ran experiments locally that suggest that some of the performance decrease from type pollution (https://github.com/mikemccand/luceneutil/pull/436) can be attributed to calls to `SimScorer#score` no longer being inlinable since they are polymorphic. This change helps `BM25Scorer` remain inlinable using similar tricks that we are applying for `Bits#get` and `ImpactsEnum#nextDoc`/`ImpactsEnum#advance`.

Hopefully changes such as #15039 will help improve performance with other similarities as well in the future.