### PR TITLE
Fix infinite loop when RefCountedSharedArena's underlying Arena#close fails due to concurrent usage of segments

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -302,6 +302,9 @@ Bug Fixes
   resulted in query branches being wrongly ignored if the QueryIndex was
   built by a different JVM. (Luke Kot-Zaniewski)
 
+* GITHUB#15106: Fix infinite loop when RefCountedSharedArena's underlying
+  Arena#close fails due to concurrent usage of segments.  (Uwe Schindler)
+
 Build
 ---------------------
 * Upgrade forbiddenapis to version 3.9.  (Uwe Schindler)


### PR DESCRIPTION
This fixes #15106.

This basically only removes the check when an arena's refcount is already closed. The problem is if a previous close on the inner arena has failed due to concurrent access to the scoped memory segments, the refcount is already in state `CLOSED`, so another call from the "retry" spinloop in `MemorySegmentIndexInput` will hit our extra check and throws `IllegalStateException` again, leading to an endless spinloop.

The extra check is not needed, because if the inner Arena was already closed, we do not need to check this before, the inner Arena's close withh throw correct exception anyways.

This affects all users which have incorrect code, if your code is sane, you won't be affected by the spinloop bug, so it is not so serious like it looks.

@ChrisHegarty I did minimal changes here, but maybe we can no simplify the whole refcounting even more? Do we still need the upper and lower 16 bits of the atomic state?