### PR TITLE
Fix the remaining missing SuppressWarnings("preview") to silence IDEs like Eclipse. Also remove redundant interface.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/FSDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/FSDirectory.java
@@ -86,6 +86,7 @@ import org.apache.lucene.util.IOUtils;
  *
  * @see Directory
  */
+@SuppressWarnings("preview") // javadocs only
 public abstract class FSDirectory extends BaseDirectory {
 
   protected final Path directory; // The underlying filesystem directory

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -81,6 +81,7 @@ import org.apache.lucene.util.Constants;
  * @see <a href="https://blog.thetaphi.de/2012/07/use-lucenes-mmapdirectory-on-64bit.html">Blog post
  *     about MMapDirectory</a>
  */
+@SuppressWarnings("preview") // javadocs only
 public class MMapDirectory extends FSDirectory {
 
   /**

--- a/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentByteVectorScorer.java
+++ b/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentByteVectorScorer.java
@@ -27,6 +27,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.MemorySegmentAccessInput;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 
+@SuppressWarnings("preview")
 abstract sealed class Lucene99MemorySegmentByteVectorScorer
     extends RandomVectorScorer.AbstractRandomVectorScorer {
 

--- a/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentByteVectorScorerSupplier.java
+++ b/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentByteVectorScorerSupplier.java
@@ -29,6 +29,7 @@ import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
 
 /** A score supplier of vectors whose element size is byte. */
+@SuppressWarnings("preview")
 public abstract sealed class Lucene99MemorySegmentByteVectorScorerSupplier
     implements RandomVectorScorerSupplier {
   final int vectorByteSize;

--- a/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFloatVectorScorer.java
+++ b/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFloatVectorScorer.java
@@ -27,6 +27,7 @@ import org.apache.lucene.store.MemorySegmentAccessInput;
 import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 
+@SuppressWarnings("preview")
 abstract sealed class Lucene99MemorySegmentFloatVectorScorer
     extends RandomVectorScorer.AbstractRandomVectorScorer {
 

--- a/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFloatVectorScorerSupplier.java
+++ b/lucene/core/src/java21/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFloatVectorScorerSupplier.java
@@ -29,6 +29,7 @@ import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
 
 /** A score supplier of vectors whose element size is byte. */
+@SuppressWarnings("preview")
 public abstract sealed class Lucene99MemorySegmentFloatVectorScorerSupplier
     implements RandomVectorScorerSupplier {
   final int vectorByteSize;

--- a/lucene/core/src/java21/org/apache/lucene/internal/vectorization/MemorySegmentBulkVectorOps.java
+++ b/lucene/core/src/java21/org/apache/lucene/internal/vectorization/MemorySegmentBulkVectorOps.java
@@ -28,6 +28,7 @@ import jdk.incubator.vector.VectorShape;
 import jdk.incubator.vector.VectorSpecies;
 
 /** Implementations of bulk vector comparison operations. Currently only supports float32. */
+@SuppressWarnings("preview")
 public final class MemorySegmentBulkVectorOps {
 
   static final VectorSpecies<Float> FLOAT_SPECIES =

--- a/lucene/core/src/java21/org/apache/lucene/internal/vectorization/MemorySegmentPostingDecodingUtil.java
+++ b/lucene/core/src/java21/org/apache/lucene/internal/vectorization/MemorySegmentPostingDecodingUtil.java
@@ -24,6 +24,7 @@ import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
 import org.apache.lucene.store.IndexInput;
 
+@SuppressWarnings("preview")
 final class MemorySegmentPostingDecodingUtil extends PostingDecodingUtil {
 
   private static final VectorSpecies<Integer> INT_SPECIES =

--- a/lucene/core/src/java21/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java21/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -52,6 +52,7 @@ import org.apache.lucene.util.SuppressForbidden;
  *
  * Setting these properties will make this code run EXTREMELY slow!
  */
+@SuppressWarnings("preview")
 final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
   // preferred vector sizes, which can be altered for testing

--- a/lucene/core/src/java21/org/apache/lucene/internal/vectorization/PanamaVectorizationProvider.java
+++ b/lucene/core/src/java21/org/apache/lucene/internal/vectorization/PanamaVectorizationProvider.java
@@ -87,6 +87,7 @@ final class PanamaVectorizationProvider extends VectorizationProvider {
   }
 
   @Override
+  @SuppressWarnings("preview")
   public PostingDecodingUtil newPostingDecodingUtil(IndexInput input) throws IOException {
     if (PanamaVectorConstants.HAS_FAST_INTEGER_VECTORS
         && input instanceof MemorySegmentAccessInput msai) {

--- a/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentAccessInput.java
+++ b/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentAccessInput.java
@@ -24,6 +24,7 @@ import java.lang.foreign.MemorySegment;
  *
  * <p>Expert API, allows access to the backing memory.
  */
+@SuppressWarnings("preview")
 public interface MemorySegmentAccessInput extends RandomAccessInput, Cloneable {
 
   /** Returns the memory segment for a given position and length, or null. */

--- a/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java21/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -39,8 +39,7 @@ import org.apache.lucene.util.IOConsumer;
  * chunkSizePower</code>).
  */
 @SuppressWarnings("preview")
-abstract class MemorySegmentIndexInput extends IndexInput
-    implements RandomAccessInput, MemorySegmentAccessInput {
+abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegmentAccessInput {
   static final ValueLayout.OfByte LAYOUT_BYTE = ValueLayout.JAVA_BYTE;
   static final ValueLayout.OfShort LAYOUT_LE_SHORT =
       ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);


### PR DESCRIPTION
This PR has no impact on the Gradle build of the 10.x branch, but silences wanrings emitted by Eclipse or other IDEs due to the fact that those does not know about our apijars and see the preview flag.

2 warnings are due to javadocs in the main branch (I could have replaced them by `{@code ...}` but referring to the preview APIs in Javadocs is good for the reader, so I had to add the warning. Not sure why javadoc does not complain, but ECJ in Eclipse does.

It also fixes a redundant interface declaration that was removed in main branch already.