### PR TITLE
feat: implement asBulkSimScorer on FeatureFields's SimScorers

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -270,6 +270,9 @@ Optimizations
 
 * GITHUB#15045: Use FixedBitSet#cardinality for counting liveDocs in CheckIndex (Zhang Chao)
 
+* GITHUB#15117: Score computations are now more reliably vectorized in FeatureField Scorer's
+  (Aditya Teltia)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14823: Decrease TieredMergePolicy's default number of segments per


### PR DESCRIPTION
Closes #15117

This change implements `asBulkSimScorer()` for FeatureField's SimScorers,
similar to the optimization added for BM25SimScorer.

The patch also includes:
- Unit tests verifying bulk scoring produces identical results to
  per-document scoring across randomized inputs.
- Refactoring to keep code consistent with BM25SimScorer’s bulk
  implementation style.

This optimization should provide measurable speedups in scenarios where
FeatureField scoring is applied to large batches of documents.