### PR TITLE
Rewrite of the GroupVInt optimization without lambdas, varhandles and no code in subclasses

### DIFF
--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/GroupVIntBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/GroupVIntBenchmark.java
@@ -25,7 +25,6 @@ import org.apache.lucene.store.ByteArrayDataInput;
 import org.apache.lucene.store.ByteArrayDataOutput;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.ByteBuffersDirectory;
-import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
@@ -147,16 +146,6 @@ public class GroupVIntBenchmark {
     mmapVIntIn = dir.openInput("vint", IOContext.DEFAULT);
   }
 
-  private void readGroupVIntsBaseline(DataInput in, int[] dst, int limit) throws IOException {
-    int i;
-    for (i = 0; i <= limit - 4; i += 4) {
-      GroupVIntUtil.readGroupVInt$Baseline(in, dst, i);
-    }
-    for (; i < limit; ++i) {
-      dst[i] = in.readVInt();
-    }
-  }
-
   @Setup(Level.Trial)
   public void init() throws Exception {
     Random r = new Random(0);
@@ -195,7 +184,7 @@ public class GroupVIntBenchmark {
   @Benchmark
   public void benchMMapDirectoryInputs_readGroupVIntBaseline(Blackhole bh) throws IOException {
     mmapGVIntIn.seek(0);
-    this.readGroupVIntsBaseline(mmapGVIntIn, values, size);
+    GroupVIntUtil.readGroupVInts$Baseline(mmapGVIntIn, values, size);
     bh.consume(values);
   }
 
@@ -225,7 +214,7 @@ public class GroupVIntBenchmark {
   @Benchmark
   public void benchNIOFSDirectoryInputs_readGroupVIntBaseline(Blackhole bh) throws IOException {
     nioGVIntIn.seek(0);
-    this.readGroupVIntsBaseline(nioGVIntIn, values, size);
+    GroupVIntUtil.readGroupVInts$Baseline(nioGVIntIn, values, size);
     bh.consume(values);
   }
 
@@ -239,7 +228,7 @@ public class GroupVIntBenchmark {
   @Benchmark
   public void benchByteBuffersIndexInput_readGroupVIntBaseline(Blackhole bh) throws IOException {
     byteBuffersGVIntIn.seek(0);
-    this.readGroupVIntsBaseline(byteBuffersGVIntIn, values, size);
+    GroupVIntUtil.readGroupVInts$Baseline(byteBuffersGVIntIn, values, size);
     bh.consume(values);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/BufferedIndexInput.java
@@ -20,7 +20,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import org.apache.lucene.util.GroupVIntUtil;
 
 /** Base implementation class for buffered {@link IndexInput}. */
 public abstract class BufferedIndexInput extends IndexInput implements RandomAccessInput {
@@ -147,16 +146,6 @@ public abstract class BufferedIndexInput extends IndexInput implements RandomAcc
       return buffer.getInt();
     } else {
       return super.readInt();
-    }
-  }
-
-  @Override
-  public void readGroupVInt(int[] dst, int offset) throws IOException {
-    final int len =
-        GroupVIntUtil.readGroupVInt(
-            this, buffer.remaining(), p -> buffer.getInt((int) p), buffer.position(), dst, offset);
-    if (len > 0) {
-      buffer.position(buffer.position() + len);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 import org.apache.lucene.util.Accountable;
-import org.apache.lucene.util.GroupVIntUtil;
 import org.apache.lucene.util.RamUsageEstimator;
 
 /**
@@ -201,25 +200,6 @@ public final class ByteBuffersDataInput extends DataInput
     } else {
       return super.readLong();
     }
-  }
-
-  @Override
-  public void readGroupVInt(int[] dst, int offset) throws IOException {
-    final ByteBuffer block = blocks[blockIndex(pos)];
-    final int blockOffset = blockOffset(pos);
-    // We MUST save the return value to local variable, could not use pos += readGroupVInt(...).
-    // because `pos +=` in java will move current value(not address) of pos to register first,
-    // then call the function, but we will update pos value in function via readByte(), then
-    // `pos +=` will use an old pos value plus return value, thereby missing 1 byte.
-    final int len =
-        GroupVIntUtil.readGroupVInt(
-            this,
-            block.limit() - blockOffset,
-            p -> block.getInt((int) p),
-            blockOffset,
-            dst,
-            offset);
-    pos += len;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersIndexInput.java
@@ -206,12 +206,6 @@ public final class ByteBuffersIndexInput extends IndexInput implements RandomAcc
   }
 
   @Override
-  public void readGroupVInt(int[] dst, int offset) throws IOException {
-    ensureOpen();
-    in.readGroupVInt(dst, offset);
-  }
-
-  @Override
   public IndexInput clone() {
     ensureOpen();
     ByteBuffersIndexInput cloned =

--- a/lucene/core/src/java/org/apache/lucene/store/DataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/DataInput.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import org.apache.lucene.util.BitUtil;
-import org.apache.lucene.util.GroupVIntUtil;
 
 /**
  * Abstract base class for performing read operations of Lucene's low-level data types.
@@ -97,16 +96,6 @@ public abstract class DataInput implements Cloneable {
     final byte b3 = readByte();
     final byte b4 = readByte();
     return ((b4 & 0xFF) << 24) | ((b3 & 0xFF) << 16) | ((b2 & 0xFF) << 8) | (b1 & 0xFF);
-  }
-
-  /**
-   * Override if you have an efficient implementation. In general this is when the input supports
-   * random access.
-   *
-   * @lucene.experimental
-   */
-  public void readGroupVInt(int[] dst, int offset) throws IOException {
-    GroupVIntUtil.readGroupVInt(this, dst, offset);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -31,7 +31,6 @@ import java.util.function.Function;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.Constants;
-import org.apache.lucene.util.GroupVIntUtil;
 import org.apache.lucene.util.IOConsumer;
 
 /**
@@ -424,23 +423,6 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
       return segments[si].get(LAYOUT_BYTE, pos & chunkSizeMask);
     } catch (IndexOutOfBoundsException _) {
       throw handlePositionalIOOBE("read", pos);
-    } catch (NullPointerException | IllegalStateException e) {
-      throw alreadyClosed(e);
-    }
-  }
-
-  @Override
-  public void readGroupVInt(int[] dst, int offset) throws IOException {
-    try {
-      final int len =
-          GroupVIntUtil.readGroupVInt(
-              this,
-              curSegment.byteSize() - curPosition,
-              p -> curSegment.get(LAYOUT_LE_INT, p),
-              curPosition,
-              dst,
-              offset);
-      curPosition += len;
     } catch (NullPointerException | IllegalStateException e) {
       throw alreadyClosed(e);
     }

--- a/lucene/core/src/java/org/apache/lucene/util/GroupVIntUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/GroupVIntUtil.java
@@ -19,6 +19,8 @@ package org.apache.lucene.util;
 import java.io.IOException;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
 
 /**
  * This class contains utility methods and constants for group varint
@@ -41,7 +43,7 @@ public final class GroupVIntUtil {
   public static void readGroupVInts(DataInput in, int[] dst, int limit) throws IOException {
     int i;
     for (i = 0; i <= limit - 4; i += 4) {
-      in.readGroupVInt(dst, i);
+      readGroupVInt(in, dst, i);
     }
     for (; i < limit; ++i) {
       dst[i] = in.readVInt();
@@ -57,6 +59,17 @@ public final class GroupVIntUtil {
    * @param offset the offset in the array to start storing ints.
    */
   public static void readGroupVInt(DataInput in, int[] dst, int offset) throws IOException {
+    readGroupVInt(true, in, dst, offset);
+  }
+
+  /** DO not use! Only visible for benchmarking purposes! */
+  public static void readGroupVInt$Baseline(DataInput in, int[] dst, int offset)
+      throws IOException {
+    readGroupVInt(false, in, dst, offset);
+  }
+
+  private static void readGroupVInt(boolean optimized, DataInput in, int[] dst, int offset)
+      throws IOException {
     final int flag = in.readByte() & 0xFF;
 
     final int n1Minus1 = flag >> 6;
@@ -64,6 +77,26 @@ public final class GroupVIntUtil {
     final int n3Minus1 = (flag >> 2) & 0x03;
     final int n4Minus1 = flag & 0x03;
 
+    // if our DataInput implements RandomAccessInput for absolute access and IndexInput for seeking,
+    // we use a branch-less implementation:
+    if (optimized && in instanceof RandomAccessInput rin && in instanceof IndexInput iin) {
+      long pos = iin.getFilePointer();
+      if (iin.length() - pos >= MAX_LENGTH_PER_GROUP) {
+        dst[offset] = rin.readInt(pos) & INT_MASKS[n1Minus1];
+        pos += 1 + n1Minus1;
+        dst[offset + 1] = rin.readInt(pos) & INT_MASKS[n2Minus1];
+        pos += 1 + n2Minus1;
+        dst[offset + 2] = rin.readInt(pos) & INT_MASKS[n3Minus1];
+        pos += 1 + n3Minus1;
+        dst[offset + 3] = rin.readInt(pos) & INT_MASKS[n4Minus1];
+        pos += 1 + n4Minus1;
+
+        iin.seek(pos);
+        return;
+      }
+    }
+
+    // fall-through: default impl
     dst[offset] = readIntInGroup(in, n1Minus1);
     dst[offset + 1] = readIntInGroup(in, n2Minus1);
     dst[offset + 2] = readIntInGroup(in, n3Minus1);
@@ -81,55 +114,6 @@ public final class GroupVIntUtil {
       default:
         return in.readInt();
     }
-  }
-
-  /**
-   * Provides an abstraction for read int values, so that decoding logic can be reused in different
-   * DataInput.
-   */
-  @FunctionalInterface
-  public static interface IntReader {
-    int read(long v);
-  }
-
-  /**
-   * Faster implementation of read single group, It read values from the buffer that would not cross
-   * boundaries.
-   *
-   * @param in the input to use to read data.
-   * @param remaining the number of remaining bytes allowed to read for current block/segment.
-   * @param reader the supplier of read int.
-   * @param pos the start pos to read from the reader.
-   * @param dst the array to read ints into.
-   * @param offset the offset in the array to start storing ints.
-   * @return the number of bytes read excluding the flag. this indicates the number of positions
-   *     should to be increased for caller, it is 0 or positive number and less than {@link
-   *     #MAX_LENGTH_PER_GROUP}
-   */
-  public static int readGroupVInt(
-      DataInput in, long remaining, IntReader reader, long pos, int[] dst, int offset)
-      throws IOException {
-    if (remaining < MAX_LENGTH_PER_GROUP) {
-      readGroupVInt(in, dst, offset);
-      return 0;
-    }
-    final int flag = in.readByte() & 0xFF;
-    final long posStart = ++pos; // exclude the flag bytes, the position has updated via readByte().
-    final int n1Minus1 = flag >> 6;
-    final int n2Minus1 = (flag >> 4) & 0x03;
-    final int n3Minus1 = (flag >> 2) & 0x03;
-    final int n4Minus1 = flag & 0x03;
-
-    // This code path has fewer conditionals and tends to be significantly faster in benchmarks
-    dst[offset] = reader.read(pos) & INT_MASKS[n1Minus1];
-    pos += 1 + n1Minus1;
-    dst[offset + 1] = reader.read(pos) & INT_MASKS[n2Minus1];
-    pos += 1 + n2Minus1;
-    dst[offset + 2] = reader.read(pos) & INT_MASKS[n3Minus1];
-    pos += 1 + n3Minus1;
-    dst[offset + 3] = reader.read(pos) & INT_MASKS[n4Minus1];
-    pos += 1 + n4Minus1;
-    return (int) (pos - posStart);
   }
 
   private static int numBytes(int v) {

--- a/lucene/core/src/java/org/apache/lucene/util/GroupVIntUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/GroupVIntUtil.java
@@ -70,7 +70,7 @@ public final class GroupVIntUtil {
     // we use a branch-less implementation:
     if (in instanceof RandomAccessInput rin && in instanceof IndexInput iin) {
       long pos = iin.getFilePointer();
-      if (iin.length() - pos >= MAX_LENGTH_PER_GROUP - 1) {
+      if (iin.length() - pos >= 4 * Integer.BYTES) {
         dst[offset] = rin.readInt(pos) & INT_MASKS[n1Minus1];
         pos += 1 + n1Minus1;
         dst[offset + 1] = rin.readInt(pos) & INT_MASKS[n2Minus1];


### PR DESCRIPTION
Hi,
this is a rewrite of the GroupVInt optimization. The results are great for MMapDirectory (more than twice as fast than the baseline implementation. The code has no risk of varhandles or lambda optimization and no callsite pollution issue, because it basically requires no optimized implementation in subclasses.

The idea is the following: Basically for GroupVIntReading in the branchless optimization we need random access to the IndexInput. The workaround in the currently existing code is to have a lambda or VarHandle to do random access as a callback.

But actually we have the correct interface available out of box: `RandomAcessInput`.

I simply changed the `GroupVIntUtil.readGroupVInt()` method to check if the `DataInput` passed in also implements `RandomAccessInput` and allows seeking (`IndexInput`). If theres enough free space till end of file _and_ it implements both interfaces the optimized impl is used:
- it casts the DataInput to RandomAccessInput for random access
- it casts the DataInput to IndexInput to get access to filesize and file pointer and seeking to cleanup position after read.

If any condition does not apply it falls back to the sequential impl with branches.

The good thing with this patch;
- No need to implement anything in custom IndexInputs.
- Out of box huge speedup without any custom impl in IndexInput if it implements random access

Small downsides:
- NIOFSDir no longer has the optimization (I don't care) because its IndexInput does not support random access. You see this in the benchmark - same numbers!
- ByteBuffersDirectory implement RandomAccess, but the code of ByteBuffersIndexInput has too many bounds checks in the positional accesses. IMHO, we should for now ignore that and rewrite ByteBuffersDirectory in main branch to reuse MemorySegmentIndexInput and the try/catch logic. This allows us also to have off-heap directory with easy release of memory (the current ByteBuffersDirectory has the downside that offheap needs GC to clean up offheap memeory as we cannot free it explicit. So when we reimplement ByteBuffersDirectory using the same code like MemorySegmentIndexInput just with MemorySegments from on-heap or shared off heap arenas we have the great performance of MMapDir also for NRTCcachingDirectory - I will open a PR for main branch to get this as a new Directoryimpl into core.

Now the numbers:
```
# JMH version: 1.37
# VM version: JDK 24, OpenJDK 64-Bit Server VM, 24+36-3646
# VM invoker: C:\Program Files\Java\jdk-24\bin\java.exe
# VM options: --add-modules=jdk.unsupported
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 3 iterations, 5 s each
# Measurement: 5 iterations, 20 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Throughput, ops/time
# Parameters: (size = 64)

Benchmark                                                            (size)   Mode  Cnt  Score   Error   Units
GroupVIntBenchmark.benchByteArrayDataInput_readGroupVInt                 64  thrpt    5  2,154 ± 0,356  ops/us
GroupVIntBenchmark.benchByteArrayDataInput_readVInt                      64  thrpt    5  1,943 ± 0,170  ops/us
GroupVIntBenchmark.benchByteBuffersIndexInput_readGroupVInt              64  thrpt    5  0,612 ± 0,024  ops/us
GroupVIntBenchmark.benchByteBuffersIndexInput_readGroupVIntBaseline      64  thrpt    5  0,763 ± 0,044  ops/us
GroupVIntBenchmark.benchMMapDirectoryInputs_readGroupVInt                64  thrpt    5  4,983 ± 0,362  ops/us
GroupVIntBenchmark.benchMMapDirectoryInputs_readGroupVIntBaseline        64  thrpt    5  1,993 ± 0,455  ops/us
GroupVIntBenchmark.benchMMapDirectoryInputs_readVInt                     64  thrpt    5  2,544 ± 0,115  ops/us
GroupVIntBenchmark.benchNIOFSDirectoryInputs_readGroupVInt               64  thrpt    5  2,461 ± 0,317  ops/us
GroupVIntBenchmark.benchNIOFSDirectoryInputs_readGroupVIntBaseline       64  thrpt    5  2,027 ± 0,422  ops/us
GroupVIntBenchmark.bench_writeGroupVInt                                  64  thrpt    5  1,347 ± 0,138  ops/us
```

Some final TODOs: 
- DataInput is now free of any GroupVint specialization or method siganures. When backporting to 10.x we must keep the old methods as noop for people who have subclassed and implemented (OpenSearch does this for their encryption directory).
- DataOutput still has write methods for both GroupVInt variants (long/int). We should reallay really remove that and implement it only in GroupVIntUtil!