### PR TITLE
Fix incorrect attribute comment in StandardTokenizer

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/analysis/standard/StandardTokenizer.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/standard/StandardTokenizer.java
@@ -135,8 +135,8 @@ public final class StandardTokenizer extends Tokenizer {
     this.scanner = new StandardTokenizerImpl(input);
   }
 
-  // this tokenizer generates three attributes:
-  // term offset, positionIncrement and type
+  // this tokenizer generates four attributes:
+  // term, offset, positionIncrement and type
   private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
   private final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
   private final PositionIncrementAttribute posIncrAtt =


### PR DESCRIPTION
This PR updates the comment in StandardTokenizer to accurately count all of the four attributes it generates: CharTermAttribute, OffsetAttribute, PositionIncrementAttribute, and TypeAttribute.