### PR TITLE
Replacing unused variable suppress warning with _ (Part 3/5)

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/AffixCondition.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/AffixCondition.java
@@ -121,9 +121,7 @@ interface AffixCondition {
         return ALWAYS_FALSE;
       }
       return regexpCondition(kind, condition.substring(0, split), conditionChars - strip.length());
-    } catch (
-        @SuppressWarnings("unused")
-        PatternSyntaxException e) {
+    } catch (PatternSyntaxException _) {
       return ALWAYS_FALSE;
     } catch (Throwable e) {
       throw new IllegalArgumentException("On line: " + line, e);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Dictionary.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Dictionary.java
@@ -697,9 +697,7 @@ public class Dictionary {
     int numLines;
     try {
       numLines = Integer.parseInt(args[3]);
-    } catch (
-        @SuppressWarnings("unused")
-        NumberFormatException e) {
+    } catch (NumberFormatException _) {
       if (tolerateAffixRuleCountMismatches()) {
         return;
       }
@@ -1321,9 +1319,7 @@ public class Dictionary {
       try {
         int alias = Integer.parseInt(morphData.trim());
         morphData = morphAliases[alias - 1];
-      } catch (
-          @SuppressWarnings("unused")
-          NumberFormatException ignored) {
+      } catch (NumberFormatException _) {
       }
     }
     if (morphData.isBlank()) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/DateRecognizerFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/DateRecognizerFilter.java
@@ -53,9 +53,7 @@ public class DateRecognizerFilter extends FilteringTokenFilter {
       // We don't care about the date, just that the term can be parsed to one.
       dateFormat.parse(termAtt.toString());
       return true;
-    } catch (
-        @SuppressWarnings("unused")
-        ParseException e) {
+    } catch (ParseException _) {
       // This term is not a date.
     }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/CharArrayIterator.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/CharArrayIterator.java
@@ -192,9 +192,7 @@ public abstract class CharArrayIterator implements CharacterIterator {
       bi.setText("\udb40\udc53");
       bi.next();
       v = false;
-    } catch (
-        @SuppressWarnings("unused")
-        Exception e) {
+    } catch (Exception _) {
       v = true;
     }
     HAS_BUGGY_BREAKITERATORS = v;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/FilesystemResourceLoader.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/FilesystemResourceLoader.java
@@ -84,7 +84,7 @@ public final class FilesystemResourceLoader implements ResourceLoader {
   public InputStream openResource(String resource) throws IOException {
     try {
       return Files.newInputStream(baseDirectory.resolve(resource));
-    } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException fnfe) {
+    } catch (FileNotFoundException | NoSuchFileException _) {
       return delegate.openResource(resource);
     }
   }

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseNumberFilter.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseNumberFilter.java
@@ -249,7 +249,7 @@ public class JapaneseNumberFilter extends TokenFilter {
         return number;
       }
       return normalizedNumber.stripTrailingZeros().toPlainString();
-    } catch (@SuppressWarnings("unused") NumberFormatException | ArithmeticException e) {
+    } catch (NumberFormatException | ArithmeticException _) {
       // Return the source number in case of error, i.e. malformed input
       return number;
     }

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestFactories.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestFactories.java
@@ -140,13 +140,9 @@ public class TestFactories extends BaseTokenStreamTestCase {
     if (factory instanceof ResourceLoaderAware) {
       try {
         ((ResourceLoaderAware) factory).inform(new StringMockResourceLoader(""));
-      } catch (
-          @SuppressWarnings("unused")
-          IOException ignored) {
+      } catch (IOException _) {
         // it's ok if the right files arent available or whatever to throw this
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException ignored) {
+      } catch (IllegalArgumentException _) {
         // is this ok? I guess so
       }
     }

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanNumberFilter.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanNumberFilter.java
@@ -238,7 +238,7 @@ public class KoreanNumberFilter extends TokenFilter {
         return number;
       }
       return normalizedNumber.stripTrailingZeros().toPlainString();
-    } catch (@SuppressWarnings("unused") NumberFormatException | ArithmeticException e) {
+    } catch (NumberFormatException | ArithmeticException _) {
       // Return the source number in case of error, i.e. malformed input
       return number;
     }

--- a/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/PhoneticFilter.java
+++ b/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/PhoneticFilter.java
@@ -72,9 +72,7 @@ public final class PhoneticFilter extends TokenFilter {
     try {
       String v = encoder.encode(value).toString();
       if (v.length() > 0 && !value.equals(v)) phonetic = v;
-    } catch (
-        @SuppressWarnings("unused")
-        Exception ignored) {
+    } catch (Exception _) {
     } // just use the direct text
 
     if (phonetic == null) return true;

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/AnalyzerProfile.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/AnalyzerProfile.java
@@ -75,9 +75,7 @@ public class AnalyzerProfile {
     try (BufferedReader reader = Files.newBufferedReader(propFile, StandardCharsets.UTF_8)) {
       prop.load(reader);
       return prop.getProperty("analysis.data.dir", "");
-    } catch (
-        @SuppressWarnings("unused")
-        IOException e) {
+    } catch (IOException _) {
       return "";
     }
   }

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/AbstractDictionary.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/AbstractDictionary.java
@@ -86,9 +86,7 @@ abstract class AbstractDictionary {
     try {
       String cchar = new String(buffer, "GB2312");
       return cchar;
-    } catch (
-        @SuppressWarnings("unused")
-        UnsupportedEncodingException e) {
+    } catch (UnsupportedEncodingException _) {
       return "";
     }
   }

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/WordDictionary.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/WordDictionary.java
@@ -79,9 +79,7 @@ class WordDictionary extends AbstractDictionary {
       singleInstance = new WordDictionary();
       try {
         singleInstance.load();
-      } catch (
-          @SuppressWarnings("unused")
-          IOException e) {
+      } catch (IOException _) {
         String wordDictRoot = AnalyzerProfile.ANALYSIS_DATA_DIR;
         singleInstance.load(wordDictRoot);
       } catch (ClassNotFoundException e) {
@@ -168,9 +166,7 @@ class WordDictionary extends AbstractDictionary {
       output.writeObject(wordItem_charArrayTable);
       output.writeObject(wordItem_frequencyTable);
       // log.info("serialize core dict.");
-    } catch (
-        @SuppressWarnings("unused")
-        Exception e) {
+    } catch (Exception _) {
       // log.warn(e.getMessage());
     }
   }

--- a/lucene/analysis/stempel/src/java/org/egothor/stemmer/Compile.java
+++ b/lucene/analysis/stempel/src/java/org/egothor/stemmer/Compile.java
@@ -130,9 +130,7 @@ public class Compile {
                 trie.add(token, diff.exec(token, stem));
               }
             }
-          } catch (
-              @SuppressWarnings("unused")
-              java.util.NoSuchElementException x) {
+          } catch (java.util.NoSuchElementException _) {
             // no base token (stem) on a line
           }
         }

--- a/lucene/analysis/stempel/src/java/org/egothor/stemmer/Diff.java
+++ b/lucene/analysis/stempel/src/java/org/egothor/stemmer/Diff.java
@@ -140,13 +140,9 @@ public class Diff {
         }
         pos--;
       }
