### PR TITLE
Restrict visibility of `TieredMergePolicy.score()`

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -31,7 +31,7 @@ API Changes
 
 * GITHUB#14844: Change IndexInput.updateReadAdvice to take an IOContext instead (Simon Cooper)
 
-* GITHUB#15131: Expose SegmentSizeAndDocs and MergeScore in TieredMergePolicy API (Trevor McCulloch)
+* GITHUB#15131: Restrict visibility of TieredMergePolicy.score() API (Trevor McCulloch)
 
 New Features
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -31,6 +31,8 @@ API Changes
 
 * GITHUB#14844: Change IndexInput.updateReadAdvice to take an IOContext instead (Simon Cooper)
 
+* GITHUB#15131: Expose SegmentSizeAndDocs and MergeScore in TieredMergePolicy API (Trevor McCulloch)
+
 New Features
 ---------------------
 * GITHUB#14097: Binary partitioning merge policy over float-valued vector field. (Mike Sokolov)

--- a/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
@@ -272,7 +272,7 @@ public class TieredMergePolicy extends MergePolicy {
    * @param maxDoc maxDoc in this segment
    * @param name name of the segment
    */
-  protected record SegmentSizeAndDocs(
+  record SegmentSizeAndDocs(
       SegmentCommitInfo segInfo, long sizeInBytes, int delCount, int maxDoc, String name) {
     /** Creates a new SegmentSizeAndDocs from an info, the byte size and deleted doc count */
     public SegmentSizeAndDocs(

--- a/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
@@ -287,10 +287,10 @@ public class TieredMergePolicy extends MergePolicy {
     protected MergeScore() {}
 
     /** Returns the score for this merge candidate; lower scores are better. */
-    abstract double getScore();
+    protected abstract double getScore();
 
     /** Human readable explanation of how the merge got this score. */
-    abstract String getExplanation();
+    protected abstract String getExplanation();
   }
 
   // The size can change concurrently while we are running here, because deletes

--- a/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
@@ -282,15 +282,15 @@ public class TieredMergePolicy extends MergePolicy {
   }
 
   /** Holds score and explanation for a single candidate merge. */
-  protected abstract static class MergeScore {
+  abstract static class MergeScore {
     /** Sole constructor. (For invocation by subclass constructors, typically implicit.) */
     protected MergeScore() {}
 
     /** Returns the score for this merge candidate; lower scores are better. */
-    protected abstract double getScore();
+    abstract double getScore();
 
     /** Human readable explanation of how the merge got this score. */
-    protected abstract String getExplanation();
+    abstract String getExplanation();
   }
 
   // The size can change concurrently while we are running here, because deletes
@@ -682,8 +682,8 @@ public class TieredMergePolicy extends MergePolicy {
     }
   }
 
-  /** Expert: scores one merge; subclasses can override. */
-  protected MergeScore score(
+  /** Expert: scores one merge */
+  MergeScore score(
       List<SegmentCommitInfo> candidate,
       boolean hitTooLarge,
       Map<SegmentCommitInfo, SegmentSizeAndDocs> segmentsSizes)

--- a/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
@@ -263,21 +263,21 @@ public class TieredMergePolicy extends MergePolicy {
     return targetSearchConcurrency;
   }
 
-  private static class SegmentSizeAndDocs {
-    private final SegmentCommitInfo segInfo;
-    /// Size of the segment in bytes, pro-rated by the number of live documents.
-    private final long sizeInBytes;
-    private final int delCount;
-    private final int maxDoc;
-    private final String name;
-
-    SegmentSizeAndDocs(SegmentCommitInfo info, final long sizeInBytes, final int segDelCount)
-        throws IOException {
-      segInfo = info;
-      this.name = info.info.name;
-      this.sizeInBytes = sizeInBytes;
-      this.delCount = segDelCount;
-      this.maxDoc = info.info.maxDoc();
+  /**
+   * Segment summary -- size and doc count -- for use when selecting merges.
+   *
+   * @param segInfo segment this wraps
+   * @param sizeInBytes size of all segment files in bytes
+   * @param delCount number of deleted documents in this segment
+   * @param maxDoc maxDoc in this segment
+   * @param name name of the segment
+   */
+  protected record SegmentSizeAndDocs(
+      SegmentCommitInfo segInfo, long sizeInBytes, int delCount, int maxDoc, String name) {
+    /** Creates a new SegmentSizeAndDocs from an info, the byte size and deleted doc count */
+    public SegmentSizeAndDocs(
+        SegmentCommitInfo info, final long sizeInBytes, final int segDelCount) {
+      this(info, sizeInBytes, segDelCount, info.info.maxDoc(), info.info.name);
     }
   }
 


### PR DESCRIPTION
This method uses both `MergeScore` and `SegmentSizeAndDocs` but neither of these are visible enough to
provide a meaningful custom implementation of `score()`. Given that no one has complained that is broken,
restrict visibility of this method and `MergeScore` instead.