### PR TITLE
Replacing unused variable suppress warning with _ (Part 4/5)

### DIFF
--- a/lucene/analysis.tests/src/test/org/apache/lucene/analysis/tests/TestAllAnalyzersHaveFactories.java
+++ b/lucene/analysis.tests/src/test/org/apache/lucene/analysis/tests/TestAllAnalyzersHaveFactories.java
@@ -121,9 +121,7 @@ public class TestAllAnalyzersHaveFactories extends LuceneTestCase {
             ((ResourceLoaderAware) instance).inform(loader);
           }
           assertSame(c, instance.create().getClass());
-        } catch (
-            @SuppressWarnings("unused")
-            IllegalArgumentException e) {
+        } catch (IllegalArgumentException _) {
           // TODO: For now pass because some factories have not yet a default config that always
           // works
         }
@@ -147,9 +145,7 @@ public class TestAllAnalyzersHaveFactories extends LuceneTestCase {
           if (KeywordTokenizer.class != createdClazz) {
             assertSame(c, createdClazz);
           }
-        } catch (
-            @SuppressWarnings("unused")
-            IllegalArgumentException e) {
+        } catch (IllegalArgumentException _) {
           // TODO: For now pass because some factories have not yet a default config that always
           // works
         }
@@ -170,9 +166,7 @@ public class TestAllAnalyzersHaveFactories extends LuceneTestCase {
           if (StringReader.class != createdClazz) {
             assertSame(c, createdClazz);
           }
-        } catch (
-            @SuppressWarnings("unused")
-            IllegalArgumentException e) {
+        } catch (IllegalArgumentException _) {
           // TODO: For now pass because some factories have not yet a default config that always
           // works
         }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestFactories.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestFactories.java
