### PR TITLE
Use BulkSimScorer on MultiNormsLeafSimScorer

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/MultiNormsLeafSimScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiNormsLeafSimScorer.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.CombinedFieldQuery.FieldAndWeight;
+import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.search.similarities.Similarity.SimScorer;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.LongsRef;
@@ -49,6 +50,7 @@ final class MultiNormsLeafSimScorer {
   }
 
   private final SimScorer scorer;
+  private final Similarity.BulkSimScorer bulkScorer;
   private final NumericDocValues norms;
   private long[] normValues = LongsRef.EMPTY_LONGS;
 
@@ -60,6 +62,7 @@ final class MultiNormsLeafSimScorer {
       boolean needsScores)
       throws IOException {
     this.scorer = Objects.requireNonNull(scorer);
+    this.bulkScorer = scorer.asBulkSimScorer();
     if (needsScores) {
       final List<NumericDocValues> normsList = new ArrayList<>();
       final List<Float> weightList = new ArrayList<>();
@@ -123,15 +126,11 @@ final class MultiNormsLeafSimScorer {
    * @see SimScorer#score(float, long)
    */
   public void scoreRange(DocAndFloatFeatureBuffer buffer) throws IOException {
-    if (normValues.length < buffer.size) {
-      normValues = ArrayUtil.growNoCopy(normValues, buffer.size);
-    }
+    normValues = ArrayUtil.growNoCopy(normValues, buffer.size);
     for (int i = 0; i < buffer.size; i++) {
       normValues[i] = getNormValue(buffer.docs[i]);
     }
-    for (int i = 0; i < buffer.size; i++) {
-      buffer.features[i] = scorer.score(buffer.features[i], normValues[i]);
-    }
+    bulkScorer.score(buffer.size, buffer.features, normValues, buffer.features);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/MultiNormsLeafSimScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiNormsLeafSimScorer.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.CombinedFieldQuery.FieldAndWeight;
-import org.apache.lucene.search.similarities.Similarity;
+import org.apache.lucene.search.similarities.Similarity.BulkSimScorer;
 import org.apache.lucene.search.similarities.Similarity.SimScorer;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.LongsRef;
@@ -50,7 +50,7 @@ final class MultiNormsLeafSimScorer {
   }
 
   private final SimScorer scorer;
-  private final Similarity.BulkSimScorer bulkScorer;
+  private final BulkSimScorer bulkScorer;
   private final NumericDocValues norms;
   private long[] normValues = LongsRef.EMPTY_LONGS;
 


### PR DESCRIPTION
### Description

This is a follow up of the [comment](https://github.com/apache/lucene/pull/15039#pullrequestreview-3099592185) from #15039 that trying to use the newly intruduced `BulkSimScorer` on `MultiNormsLeafSimScorer`. Actually this change didn't bring any speedup, at least on my machine, maybe it's already auto-vectorized, but since it didn't bring any slowdown either and it does simplify the code, I think this change might be acceptable.


```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                     AndHighHigh       21.66      (7.8%)       21.23     (10.5%)   -2.0% ( -18% -   17%) 0.499
                      AndHighMed       50.24      (8.6%)       49.37     (10.6%)   -1.7% ( -19% -   19%) 0.569
                         Term100      438.36      (6.5%)      431.78      (7.4%)   -1.5% ( -14% -   13%) 0.496
                         TermB1M      437.93      (6.4%)      431.51      (7.4%)   -1.5% ( -14% -   13%) 0.501
                         Term10K      438.74      (6.5%)      432.43      (7.5%)   -1.4% ( -14% -   13%) 0.515
                          Term1M      438.18      (6.5%)      431.92      (7.5%)   -1.4% ( -14% -   13%) 0.518
                            Term      437.84      (6.5%)      431.64      (7.4%)   -1.4% ( -14% -   13%) 0.519
                       TermB1M1P      436.98      (6.4%)      431.29      (7.4%)   -1.3% ( -14% -   13%) 0.550
                       And3Terms       66.13      (7.9%)       65.35      (9.0%)   -1.2% ( -16% -   17%) 0.661
                    AndStopWords        8.27      (5.3%)        8.19      (6.7%)   -1.0% ( -12% -   11%) 0.610
                    CombinedTerm       11.04      (3.7%)       10.94      (3.8%)   -0.9% (  -8% -    6%) 0.448
             CombinedAndHighHigh        5.61      (1.2%)        5.57      (1.3%)   -0.8% (  -3% -    1%) 0.031
                      DismaxTerm      470.11      (4.9%)      466.40      (5.5%)   -0.8% ( -10% -   10%) 0.631
                          OrMany        4.17      (5.5%)        4.14      (5.0%)   -0.7% ( -10% -   10%) 0.664
                      OrHighRare       92.18      (5.8%)       91.54      (6.6%)   -0.7% ( -12% -   12%) 0.721
                AndMedOrHighHigh       14.99      (3.9%)       14.90      (4.9%)   -0.6% (  -8% -    8%) 0.681
              FilteredAndHighMed       30.11      (3.9%)       29.97      (4.2%)   -0.5% (  -8% -    7%) 0.718
             And2Terms2StopWords       51.89      (8.2%)       51.67      (8.4%)   -0.4% ( -15% -   17%) 0.873
              CombinedOrHighHigh        5.50      (3.8%)        5.48      (3.1%)   -0.3% (  -6% -    6%) 0.779
                        SpanNear        2.43      (5.1%)        2.42      (5.4%)   -0.3% ( -10% -   10%) 0.869
              CombinedAndHighMed       19.55      (4.4%)       19.50      (4.9%)   -0.2% (  -9% -    9%) 0.876
               FilteredAnd3Terms       98.45      (4.0%)       98.25      (3.3%)   -0.2% (  -7% -    7%) 0.864
                 CountAndHighMed       70.42      (2.9%)       70.29      (2.6%)   -0.2% (  -5% -    5%) 0.826
             FilteredAndHighHigh       10.22      (2.5%)       10.21      (2.6%)   -0.1% (  -5% -    5%) 0.874
                 AndHighOrMedMed       13.54      (2.5%)       13.52      (3.0%)   -0.1% (  -5% -    5%) 0.913
     FilteredAnd2Terms2StopWords       54.95      (5.4%)       54.90      (5.6%)   -0.1% ( -10% -   11%) 0.962
             FilteredOrStopWords        7.83      (2.2%)        7.82      (2.7%)   -0.1% (  -4% -    4%) 0.918
                   TermTitleSort       51.06      (3.7%)       51.05      (3.8%)   -0.0% (  -7% -    7%) 0.992
            FilteredAndStopWords        8.21      (2.5%)        8.21      (2.7%)    0.0% (  -5% -    5%) 0.992
               TermDayOfYearSort      250.94      (2.1%)      250.98      (2.2%)    0.0% (  -4% -    4%) 0.985
                    SloppyPhrase        1.11      (3.5%)        1.12      (3.4%)    0.0% (  -6% -    7%) 0.973
                        Or3Terms       60.30      (8.3%)       60.33      (8.3%)    0.0% ( -15% -   18%) 0.987
          CountFilteredOrHighMed       17.76      (0.6%)       17.77      (0.7%)    0.0% (  -1% -    1%) 0.835
         CountFilteredOrHighHigh       15.69      (0.8%)       15.70      (0.8%)    0.0% (  -1% -    1%) 0.846
             CountFilteredIntNRQ       16.31      (1.1%)       16.32      (1.1%)    0.1% (  -2% -    2%) 0.872
                  FilteredOrMany        3.81      (3.5%)        3.82      (3.3%)    0.1% (  -6% -    7%) 0.936
              FilteredOrHighHigh       12.32      (2.6%)       12.33      (3.1%)    0.1% (  -5% -    6%) 0.923
                      OrHighHigh       21.01      (7.3%)       21.03      (8.0%)    0.1% ( -14% -   16%) 0.968
                  CountOrHighMed       71.66      (2.2%)       71.75      (2.1%)    0.1% (  -4% -    4%) 0.841
                     OrStopWords        9.04      (6.5%)        9.06      (6.8%)    0.2% ( -12% -   14%) 0.940
                          Fuzzy2       33.60      (4.1%)       33.66      (4.2%)    0.2% (  -7% -    8%) 0.898
                    FilteredTerm       60.25      (2.1%)       60.36      (2.5%)    0.2% (  -4% -    4%) 0.815
                FilteredOr3Terms       40.55      (4.2%)       40.62      (4.3%)    0.2% (  -7% -    8%) 0.896
                   TermMonthSort     2020.50      (2.1%)     2025.02      (2.7%)    0.2% (  -4% -    5%) 0.769
               FilteredOrHighMed       35.80      (4.0%)       35.88      (4.2%)    0.2% (  -7% -    8%) 0.862
                CountAndHighHigh       48.21      (1.5%)       48.34      (1.9%)    0.3% (  -3% -    3%) 0.606
               CombinedOrHighMed       19.21      (5.0%)       19.26      (5.3%)    0.3% (  -9% -   11%) 0.861
                 CountOrHighHigh       49.39      (1.7%)       49.53      (2.2%)    0.3% (  -3% -    4%) 0.640
                  FilteredIntNRQ       42.01      (2.8%)       42.13      (3.0%)    0.3% (  -5% -    6%) 0.748
                DismaxOrHighHigh       33.47      (3.8%)       33.57      (4.7%)    0.3% (  -7% -    9%) 0.827
                       OrHighMed       61.14      (9.2%)       61.34      (9.6%)    0.3% ( -16% -   21%) 0.913
      FilteredOr2Terms2StopWords       45.29      (4.9%)       45.45      (5.2%)    0.4% (  -9% -   11%) 0.825
                          IntSet      281.58      (5.1%)      282.68      (5.0%)    0.4% (  -9% -   11%) 0.807
                          IntNRQ       42.31      (2.7%)       42.48      (3.0%)    0.4% (  -5% -    6%) 0.661
                      TermDTSort      136.68      (3.6%)      137.27      (3.9%)    0.4% (  -6% -    8%) 0.715
             CountFilteredOrMany        4.26      (2.5%)        4.28      (2.9%)    0.4% (  -4% -    6%) 0.606
                     CountOrMany        4.80      (2.8%)        4.83      (3.2%)    0.5% (  -5% -    6%) 0.630
                          Fuzzy1       37.01      (4.6%)       37.19      (4.6%)    0.5% (  -8% -   10%) 0.739
                       CountTerm     5389.62      (1.8%)     5416.01      (2.6%)    0.5% (  -3% -    4%) 0.486
                 DismaxOrHighMed       45.43      (6.5%)       45.66      (7.0%)    0.5% ( -12% -   14%) 0.816
                  FilteredPhrase        9.26      (2.7%)        9.31      (3.1%)    0.5% (  -5% -    6%) 0.580
              Or2Terms2StopWords       53.50      (7.7%)       53.79      (8.1%)    0.5% ( -14% -   17%) 0.828
                          Phrase        7.32      (2.1%)        7.36      (2.6%)    0.6% (  -4% -    5%) 0.464
             CountFilteredPhrase        8.52      (3.2%)        8.57      (3.4%)    0.6% (  -5% -    7%) 0.565
                IntervalsOrdered        2.41      (3.4%)        2.43      (3.2%)    0.7% (  -5% -    7%) 0.490
                     CountPhrase        2.61      (4.0%)        2.63      (3.1%)    0.9% (  -5% -    8%) 0.420
                         Respell       34.51      (2.9%)       34.83      (3.7%)    0.9% (  -5% -    7%) 0.363
                        Wildcard       44.15      (6.5%)       44.94      (6.4%)    1.8% ( -10% -   15%) 0.377
                         Prefix3       64.97     (17.9%)       67.94     (17.3%)    4.6% ( -25% -   48%) 0.409
                 FilteredPrefix3       60.90     (17.0%)       63.74     (16.2%)    4.7% ( -24% -   45%) 0.376
```

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