-    } catch (
-        @SuppressWarnings("unused")
-        StringIndexOutOfBoundsException x) {
+    } catch (StringIndexOutOfBoundsException _) {
       // x.printStackTrace();
-    } catch (
-        @SuppressWarnings("unused")
-        ArrayIndexOutOfBoundsException x) {
+    } catch (ArrayIndexOutOfBoundsException _) {
       // x.printStackTrace();
     }
   }

--- a/lucene/analysis/stempel/src/java/org/egothor/stemmer/DiffIt.java
+++ b/lucene/analysis/stempel/src/java/org/egothor/stemmer/DiffIt.java
@@ -71,9 +71,7 @@ public class DiffIt {
   static int get(int i, String s) {
     try {
       return Integer.parseInt(s.substring(i, i + 1));
-    } catch (
-        @SuppressWarnings("unused")
-        Exception x) {
+    } catch (Exception _) {
       return 1;
     }
   }
@@ -113,9 +111,7 @@ public class DiffIt {
                 System.out.println(stem + " " + diff.exec(token, stem));
               }
             }
-          } catch (
-              @SuppressWarnings("unused")
-              java.util.NoSuchElementException x) {
+          } catch (java.util.NoSuchElementException _) {
             // no base token (stem) on a line
           }
         }

--- a/lucene/analysis/stempel/src/java/org/egothor/stemmer/MultiTrie2.java
+++ b/lucene/analysis/stempel/src/java/org/egothor/stemmer/MultiTrie2.java
@@ -124,9 +124,7 @@ public class MultiTrie2 extends MultiTrie {
           lastkey = key;
         }
       }