@@ -142,13 +142,9 @@ public class TestFactories extends BaseTokenStreamTestCase {
     if (factory instanceof ResourceLoaderAware) {
       try {
         ((ResourceLoaderAware) factory).inform(new StringMockResourceLoader(""));
-      } catch (
-          @SuppressWarnings("unused")
-          IOException ignored) {
+      } catch (IOException _) {
         // it's ok if the right files arent available or whatever to throw this
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException ignored) {
+      } catch (IllegalArgumentException _) {
         // is this ok? I guess so
       }
     }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestAllDictionaries.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestAllDictionaries.java
@@ -176,9 +176,7 @@ public class TestAllDictionaries extends LuceneTestCase {
             Suggester suggester = new Suggester(dic).withSuggestibleEntryCache();
             try {
               suggester.suggestWithTimeout("aaaaaaaaaa", Hunspell.SUGGEST_TIME_LIMIT, () -> {});
-            } catch (
-                @SuppressWarnings("unused")
-                SuggestionTimeoutException e) {
+            } catch (SuggestionTimeoutException _) {
             }
             totalMemory.addAndGet(RamUsageTester.ramUsed(dic));
             memoryWithCache.addAndGet(RamUsageTester.ramUsed(suggester));

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestPerformance.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestPerformance.java
@@ -220,9 +220,7 @@ public class TestPerformance extends LuceneTestCase {
     List<String> fromOptimized;
     try {
       fromOptimized = optimized.suggestWithTimeout(word, Hunspell.SUGGEST_TIME_LIMIT, () -> {});
-    } catch (
-        @SuppressWarnings("unused")
-        SuggestionTimeoutException e) {
+    } catch (SuggestionTimeoutException _) {
       System.out.println("Timeout happened for " + word + ", skipping");
       return false;
     }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/synonym/TestSynonymGraphFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/synonym/TestSynonymGraphFilter.java
@@ -1473,9 +1473,7 @@ public class TestSynonymGraphFilter extends BaseTokenStreamTestCase {
       // output token that also happens to be in the input:
       try {
         actual = Operations.determinize(actual, 50000);
-      } catch (
-          @SuppressWarnings("unused")
-          TooComplexToDeterminizeException tctde) {
+      } catch (TooComplexToDeterminizeException _) {
         // Unfortunately the syns can easily create difficult-to-determinize graphs:
         assertTrue(approxEquals(actual, expected));
         continue;
@@ -1483,9 +1481,7 @@ public class TestSynonymGraphFilter extends BaseTokenStreamTestCase {
 
       try {
         expected = Operations.determinize(expected, 50000);
-      } catch (
-          @SuppressWarnings("unused")
-          TooComplexToDeterminizeException tctde) {
+      } catch (TooComplexToDeterminizeException _) {
         // Unfortunately the syns can easily create difficult-to-determinize graphs:
         assertTrue(approxEquals(actual, expected));
         continue;

--- a/lucene/classification/src/java/org/apache/lucene/classification/utils/ConfusionMatrixGenerator.java
+++ b/lucene/classification/src/java/org/apache/lucene/classification/utils/ConfusionMatrixGenerator.java
@@ -137,9 +137,7 @@ public class ConfusionMatrixGenerator {
                   }
                 }
               }
-            } catch (
-                @SuppressWarnings("unused")
-                TimeoutException timeoutException) {
+            } catch (TimeoutException _) {
               // add classification timeout
               time += 5000;
             } catch (ExecutionException | InterruptedException executionException) {

--- a/lucene/classification/src/test/org/apache/lucene/classification/Test20NewsgroupsClassification.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/Test20NewsgroupsClassification.java
@@ -88,9 +88,7 @@ public final class Test20NewsgroupsClassification extends LuceneTestCase {
     if (indexProperty != null) {
       try {
         index = Boolean.parseBoolean(indexProperty);
-      } catch (
-          @SuppressWarnings("unused")
-          Exception e) {
+      } catch (Exception _) {
         // ignore
       }
     }
@@ -99,9 +97,7 @@ public final class Test20NewsgroupsClassification extends LuceneTestCase {
     if (splitProperty != null) {
       try {
         split = Boolean.parseBoolean(splitProperty);
-      } catch (
-          @SuppressWarnings("unused")
-          Exception e) {
+      } catch (Exception _) {
         // ignore
       }
     }
@@ -434,9 +430,7 @@ public final class Test20NewsgroupsClassification extends LuceneTestCase {
         }
       }
       return new NewsPost(body.toString(), subject, groupName);
-    } catch (
-        @SuppressWarnings("unused")
-        Throwable e) {
+    } catch (Throwable _) {
       return null;
     }
   }

--- a/lucene/classification/src/test/org/apache/lucene/classification/utils/TestDataSplitter.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/utils/TestDataSplitter.java
@@ -144,9 +144,7 @@ public class TestDataSplitter extends LuceneTestCase {
   private static void closeQuietly(IndexReader reader) throws IOException {
     try {
       IOUtils.close(reader);
-    } catch (
-        @SuppressWarnings("unused")
-        Exception e) {
+    } catch (Exception _) {
       // do nothing
     }
   }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/DirectPostingsFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/DirectPostingsFormat.java
@@ -1922,9 +1922,7 @@ public final class DirectPostingsFormat extends PostingsFormat {
       upto++;
       try {
         return docID = docIDs[upto];
-      } catch (
-          @SuppressWarnings("unused")
-          ArrayIndexOutOfBoundsException e) {
+      } catch (ArrayIndexOutOfBoundsException _) {
       }
       return docID = NO_MORE_DOCS;
     }

--- a/lucene/demo/src/java/org/apache/lucene/demo/IndexFiles.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/IndexFiles.java
@@ -212,9 +212,7 @@ public class IndexFiles implements AutoCloseable {
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
               try {
                 indexDoc(writer, file, attrs.lastModifiedTime().toMillis());
-              } catch (
-                  @SuppressWarnings("unused")
-                  IOException ignore) {
+              } catch (IOException _) {
                 ignore.printStackTrace(System.err);
                 // don't index files that can't be read.
               }

--- a/lucene/demo/src/java/org/apache/lucene/demo/IndexFiles.java
+++ b/lucene/demo/src/java/org/apache/lucene/demo/IndexFiles.java
@@ -212,7 +212,9 @@ public class IndexFiles implements AutoCloseable {
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
               try {
                 indexDoc(writer, file, attrs.lastModifiedTime().toMillis());
-              } catch (IOException _) {
+              } catch (
+                  @SuppressWarnings("unused")
+                  IOException ignore) {
                 ignore.printStackTrace(System.err);
                 // don't index files that can't be read.
               }

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/js/JavascriptCompiler.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/js/JavascriptCompiler.java
@@ -851,7 +851,7 @@ public final class JavascriptCompiler {
                   + "#"
                   + cracked.getName()
                   + cracked.getMethodType();
-    } catch (@SuppressWarnings("unused") IllegalArgumentException | SecurityException iae) {
+    } catch (IllegalArgumentException | SecurityException _) {
       // can't check for static, we assume it is static
       // (it does not matter as we call the MethodHandle directly if it is compatible):
       refKind = MethodHandleInfo.REF_invokeStatic;

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/directory/DirectoryTaxonomyReader.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/directory/DirectoryTaxonomyReader.java
@@ -683,9 +683,7 @@ public class DirectoryTaxonomyReader extends TaxonomyReader implements Accountab
           continue;
         }
         sb.append(i).append(": ").append(category).append("\n");
-      } catch (
-          @SuppressWarnings("unused")
-          IOException e) {
+      } catch (IOException _) {
         sb.append(i).append(": EXCEPTION!! \n");
       }
     }

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyCombined.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyCombined.java
@@ -905,9 +905,7 @@ public class TestTaxonomyCombined extends FacetTestCase {
       assertEquals(
           TaxonomyReader.ROOT_ORDINAL, tr.getParallelTaxonomyArrays().parents().get(author));
       // ok
-    } catch (
-        @SuppressWarnings("unused")
-        ArrayIndexOutOfBoundsException e) {
+    } catch (ArrayIndexOutOfBoundsException _) {
       fail(
           "After category addition, commit() and refresh(), getParent for "
               + author

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/writercache/Test2GBCharBlockArray.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/writercache/Test2GBCharBlockArray.java
@@ -35,9 +35,7 @@ public class Test2GBCharBlockArray extends LuceneTestCase {
       count++;
       try {
         array.append(chars, 0, size);
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalStateException ise) {
+      } catch (IllegalStateException _) {
         assertTrue(count * (long) size + blockSize > Integer.MAX_VALUE);
         break;
       }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/Highlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/Highlighter.java
@@ -313,9 +313,7 @@ public class Highlighter {
         try {
           tokenStream.end();
           tokenStream.close();
-        } catch (
-            @SuppressWarnings("unused")
-            Exception e) {
+        } catch (Exception _) {
         }
       }
     }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/QueryTermExtractor.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/QueryTermExtractor.java
@@ -78,9 +78,7 @@ public final class QueryTermExtractor {
         // IDF algorithm taken from ClassicSimilarity class
         float idf = (float) (Math.log(totalNumDocs / (double) (docFreq + 1)) + 1.0);
         terms[i].weight *= idf;
-      } catch (
-          @SuppressWarnings("unused")
-          IOException e) {
+      } catch (IOException _) {
         // ignore
       }
     }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/OffsetsEnum.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/OffsetsEnum.java
@@ -103,16 +103,12 @@ public abstract class OffsetsEnum implements Comparable<OffsetsEnum>, Closeable 
     String offset = "";
     try {
       offset = ",[" + startOffset() + "-" + endOffset() + "]";
-    } catch (
-        @SuppressWarnings("unused")
-        Exception e) {
+    } catch (Exception _) {
       // ignore; for debugging only
     }
     try {
       return name + "(term:" + getTerm().utf8ToString() + offset + ")";
-    } catch (
-        @SuppressWarnings("unused")
-        Exception e) {
+    } catch (Exception _) {
       return name;
     }
   }

--- a/lucene/misc/src/java/org/apache/lucene/misc/HighFreqTerms.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/HighFreqTerms.java
@@ -65,9 +65,7 @@ public class HighFreqTerms {
       } else {
         try {
           numTerms = Integer.parseInt(args[i]);
-        } catch (
-            @SuppressWarnings("unused")
-            NumberFormatException e) {
+        } catch (NumberFormatException _) {
           field = args[i];
         }
       }

--- a/lucene/misc/src/java/org/apache/lucene/misc/index/BPReorderingMergePolicy.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/index/BPReorderingMergePolicy.java
@@ -136,9 +136,7 @@ public final class BPReorderingMergePolicy extends FilterMergePolicy {
               if (reader.numDocs() >= minNumDocs) {
                 try {
                   docMap = reorderer.computeDocMap(reader, dir, executor);
-                } catch (
-                    @SuppressWarnings("unused")
-                    NotEnoughRAMException e) {
+                } catch (NotEnoughRAMException _) {
                   // skip reordering, we don't have enough RAM anyway
                 }
               }

--- a/lucene/misc/src/java/org/apache/lucene/misc/index/MultiPassIndexSplitter.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/index/MultiPassIndexSplitter.java
@@ -150,9 +150,7 @@ public class MultiPassIndexSplitter {
             System.err.println("Invalid input index - skipping: " + file);
             continue;
           }
-        } catch (
-            @SuppressWarnings("unused")
-            Exception e) {
+        } catch (Exception _) {
           System.err.println("Invalid input index - skipping: " + file);
           continue;
         }

--- a/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
@@ -105,9 +105,7 @@ public class DirectIODirectory extends FilterDirectory {
               .filter(e -> e.toString().equalsIgnoreCase("DIRECT"))
               .findFirst()
               .orElse(null);
-    } catch (
-        @SuppressWarnings("unused")
-        Exception e) {
+    } catch (Exception _) {
       option = null;
     }
     ExtendedOpenOption_DIRECT = option;

--- a/lucene/misc/src/test/org/apache/lucene/misc/document/TestLazyDocument.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/document/TestLazyDocument.java
@@ -60,9 +60,7 @@ public class TestLazyDocument extends LuceneTestCase {
       try {
         dir.close();
         dir = null;
-      } catch (
-          @SuppressWarnings("unused")
-          Exception e) {
+      } catch (Exception _) {
         /* NOOP */
       }
     }

--- a/lucene/misc/src/test/org/apache/lucene/misc/store/TestHardLinkCopyDirectoryWrapper.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/store/TestHardLinkCopyDirectoryWrapper.java
@@ -77,9 +77,7 @@ public class TestHardLinkCopyDirectoryWrapper extends BaseDirectoryTestCase {
         assumeTrue(
             "hardlinks are not supported",
             destAttr.fileKey() != null && destAttr.fileKey().equals(sourceAttr.fileKey()));
-      } catch (
-          @SuppressWarnings("unused")
-          UnsupportedOperationException ex) {
+      } catch (UnsupportedOperationException _) {
         assumeFalse("hardlinks are not supported", true);
       }
 

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/ConcurrentQueryLoader.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/ConcurrentQueryLoader.java
@@ -109,9 +109,7 @@ public class ConcurrentQueryLoader implements Closeable {
     this.executor.shutdown();
     try {
       this.shutdownLatch.await();
-    } catch (
-        @SuppressWarnings("unused")
-        InterruptedException e) {
+    } catch (InterruptedException _) {
       // fine
     }
     if (errors.size() > 0) {
@@ -145,9 +143,7 @@ public class ConcurrentQueryLoader implements Closeable {
         }
       } catch (IOException e) {
         errors.add(e);
-      } catch (
-          @SuppressWarnings("unused")
-          InterruptedException e) {
+      } catch (InterruptedException _) {
         Thread.currentThread().interrupt();
       } finally {
         shutdownLatch.countDown();

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/EnumFieldSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/EnumFieldSource.java
@@ -49,9 +49,7 @@ public class EnumFieldSource extends FieldCacheSource {
     Integer intValue = null;
     try {
       intValue = Integer.parseInt(valueStr);
-    } catch (
-        @SuppressWarnings("unused")
-        NumberFormatException e) {
+    } catch (NumberFormatException _) {
     }
     return intValue;
   }

--- a/lucene/queries/src/java/org/apache/lucene/queries/mlt/MoreLikeThis.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/mlt/MoreLikeThis.java
@@ -608,9 +608,7 @@ public final class MoreLikeThis {
 
       try {
         query.add(tq, BooleanClause.Occur.SHOULD);
-      } catch (
-          @SuppressWarnings("unused")
-          IndexSearcher.TooManyClauses ignore) {
+      } catch (IndexSearcher.TooManyClauses _) {
         break;
       }
     }

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/Node.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/Node.java
@@ -216,7 +216,7 @@ public abstract class Node implements Closeable {
           header = CodecUtil.readIndexHeader(in);
           footer = CodecUtil.readFooter(in);
           checksum = CodecUtil.retrieveChecksum(in);
-        } catch (@SuppressWarnings("unused") EOFException | CorruptIndexException cie) {
+        } catch (EOFException | CorruptIndexException _) {
           // File exists but is busted: we must copy it.  This happens when node had crashed,
           // corrupting an un-fsync'd file.  On init we try
           // to delete such unreferenced files, but virus checker can block that, leaving this bad
@@ -229,7 +229,7 @@ public abstract class Node implements Closeable {
         if (verboseFiles) {
           message("file " + fileName + " has length=" + bytesToString(length));
         }
-      } catch (@SuppressWarnings("unused") FileNotFoundException | NoSuchFileException e) {
+      } catch (FileNotFoundException | NoSuchFileException _) {
         if (verboseFiles) {
           message("file " + fileName + ": will copy [file does not exist]");
         }

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimplePrimaryNode.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimplePrimaryNode.java
@@ -533,9 +533,7 @@ class SimplePrimaryNode extends PrimaryNode {
       byte cmd;
       try {
         cmd = in.readByte();
-      } catch (
-          @SuppressWarnings("unused")
-          EOFException eofe) {
+      } catch (EOFException _) {
         // done
         return;
       }
@@ -682,9 +680,7 @@ class SimplePrimaryNode extends PrimaryNode {
 
       try {
         cmd = in.readByte();
-      } catch (
-          @SuppressWarnings("unused")
-          EOFException eofe) {
+      } catch (EOFException _) {
         break;
       }
 

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimpleReplicaNode.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/SimpleReplicaNode.java
@@ -197,9 +197,7 @@ class SimpleReplicaNode extends ReplicaNode {
 
       try {
         cmd = in.readByte();
-      } catch (
-          @SuppressWarnings("unused")
-          EOFException eofe) {
+      } catch (EOFException _) {
         break;
       }
 

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestSimpleServer.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestSimpleServer.java
@@ -302,9 +302,7 @@ public class TestSimpleServer extends LuceneTestCase {
                 while (System.nanoTime() < endTime) {
                   try {
                     Thread.sleep(10);
-                  } catch (
-                      @SuppressWarnings("unused")
-                      InterruptedException e) {
+                  } catch (InterruptedException _) {
                   }
                   if (stop.get()) {
                     break;
@@ -333,9 +331,7 @@ public class TestSimpleServer extends LuceneTestCase {
                     while (true) {
                       try {
                         new CountDownLatch(1).await();
-                      } catch (
-                          @SuppressWarnings("unused")
-                          InterruptedException e) {
+                      } catch (InterruptedException _) {
                         // We'll eventually be killed by an outside process, retry.
                       }
                     }
@@ -363,9 +359,7 @@ public class TestSimpleServer extends LuceneTestCase {
         Socket socket;
         try {
           socket = ss.accept();
-        } catch (
-            @SuppressWarnings("unused")
-            SocketException se) {
+        } catch (SocketException _) {
           // when ClientHandler closes our ss we will hit this
           node.message("top: server socket exc; now exit");
           break;

--- a/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestStressNRTReplication.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/nrt/TestStressNRTReplication.java
@@ -723,9 +723,7 @@ public class TestStressNRTReplication extends LuceneTestCase {
                       while (System.nanoTime() < deadline && p.isAlive()) {
                         try {
                           pause(250);
-                        } catch (
-                            @SuppressWarnings("unused")
-                            InterruptedException e) {
+                        } catch (InterruptedException _) {
                           // If we do get interrupted, it's likely we're being cleaned up. Do
                           // proceed immediately then.
                           break;
@@ -1133,9 +1131,7 @@ public class TestStressNRTReplication extends LuceneTestCase {
                     "version=" + version + " oldHitCount=" + oldHitCount + " hitCount=" + hitCount);
               }
             }
-          } catch (
-              @SuppressWarnings("unused")
-              IOException ioe) {
+          } catch (IOException _) {
             // message("top: searcher: ignore exc talking to node " + node + ": " + ioe);
             // ioe.printStackTrace(System.out);
             IOUtils.closeWhileHandlingException(c);
@@ -1199,9 +1195,7 @@ public class TestStressNRTReplication extends LuceneTestCase {
                 stop.set(true);
                 fail(failMessage);
               }
-            } catch (
-                @SuppressWarnings("unused")
-                IOException ioe) {
+            } catch (IOException _) {
               // message("top: searcher: ignore exc talking to node " + node + ": " + ioe);
               // throw new RuntimeException(ioe);
               // ioe.printStackTrace(System.out);
@@ -1302,18 +1296,14 @@ public class TestStressNRTReplication extends LuceneTestCase {
               curPrimary.addOrUpdateDocument(c, doc, false);
               transLog.addDocument(idString, doc);
             }
-          } catch (
-              @SuppressWarnings("unused")
-              IOException se) {
+          } catch (IOException _) {
             // Assume primary crashed
             if (c != null) {
               message("top: indexer lost connection to primary");
             }
             try {
               c.close();
-            } catch (
-                @SuppressWarnings("unused")
-                Throwable t) {
+            } catch (Throwable _) {
             }
             curPrimary = null;
             c = null;
@@ -1335,16 +1325,12 @@ public class TestStressNRTReplication extends LuceneTestCase {
             c.out.writeByte(SimplePrimaryNode.CMD_INDEXING_DONE);
             c.flush();
             c.in.readByte();
-          } catch (
-              @SuppressWarnings("unused")
-              IOException se) {
+          } catch (IOException _) {
             // Assume primary crashed
             message("top: indexer lost connection to primary");
             try {
               c.close();
-            } catch (
-                @SuppressWarnings("unused")
-                Throwable t) {
+            } catch (Throwable _) {
             }
             curPrimary = null;
             c = null;

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/codecs/idversion/TestIDVersionPostingsFormat.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/codecs/idversion/TestIDVersionPostingsFormat.java
@@ -424,9 +424,7 @@ public class TestIDVersionPostingsFormat extends LuceneTestCase {
       w.commit();
       w.forceMerge(1);
       fail("didn't hit exception");
-    } catch (
-        @SuppressWarnings("unused")
-        IllegalArgumentException iae) {
+    } catch (IllegalArgumentException _) {
       // expected: SMS will hit this
     } catch (IOException | IllegalStateException exc) {
       // expected

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestQueryEqualsHashCode.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestQueryEqualsHashCode.java
@@ -100,9 +100,7 @@ public class TestQueryEqualsHashCode extends LuceneTestCase {
     Object first;
     try {
       first = generator.gen(args1);
-    } catch (
-        @SuppressWarnings("unused")
-        UnsupportedOperationException e) {
+    } catch (UnsupportedOperationException _) {
       return;
     }
     if (first == null) return; // unsupported op?

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/RandomizedShapeTestCase.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/RandomizedShapeTestCase.java
@@ -33,16 +33,12 @@ public abstract class RandomizedShapeTestCase extends LuceneTestCase {
     for (Class<?> clazz : classes) {
       try {
         clazz.getDeclaredMethod("equals", Object.class);
-      } catch (
-          @SuppressWarnings("unused")
-          Exception e) {
+      } catch (Exception _) {
         fail("Shape needs to define 'equals' : " + clazz.getName());
       }
       try {
         clazz.getDeclaredMethod("hashCode");
-      } catch (
-          @SuppressWarnings("unused")
-          Exception e) {
+      } catch (Exception _) {
         fail("Shape needs to define 'hashCode' : " + clazz.getName());
       }
     }

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/ShapeRectRelationTestCase.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/ShapeRectRelationTestCase.java
@@ -141,9 +141,7 @@ public abstract class ShapeRectRelationTestCase extends RandomizedShapeTestCase 
           }
           try {
             return builder.build();
-          } catch (
-              @SuppressWarnings("unused")
-              IllegalArgumentException e) {
+          } catch (IllegalArgumentException _) {
             // This is what happens when we create a shape that is invalid.  Although it is
             // conceivable that there are cases where
             // the exception is thrown incorrectly, we aren't going to be able to do that in this
@@ -186,9 +184,7 @@ public abstract class ShapeRectRelationTestCase extends RandomizedShapeTestCase 
           builder.buffer(width);
           try {
             return builder.build();
-          } catch (
-              @SuppressWarnings("unused")
-              IllegalArgumentException e) {
+          } catch (IllegalArgumentException _) {
             // This is what happens when we create a shape that is invalid.  Although it is
             // conceivable that there are cases where
             // the exception is thrown incorrectly, we aren't going to be able to do that in this

--- a/lucene/spatial-test-fixtures/src/java/org/apache/lucene/spatial3d/tests/RandomGeo3dShapeGenerator.java
+++ b/lucene/spatial-test-fixtures/src/java/org/apache/lucene/spatial3d/tests/RandomGeo3dShapeGenerator.java
@@ -357,9 +357,7 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return pointShape;
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException e) {
+      } catch (IllegalArgumentException _) {
         continue;
       }
     }
@@ -392,9 +390,7 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return circle;
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException e) {
+      } catch (IllegalArgumentException _) {
         continue;
       }
     }
@@ -428,9 +424,7 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return circle;
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException e) {
+      } catch (IllegalArgumentException _) {
         continue;
       }
     }
@@ -470,9 +464,7 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return bbox;
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException e) {
+      } catch (IllegalArgumentException _) {
         continue;
       }
     }
@@ -504,9 +496,7 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return path;
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException e) {
+      } catch (IllegalArgumentException _) {
         continue;
       }
     }
@@ -539,9 +529,7 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return path;
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException e) {
+      } catch (IllegalArgumentException _) {
         continue;
       }
     }
@@ -601,9 +589,7 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return polygon;
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException e) {
+      } catch (IllegalArgumentException _) {
         continue;
       }
     }
@@ -660,9 +646,7 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return polygon;
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException e) {
+      } catch (IllegalArgumentException _) {
         continue;
       }
     }
@@ -712,9 +696,7 @@ public final class RandomGeo3dShapeGenerator {
           return holes;
         }
         pointConstraints.put(hole, GeoArea.DISJOINT);
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException e) {
+      } catch (IllegalArgumentException _) {
         continue;
       }
     }
@@ -747,9 +729,7 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return polygon;
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException e) {
+      } catch (IllegalArgumentException _) {
         continue;
       }
     }
@@ -806,9 +786,7 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return polygon;
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException e) {
+      } catch (IllegalArgumentException _) {
         continue;
       }
     }
@@ -844,9 +822,7 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return polygon;
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException e) {
+      } catch (IllegalArgumentException _) {
         continue;
       }
     }
