### PR TITLE
Rewrite SortedNumericDocValuesRangeQuery using DocValuesSkippers

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -241,6 +241,8 @@ Optimizations
 
 * GITHUB#15004: Wraps all iterator with likelyImpactsEnum under BlockMaxConjunctionBulkScorer. (Ge Song)
 
+* GITHUB#15080: Use DocValuesSkippers in SortedNumericDocValuesRangeQuery#count(). (Alan Woodward)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14823: Decrease TieredMergePolicy's default number of segments per

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -248,6 +248,8 @@ Optimizations
 * GITHUB#15039: Score computations are now more reliably vectorized.
   (Adrien Grand, Guo Feng)
 
+* GITHUB#15083: Use DocValuesSkippers in SortedNumericDocValuesRangeQuery#rewrite(). (Alan Woodward)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14823: Decrease TieredMergePolicy's default number of segments per

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -103,8 +103,10 @@ final class SortedNumericDocValuesRangeQuery extends Query {
     if (lowerValue > globalMax || upperValue < globalMin) {
       return new MatchNoDocsQuery();
     }
-    if (lowerValue <= globalMin && upperValue >= globalMax &&
-        DocValuesSkipper.globalDocCount(indexSearcher, field) == indexSearcher.getIndexReader().maxDoc()) {
+    if (lowerValue <= globalMin
+        && upperValue >= globalMax
+        && DocValuesSkipper.globalDocCount(indexSearcher, field)
+            == indexSearcher.getIndexReader().maxDoc()) {
       return new MatchAllDocsQuery();
     }
     return super.rewrite(indexSearcher);

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -195,11 +195,10 @@ final class SortedNumericDocValuesRangeQuery extends Query {
           return 0;
         }
         if (skipper.docCount() == context.reader().maxDoc()
-            && context.reader().hasDeletions() == false
             && skipper.minValue() >= lowerValue
             && skipper.maxValue() <= upperValue) {
 
-          return context.reader().maxDoc();
+          return context.reader().numDocs();
         }
         return -1;
       }

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -184,6 +184,25 @@ final class SortedNumericDocValuesRangeQuery extends Query {
         return ConstantScoreScorerSupplier.fromIterator(
             TwoPhaseIterator.asDocIdSetIterator(iterator), score(), scoreMode, maxDoc);
       }
+
+      @Override
+      public int count(LeafReaderContext context) throws IOException {
+        DocValuesSkipper skipper = context.reader().getDocValuesSkipper(field);
+        if (skipper == null) {
+          return -1;
+        }
+        if (skipper.minValue() > upperValue || skipper.maxValue() < lowerValue) {
+          return 0;
+        }
+        if (skipper.docCount() == context.reader().maxDoc()
+            && context.reader().hasDeletions() == false
+            && skipper.minValue() >= lowerValue
+            && skipper.maxValue() <= upperValue) {
+
+          return context.reader().maxDoc();
+        }
+        return -1;
+      }
     };
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
 
 /**
  * Skipper for {@link DocValues}.
@@ -121,5 +122,57 @@ public abstract class DocValuesSkipper {
       }
       advance(maxDocID + 1);
     }
+  }
+
+  /**
+   * Returns the minimum value for a field across all segments, or {@link Long#MIN_VALUE} if not available
+   * @param searcher  a searcher over the index
+   * @param field     the field to retrieve values for
+   */
+  public static long globalMinValue(IndexSearcher searcher, String field) throws IOException {
+    long minValue = Long.MAX_VALUE;
+    for (LeafReaderContext ctx : searcher.getLeafContexts()) {
+      DocValuesSkipper skipper = ctx.reader().getDocValuesSkipper(field);
+      if (skipper == null) {
+        minValue = Long.MIN_VALUE;
+      } else {
+        minValue = Math.min(minValue, skipper.minValue());
+      }
+    }
+    return minValue;
+  }
+
+  /**
+   * Returns the maximum value for a field across all segments, or {@link Long#MIN_VALUE} if not available
+   * @param searcher  a searcher over the index
+   * @param field     the field to retrieve values for
+   */
+  public static long globalMaxValue(IndexSearcher searcher, String field) throws IOException {
+    long maxValue = Long.MIN_VALUE;
+    for (LeafReaderContext ctx : searcher.getLeafContexts()) {
+      DocValuesSkipper skipper = ctx.reader().getDocValuesSkipper(field);
+      if (skipper == null) {
+        maxValue = Long.MAX_VALUE;
+      } else {
+        maxValue = Math.max(maxValue, skipper.maxValue());
+      }
+    }
+    return maxValue;
+  }
+
+  /**
+   * Returns the total skipper document count for a field across all segments
+   * @param searcher  a searcher over the index
+   * @param field     the field to retrieve values for
+   */
+  public static int globalDocCount(IndexSearcher searcher, String field) throws IOException {
+    int docCount = 0;
+    for (LeafReaderContext ctx : searcher.getLeafContexts()) {
+      DocValuesSkipper skipper = ctx.reader().getDocValuesSkipper(field);
+      if (skipper != null) {
+        docCount += skipper.docCount();
+      }
+    }
+    return docCount;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
@@ -125,9 +125,11 @@ public abstract class DocValuesSkipper {
   }
 
   /**
-   * Returns the minimum value for a field across all segments, or {@link Long#MIN_VALUE} if not available
-   * @param searcher  a searcher over the index
-   * @param field     the field to retrieve values for
+   * Returns the minimum value for a field across all segments, or {@link Long#MIN_VALUE} if not
+   * available
+   *
+   * @param searcher a searcher over the index
+   * @param field the field to retrieve values for
    */
   public static long globalMinValue(IndexSearcher searcher, String field) throws IOException {
     long minValue = Long.MAX_VALUE;
@@ -143,9 +145,11 @@ public abstract class DocValuesSkipper {
   }
 
   /**
-   * Returns the maximum value for a field across all segments, or {@link Long#MIN_VALUE} if not available
-   * @param searcher  a searcher over the index
-   * @param field     the field to retrieve values for
+   * Returns the maximum value for a field across all segments, or {@link Long#MIN_VALUE} if not
+   * available
+   *
+   * @param searcher a searcher over the index
+   * @param field the field to retrieve values for
    */
   public static long globalMaxValue(IndexSearcher searcher, String field) throws IOException {
     long maxValue = Long.MIN_VALUE;
@@ -162,8 +166,9 @@ public abstract class DocValuesSkipper {
 
   /**
    * Returns the total skipper document count for a field across all segments
-   * @param searcher  a searcher over the index
-   * @param field     the field to retrieve values for
+   *
+   * @param searcher a searcher over the index
+   * @param field the field to retrieve values for
    */
   public static int globalDocCount(IndexSearcher searcher, String field) throws IOException {
     int docCount = 0;

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
@@ -134,6 +134,9 @@ public abstract class DocValuesSkipper {
   public static long globalMinValue(IndexSearcher searcher, String field) throws IOException {
     long minValue = Long.MAX_VALUE;
     for (LeafReaderContext ctx : searcher.getLeafContexts()) {
+      if (ctx.reader().getFieldInfos().fieldInfo(field) == null) {
+        continue; // no field values in this segment, so we can ignore it
+      }
       DocValuesSkipper skipper = ctx.reader().getDocValuesSkipper(field);
       if (skipper == null) {
         minValue = Long.MIN_VALUE;
@@ -154,6 +157,9 @@ public abstract class DocValuesSkipper {
   public static long globalMaxValue(IndexSearcher searcher, String field) throws IOException {
     long maxValue = Long.MIN_VALUE;
     for (LeafReaderContext ctx : searcher.getLeafContexts()) {
+      if (ctx.reader().getFieldInfos().fieldInfo(field) == null) {
+        continue; // no field values in this segment, so we can ignore it
+      }
       DocValuesSkipper skipper = ctx.reader().getDocValuesSkipper(field);
       if (skipper == null) {
         maxValue = Long.MAX_VALUE;

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
@@ -707,5 +707,4 @@ public class TestDocValuesQueries extends LuceneTestCase {
       }
     }
   }
-
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
@@ -687,7 +687,8 @@ public class TestDocValuesQueries extends LuceneTestCase {
             searcher.rewrite(SortedNumericDocValuesField.newSlowRangeQuery("super_sparse", 0, 50)),
             instanceOf(MatchNoDocsQuery.class));
         assertThat(
-            searcher.rewrite(SortedNumericDocValuesField.newSlowRangeQuery("super_sparse", 250, 350)),
+            searcher.rewrite(
+                SortedNumericDocValuesField.newSlowRangeQuery("super_sparse", 250, 350)),
             instanceOf(MatchNoDocsQuery.class));
         assertThat(
             searcher

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
@@ -665,6 +665,9 @@ public class TestDocValuesQueries extends LuceneTestCase {
         if (i != 55) {
           doc.add(SortedNumericDocValuesField.indexedField("sparse", 100 + i));
         }
+        if (i == 74) {
+          doc.add(SortedNumericDocValuesField.indexedField("super_sparse", 174));
+        }
         iw.addDocument(doc);
       }
       iw.commit();
@@ -680,6 +683,18 @@ public class TestDocValuesQueries extends LuceneTestCase {
         assertThat(
             searcher.rewrite(SortedNumericDocValuesField.newSlowRangeQuery("sparse", 0, 50)),
             instanceOf(MatchNoDocsQuery.class));
+        assertThat(
+            searcher.rewrite(SortedNumericDocValuesField.newSlowRangeQuery("super_sparse", 0, 50)),
+            instanceOf(MatchNoDocsQuery.class));
+        assertThat(
+            searcher.rewrite(SortedNumericDocValuesField.newSlowRangeQuery("super_sparse", 250, 350)),
+            instanceOf(MatchNoDocsQuery.class));
+        assertThat(
+            searcher
+                .rewrite(SortedNumericDocValuesField.newSlowRangeQuery("super_sparse", 174, 174))
+                .getClass()
+                .toString(),
+            containsString("SortedNumericDocValuesRangeQuery"));
         assertThat(
             searcher
                 .rewrite(SortedNumericDocValuesField.newSlowRangeQuery("with_index", 0, 150))

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
@@ -580,4 +580,72 @@ public class TestDocValuesQueries extends LuceneTestCase {
       dir.close();
     }
   }
+
+  public void testSortedNumericDocValuesRangeQueryCount() throws Exception {
+    try (Directory dir = newDirectory();
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+      for (int i = 0; i < 100; i++) {
+        Document doc = new Document();
+        doc.add(SortedNumericDocValuesField.indexedField("with_index", 100 + i));
+        doc.add(new SortedNumericDocValuesField("without_index", 100 + i));
+        if (i != 55) {
+          doc.add(SortedNumericDocValuesField.indexedField("sparse", 100 + i));
+        }
+        iw.addDocument(doc);
+      }
+      iw.commit();
+      iw.forceMerge(1);
+
+      try (IndexReader reader = iw.getReader()) {
+        IndexSearcher searcher = new IndexSearcher(reader);
+
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 0, 50), 0);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("without_index", 0, 50), -1);
+        assertCount(searcher, SortedNumericDocValuesField.newSlowRangeQuery("sparse", 0, 50), 0);
+
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 50, 250), 100);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("without_index", 50, 250), -1);
+        assertCount(searcher, SortedNumericDocValuesField.newSlowRangeQuery("sparse", 50, 250), -1);
+
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 150, 250), -1);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("without_index", 150, 250), -1);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("sparse", 150, 250), -1);
+
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 250, 350), 0);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("without_index", 250, 350), -1);
+        assertCount(searcher, SortedNumericDocValuesField.newSlowRangeQuery("sparse", 250, 350), 0);
+      }
+
+      iw.deleteDocuments(SortedNumericDocValuesField.newSlowRangeQuery("with_index", 102, 103));
+      iw.commit();
+
+      try (IndexReader reader = iw.getReader()) {
+        IndexSearcher searcher = new IndexSearcher(reader);
+
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 0, 50), 0);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 50, 250), -1);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 150, 250), -1);
+        assertCount(
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 250, 350), 0);
+      }
+    }
+  }
+
+  private void assertCount(IndexSearcher searcher, Query query, int expectedCount)
+      throws IOException {
+    Weight w = searcher.createWeight(query, ScoreMode.COMPLETE, 1.0f);
+    assertEquals(expectedCount, w.count(searcher.reader.leaves().getFirst()));
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
@@ -634,7 +634,7 @@ public class TestDocValuesQueries extends LuceneTestCase {
         assertCount(
             searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 0, 50), 0);
         assertCount(
-            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 50, 250), -1);
+            searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 50, 250), 98);
         assertCount(
             searcher, SortedNumericDocValuesField.newSlowRangeQuery("with_index", 150, 250), -1);
         assertCount(

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
@@ -16,6 +16,9 @@
  */
 package org.apache.lucene.search;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -647,5 +650,61 @@ public class TestDocValuesQueries extends LuceneTestCase {
       throws IOException {
     Weight w = searcher.createWeight(query, ScoreMode.COMPLETE, 1.0f);
     assertEquals(expectedCount, w.count(searcher.reader.leaves().getFirst()));
+  }
+
+  public void testSortedNumericDocValuesRangeQueryRewrites() throws Exception {
+    try (Directory dir = newDirectory();
+        RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+      for (int i = 0; i < 100; i++) {
+        Document doc = new Document();
+        doc.add(SortedNumericDocValuesField.indexedField("with_index", 100 + i));
+        doc.add(new SortedNumericDocValuesField("without_index", 100 + i));
+        if (i % 17 == 0) {
+          iw.commit();
+        }
+        if (i != 55) {
+          doc.add(SortedNumericDocValuesField.indexedField("sparse", 100 + i));
+        }
+        iw.addDocument(doc);
+      }
+      iw.commit();
+
+      try (IndexReader reader = iw.getReader()) {
+        IndexSearcher searcher = new IndexSearcher(reader);
+        assertThat(
+            searcher.rewrite(SortedNumericDocValuesField.newSlowRangeQuery("with_index", 0, 50)),
+            instanceOf(MatchNoDocsQuery.class));
+        assertThat(
+            searcher.rewrite(SortedNumericDocValuesField.newSlowRangeQuery("with_index", 0, 250)),
+            instanceOf(MatchAllDocsQuery.class));
+        assertThat(
+            searcher.rewrite(SortedNumericDocValuesField.newSlowRangeQuery("sparse", 0, 50)),
+            instanceOf(MatchNoDocsQuery.class));
+        assertThat(
+            searcher
+                .rewrite(SortedNumericDocValuesField.newSlowRangeQuery("with_index", 0, 150))
+                .getClass()
+                .toString(),
+            containsString("SortedNumericDocValuesRangeQuery"));
+        assertThat(
+            searcher
+                .rewrite(SortedNumericDocValuesField.newSlowRangeQuery("with_index", 150, 250))
+                .getClass()
+                .toString(),
+            containsString("SortedNumericDocValuesRangeQuery"));
+        assertThat(
+            searcher
+                .rewrite(SortedNumericDocValuesField.newSlowRangeQuery("with_index", 120, 150))
+                .getClass()
+                .toString(),
+            containsString("SortedNumericDocValuesRangeQuery"));
+        assertThat(
+            searcher
+                .rewrite(SortedNumericDocValuesField.newSlowRangeQuery("sparse", 0, 250))
+                .getClass()
+                .toString(),
+            containsString("SortedNumericDocValuesRangeQuery"));
+      }
+    }
   }
 }


### PR DESCRIPTION
If DocValuesSkippers are enabled on a field, we can check at rewrite time
if a range query will match all or none of the documents in all segments,
and rewrite to a corresponding MatchAllDocsQuery or MatchNoDocsQuery.