### PR TITLE
DataInput: Unroll loop in readVInt and readVLong

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -112,6 +112,8 @@ Other
 
 API Changes
 ---------------------
+* GITHUB:#15122: DataInput: Unroll loop in readVInt and readVLong. (Ramakrishna Chilaka)
+
 * GITHUB#14401: Added LeafCollector#collectRange to enable collector to take
   advantage of pre-aggregated data to speed up faceting. (Adrien Grand)
 


### PR DESCRIPTION
### Description

After reviewing the PR: https://github.com/apache/lucene/pull/15065, I considered further improving it by unrolling the for loop.

This PR optimizes the performance of VInt and GroupVInt benchmarks by unrolling loops.

#### Baseline:
```
Benchmark                                                            (size)   Mode  Cnt   Score   Error   Units
GroupVIntBenchmark.benchByteArrayDataInput_readGroupVInt                 64  thrpt    5   9.922 ± 0.079  ops/us
GroupVIntBenchmark.benchByteArrayDataInput_readVInt                      64  thrpt    5  13.411 ± 0.047  ops/us
GroupVIntBenchmark.benchByteBuffersIndexInput_readGroupVInt              64  thrpt    5   6.122 ± 0.007  ops/us
GroupVIntBenchmark.benchByteBuffersIndexInput_readGroupVIntBaseline      64  thrpt    5   3.300 ± 0.082  ops/us
GroupVIntBenchmark.benchMMapDirectoryInputs_readGroupVInt                64  thrpt    5  14.618 ± 0.011  ops/us
GroupVIntBenchmark.benchMMapDirectoryInputs_readGroupVIntBaseline        64  thrpt    5  11.376 ± 0.369  ops/us
GroupVIntBenchmark.benchMMapDirectoryInputs_readVInt                     64  thrpt    5  13.678 ± 0.044  ops/us
GroupVIntBenchmark.benchNIOFSDirectoryInputs_readGroupVInt               64  thrpt    5  11.356 ± 0.016  ops/us
GroupVIntBenchmark.benchNIOFSDirectoryInputs_readGroupVIntBaseline       64  thrpt    5   8.437 ± 0.039  ops/us
GroupVIntBenchmark.bench_writeGroupVInt                                  64  thrpt    5   5.745 ± 0.208  ops/us
VIntBenchmark.benchByteArrayDataInput_readVInt                           64  thrpt    5  12.726 ± 0.301  ops/us
VIntBenchmark.benchByteArrayDataInput_readVLong                          64  thrpt    5   7.748 ± 0.181  ops/us
VIntBenchmark.benchMMapDirectoryInputs_readVInt                          64  thrpt    5  13.689 ± 0.008  ops/us
VIntBenchmark.benchMMapDirectoryInputs_readVLong                         64  thrpt    5   6.655 ± 0.031  ops/us
```

#### Contender
```
Benchmark                                                            (size)   Mode  Cnt   Score   Error   Units
GroupVIntBenchmark.benchByteArrayDataInput_readGroupVInt                 64  thrpt    5   9.963 ± 0.371  ops/us
GroupVIntBenchmark.benchByteArrayDataInput_readVInt                      64  thrpt    5  19.952 ± 0.538  ops/us
GroupVIntBenchmark.benchByteBuffersIndexInput_readGroupVInt              64  thrpt    5   6.128 ± 0.014  ops/us
GroupVIntBenchmark.benchByteBuffersIndexInput_readGroupVIntBaseline      64  thrpt    5   3.288 ± 0.039  ops/us
GroupVIntBenchmark.benchMMapDirectoryInputs_readGroupVInt                64  thrpt    5  14.596 ± 0.046  ops/us
GroupVIntBenchmark.benchMMapDirectoryInputs_readGroupVIntBaseline        64  thrpt    5  21.632 ± 0.282  ops/us
GroupVIntBenchmark.benchMMapDirectoryInputs_readVInt                     64  thrpt    5  16.079 ± 0.097  ops/us
GroupVIntBenchmark.benchNIOFSDirectoryInputs_readGroupVInt               64  thrpt    5  11.355 ± 0.026  ops/us
GroupVIntBenchmark.benchNIOFSDirectoryInputs_readGroupVIntBaseline       64  thrpt    5   8.598 ± 0.016  ops/us
GroupVIntBenchmark.bench_writeGroupVInt                                  64  thrpt    5   5.758 ± 0.180  ops/us
VIntBenchmark.benchByteArrayDataInput_readVInt                           64  thrpt    5  19.378 ± 0.038  ops/us
VIntBenchmark.benchByteArrayDataInput_readVLong                          64  thrpt    5  11.414 ± 0.061  ops/us
VIntBenchmark.benchMMapDirectoryInputs_readVInt                          64  thrpt    5  17.928 ± 0.132  ops/us
VIntBenchmark.benchMMapDirectoryInputs_readVLong                         64  thrpt    5  10.053 ± 0.064  ops/us
```

#### Summarising:

| Benchmark                                                           | Baseline Score (ops/us) | Contender Score (ops/us) | Change (%) |
| ------------------------------------------------------------------- | ----------------------- | ------------------------ | ---------- |
| GroupVIntBenchmark.benchByteArrayDataInput\_readGroupVInt           | 9.922                   | 9.963                    | +0.41      |
| GroupVIntBenchmark.benchByteArrayDataInput\_readVInt                | 13.411                  | 19.952                   | +48.78     |
| GroupVIntBenchmark.benchByteBuffersIndexInput\_readGroupVInt        | 6.122                   | 6.128                    | +0.09      |
| GroupVIntBenchmark.benchMMapDirectoryInputs\_readGroupVInt          | 14.618                  | 14.596                   | -0.15      |
| GroupVIntBenchmark.benchMMapDirectoryInputs\_readGroupVIntBaseline  | 11.376                  | 21.632                   | +89.88     |
| GroupVIntBenchmark.benchMMapDirectoryInputs\_readVInt               | 13.678                  | 16.079                   | +17.56     |
| GroupVIntBenchmark.benchNIOFSDirectoryInputs\_readGroupVInt         | 11.356                  | 11.355                   | -0.01      |
| GroupVIntBenchmark.benchNIOFSDirectoryInputs\_readGroupVIntBaseline | 8.437                   | 8.598                    | +1.91      |
| GroupVIntBenchmark.bench\_writeGroupVInt                            | 5.745                   | 5.758                    | +0.23      |
| VIntBenchmark.benchByteArrayDataInput\_readVInt                     | 12.726                  | 19.378                   | +52.27     |
| VIntBenchmark.benchByteArrayDataInput\_readVLong                    | 7.748                   | 11.414                   | +47.32     |
| VIntBenchmark.benchMMapDirectoryInputs\_readVInt                    | 13.689                  | 17.928                   | +30.97     |
| VIntBenchmark.benchMMapDirectoryInputs\_readVLong                   | 6.655                   | 10.053                   | +51.06     |