@@ -877,9 +853,7 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return polygon;
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException e) {
+      } catch (IllegalArgumentException _) {
         continue;
       }
     }
@@ -911,9 +885,7 @@ public final class RandomGeo3dShapeGenerator {
           continue;
         }
         return polygon;
-      } catch (
-          @SuppressWarnings("unused")
-          IllegalArgumentException e) {
+      } catch (IllegalArgumentException _) {
         continue;
       }
     }

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/FileDictionary.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/FileDictionary.java
@@ -208,9 +208,7 @@ public class FileDictionary implements Dictionary {
       // keep reading floats for bw compat
       try {
         curWeight = Long.parseLong(weight);
-      } catch (
-          @SuppressWarnings("unused")
-          NumberFormatException e) {
+      } catch (NumberFormatException _) {
         curWeight = (long) Double.parseDouble(weight);
       }
     }

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionQuery.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionQuery.java
@@ -93,9 +93,7 @@ public abstract class CompletionQuery extends Query {
         if ((terms = leafReader.terms(getField())) == null) {
           continue;
         }
-      } catch (
-          @SuppressWarnings("unused")
-          IOException e) {
+      } catch (IOException _) {
         continue;
       }
       if (terms instanceof CompletionTerms completionTerms) {

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/SuggestIndexSearcher.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/SuggestIndexSearcher.java
@@ -74,9 +74,7 @@ public class SuggestIndexSearcher extends IndexSearcher {
           leafCollector = collector.getLeafCollector(context);
           scorer.score(
               leafCollector, context.reader().getLiveDocs(), 0, DocIdSetIterator.NO_MORE_DOCS);
-        } catch (
-            @SuppressWarnings("unused")
-            CollectionTerminatedException e) {
+        } catch (CollectionTerminatedException _) {
           // collection was terminated prematurely
           // continue with the following leaf
         }

--- a/lucene/suggest/src/test/org/apache/lucene/search/spell/TestSpellChecker.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/spell/TestSpellChecker.java
@@ -531,9 +531,7 @@ public class TestSpellChecker extends LuceneTestCase {
         while (true) {
           try {
             checkCommonSuggestions(reader);
-          } catch (
-              @SuppressWarnings("unused")
-              AlreadyClosedException e) {
+          } catch (AlreadyClosedException _) {
 
             return;
           } catch (Throwable e) {

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/TestLookupBenchmark.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/TestLookupBenchmark.java
@@ -150,7 +150,7 @@ public class TestLookupBenchmark extends LuceneTestCase {
     } else {
       try {
         lookup = cls.getConstructor().newInstance();
-      } catch (@SuppressWarnings("unused") InstantiationException | NoSuchMethodException e) {
+      } catch (InstantiationException | NoSuchMethodException _) {
         Analyzer a = new MockAnalyzer(random, MockTokenizer.KEYWORD, false);
         if (cls == AnalyzingInfixSuggester.class || cls == BlendedInfixSuggester.class) {
           Constructor<? extends Lookup> ctor = cls.getConstructor(Directory.class, Analyzer.class);


### PR DESCRIPTION
### Description
I noticed quite a few occurrences of @SuppressWarnings("unused") which can be replaced with unnamed variable for 11.0. Getting this done across few PRs to not make any individual PR too big. Related to https://github.com/apache/lucene/pull/15102, https://github.com/apache/lucene/pull/15105, https://github.com/apache/lucene/pull/15109

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
