### PR TITLE
Hunspell suggestions: Ensure candidate roots are not worse before updating

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -65,6 +65,8 @@ Optimizations
 
 * GITHUB#15043: Vectorize L2 normalize function. (Ramakrishna Chilaka)
 
+* GITHUB#15085: Hunspell suggestions: Ensure candidate roots are not worse before updating. (Ilia Permiashkin)
+
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/GeneratingSuggester.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/GeneratingSuggester.java
@@ -92,14 +92,17 @@ class GeneratingSuggester {
 
           speller.checkCanceled.run();
 
-          String root = rootChars.toString();
           IntsRef forms = entry.forms();
           for (int i = 0; i < forms.length; i++) {
-            if (isSuggestible.test(forms.ints[forms.offset + i])) {
-              roots.add(new Weighted<>(new Root<>(root, forms.ints[forms.offset + i]), sc));
-              if (roots.size() == MAX_ROOTS) {
-                roots.poll();
-              }
+            int form = forms.ints[forms.offset + i];
+            if (!isSuggestible.test(form)
+                || roots.size() == MAX_ROOTS && isWorseThan(sc, rootChars, roots.peek())) {
+              continue;
+            }
+
+            roots.add(new Weighted<>(new Root<>(rootChars.toString(), form), sc));
+            if (roots.size() > MAX_ROOTS) {
+              roots.poll();
             }
           }
         });


### PR DESCRIPTION
### Description

This PR suggest some performance improvements. CPU profiling showed that some time is taken by `PriorityQueue`'s `poll` / `add` operations.

Changes made:
* Ensure current wosrt root `isWorseThan` candidate before adding it to the queue

Before:
<img width="982" height="353" alt="Screenshot 2025-08-18 at 7 15 35 PM" src="https://github.com/user-attachments/assets/f9410ae6-0003-428a-8867-2fd0d8dc955c" />


After:
<img width="975" height="305" alt="Screenshot 2025-08-18 at 7 15 23 PM" src="https://github.com/user-attachments/assets/449eea18-27da-40a4-90ab-80becc75c899" />