### PR TITLE
Fix GroupVIntBenchmark and some tests to actually use DataInput#readGroupVInt; deprecate/remove obsolete long[] code

### DIFF
--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/GroupVIntBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/GroupVIntBenchmark.java
@@ -86,8 +86,8 @@ public class GroupVIntBenchmark {
       };
 
   final int maxSize = 256;
-  final long[] docs = new long[maxSize];
-  final long[] values = new long[maxSize];
+  final int[] docs = new int[maxSize];
+  final int[] values = new int[maxSize];
 
   IndexInput byteBufferGVIntIn;
   IndexInput nioGVIntIn;
@@ -103,7 +103,7 @@ public class GroupVIntBenchmark {
   @Param({"64"})
   public int size;
 
-  void initArrayInput(long[] docs) throws Exception {
+  void initArrayInput(int[] docs) throws Exception {
     byte[] gVIntBytes = new byte[Integer.BYTES * maxSize * 2];
     byte[] vIntBytes = new byte[Integer.BYTES * maxSize * 2];
     ByteArrayDataOutput vIntOut = new ByteArrayDataOutput(vIntBytes);
@@ -116,7 +116,7 @@ public class GroupVIntBenchmark {
     byteArrayGVIntIn = new ByteArrayDataInput(gVIntBytes);
   }
 
-  void initNioInput(long[] docs) throws Exception {
+  void initNioInput(int[] docs) throws Exception {
     Directory dir = new NIOFSDirectory(Files.createTempDirectory("groupvintdata"));
     IndexOutput out = dir.createOutput("gvint", IOContext.DEFAULT);
     out.writeGroupVInts(docs, docs.length);
@@ -124,13 +124,13 @@ public class GroupVIntBenchmark {
     nioGVIntIn = dir.openInput("gvint", IOContext.DEFAULT);
   }
 
-  void initByteBuffersInput(long[] docs) throws Exception {
+  void initByteBuffersInput(int[] docs) throws Exception {
     ByteBuffersDataOutput buffer = new ByteBuffersDataOutput();
     buffer.writeGroupVInts(docs, docs.length);
     byteBuffersGVIntIn = buffer.toDataInput();
   }
 
-  void initByteBufferInput(long[] docs) throws Exception {
+  void initByteBufferInput(int[] docs) throws Exception {
     Directory dir = new MMapDirectory(Files.createTempDirectory("groupvintdata"));
     IndexOutput vintOut = dir.createOutput("vint", IOContext.DEFAULT);
     IndexOutput gvintOut = dir.createOutput("gvint", IOContext.DEFAULT);
@@ -145,7 +145,7 @@ public class GroupVIntBenchmark {
     byteBufferVIntIn = dir.openInput("vint", IOContext.DEFAULT);
   }
 
-  private void readGroupVIntsBaseline(DataInput in, long[] dst, int limit) throws IOException {
+  private void readGroupVIntsBaseline(DataInput in, int[] dst, int limit) throws IOException {
     int i;
     for (i = 0; i <= limit - 4; i += 4) {
       GroupVIntUtil.readGroupVInt(in, dst, i);

--- a/lucene/core/src/java/org/apache/lucene/store/DataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/DataOutput.java
@@ -333,7 +333,9 @@ public abstract class DataOutput {
    * @param values the values to write
    * @param limit the number of values to write.
    * @lucene.experimental
+   * @deprecated This method is preserved only for backwards codecs
    */
+  @Deprecated
   public void writeGroupVInts(long[] values, int limit) throws IOException {
     if (groupVIntBytes == null) {
       groupVIntBytes = new byte[GroupVIntUtil.MAX_LENGTH_PER_GROUP];

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseChunkedDirectoryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseChunkedDirectoryTestCase.java
@@ -61,7 +61,7 @@ public abstract class BaseChunkedDirectoryTestCase extends BaseDirectoryTestCase
   public void testCloneClose() throws Exception {
     Directory dir = getDirectory(createTempDir("testCloneClose"));
     IndexOutput io = dir.createOutput("bytes", newIOContext(random()));
-    final long[] values = new long[] {0, 7, 11, 9};
+    final int[] values = new int[] {0, 7, 11, 9};
     io.writeVInt(5);
     io.writeGroupVInts(values, values.length);
     io.close();
@@ -89,7 +89,7 @@ public abstract class BaseChunkedDirectoryTestCase extends BaseDirectoryTestCase
   public void testCloneSliceClose() throws Exception {
     Directory dir = getDirectory(createTempDir("testCloneSliceClose"));
     IndexOutput io = dir.createOutput("bytes", newIOContext(random()));
-    final long[] values = new long[] {0, 7, 11, 9};
+    final int[] values = new int[] {0, 7, 11, 9};
     io.writeInt(1);
     io.writeInt(2);
     io.writeGroupVInts(values, values.length); // will write 5 bytes

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/BaseDirectoryTestCase.java
@@ -1458,7 +1458,7 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
   }
 
   public void testDataTypes() throws IOException {
-    final long[] values = new long[] {43, 12345, 123456, 1234567890};
+    final int[] values = new int[] {43, 12345, 123456, 1234567890};
     try (Directory dir = getDirectory(createTempDir("testDataTypes"))) {
       IndexOutput out = dir.createOutput("test", IOContext.DEFAULT);
       out.writeByte((byte) 43);
@@ -1468,7 +1468,7 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
       out.writeLong(1234567890123456789L);
       out.close();
 
-      long[] restored = new long[4];
+      int[] restored = new int[4];
       IndexInput in = dir.openInput("test", IOContext.DEFAULT);
       assertEquals(43, in.readByte());
       assertEquals(12345, in.readShort());
@@ -1480,6 +1480,7 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
     }
   }
 
+  @Deprecated
   public void testGroupVIntOverflow() throws IOException {
     try (Directory dir = getDirectory(createTempDir("testGroupVIntOverflow"))) {
       final int size = 32;
@@ -1526,7 +1527,7 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
 
   protected void doTestGroupVInt(
       Directory dir, int iterations, int minBpv, int maxBpv, int maxNumValues) throws IOException {
-    long[] values = new long[maxNumValues];
+    int[] values = new int[maxNumValues];
     int[] numValuesArray = new int[iterations];
     IndexOutput groupVIntOut = dir.createOutput("group-varint", IOContext.DEFAULT);
     IndexOutput vIntOut = dir.createOutput("vint", IOContext.DEFAULT);
@@ -1537,7 +1538,7 @@ public abstract class BaseDirectoryTestCase extends LuceneTestCase {
       numValuesArray[iter] = TestUtil.nextInt(random(), 1, maxNumValues);
       for (int j = 0; j < numValuesArray[iter]; j++) {
         values[j] = RandomNumbers.randomIntBetween(random(), 0, (int) PackedInts.maxValue(bpv));
-        vIntOut.writeVInt((int) values[j]);
+        vIntOut.writeVInt(values[j]);
       }
       groupVIntOut.writeGroupVInts(values, numValuesArray[iter]);
     }


### PR DESCRIPTION
When group-varint was first introduced, it worked on long[], because this was the representation that our postings format used for doc IDs (to be able to do pseudo SIMD when storing two doc IDs in a single long). When postings later moved to int[], group-varint also moved to int[], only preserving the slower implementation for long[] (not letting `DataInput` sub-classes optimize it).

However, `GroupVIntBenchmark` was not updated, so every time that it benchmarks group-varint, it actually runs the naive implementation that decodes into a long[]. This PR fixes this benchmark to use the optimized impls that decode into an int[] instead.