### PR TITLE
early exit in SortedNumericDocValuesRangeQuery & SortedSetDocValuesRangeQuery

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -237,6 +237,9 @@ final class SortedNumericDocValuesRangeQuery extends Query {
       return null;
     }
 
+    if (skipper.maxValue() < lowerValue || skipper.minValue() > upperValue) {
+      return DocIdSetIterator.empty();
+    }
     final int minDocID;
     final int maxDocID;
     if (indexSort.getSort()[0].getReverse()) {

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
@@ -252,6 +252,10 @@ final class SortedSetDocValuesRangeQuery extends Query {
       return null;
     }
 
+    if (skipper.maxValue() < minOrd || skipper.minValue() > maxOrd) {
+      return DocIdSetIterator.empty();
+    }
+
     final int minDocID;
     final int maxDocID;
     if (indexSort.getSort()[0].getReverse()) {


### PR DESCRIPTION
Skipping segments if segment's min and max are out of range of the query