-    } catch (
-        @SuppressWarnings("unused")
-        IndexOutOfBoundsException x) {
+    } catch (IndexOutOfBoundsException _) {
     }
     return result;
   }
@@ -169,9 +167,7 @@ public class MultiTrie2 extends MultiTrie {
           lastkey = key;
         }
       }
-    } catch (
-        @SuppressWarnings("unused")
-        IndexOutOfBoundsException x) {
+    } catch (IndexOutOfBoundsException _) {
     }
     return result;
   }

--- a/lucene/analysis/stempel/src/test/org/egothor/stemmer/TestCompile.java
+++ b/lucene/analysis/stempel/src/test/org/egothor/stemmer/TestCompile.java
@@ -150,9 +150,7 @@ public class TestCompile extends LuceneTestCase {
           Diff.apply(stm, cmd);
           assertEquals(stem.toLowerCase(Locale.ROOT), stm.toString().toLowerCase(Locale.ROOT));
         }
-      } catch (
-          @SuppressWarnings("unused")
-          java.util.NoSuchElementException x) {
+      } catch (java.util.NoSuchElementException _) {
         // no base token (stem) on a line
       }
     }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene40/blocktree/IntersectTermsEnum.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene40/blocktree/IntersectTermsEnum.java
@@ -370,9 +370,7 @@ final class IntersectTermsEnum extends BaseTermsEnum {
   public BytesRef next() throws IOException {
     try {
       return _next();
-    } catch (
-        @SuppressWarnings("unused")
-        NoMoreTermsException eoi) {
+    } catch (NoMoreTermsException _) {
       // Provoke NPE if we are (illegally!) called again:
       currentFrame = null;
       return null;

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/blocktree/IntersectTermsEnum.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/blocktree/IntersectTermsEnum.java
@@ -375,9 +375,7 @@ final class IntersectTermsEnum extends BaseTermsEnum {
   public BytesRef next() throws IOException {
     try {
       return _next();
-    } catch (
-        @SuppressWarnings("unused")
-        NoMoreTermsException eoi) {
+    } catch (NoMoreTermsException _) {
       // Provoke NPE if we are (illegally!) called again:
       currentFrame = null;
       return null;

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingStoredFieldsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingStoredFieldsWriter.java
@@ -493,9 +493,7 @@ public final class Lucene50CompressingStoredFieldsWriter extends StoredFieldsWri
     boolean v = true;
     try {
       v = Boolean.parseBoolean(System.getProperty(BULK_MERGE_ENABLED_SYSPROP, "true"));
-    } catch (
-        @SuppressWarnings("unused")
-        SecurityException ignored) {
+    } catch (SecurityException _) {
     }
     BULK_MERGE_ENABLED = v;
   }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene50/compressing/Lucene50CompressingTermVectorsWriter.java
@@ -786,9 +786,7 @@ public final class Lucene50CompressingTermVectorsWriter extends TermVectorsWrite
     boolean v = true;
     try {
       v = Boolean.parseBoolean(System.getProperty(BULK_MERGE_ENABLED_SYSPROP, "true"));
-    } catch (
-        @SuppressWarnings("unused")
-        SecurityException ignored) {
+    } catch (SecurityException _) {
     }
     BULK_MERGE_ENABLED = v;
   }

--- a/lucene/core/src/test/org/apache/lucene/TestAssertions.java
+++ b/lucene/core/src/test/org/apache/lucene/TestAssertions.java
@@ -51,9 +51,7 @@ public class TestAssertions extends LuceneTestCase {
       if (assertsAreEnabled) {
         fail("TestTokenStream3 should fail assertion");
       }
-    } catch (
-        @SuppressWarnings("unused")
-        AssertionError e) {
+    } catch (AssertionError _) {
       // expected
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/TestMergeSchedulerExternal.java
+++ b/lucene/core/src/test/org/apache/lucene/TestMergeSchedulerExternal.java
@@ -136,9 +136,7 @@ public class TestMergeSchedulerExternal extends LuceneTestCase {
       for (int i = 0; i < 60; i++) {
         writer.addDocument(doc);
       }
-    } catch (
-        @SuppressWarnings("unused")
-        IllegalStateException ise) {
+    } catch (IllegalStateException _) {
       // OK
     }
 

--- a/lucene/core/src/test/org/apache/lucene/document/BaseLatLonSpatialTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/document/BaseLatLonSpatialTestCase.java
@@ -202,9 +202,7 @@ public abstract class BaseLatLonSpatialTestCase extends BaseSpatialTestCase {
           try {
             Tessellator.tessellate(p, random().nextBoolean());
             return p;
-          } catch (
-              @SuppressWarnings("unused")
-              IllegalArgumentException e) {
+          } catch (IllegalArgumentException _) {
             // if we can't tessellate; then random polygon generator created a malformed shape
           }
         }

--- a/lucene/core/src/test/org/apache/lucene/document/BaseXYShapeTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/document/BaseXYShapeTestCase.java
@@ -228,9 +228,7 @@ public abstract class BaseXYShapeTestCase extends BaseSpatialTestCase {
           try {
             Tessellator.tessellate(p, true);
             return p;
-          } catch (
-              @SuppressWarnings("unused")
-              IllegalArgumentException e) {
+          } catch (IllegalArgumentException _) {
             // if we can't tessellate; then random polygon generator created a malformed shape
           }
         }

--- a/lucene/core/src/test/org/apache/lucene/document/TestLatLonShape.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLatLonShape.java
@@ -788,9 +788,7 @@ public class TestLatLonShape extends LuceneTestCase {
         polygon = new Polygon(lats, lons);
         Tessellator.tessellate(polygon, random().nextBoolean());
         break;
-      } catch (
-          @SuppressWarnings("unused")
-          Exception e) {
+      } catch (Exception _) {
         // invalid polygon, try a new one
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/document/TestXYShape.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestXYShape.java
@@ -135,9 +135,7 @@ public class TestXYShape extends LuceneTestCase {
         try {
           Tessellator.tessellate(p, random.nextBoolean());
           break;
-        } catch (
-            @SuppressWarnings("unused")
-            Exception e) {
+        } catch (Exception _) {
           // ignore, try other combination
         }
       }

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestFloatArrayList.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestFloatArrayList.java
@@ -278,7 +278,7 @@ public class TestFloatArrayList extends LuceneTestCase {
 
     count = 0;
     list.resize(0);
-    for (@SuppressWarnings("unused") FloatCursor cursor : list) {
+    for (FloatCursor _ : list) {
       count++;
     }
     assertEquals(0, count);

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntArrayList.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntArrayList.java
@@ -279,7 +279,7 @@ public class TestIntArrayList extends LuceneTestCase {
 
     count = 0;
     list.resize(0);
-    for (@SuppressWarnings("unused") IntCursor cursor : list) {
+    for (IntCursor _ : list) {
       count++;
     }
     assertEquals(0, count);

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongArrayList.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongArrayList.java
@@ -279,7 +279,7 @@ public class TestLongArrayList extends LuceneTestCase {
 
     count = 0;
     list.resize(0);
-    for (@SuppressWarnings("unused") LongCursor cursor : list) {
+    for (LongCursor _ : list) {
       count++;
     }
     assertEquals(0, count);

--- a/lucene/core/src/test/org/apache/lucene/search/TestFilterWeight.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFilterWeight.java
@@ -49,9 +49,7 @@ public class TestFilterWeight extends LuceneTestCase {
                   + " but it does override\n'"
                   + subClassMethod
                   + "'");
-        } catch (
-            @SuppressWarnings("unused")
-            NoSuchMethodException e) {
+        } catch (NoSuchMethodException _) {
           /* FilterWeight must not override the bulkScorer method
            * since as of July 2016 not all deriving classes use the
            * {code}return in.bulkScorer(content);{code}
@@ -68,9 +66,7 @@ public class TestFilterWeight extends LuceneTestCase {
             "getReturnType() difference",
             superClassMethod.getReturnType(),
             subClassMethod.getReturnType());
-      } catch (
-          @SuppressWarnings("unused")
-          NoSuchMethodException e) {
+      } catch (NoSuchMethodException _) {
         fail(subClass + " needs to override '" + superClassMethod + "'");
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -1238,9 +1238,7 @@ public class TestLRUQueryCache extends LuceneTestCase {
       // trigger an eviction
       searcher.search(new MatchAllDocsQuery(), DummyTotalHitCountCollector.createManager());
       fail();
-    } catch (
-        @SuppressWarnings("unused")
-        ConcurrentModificationException e) {
+    } catch (ConcurrentModificationException _) {
       // expected
     } catch (RuntimeException e) {
       // expected: wrapped when executor is in use

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -241,9 +241,7 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
                 awaitEnterWarm.countDown();
                 awaitClose.await();
               }
-            } catch (
-                @SuppressWarnings("unused")
-                InterruptedException e) {
+            } catch (InterruptedException _) {
               //
             }
             return new IndexSearcher(r, es);
@@ -278,9 +276,7 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
                   }
                   searcherManager.maybeRefresh();
                   success.set(true);
-                } catch (
-                    @SuppressWarnings("unused")
-                    AlreadyClosedException e) {
+                } catch (AlreadyClosedException _) {
                   // expected
                 } catch (Throwable e) {
                   if (VERBOSE) {
@@ -652,9 +648,7 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
                   IndexSearcher searcher;
                   try {
                     searcher = mgr.acquire();
-                  } catch (
-                      @SuppressWarnings("unused")
-                      AlreadyClosedException ace) {
+                  } catch (AlreadyClosedException _) {
                     // ok
                     continue;
                   }
@@ -684,9 +678,7 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
                   refreshCount++;
                   try {
                     mgr.maybeRefreshBlocking();
-                  } catch (
-                      @SuppressWarnings("unused")
-                      AlreadyClosedException ace) {
+                  } catch (AlreadyClosedException _) {
                     // ok
                     aceCount++;
                     continue;
@@ -718,9 +710,7 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
                   try {
                     mgrRef.set(new SearcherManager(writerRef.get(), null));
                     break;
-                  } catch (
-                      @SuppressWarnings("unused")
-                      AlreadyClosedException ace) {
+                  } catch (AlreadyClosedException _) {
                     // ok
                     aceCount++;
                   }

--- a/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
@@ -76,9 +76,7 @@ public class TestMMapDirectory extends BaseDirectoryTestCase {
                       clone.seek(0);
                       clone.readBytes(accum, 0, accum.length);
                     }
-                  } catch (
-                      @SuppressWarnings("unused")
-                      AlreadyClosedException ok) {
+                  } catch (AlreadyClosedException _) {
                     // OK
                   } catch (InterruptedException | IOException e) {
                     throw new RuntimeException(e);

--- a/lucene/core/src/test/org/apache/lucene/util/TestByteBlockPool.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestByteBlockPool.java
@@ -158,9 +158,7 @@ public class TestByteBlockPool extends LuceneTestCase {
     for (int i = 0; i < Integer.MAX_VALUE / ByteBlockPool.BYTE_BLOCK_SIZE + 1; i++) {
       try {
         pool.nextBuffer();
-      } catch (
-          @SuppressWarnings("unused")
-          ArithmeticException ignored) {
+      } catch (ArithmeticException _) {
         // The offset overflows on the last attempt to call nextBuffer()
         throwsException = true;
         break;

--- a/lucene/core/src/test/org/apache/lucene/util/TestSetOnce.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestSetOnce.java
@@ -39,13 +39,9 @@ public class TestSetOnce extends LuceneTestCase {
         sleep(RAND.nextInt(10)); // sleep for a short time
         set.set(Integer.valueOf(getName().substring(2)));
         success = true;
-      } catch (
-          @SuppressWarnings("unused")
-          InterruptedException e) {
+      } catch (InterruptedException _) {
         // ignore
-      } catch (
-          @SuppressWarnings("unused")
-          RuntimeException e) {
+      } catch (RuntimeException _) {
         // TODO: change exception type
         // expected.
         success = false;

--- a/lucene/core/src/test/org/apache/lucene/util/TestStressRamUsageEstimator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestStressRamUsageEstimator.java
@@ -94,9 +94,7 @@ public class TestStressRamUsageEstimator extends LuceneTestCase {
           seg[i] = new byte[random().nextInt(7)];
         }
       }
-    } catch (
-        @SuppressWarnings("unused")
-        OutOfMemoryError e) {
+    } catch (OutOfMemoryError _) {
       // Release and quit.
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/util/TestUnicodeUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestUnicodeUtil.java
@@ -261,9 +261,7 @@ public class TestUnicodeUtil extends LuceneTestCase {
         assertFalse(rc == -1);
         assertEquals(cpString.substring(rs, rs + rc), str);
         continue;
-      } catch (@SuppressWarnings("unused")
-          IndexOutOfBoundsException
-          | IllegalArgumentException e1) {
+      } catch (IndexOutOfBoundsException | IllegalArgumentException _) {
         // Ignored.
       }
       assertTrue(rc == -1);

--- a/lucene/core/src/test/org/apache/lucene/util/TestWeakIdentityMap.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestWeakIdentityMap.java
@@ -135,9 +135,7 @@ public class TestWeakIdentityMap extends LuceneTestCase {
         assertTrue("previousSize(" + size + ")>=iteratorSize(" + c + ")", size >= c);
         assertTrue("iteratorSize(" + c + ")>=newSize(" + newSize + ")", c >= newSize);
         size = newSize;
-      } catch (
-          @SuppressWarnings("unused")
-          InterruptedException ie) {
+      } catch (InterruptedException _) {
       }
 
     map.clear();
@@ -248,9 +246,7 @@ public class TestWeakIdentityMap extends LuceneTestCase {
         assertTrue("previousSize(" + size + ")>=iteratorSize(" + c + ")", size >= c);
         assertTrue("iteratorSize(" + c + ")>=newSize(" + newSize + ")", c >= newSize);
         size = newSize;
-      } catch (
-          @SuppressWarnings("unused")
-          InterruptedException ie) {
+      } catch (InterruptedException _) {
       }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestLimitedFiniteStringsIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestLimitedFiniteStringsIterator.java
@@ -41,9 +41,7 @@ public class TestLimitedFiniteStringsIterator extends LuceneTestCase {
         // NOTE: cannot do this, because the method is not
         // guaranteed to detect cycles when you have a limit
         // assertTrue(AutomatonTestUtil.isFinite(a));
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException iae) {
+      } catch (IllegalArgumentException _) {
         assertFalse(AutomatonTestUtil.isFinite(a));
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/util/fst/TestFSTs.java
+++ b/lucene/core/src/test/org/apache/lucene/util/fst/TestFSTs.java
@@ -386,9 +386,7 @@ public class TestFSTs extends LuceneTestCase {
         if (ord == 0) {
           try {
             termsEnum.ord();
-          } catch (
-              @SuppressWarnings("unused")
-              UnsupportedOperationException uoe) {
+          } catch (UnsupportedOperationException _) {
             if (VERBOSE) {
               System.out.println("TEST: codec doesn't support ord; FST stores docFreq");
             }
@@ -1751,9 +1749,7 @@ public class TestFSTs extends LuceneTestCase {
     fst.getFirstArc(arc);
     try {
       fst.findTargetArc((int) 'm', arc, arc, reader);
-    } catch (
-        @SuppressWarnings("unused")
-        AssertionError ae) {
+    } catch (AssertionError _) {
       // expected
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
@@ -433,9 +433,7 @@ public class TestPackedInts extends LuceneTestCase {
     Packed64 p64 = null;
     try {
       p64 = new Packed64(INDEX, BITS);
-    } catch (
-        @SuppressWarnings("unused")
-        OutOfMemoryError oome) {
+    } catch (OutOfMemoryError _) {
       // This can easily happen: we're allocating a
       // long[] that needs 256-273 MB.  Heap is 512 MB,
       // but not all of that is available for large
@@ -454,9 +452,7 @@ public class TestPackedInts extends LuceneTestCase {
     Packed64SingleBlock p64sb = null;
     try {
       p64sb = Packed64SingleBlock.create(INDEX, BITS);
-    } catch (
-        @SuppressWarnings("unused")
-        OutOfMemoryError oome) {
+    } catch (OutOfMemoryError _) {
       // Ignore: see comment above
     }
     if (p64sb != null) {

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/CreateIndexDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/CreateIndexDialogFactory.java
@@ -334,9 +334,7 @@ public class CreateIndexDialogFactory implements DialogOpener.DialogFactory {
                           }
                         });
                     Files.deleteIfExists(path);
-                  } catch (
-                      @SuppressWarnings("unused")
-                      IOException ex2) {
+                  } catch (IOException _) {
                   }
 
                   log.log(Level.SEVERE, "Cannot create index", ex);

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/NumericUtils.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/util/NumericUtils.java
@@ -95,9 +95,7 @@ public class NumericUtils {
     try {
       // try parse to long
       return Long.parseLong(value.trim());
-    } catch (
-        @SuppressWarnings("unused")
-        NumberFormatException e) {
+    } catch (NumberFormatException _) {
       // try parse to double
       double dvalue = Double.parseDouble(value.trim());
       return org.apache.lucene.util.NumericUtils.doubleToSortableLong(dvalue);

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
@@ -249,18 +249,14 @@ public final class AnalysisImpl implements Analysis {
             new NamedTokens(TokenFilterFactory.findSPIName(tokenFilterFactory.getClass()), tokens));
         try {
           listBasedTokenStream.close();
-        } catch (
-            @SuppressWarnings("unused")
-            IOException e) {
+        } catch (IOException _) {
           // do nothing;
         }
         listBasedTokenStream = new ListBasedTokenStream(listBasedTokenStream, attributeSources);
       }
       try {
         listBasedTokenStream.close();
-      } catch (
-          @SuppressWarnings("unused")
-          IOException e) {
+      } catch (IOException _) {
         // do nothing.
       } finally {
         reader.close();

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/commits/Commit.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/commits/Commit.java
@@ -39,9 +39,7 @@ public final class Commit {
     commit.segCount = ic.getSegmentCount();
     try {
       commit.userData = IndexUtils.getCommitUserData(ic);
-    } catch (
-        @SuppressWarnings("unused")
-        IOException e) {
+    } catch (IOException _) {
     }
     return commit;
   }

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/commits/File.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/commits/File.java
@@ -31,9 +31,7 @@ public final class File {
     file.fileName = name;
     try {
       file.displaySize = CommitsImpl.toDisplaySize(Files.size(Paths.get(indexPath, name)));
-    } catch (
-        @SuppressWarnings("unused")
-        IOException e) {
+    } catch (IOException _) {
       file.displaySize = "unknown";
     }
     return file;

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/commits/Segment.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/commits/Segment.java
@@ -49,9 +49,7 @@ public final class Segment {
     segment.codecName = segInfo.info.getCodec().getName();
     try {
       segment.displaySize = CommitsImpl.toDisplaySize(segInfo.sizeInBytes());
-    } catch (
-        @SuppressWarnings("unused")
-        IOException e) {
+    } catch (IOException _) {
     }
     segment.useCompoundFile = segInfo.info.getUseCompoundFile();
     return segment;

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/tools/IndexToolsImpl.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/tools/IndexToolsImpl.java
@@ -191,9 +191,7 @@ public final class IndexToolsImpl extends LukeModel implements IndexTools {
       if (writer != null) {
         try {
           writer.close();
-        } catch (
-            @SuppressWarnings("unused")
-            IOException e) {
+        } catch (IOException _) {
         }
       }
     }

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/util/twentynewsgroups/MessageFilesParser.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/util/twentynewsgroups/MessageFilesParser.java
@@ -98,9 +98,7 @@ public class MessageFilesParser extends SimpleFileVisitor<Path> {
           case "Lines":
             try {
               message.setLines(Integer.parseInt(ary[1].trim()));
-            } catch (
-                @SuppressWarnings("unused")
-                NumberFormatException e) {
+            } catch (NumberFormatException _) {
             }
             break;
           default:

--- a/lucene/luke/src/java/org/apache/lucene/luke/util/BytesRefUtils.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/util/BytesRefUtils.java
@@ -25,9 +25,7 @@ public final class BytesRefUtils {
   public static String decode(BytesRef ref) {
     try {
       return ref.utf8ToString();
-    } catch (
-        @SuppressWarnings("unused")
-        Exception e) {
+    } catch (Exception _) {
       return ref.toString();
     }
   }


### PR DESCRIPTION
### Description
I noticed quite a few occurrences of @SuppressWarnings("unused") which can be replaced with unnamed variable for 11.0. Getting this done across few PRs to not make any individual PR too big. Related to https://github.com/apache/lucene/pull/15102, https://github.com/apache/lucene/pull/15105

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
