### PR TITLE
Replacing unused variable suppress warning with _

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestAllFilesDetectTruncation.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAllFilesDetectTruncation.java
@@ -144,9 +144,7 @@ public class TestAllFilesDetectTruncation extends LuceneTestCase {
               // In some rare cases, the codec footer would still appear as correct even though the
               // file has been truncated. We just skip the test is this rare case.
               return;
-            } catch (
-                @SuppressWarnings("unused")
-                CorruptIndexException e) {
+            } catch (CorruptIndexException _) {
               // expected
             }
           }

--- a/lucene/core/src/test/org/apache/lucene/index/TestCodecs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestCodecs.java
@@ -459,9 +459,7 @@ public class TestCodecs extends LuceneTestCase {
         try {
           termsEnum.seekExact(idx);
           success = true;
-        } catch (
-            @SuppressWarnings("unused")
-            UnsupportedOperationException uoe) {
+        } catch (UnsupportedOperationException _) {
           // ok -- skip it
         }
         if (success) {
@@ -513,9 +511,7 @@ public class TestCodecs extends LuceneTestCase {
             termsEnum.seekExact(i);
             assertEquals(field.terms[i].docs.length, termsEnum.docFreq());
             assertTrue(termsEnum.term().bytesEquals(new BytesRef(field.terms[i].text2)));
-          } catch (
-              @SuppressWarnings("unused")
-              UnsupportedOperationException uoe) {
+          } catch (UnsupportedOperationException _) {
           }
         }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestDeletionPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDeletionPolicy.java
@@ -301,9 +301,7 @@ public class TestDeletionPolicy extends LuceneTestCase {
                 + (lastDeleteTime - modTime)
                 + " ms) but did not get deleted ",
             lastDeleteTime - modTime <= leeway);
-      } catch (
-          @SuppressWarnings("unused")
-          IOException e) {
+      } catch (IOException _) {
         // OK
         break;
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocValuesIndexing.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocValuesIndexing.java
@@ -568,9 +568,7 @@ public class TestDocValuesIndexing extends LuceneTestCase {
               try {
                 startingGun.await();
                 w.addDocument(doc);
-              } catch (
-                  @SuppressWarnings("unused")
-                  IllegalArgumentException iae) {
+              } catch (IllegalArgumentException _) {
                 // expected
                 hitExc.set(true);
               } catch (Exception e) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterPerThreadPool.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocumentsWriterPerThreadPool.java
@@ -93,9 +93,7 @@ public class TestDocumentsWriterPerThreadPool extends LuceneTestCase {
                   latch.countDown();
                   pool.getAndLock();
                   fail();
-                } catch (
-                    @SuppressWarnings("unused")
-                    AlreadyClosedException e) {
+                } catch (AlreadyClosedException _) {
                   // fine
                 }
               });

