### PR TITLE
Early exit while computing globalMin/Max using skipper

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
@@ -139,9 +139,8 @@ public abstract class DocValuesSkipper {
       }
       DocValuesSkipper skipper = ctx.reader().getDocValuesSkipper(field);
       if (skipper == null) {
-        return Long
-            .MIN_VALUE; // minimum cannot be computed correctly since skipper is not enabled for
-        // some leaf
+        // minimum cannot be computed correctly since skipper is not enabled for some leaf
+        return Long.MIN_VALUE;
       } else {
         minValue = Math.min(minValue, skipper.minValue());
       }
@@ -164,9 +163,8 @@ public abstract class DocValuesSkipper {
       }
       DocValuesSkipper skipper = ctx.reader().getDocValuesSkipper(field);
       if (skipper == null) {
-        return Long
-            .MAX_VALUE; // maximum cannot be computed correctly since skipper is not enabled for
-        // some leaf
+        // maximum cannot be computed correctly since skipper is not enabled for some leaf
+        return Long.MAX_VALUE;
       } else {
         maxValue = Math.max(maxValue, skipper.maxValue());
       }

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
@@ -141,7 +141,7 @@ public abstract class DocValuesSkipper {
       if (skipper == null) {
         return Long
             .MIN_VALUE; // minimum cannot be computed correctly since skipper is not enabled for
-                        // some leaf
+        // some leaf
       } else {
         minValue = Math.min(minValue, skipper.minValue());
       }
@@ -166,7 +166,7 @@ public abstract class DocValuesSkipper {
       if (skipper == null) {
         return Long
             .MAX_VALUE; // maximum cannot be computed correctly since skipper is not enabled for
-                        // some leaf
+        // some leaf
       } else {
         maxValue = Math.max(maxValue, skipper.maxValue());
       }

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
@@ -139,7 +139,7 @@ public abstract class DocValuesSkipper {
       }
       DocValuesSkipper skipper = ctx.reader().getDocValuesSkipper(field);
       if (skipper == null) {
-        minValue = Long.MIN_VALUE;
+        return Long.MIN_VALUE; // minimum cannot be computed correctly since skipper is not enabled for some leaf
       } else {
         minValue = Math.min(minValue, skipper.minValue());
       }
@@ -162,7 +162,7 @@ public abstract class DocValuesSkipper {
       }
       DocValuesSkipper skipper = ctx.reader().getDocValuesSkipper(field);
       if (skipper == null) {
-        maxValue = Long.MAX_VALUE;
+        return Long.MAX_VALUE; // maximum cannot be computed correctly since skipper is not enabled for some leaf
       } else {
         maxValue = Math.max(maxValue, skipper.maxValue());
       }

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
@@ -139,7 +139,9 @@ public abstract class DocValuesSkipper {
       }
       DocValuesSkipper skipper = ctx.reader().getDocValuesSkipper(field);
       if (skipper == null) {
-        return Long.MIN_VALUE; // minimum cannot be computed correctly since skipper is not enabled for some leaf
+        return Long
+            .MIN_VALUE; // minimum cannot be computed correctly since skipper is not enabled for
+                        // some leaf
       } else {
         minValue = Math.min(minValue, skipper.minValue());
       }
@@ -162,7 +164,9 @@ public abstract class DocValuesSkipper {
       }
       DocValuesSkipper skipper = ctx.reader().getDocValuesSkipper(field);
       if (skipper == null) {
-        return Long.MAX_VALUE; // maximum cannot be computed correctly since skipper is not enabled for some leaf
+        return Long
+            .MAX_VALUE; // maximum cannot be computed correctly since skipper is not enabled for
+                        // some leaf
       } else {
         maxValue = Math.max(maxValue, skipper.maxValue());
       }


### PR DESCRIPTION
### Description
Skipper should exit early while computing globalMin/Max if it is not for some of the leaves as min/max cannot be computed correctly using skipper

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