--- a/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
@@ -75,9 +75,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
         try {
           // Sleep for 100ms before each .next() call.
           Thread.sleep(100);
-        } catch (
-            @SuppressWarnings("unused")
-            InterruptedException e) {
+        } catch (InterruptedException _) {
         }
         return in.next();
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldsReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldsReader.java
@@ -219,17 +219,13 @@ public class TestFieldsReader extends LuceneTestCase {
     for (int i = 0; i < 2; i++) {
       try {
         storedFields.document(i);
-      } catch (
-          @SuppressWarnings("unused")
-          IOException ioe) {
+      } catch (IOException _) {
         // expected
         exc = true;
       }
       try {
         storedFields.document(i);
-      } catch (
-          @SuppressWarnings("unused")
-          IOException ioe) {
+      } catch (IOException _) {
         // expected
         exc = true;
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFilterCodecReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFilterCodecReader.java
@@ -60,9 +60,7 @@ public class TestFilterCodecReader extends LuceneTestCase {
             "getReturnType() difference",
             superClassMethod.getReturnType(),
             subClassMethod.getReturnType());
-      } catch (
-          @SuppressWarnings("unused")
-          NoSuchMethodException e) {
+      } catch (NoSuchMethodException _) {
         fail(subClass + " needs to override '" + superClassMethod + "'");
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFilterMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFilterMergePolicy.java
@@ -27,9 +27,7 @@ public class TestFilterMergePolicy extends LuceneTestCase {
       if (Modifier.isFinal(m.getModifiers()) || Modifier.isPrivate(m.getModifiers())) continue;
       try {
         FilterMergePolicy.class.getDeclaredMethod(m.getName(), m.getParameterTypes());
-      } catch (
-          @SuppressWarnings("unused")
-          NoSuchMethodException e) {
+      } catch (NoSuchMethodException _) {
         fail("FilterMergePolicy needs to override '" + m + "'");
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFlex.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFlex.java
@@ -80,9 +80,7 @@ public class TestFlex extends LuceneTestCase {
     assertTrue(terms.next() != null);
     try {
       assertEquals(0, terms.ord());
-    } catch (
-        @SuppressWarnings("unused")
-        UnsupportedOperationException uoe) {
+    } catch (UnsupportedOperationException _) {
       // ok -- codec is not required to support this op
     }
     r.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -921,9 +921,7 @@ public class TestIndexWriter extends LuceneTestCase {
               // w.rollback();
               try {
                 w.close();
-              } catch (
-                  @SuppressWarnings("unused")
-                  AlreadyClosedException ace) {
+              } catch (AlreadyClosedException _) {
                 // OK
               }
               w = null;
@@ -2643,9 +2641,7 @@ public class TestIndexWriter extends LuceneTestCase {
     startCommit.await();
     try {
       iw.close();
-    } catch (
-        @SuppressWarnings("unused")
-        IllegalStateException ise) {
+    } catch (IllegalStateException _) {
       // OK, but not required (depends on thread scheduling)
     }
     finishCommit.await();
@@ -3059,7 +3055,7 @@ public class TestIndexWriter extends LuceneTestCase {
     try {
       dir.openInput(tempName, IOContext.DEFAULT);
       fail("did not hit exception");
-    } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException e) {
+    } catch (FileNotFoundException | NoSuchFileException _) {
       // expected
     }
     w.close();
@@ -4141,9 +4137,7 @@ public class TestIndexWriter extends LuceneTestCase {
                   indexedDocs.release(1);
                 } catch (IOException e) {
                   throw new AssertionError(e);
-                } catch (
-                    @SuppressWarnings("unused")
-                    AlreadyClosedException ignored) {
+                } catch (AlreadyClosedException _) {
                   return;
                 }
               }
@@ -4158,9 +4152,7 @@ public class TestIndexWriter extends LuceneTestCase {
                   sm.maybeRefreshBlocking();
                 } catch (IOException e) {
                   throw new AssertionError(e);
-                } catch (
-                    @SuppressWarnings("unused")
-                    AlreadyClosedException ignored) {
+                } catch (AlreadyClosedException _) {
                   return;
                 }
               }
@@ -4234,9 +4226,7 @@ public class TestIndexWriter extends LuceneTestCase {
                   queue.processEvents();
                 } catch (IOException e) {
                   throw new AssertionError(e);
-                } catch (
-                    @SuppressWarnings("unused")
-                    AlreadyClosedException ex) {
+                } catch (AlreadyClosedException _) {
                   // possible
                 }
               });

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterDelete.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterDelete.java
@@ -944,9 +944,7 @@ public class TestIndexWriterDelete extends LuceneTestCase {
     try {
       modifier.commit();
       writerClosed = false;
-    } catch (
-        @SuppressWarnings("unused")
-        IllegalStateException ise) {
+    } catch (IllegalStateException _) {
       // The above exc struck during merge, and closed the writer
       writerClosed = true;
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
@@ -472,18 +472,14 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
     for (int i = 0; i < 10; i++) {
       try {
         w.addDocument(doc);
-      } catch (
-          @SuppressWarnings("unused")
-          RuntimeException re) {
+      } catch (RuntimeException _) {
         break;
       }
     }
 
     try {
       ((ConcurrentMergeScheduler) w.getConfig().getMergeScheduler()).sync();
-    } catch (
-        @SuppressWarnings("unused")
-        IllegalStateException ise) {
+    } catch (IllegalStateException _) {
       // OK: merge exc causes tragedy
     }
     assertTrue(testPoint.failed);
@@ -962,9 +958,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
       if ((i - 1) % 2 == 0) {
         try {
           writer.commit();
-        } catch (
-            @SuppressWarnings("unused")
-            IOException ioe) {
+        } catch (IOException _) {
           // expected
         }
       }
@@ -1097,9 +1091,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
       dir.setRandomIOExceptionRate(0.5);
       try {
         w.forceMerge(1);
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalStateException ise) {
+      } catch (IllegalStateException _) {
         // expected
       } catch (IOException ioe) {
         if (ioe.getCause() == null) {
@@ -1110,9 +1102,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
       // System.out.println("TEST: now close IW");
       try {
         w.close();
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalStateException ise) {
+      } catch (IllegalStateException _) {
         // ok
       }
       dir.close();
@@ -1196,9 +1186,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
 
     try {
       writer.close();
-    } catch (
-        @SuppressWarnings("unused")
-        IllegalArgumentException ok) {
+    } catch (IllegalArgumentException _) {
       // ok
     }
 
@@ -1925,12 +1913,10 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
       } catch (AssertionError ex) {
         // This is fine: we tripped IW's assert that all files it's about to fsync do exist:
         assertTrue(ex.getMessage().matches("file .* does not exist; files=\\[.*\\]"));
-      } catch (
-          @SuppressWarnings("unused")
-          CorruptIndexException ex) {
+      } catch (CorruptIndexException _) {
         // Exceptions are fine - we are running out of file handlers here
         continue;
-      } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException ex) {
+      } catch (FileNotFoundException | NoSuchFileException _) {
         continue;
       }
       failure.clearDoFail();
@@ -2116,9 +2102,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
 
       try {
         iw.rollback();
-      } catch (
-          @SuppressWarnings("unused")
-          FakeIOException expected) {
+      } catch (FakeIOException _) {
         // ok, we randomly hit exc here
       }
 
@@ -2189,19 +2173,13 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
           // Flush new segment:
           DirectoryReader.open(w).close();
         }
-      } catch (
-          @SuppressWarnings("unused")
-          AlreadyClosedException ace) {
+      } catch (AlreadyClosedException _) {
         // OK: e.g. CMS hit the exc in BG thread and closed the writer
         break;
-      } catch (
-          @SuppressWarnings("unused")
-          FakeIOException fioe) {
+      } catch (FakeIOException _) {
         // OK: e.g. SMS hit the exception
         break;
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalStateException ise) {
+      } catch (IllegalStateException _) {
         // OK: Merge-on-refresh refuses to run because IndexWriter hit a tragedy
         break;
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions2.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions2.java
@@ -150,9 +150,7 @@ public class TestIndexWriterExceptions2 extends LuceneTestCase {
                   "dv2",
                   new BytesRef(Integer.toString(i + 1)));
             }
-          } catch (
-              @SuppressWarnings("unused")
-              AlreadyClosedException ace) {
+          } catch (AlreadyClosedException _) {
             // OK: writer was closed by abort; we just reopen now:
             assertTrue(iw.isDeleterClosed());
             assertTrue(allowAlreadyClosed);
@@ -189,9 +187,7 @@ public class TestIndexWriterExceptions2 extends LuceneTestCase {
               iw.deleteDocuments(
                   new Term("id", Integer.toString(i)), new Term("id", Integer.toString(-i)));
             }
-          } catch (
-              @SuppressWarnings("unused")
-              AlreadyClosedException ace) {
+          } catch (AlreadyClosedException _) {
             // OK: writer was closed by abort; we just reopen now:
             assertTrue(iw.isDeleterClosed());
             assertTrue(allowAlreadyClosed);
@@ -229,9 +225,7 @@ public class TestIndexWriterExceptions2 extends LuceneTestCase {
             if (DirectoryReader.indexExists(dir)) {
               TestUtil.checkIndex(dir);
             }
-          } catch (
-              @SuppressWarnings("unused")
-              AlreadyClosedException ace) {
+          } catch (AlreadyClosedException _) {
             // OK: writer was closed by abort; we just reopen now:
             assertTrue(iw.isDeleterClosed());
             assertTrue(allowAlreadyClosed);
@@ -261,9 +255,7 @@ public class TestIndexWriterExceptions2 extends LuceneTestCase {
           e.printStackTrace(exceptionStream);
           try {
             iw.rollback();
-          } catch (
-              @SuppressWarnings("unused")
-              Throwable t) {
+          } catch (Throwable _) {
           }
         } else {
           Rethrow.rethrow(e);

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterLockRelease.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterLockRelease.java
@@ -35,11 +35,11 @@ public class TestIndexWriterLockRelease extends LuceneTestCase {
     try {
       new IndexWriter(
           dir, new IndexWriterConfig(new MockAnalyzer(random())).setOpenMode(OpenMode.APPEND));
-    } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException e) {
+    } catch (FileNotFoundException | NoSuchFileException _) {
       try {
         new IndexWriter(
             dir, new IndexWriterConfig(new MockAnalyzer(random())).setOpenMode(OpenMode.APPEND));
-      } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException e1) {
+      } catch (FileNotFoundException | NoSuchFileException _) {
       }
     } finally {
       dir.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
@@ -409,9 +409,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     try {
       w.addIndexes(dirs);
       fail("didn't get expected exception");
-    } catch (
-        @SuppressWarnings("unused")
-        IllegalArgumentException expected) {
+    } catch (IllegalArgumentException _) {
       // pass
     } catch (IOException fakeDiskFull) {
       final Exception e;
@@ -461,9 +459,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     try {
       w.addIndexes(readers);
       fail("didn't get expected exception");
-    } catch (
-        @SuppressWarnings("unused")
-        IllegalArgumentException expected) {
+    } catch (IllegalArgumentException _) {
       // pass
     } catch (IOException fakeDiskFull) {
       final Exception e;

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
@@ -416,14 +416,10 @@ public class TestIndexWriterMerging extends LuceneTestCase {
                   for (int i = 0; i < 100; i++) {
                     try {
                       finalWriter.addDocument(doc);
-                    } catch (
-                        @SuppressWarnings("unused")
-                        AlreadyClosedException e) {
+                    } catch (AlreadyClosedException _) {
                       done = true;
                       break;
-                    } catch (
-                        @SuppressWarnings("unused")
-                        NullPointerException e) {
+                    } catch (NullPointerException _) {
                       done = true;
                       break;
                     } catch (Throwable e) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterNRTIsCurrent.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterNRTIsCurrent.java
@@ -132,9 +132,7 @@ public class TestIndexWriterNRTIsCurrent extends LuceneTestCase {
         if (currentReader != null) {
           try {
             currentReader.decRef();
-          } catch (
-              @SuppressWarnings("unused")
-              IOException e) {
+          } catch (IOException _) {
           }
         }
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
@@ -119,9 +119,7 @@ public class TestIndexWriterOnDiskFull extends LuceneTestCase {
               dir.setMaxSizeInBytes(0);
               try {
                 writer.close();
-              } catch (
-                  @SuppressWarnings("unused")
-                  AlreadyClosedException ace) {
+              } catch (AlreadyClosedException _) {
                 // OK
               }
             }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
@@ -1221,9 +1221,7 @@ public class TestIndexWriterReader extends LuceneTestCase {
                       ASC_SORT ? points.getMinPackedValue() : points.getMaxPackedValue();
                   return LongPoint.decodeDimension(sortValue, 0);
                 }
-              } catch (
-                  @SuppressWarnings("unused")
-                  IOException e) {
+              } catch (IOException _) {
               }
               return MISSING_VALUE;
             });

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterThreadsToSegments.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterThreadsToSegments.java
@@ -278,9 +278,7 @@ public class TestIndexWriterThreadsToSegments extends LuceneTestCase {
                 for (int j = 0; j < 1000; j++) {
                   w.addDocument(doc);
                 }
-              } catch (
-                  @SuppressWarnings("unused")
-                  AlreadyClosedException ace) {
+              } catch (AlreadyClosedException _) {
                 // ok
               } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -295,9 +293,7 @@ public class TestIndexWriterThreadsToSegments extends LuceneTestCase {
     Thread.sleep(100);
     try {
       w.close();
-    } catch (
-        @SuppressWarnings("unused")
-        IllegalStateException ise) {
+    } catch (IllegalStateException _) {
       // OK but not required
     }
     for (Thread t : threads) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterWithThreads.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterWithThreads.java
@@ -116,9 +116,7 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
             }
             break;
           }
-        } catch (
-            @SuppressWarnings("unused")
-            IllegalStateException ise) {
+        } catch (IllegalStateException _) {
           // OK: abort closes the writer
           break;
         } catch (Throwable t) {
@@ -176,9 +174,7 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
       dir.setMaxSizeInBytes(0);
       try {
         writer.commit();
-      } catch (
-          @SuppressWarnings("unused")
-          AlreadyClosedException ace) {
+      } catch (AlreadyClosedException _) {
         // OK: abort closes the writer
         assertTrue(writer.isDeleterClosed());
       } finally {
@@ -309,14 +305,10 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
         writer.commit();
         writer.close();
         success = true;
-      } catch (
-          @SuppressWarnings("unused")
-          AlreadyClosedException ace) {
+      } catch (AlreadyClosedException _) {
         // OK: abort closes the writer
         assertTrue(writer.isDeleterClosed());
-      } catch (
-          @SuppressWarnings("unused")
-          IOException ioe) {
+      } catch (IOException _) {
         writer.rollback();
         failure.clearDoFail();
       } finally {
@@ -617,9 +609,8 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
                           writerRef.get().prepareCommit();
                         }
                         writerRef.get().commit();
-                      } catch (@SuppressWarnings("unused")
-                          AlreadyClosedException
-                          | NullPointerException ace) {
+                      } catch (AlreadyClosedException
+                          | NullPointerException _) {
                         // ok
                       } finally {
                         commitLock.unlock();
@@ -632,10 +623,9 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
                       }
                       try {
                         writerRef.get().addDocument(docs.nextDoc());
-                      } catch (@SuppressWarnings("unused")
-                          AlreadyClosedException
+                      } catch (AlreadyClosedException
                           | NullPointerException
-                          | AssertionError ace) {
+                          | AssertionError _) {
                         // ok
                       }
                       break;

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterWithThreads.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterWithThreads.java
@@ -609,8 +609,7 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
                           writerRef.get().prepareCommit();
                         }
                         writerRef.get().commit();
-                      } catch (AlreadyClosedException
-                          | NullPointerException _) {
+                      } catch (AlreadyClosedException | NullPointerException _) {
                         // ok
                       } finally {
                         commitLock.unlock();
@@ -623,9 +622,7 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
                       }
                       try {
                         writerRef.get().addDocument(docs.nextDoc());
-                      } catch (AlreadyClosedException
-                          | NullPointerException
-                          | AssertionError _) {
+                      } catch (AlreadyClosedException | NullPointerException | AssertionError _) {
                         // ok
                       }
                       break;

--- a/lucene/core/src/test/org/apache/lucene/index/TestIntBlockPool.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIntBlockPool.java
@@ -77,9 +77,7 @@ public class TestIntBlockPool extends LuceneTestCase {
     for (int i = 0; i < Integer.MAX_VALUE / INT_BLOCK_SIZE + 1; i++) {
       try {
         pool.nextBuffer();
-      } catch (
-          @SuppressWarnings("unused")
-          ArithmeticException ignored) {
+      } catch (ArithmeticException _) {
         // The offset overflows on the last attempt to call nextBuffer()
         throwsException = true;
         break;

--- a/lucene/core/src/test/org/apache/lucene/index/TestReaderClosed.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestReaderClosed.java
@@ -68,13 +68,9 @@ public class TestReaderClosed extends LuceneTestCase {
     reader.close();
     try {
       searcher.search(query, 5);
-    } catch (
-        @SuppressWarnings("unused")
-        AlreadyClosedException ace) {
+    } catch (AlreadyClosedException _) {
       // expected
-    } catch (
-        @SuppressWarnings("unused")
-        RejectedExecutionException ree) {
+    } catch (RejectedExecutionException _) {
       // expected if the searcher has been created with threads since LuceneTestCase
       // closes the thread-pool in a reader close listener
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentInfos.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentInfos.java
@@ -381,9 +381,7 @@ public class TestSegmentInfos extends LuceneTestCase {
             System.out.println("TEST: Altering the file did not update the checksum, aborting...");
           }
           return;
-        } catch (
-            @SuppressWarnings("unused")
-            CorruptIndexException e) {
+        } catch (CorruptIndexException _) {
           // ok
         }
         corrupt = true;

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentTermEnum.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentTermEnum.java
@@ -87,9 +87,7 @@ public class TestSegmentTermEnum extends LuceneTestCase {
     long ordB;
     try {
       ordB = terms.ord();
-    } catch (
-        @SuppressWarnings("unused")
-        UnsupportedOperationException uoe) {
+    } catch (UnsupportedOperationException _) {
       // ok -- codec is not required to support ord
       reader.close();
       return;

--- a/lucene/core/src/test/org/apache/lucene/index/TestTragicIndexWriterDeadlock.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTragicIndexWriterDeadlock.java
@@ -53,9 +53,7 @@ public class TestTragicIndexWriterDeadlock extends LuceneTestCase {
                 w.addDocument(new Document());
                 w.commit();
               }
-            } catch (
-                @SuppressWarnings("unused")
-                Throwable t) {
+            } catch (Throwable _) {
               done.set(true);
               // System.out.println("commit exc:");
               // t.printStackTrace(System.out);
@@ -83,9 +81,7 @@ public class TestTragicIndexWriterDeadlock extends LuceneTestCase {
               } finally {
                 r.close();
               }
-            } catch (
-                @SuppressWarnings("unused")
-                Throwable t) {
+            } catch (Throwable _) {
               done.set(true);
               // System.out.println("nrt exc:");
               // t.printStackTrace(System.out);

--- a/lucene/core/src/test/org/apache/lucene/index/TestTransactions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTransactions.java
@@ -125,41 +125,29 @@ public class TestTransactions extends LuceneTestCase {
         synchronized (lock) {
           try {
             writer1.prepareCommit();
-          } catch (
-              @SuppressWarnings("unused")
-              Throwable t) {
+          } catch (Throwable _) {
             // release resources
             try {
               writer1.rollback();
-            } catch (
-                @SuppressWarnings("unused")
-                Throwable ignore) {
+            } catch (Throwable _) {
             }
             try {
               writer2.rollback();
-            } catch (
-                @SuppressWarnings("unused")
-                Throwable ignore) {
+            } catch (Throwable _) {
             }
             return;
           }
           try {
             writer2.prepareCommit();
-          } catch (
-              @SuppressWarnings("unused")
-              Throwable t) {
+          } catch (Throwable _) {
             // release resources
             try {
               writer1.rollback();
-            } catch (
-                @SuppressWarnings("unused")
-                Throwable ignore) {
+            } catch (Throwable _) {
             }
             try {
               writer2.rollback();
-            } catch (
-                @SuppressWarnings("unused")
-                Throwable ignore) {
+            } catch (Throwable _) {
             }
             return;
           }

--- a/lucene/core/src/test/org/apache/lucene/index/TestTwoPhaseCommitTool.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTwoPhaseCommitTool.java
@@ -104,9 +104,7 @@ public class TestTwoPhaseCommitTool extends LuceneTestCase {
     boolean anyFailure = false;
     try {
       TwoPhaseCommitTool.execute(objects);
-    } catch (
-        @SuppressWarnings("unused")
-        Throwable t) {
+    } catch (Throwable _) {
       anyFailure = true;
     }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/BaseTokenStreamTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/BaseTokenStreamTestCase.java
@@ -913,9 +913,7 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
         // System.out.println(ts.reflectAsString(false));
         fail("didn't get expected exception when reset() not called");
       }
-    } catch (
-        @SuppressWarnings("unused")
-        IllegalStateException expected) {
+    } catch (IllegalStateException _) {
       // ok
     } catch (Exception unexpected) {
       unexpected.printStackTrace(System.err);
@@ -936,9 +934,7 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
     try {
       ts = a.tokenStream("bogus", input);
       fail("didn't get expected exception when close() not called");
-    } catch (
-        @SuppressWarnings("unused")
-        IllegalStateException expected) {
+    } catch (IllegalStateException _) {
       // ok
     } finally {
       ts.close();

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/geo/GeoTestUtil.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/geo/GeoTestUtil.java
@@ -462,9 +462,7 @@ public class GeoTestUtil {
             random().nextDouble() * GeoUtils.EARTH_MEAN_RADIUS_METERS * Math.PI / 2.0 + 1.0;
         try {
           return createRegularPolygon(nextLatitude(), nextLongitude(), radiusMeters, gons);
-        } catch (
-            @SuppressWarnings("unused")
-            IllegalArgumentException iae) {
+        } catch (IllegalArgumentException _) {
           // we tried to cross dateline or pole ... try again
         }
       }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/geo/ShapeTestUtil.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/geo/ShapeTestUtil.java
@@ -46,9 +46,7 @@ public class ShapeTestUtil {
         double radius = random.nextDouble() * 0.5 * Float.MAX_VALUE + 1.0;
         try {
           return createRegularPolygon(nextFloat(random), nextFloat(random), radius, gons);
-        } catch (
-            @SuppressWarnings("unused")
-            IllegalArgumentException iae) {
+        } catch (IllegalArgumentException _) {
           // something went wrong, try again
         }
       }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
@@ -658,9 +658,7 @@ public abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
           iw.addDocument(doc);
           // we made it, sometimes delete our doc
           iw.deleteDocuments(new Term("id", Integer.toString(i)));
-        } catch (
-            @SuppressWarnings("unused")
-            AlreadyClosedException ace) {
+        } catch (AlreadyClosedException _) {
           // OK: writer was closed by abort; we just reopen now:
           dir.setRandomIOExceptionRateOnOpen(
               0.0); // disable exceptions on openInput until next iteration
@@ -699,9 +697,7 @@ public abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
             if (DirectoryReader.indexExists(dir)) {
               TestUtil.checkIndex(dir);
             }
-          } catch (
-              @SuppressWarnings("unused")
-              AlreadyClosedException ace) {
+          } catch (AlreadyClosedException _) {
             // OK: writer was closed by abort; we just reopen now:
             dir.setRandomIOExceptionRateOnOpen(
                 0.0); // disable exceptions on openInput until next iteration
@@ -729,9 +725,7 @@ public abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
         handleFakeIOException(e, exceptionStream);
         try {
           iw.rollback();
-        } catch (
-            @SuppressWarnings("unused")
-            Throwable t) {
+        } catch (Throwable _) {
         }
       }
       dir.close();

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BasePostingsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BasePostingsFormatTestCase.java
@@ -726,9 +726,7 @@ public abstract class BasePostingsFormatTestCase extends BaseIndexFileFormatTest
         long ord;
         try {
           ord = termsEnum.ord();
-        } catch (
-            @SuppressWarnings("unused")
-            UnsupportedOperationException uoe) {
+        } catch (UnsupportedOperationException _) {
           supportsOrds = false;
           ord = -1;
         }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomPostingsTester.java
@@ -1613,9 +1613,7 @@ public class RandomPostingsTester {
           // Try seek by ord sometimes:
           try {
             termsEnum.seekExact(fieldAndTerm.ord);
-          } catch (
-              @SuppressWarnings("unused")
-              UnsupportedOperationException uoe) {
+          } catch (UnsupportedOperationException _) {
             supportsOrds = false;
             assertTrue(termsEnum.seekExact(fieldAndTerm.term));
           }
@@ -1633,9 +1631,7 @@ public class RandomPostingsTester {
       if (supportsOrds) {
         try {
           termOrd = termsEnum.ord();
-        } catch (
-            @SuppressWarnings("unused")
-            UnsupportedOperationException uoe) {
+        } catch (UnsupportedOperationException _) {
           supportsOrds = false;
           termOrd = -1;
         }
@@ -1776,9 +1772,7 @@ public class RandomPostingsTester {
       try {
         iterator.remove();
         throw new AssertionError("Fields.iterator() allows for removal");
-      } catch (
-          @SuppressWarnings("unused")
-          UnsupportedOperationException expected) {
+      } catch (UnsupportedOperationException _) {
         // expected;
       }
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/ExtrasFS.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/ExtrasFS.java
@@ -66,9 +66,7 @@ public class ExtrasFS extends FilterFileSystemProvider {
         } else {
           Files.createFile(target);
         }
-      } catch (
-          @SuppressWarnings("unused")
-          Exception ignored) {
+      } catch (Exception _) {
         // best effort
       }
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsFS.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/mockfile/WindowsFS.java
@@ -97,9 +97,7 @@ public class WindowsFS extends HandleTrackingFS {
   private Object getKeyOrNull(Path path) {
     try {
       return getKey(path);
-    } catch (
-        @SuppressWarnings("unused")
-        Exception ignore) {
+    } catch (Exception _) {
       // we don't care if the file doesn't exist
     }
     return null;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/CheckHits.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/CheckHits.java
@@ -391,9 +391,7 @@ public class CheckHits {
     // TODO: clean this up if we use junit 5 (the assert message is costly)
     try {
       assertEquals(score, value, 0d);
-    } catch (
-        @SuppressWarnings("unused")
-        Exception e) {
+    } catch (Exception _) {
       fail(
           q
               + ": score(doc="
@@ -450,9 +448,7 @@ public class CheckHits {
               if (descr.substring(k2).trim().equals("times others of:")) {
                 maxTimesOthers = true;
               }
-            } catch (
-                @SuppressWarnings("unused")
-                NumberFormatException e) {
+            } catch (NumberFormatException _) {
             }
           }
         }
@@ -502,9 +498,7 @@ public class CheckHits {
         // TODO: clean this up if we use junit 5 (the assert message is costly)
         try {
           assertEquals(combined, value, maxError);
-        } catch (
-            @SuppressWarnings("unused")
-            Exception e) {
+        } catch (Exception _) {
           fail(
               q
                   + ": actual subDetails combined=="

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/similarities/BaseSimilarityTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/similarities/BaseSimilarityTestCase.java
@@ -139,9 +139,7 @@ public abstract class BaseSimilarityTestCase extends LuceneTestCase {
     long upperBound;
     try {
       upperBound = Math.min(MAXTOKENS_FORTESTING, Math.multiplyExact(docCount, Integer.MAX_VALUE));
-    } catch (
-        @SuppressWarnings("unused")
-        ArithmeticException overflow) {
+    } catch (ArithmeticException _) {
       upperBound = MAXTOKENS_FORTESTING;
     }
     final long sumDocFreq;
@@ -207,9 +205,7 @@ public abstract class BaseSimilarityTestCase extends LuceneTestCase {
     try {
       upperBound =
           Math.min(corpus.sumTotalTermFreq(), Math.multiplyExact(docFreq, Integer.MAX_VALUE));
-    } catch (
-        @SuppressWarnings("unused")
-        ArithmeticException overflow) {
+    } catch (ArithmeticException _) {
       upperBound = corpus.sumTotalTermFreq();
     }
     if (corpus.sumTotalTermFreq() == corpus.sumDocFreq()) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
@@ -650,9 +650,7 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
                         try (IndexInput input = dir.openInput(file, newIOContext(random()))) {
                           // Just open, nothing else.
                           assert input != null;
-                        } catch (
-                            @SuppressWarnings("unused")
-                            AccessDeniedException e) {
+                        } catch (AccessDeniedException _) {
                           // Access denied is allowed for files for which the output is still open
                           // (MockDirectoryWriter enforces
                           // this, for example). Since we don't synchronize with the writer thread,

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseLockFactoryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseLockFactoryTestCase.java
@@ -145,9 +145,7 @@ public abstract class BaseLockFactoryTestCase extends LuceneTestCase {
                     fail();
                   }
                   assert lock != null; // stupid compiler
-                } catch (
-                    @SuppressWarnings("unused")
-                    IOException ex) {
+                } catch (IOException _) {
                   //
                 }
                 if (atomicCounter.incrementAndGet() > runs) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockDirectoryWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockDirectoryWrapper.java
@@ -520,9 +520,7 @@ public class MockDirectoryWrapper extends BaseDirectoryWrapper {
     for (Closeable f : m.keySet()) {
       try {
         f.close();
-      } catch (
-          @SuppressWarnings("unused")
-          Exception ignored) {
+      } catch (Exception _) {
       }
     }
     corruptFiles(unSyncedFiles);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/SlowOpeningMockIndexInputWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/SlowOpeningMockIndexInputWrapper.java
@@ -43,9 +43,7 @@ class SlowOpeningMockIndexInputWrapper extends MockIndexInputWrapper {
     } catch (InterruptedException ie) {
       try {
         super.close();
-      } catch (
-          @SuppressWarnings("unused")
-          Throwable ignore) {
+      } catch (Throwable _) {
         // we didnt open successfully
       }
       throw new ThreadInterruptedException(ie);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -1355,9 +1355,7 @@ public abstract class LuceneTestCase extends Assert {
     try {
       try {
         clazz = CommandLineUtil.loadFSDirectoryClass(fsdirClass);
-      } catch (
-          @SuppressWarnings("unused")
-          ClassCastException e) {
+      } catch (ClassCastException _) {
         // TEST_DIRECTORY is not a sub-class of FSDirectory, so draw one at random
         fsdirClass = RandomPicks.randomFrom(random(), FS_DIRECTORIES);
         clazz = CommandLineUtil.loadFSDirectoryClass(fsdirClass);
@@ -1637,9 +1635,7 @@ public abstract class LuceneTestCase extends Assert {
             clazz.getConstructor(Path.class, LockFactory.class);
         final Path dir = createTempDir("index");
         return pathCtor.newInstance(dir, lf);
-      } catch (
-          @SuppressWarnings("unused")
-          NoSuchMethodException nsme) {
+      } catch (NoSuchMethodException _) {
         // Ignore
       }
 
@@ -1649,9 +1645,7 @@ public abstract class LuceneTestCase extends Assert {
         // try ctor with only LockFactory
         try {
           return clazz.getConstructor(LockFactory.class).newInstance(lf);
-        } catch (
-            @SuppressWarnings("unused")
-            NoSuchMethodException nsme) {
+        } catch (NoSuchMethodException _) {
           // Ignore
         }
       }
@@ -3053,7 +3047,7 @@ public abstract class LuceneTestCase extends Assert {
     try {
       dir.openInput(fileName, IOContext.READONCE).close();
       return true;
-    } catch (@SuppressWarnings("unused") NoSuchFileException | FileNotFoundException e) {
+    } catch (NoSuchFileException | FileNotFoundException _) {
       return false;
     }
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleAssertionsRequired.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleAssertionsRequired.java
@@ -44,9 +44,7 @@ public class TestRuleAssertionsRequired implements TestRule {
             System.err.println(msg);
             throw new Exception(msg);
           }
-        } catch (
-            @SuppressWarnings("unused")
-            AssertionError e) {
+        } catch (AssertionError _) {
           // Ok, enabled.
         }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleTemporaryFilesCleanup.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleTemporaryFilesCleanup.java
@@ -251,9 +251,7 @@ final class TestRuleTemporaryFilesCleanup extends TestRuleAdapter {
         try {
           Files.createDirectory(f);
           success = true;
-        } catch (
-            @SuppressWarnings("unused")
-            IOException ignore) {
+        } catch (IOException _) {
         }
       } while (!success);
 
@@ -282,9 +280,7 @@ final class TestRuleTemporaryFilesCleanup extends TestRuleAdapter {
       try {
         Files.createDirectory(f);
         success = true;
-      } catch (
-          @SuppressWarnings("unused")
-          IOException ignore) {
+      } catch (IOException _) {
       }
     } while (!success);
 
@@ -311,9 +307,7 @@ final class TestRuleTemporaryFilesCleanup extends TestRuleAdapter {
       try {
         Files.createFile(f);
         success = true;
-      } catch (
-          @SuppressWarnings("unused")
-          IOException ignore) {
+      } catch (IOException _) {
       }
     } while (!success);
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestUtil.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestUtil.java
@@ -197,9 +197,7 @@ public final class TestUtil {
         try {
           iterator.remove();
           throw new AssertionError("broken iterator (supports remove): " + iterator);
-        } catch (
-            @SuppressWarnings("unused")
-            UnsupportedOperationException expected) {
+        } catch (UnsupportedOperationException _) {
           // ok
         }
       }
@@ -208,9 +206,7 @@ public final class TestUtil {
     try {
       iterator.next();
       throw new AssertionError("broken iterator (allows next() when hasNext==false) " + iterator);
-    } catch (
-        @SuppressWarnings("unused")
-        NoSuchElementException expected) {
+    } catch (NoSuchElementException _) {
       // ok
     }
   }
@@ -232,18 +228,14 @@ public final class TestUtil {
       try {
         iterator.remove();
         throw new AssertionError("broken iterator (supports remove): " + iterator);
-      } catch (
-          @SuppressWarnings("unused")
-          UnsupportedOperationException expected) {
+      } catch (UnsupportedOperationException _) {
         // ok
       }
     }
     try {
       iterator.next();
       throw new AssertionError("broken iterator (allows next() when hasNext==false) " + iterator);
-    } catch (
-        @SuppressWarnings("unused")
-        NoSuchElementException expected) {
+    } catch (NoSuchElementException _) {
       // ok
     }
   }
@@ -255,7 +247,7 @@ public final class TestUtil {
    */
   public static <T> void checkReadOnly(Collection<T> coll) {
     int size = 0;
-    for (@SuppressWarnings("unused") T t : coll) {
+    for (T _ : coll) {
       size += 1;
     }
     if (size != coll.size()) {
@@ -272,9 +264,7 @@ public final class TestUtil {
       try {
         coll.remove(coll.iterator().next());
         throw new AssertionError("broken collection (supports remove): " + coll);
-      } catch (
-          @SuppressWarnings("unused")
-          UnsupportedOperationException e) {
+      } catch (UnsupportedOperationException _) {
         // ok
       }
     }
@@ -282,18 +272,14 @@ public final class TestUtil {
     try {
       coll.add(null);
       throw new AssertionError("broken collection (supports add): " + coll);
-    } catch (
-        @SuppressWarnings("unused")
-        UnsupportedOperationException e) {
+    } catch (UnsupportedOperationException _) {
       // ok
     }
 
     try {
       coll.addAll(Collections.singleton(null));
       throw new AssertionError("broken collection (supports addAll): " + coll);
-    } catch (
-        @SuppressWarnings("unused")
-        UnsupportedOperationException e) {
+    } catch (UnsupportedOperationException _) {
       // ok
     }
 
@@ -1663,9 +1649,7 @@ public final class TestUtil {
         // ignore bugs in Sun's regex impl
         try {
           replacement = p.matcher(nonBmpString).replaceAll("_");
-        } catch (
-            @SuppressWarnings("unused")
-            StringIndexOutOfBoundsException jdkBug) {
+        } catch (StringIndexOutOfBoundsException _) {
           System.out.println("WARNING: your jdk is buggy!");
           System.out.println(
               "Pattern.compile(\""
@@ -1677,9 +1661,7 @@ public final class TestUtil {
         if (replacement != null && UnicodeUtil.validUTF16String(replacement)) {
           return p;
         }
-      } catch (
-          @SuppressWarnings("unused")
-          PatternSyntaxException ignored) {
+      } catch (PatternSyntaxException _) {
         // Loop trying until we hit something that compiles.
       }
     }
@@ -1769,7 +1751,7 @@ public final class TestUtil {
     } else {
       try {
         return br.utf8ToString() + " " + br;
-      } catch (@SuppressWarnings("unused") AssertionError | IllegalArgumentException t) {
+      } catch (AssertionError | IllegalArgumentException _) {
         // If BytesRef isn't actually UTF8, or it's e.g. a
         // prefix of UTF8 that ends mid-unicode-char, we
         // fall back to hex:

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/automaton/AutomatonTestUtil.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/automaton/AutomatonTestUtil.java
@@ -61,9 +61,7 @@ public class AutomatonTestUtil extends Assert {
       try {
         new RegExp(regexp, RegExp.NONE);
         return regexp;
-      } catch (
-          @SuppressWarnings("unused")
-          Exception e) {
+      } catch (Exception _) {
       }
     }
   }
@@ -269,9 +267,7 @@ public class AutomatonTestUtil extends Assert {
           a1 = Operations.complement(a1, DEFAULT_MAX_DETERMINIZED_STATES);
         }
         return a1;
-      } catch (
-          @SuppressWarnings("unused")
-          TooComplexToDeterminizeException tctde) {
+      } catch (TooComplexToDeterminizeException _) {
         // This can (rarely) happen if the random regexp is too hard; just try again...
       }
     }

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/mockfile/TestWindowsFS.java
@@ -122,9 +122,7 @@ public class TestWindowsFS extends MockFileSystemTestCase {
                   Files.move(file, target);
                   Files.delete(target);
                 }
-              } catch (
-                  @SuppressWarnings("unused")
-                  IOException ignored) {
+              } catch (IOException _) {
                 // continue
               }
             }
@@ -140,7 +138,7 @@ public class TestWindowsFS extends MockFileSystemTestCase {
           opened = true;
           stream.write(0);
           // just create
-        } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException ex) {
+        } catch (FileNotFoundException | NoSuchFileException _) {
           assertEquals(
               "File handle leaked - file is closed but still registered",
               0,

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/store/TestMockDirectoryWrapper.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/store/TestMockDirectoryWrapper.java
@@ -148,7 +148,7 @@ public class TestMockDirectoryWrapper extends BaseDirectoryTestCase {
     IndexInput in = null;
     try {
       in = dir.openInput("foo", IOContext.DEFAULT);
-    } catch (@SuppressWarnings("unused") NoSuchFileException | FileNotFoundException fnfe) {
+    } catch (NoSuchFileException | FileNotFoundException _) {
       // ok
       changed = true;
     }
@@ -157,9 +157,7 @@ public class TestMockDirectoryWrapper extends BaseDirectoryTestCase {
         int x;
         try {
           x = in.readInt();
-        } catch (
-            @SuppressWarnings("unused")
-            EOFException eofe) {
+        } catch (EOFException _) {
           changed = true;
           break;
         }

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestMaxFailuresRule.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestMaxFailuresRule.java
@@ -131,9 +131,7 @@ public class TestMaxFailuresRule extends WithNestedTests {
                   try {
                     die.await();
                     return;
-                  } catch (
-                      @SuppressWarnings("unused")
-                      Exception ignored) {
+                  } catch (Exception _) {
                     /* ignore */
                   }
                 }

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestRamUsageTesterOnWildAnimals.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestRamUsageTesterOnWildAnimals.java
@@ -39,9 +39,7 @@ public class TestRamUsageTesterOnWildAnimals extends LuceneTestCase {
         }
         RamUsageTester.ramUsed(first); // cause SOE or pass.
         lower = mid;
-      } catch (
-          @SuppressWarnings("unused")
-          StackOverflowError e) {
+      } catch (StackOverflowError _) {
         upper = mid;
       }
     }

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestWorstCaseTestBehavior.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestWorstCaseTestBehavior.java
@@ -31,9 +31,7 @@ public class TestWorstCaseTestBehavior extends LuceneTestCase {
           public void run() {
             try {
               Thread.sleep(10000);
-            } catch (
-                @SuppressWarnings("unused")
-                InterruptedException ignored) {
+            } catch (InterruptedException _) {
               // Ignore.
             }
           }
@@ -97,9 +95,7 @@ public class TestWorstCaseTestBehavior extends LuceneTestCase {
     while (true) {
       try {
         Thread.sleep(1000);
-      } catch (
-          @SuppressWarnings("unused")
-          InterruptedException ignored) {
+      } catch (InterruptedException _) {
       }
     }
   }


### PR DESCRIPTION
### Description

I noticed quite a few occurrences of `@SuppressWarnings("unused")` which can be replaced with unnamed variable for 11.0. Will get this done across few PRs to not make any individual PR too big.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
