### PR TITLE
Adding 3-ary LongHeap to speed up collectors like TopDoc*Collectors

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -122,7 +122,7 @@ Improvements
 
 Optimizations
 ---------------------
-(No changes)
+* GITHUB#15140: Optimize TopScoreDocCollector with TernaryLongHeap for improved performance over Binary-LongHeap. (Ramakrishna Chilaka)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
@@ -18,7 +18,7 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.util.LongHeap;
+import org.apache.lucene.util.TernaryLongHeap;
 
 /**
  * A {@link Collector} implementation that collects the top-scoring hits, returning them as a {@link
@@ -33,7 +33,7 @@ import org.apache.lucene.util.LongHeap;
 public class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
 
   private final ScoreDoc after;
-  private final LongHeap heap;
+  private final TernaryLongHeap heap;
   final int totalHitsThreshold;
   final MaxScoreAccumulator minScoreAcc;
 
@@ -41,7 +41,7 @@ public class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
   TopScoreDocCollector(
       int numHits, ScoreDoc after, int totalHitsThreshold, MaxScoreAccumulator minScoreAcc) {
     super(null);
-    this.heap = new LongHeap(numHits, DocScoreEncoder.LEAST_COMPETITIVE_CODE);
+    this.heap = new TernaryLongHeap(numHits, DocScoreEncoder.LEAST_COMPETITIVE_CODE);
     this.after = after;
     this.totalHitsThreshold = totalHitsThreshold;
     this.minScoreAcc = minScoreAcc;

--- a/lucene/core/src/java/org/apache/lucene/util/LongHeap.java
+++ b/lucene/core/src/java/org/apache/lucene/util/LongHeap.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
  * A min heap that stores longs; a primitive priority queue that like all priority queues maintains
  * a partial ordering of its elements such that the least element can always be found in constant
  * time. Put()'s and pop()'s require log(size). This heap provides unbounded growth via {@link
- * #push(long)}, and bounded-size insertion based on its nominal maxSize via {@link
+ * #push(long)}, and bounded-size insertion based on its initial capacity via {@link
  * #insertWithOverflow(long)}. The heap is a min heap, meaning that the top element is the lowest
  * value of the heap. LongHeap implements 2-ary heap.
  *
@@ -30,7 +30,7 @@ import java.util.Arrays;
  */
 public final class LongHeap {
 
-  private final int maxSize;
+  private final int initialCapacity;
 
   private long[] heap;
   private int size = 0;
@@ -50,19 +50,21 @@ public final class LongHeap {
   /**
    * Create an empty priority queue of the configured initial size.
    *
-   * @param maxSize the maximum size of the heap, or if negative, the initial size of an unbounded
-   *     heap
+   * @param initialCapacity the initial capacity of the heap
    */
-  public LongHeap(int maxSize) {
+  public LongHeap(int initialCapacity) {
     final int heapSize;
-    if (maxSize < 1 || maxSize >= ArrayUtil.MAX_ARRAY_LENGTH) {
+    if (initialCapacity < 1 || initialCapacity >= ArrayUtil.MAX_ARRAY_LENGTH) {
       // Throw exception to prevent confusing OOME:
       throw new IllegalArgumentException(
-          "maxSize must be > 0 and < " + (ArrayUtil.MAX_ARRAY_LENGTH - 1) + "; got: " + maxSize);
+          "initialCapacity must be > 0 and < "
+              + (ArrayUtil.MAX_ARRAY_LENGTH - 1)
+              + "; got: "
+              + initialCapacity);
     }
     // NOTE: we add +1 because all access to heap is 1-based not 0-based.  heap[0] is unused.
-    heapSize = maxSize + 1;
-    this.maxSize = maxSize;
+    heapSize = initialCapacity + 1;
+    this.initialCapacity = initialCapacity;
     this.heap = new long[heapSize];
   }
 
@@ -83,13 +85,13 @@ public final class LongHeap {
 
   /**
    * Adds a value to an LongHeap in log(size) time. If the number of values would exceed the heap's
-   * maxSize, the least value is discarded.
+   * initialCapacity, the least value is discarded.
    *
    * @return whether the value was added (unless the heap is full, or the new value is less than the
    *     top value)
    */
   public boolean insertWithOverflow(long value) {
-    if (size >= maxSize) {
+    if (size >= initialCapacity) {
       if (value < heap[1]) {
         return false;
       }

--- a/lucene/core/src/java/org/apache/lucene/util/TernaryLongHeap.java
+++ b/lucene/core/src/java/org/apache/lucene/util/TernaryLongHeap.java
@@ -19,21 +19,22 @@ package org.apache.lucene.util;
 import java.util.Arrays;
 
 /**
- * A min heap that stores longs; a primitive priority queue that like all priority queues maintains
- * a partial ordering of its elements such that the least element can always be found in constant
- * time. Put()'s and pop()'s require log(size). This heap provides unbounded growth via {@link
- * #push(long)}, and bounded-size insertion based on its nominal maxSize via {@link
+ * A ternary min heap that stores longs; a primitive priority queue that like all priority queues
+ * maintains a partial ordering of its elements such that the least element can always be found in
+ * constant time. Put()'s and pop()'s require log_3(size). This heap provides unbounded growth via
+ * {@link #push(long)}, and bounded-size insertion based on its nominal maxSize via {@link
  * #insertWithOverflow(long)}. The heap is a min heap, meaning that the top element is the lowest
- * value of the heap. LongHeap implements 2-ary heap.
+ * value of the heap. TernaryLongHeap implements 3-ary heap.
  *
  * @lucene.internal
  */
-public final class LongHeap {
+public final class TernaryLongHeap {
 
   private final int maxSize;
 
   private long[] heap;
   private int size = 0;
+  private static final int ARITY = 3;
 
   /**
    * Constructs a heap with specified size and initializes all elements with the given value.
@@ -41,8 +42,8 @@ public final class LongHeap {
    * @param size the number of elements to initialize in the heap.
    * @param initialValue the value to fill the heap with.
    */
-  public LongHeap(int size, long initialValue) {
-    this(size);
+  public TernaryLongHeap(int size, long initialValue) {
+    this(size <= 0 ? 1 : size);
     Arrays.fill(heap, 1, size + 1, initialValue);
     this.size = size;
   }
@@ -53,15 +54,14 @@ public final class LongHeap {
    * @param maxSize the maximum size of the heap, or if negative, the initial size of an unbounded
    *     heap
    */
-  public LongHeap(int maxSize) {
-    final int heapSize;
+  public TernaryLongHeap(int maxSize) {
     if (maxSize < 1 || maxSize >= ArrayUtil.MAX_ARRAY_LENGTH) {
       // Throw exception to prevent confusing OOME:
       throw new IllegalArgumentException(
           "maxSize must be > 0 and < " + (ArrayUtil.MAX_ARRAY_LENGTH - 1) + "; got: " + maxSize);
     }
     // NOTE: we add +1 because all access to heap is 1-based not 0-based.  heap[0] is unused.
-    heapSize = maxSize + 1;
+    final int heapSize = maxSize + 1;
     this.maxSize = maxSize;
     this.heap = new long[heapSize];
   }
@@ -77,13 +77,13 @@ public final class LongHeap {
       heap = ArrayUtil.grow(heap, (size * 3 + 1) / 2);
     }
     heap[size] = element;
-    upHeap(size);
+    TernaryLongHeap.upHeap(heap, size, ARITY);
     return heap[1];
   }
 
   /**
-   * Adds a value to an LongHeap in log(size) time. If the number of values would exceed the heap's
-   * maxSize, the least value is discarded.
+   * Adds a value to an TernaryLongHeap in log(size) time. If the number of values would exceed the
+   * heap's maxSize, the least value is discarded.
    *
    * @return whether the value was added (unless the heap is full, or the new value is less than the
    *     top value)
@@ -101,9 +101,9 @@ public final class LongHeap {
   }
 
   /**
-   * Returns the least element of the LongHeap in constant time. It is up to the caller to verify
-   * that the heap is not empty; no checking is done, and if no elements have been added, 0 is
-   * returned.
+   * Returns the least element of the TernaryLongHeap in constant time. It is up to the caller to
+   * verify that the heap is not empty; no checking is done, and if no elements have been added, 0
+   * is returned.
    */
   public long top() {
     return heap[1];
@@ -112,14 +112,14 @@ public final class LongHeap {
   /**
    * Removes and returns the least element of the PriorityQueue in log(size) time.
    *
-   * @throws IllegalStateException if the LongHeap is empty.
+   * @throws IllegalStateException if the TernaryLongHeap is empty.
    */
   public long pop() {
     if (size > 0) {
       long result = heap[1]; // save first value
       heap[1] = heap[size]; // move last to first
       size--;
-      downHeap(1); // adjust heap
+      TernaryLongHeap.downHeap(heap, 1, size, ARITY); // adjust heap
       return result;
     } else {
       throw new IllegalStateException("The heap is empty");
@@ -134,21 +134,21 @@ public final class LongHeap {
    * pq.updateTop(value);
    * </pre>
    *
-   * instead of
+   * <p>instead of
    *
    * <pre class="prettyprint">
    * pq.pop();
    * pq.push(value);
    * </pre>
    *
-   * Calling this method on an empty LongHeap has no visible effect.
+   * <p>Calling this method on an empty TernaryLongHeap has no visible effect.
    *
    * @param value the new element that is less than the current top.
    * @return the new 'top' element after shuffling the heap.
    */
   public long updateTop(long value) {
     heap[1] = value;
-    downHeap(1);
+    TernaryLongHeap.downHeap(heap, 1, size, ARITY);
     return heap[1];
   }
 
@@ -162,38 +162,7 @@ public final class LongHeap {
     size = 0;
   }
 
-  private void upHeap(int origPos) {
-    int i = origPos;
-    long value = heap[i]; // save bottom value
-    int j = i >>> 1;
-    while (j > 0 && value < heap[j]) {
-      heap[i] = heap[j]; // shift parents down
-      i = j;
-      j = j >>> 1;
-    }
-    heap[i] = value; // install saved value
-  }
-
-  private void downHeap(int i) {
-    long value = heap[i]; // save top value
-    int j = i << 1; // find smaller child
-    int k = j + 1;
-    if (k <= size && heap[k] < heap[j]) {
-      j = k;
-    }
-    while (j <= size && heap[j] < value) {
-      heap[i] = heap[j]; // shift up child
-      i = j;
-      j = i << 1;
-      k = j + 1;
-      if (k <= size && heap[k] < heap[j]) {
-        j = k;
-      }
-    }
-    heap[i] = value; // install saved value
-  }
-
-  public void pushAll(LongHeap other) {
+  public void pushAll(TernaryLongHeap other) {
     for (int i = 1; i <= other.size; i++) {
       push(other.heap[i]);
     }
@@ -215,5 +184,64 @@ public final class LongHeap {
   // pkg-private for testing
   long[] getHeapArray() {
     return heap;
+  }
+
+  /**
+   * Restores heap order by moving an element up the heap until it finds its proper position. Works
+   * with heaps of any arity (number of children per node).
+   *
+   * @param heap the heap array (1-based indexing)
+   * @param i the index of the element to move up
+   * @param arity the number of children each node can have
+   */
+  static void upHeap(long[] heap, int i, int arity) {
+    final long value = heap[i]; // save bottom value
+    while (i > 1) {
+      // parent formula for 1-based indexing
+      final int parent = ((i - 2) / arity) + 1;
+      final long parentVal = heap[parent];
+      if (value >= parentVal) break;
+      heap[i] = parentVal; // shift parent down
+      i = parent;
+    }
+    heap[i] = value; // install saved value
+  }
+
+  /**
+   * Restores heap order by moving an element down the heap until it finds its proper position.
+   * Works with heaps of any arity (number of children per node).
+   *
+   * @param heap the heap array (1-based indexing)
+   * @param i the index of the element to move down
+   * @param size the current size of the heap
+   * @param arity the number of children each node can have
+   */
+  static void downHeap(long[] heap, int i, int size, int arity) {
+    long value = heap[i]; // save top value
+    for (; ; ) {
+      // first child formula for 1-based indexing
+      int firstChild = arity * (i - 1) + 2;
+      if (firstChild > size) break; // i is a leaf
+
+      int lastChild = Math.min(firstChild + arity - 1, size);
+
+      // find the smallest child in [firstChild, lastChild]
+      int best = firstChild;
+      long bestVal = heap[firstChild];
+
+      for (int c = firstChild + 1; c <= lastChild; c++) {
+        final long v = heap[c];
+        if (v < bestVal) {
+          bestVal = v;
+          best = c;
+        }
+      }
+
+      if (bestVal >= value) break;
+
+      heap[i] = bestVal;
+      i = best;
+    }
+    heap[i] = value; // install saved value
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/TernaryLongHeap.java
+++ b/lucene/core/src/java/org/apache/lucene/util/TernaryLongHeap.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
  * A ternary min heap that stores longs; a primitive priority queue that like all priority queues
  * maintains a partial ordering of its elements such that the least element can always be found in
  * constant time. Put()'s and pop()'s require log_3(size). This heap provides unbounded growth via
- * {@link #push(long)}, and bounded-size insertion based on its nominal maxSize via {@link
+ * {@link #push(long)}, and bounded-size insertion based on its nominal initial capacity via {@link
  * #insertWithOverflow(long)}. The heap is a min heap, meaning that the top element is the lowest
  * value of the heap. TernaryLongHeap implements 3-ary heap.
  *
@@ -30,7 +30,7 @@ import java.util.Arrays;
  */
 public final class TernaryLongHeap {
 
-  private final int maxSize;
+  private final int initialCapacity;
 
   private long[] heap;
   private int size = 0;
@@ -51,18 +51,20 @@ public final class TernaryLongHeap {
   /**
    * Create an empty priority queue of the configured initial size.
    *
-   * @param maxSize the maximum size of the heap, or if negative, the initial size of an unbounded
-   *     heap
+   * @param initialCapacity the initial capacity of the heap
    */
-  public TernaryLongHeap(int maxSize) {
-    if (maxSize < 1 || maxSize >= ArrayUtil.MAX_ARRAY_LENGTH) {
+  public TernaryLongHeap(int initialCapacity) {
+    if (initialCapacity < 1 || initialCapacity >= ArrayUtil.MAX_ARRAY_LENGTH) {
       // Throw exception to prevent confusing OOME:
       throw new IllegalArgumentException(
-          "maxSize must be > 0 and < " + (ArrayUtil.MAX_ARRAY_LENGTH - 1) + "; got: " + maxSize);
+          "initialCapacity must be > 0 and < "
+              + (ArrayUtil.MAX_ARRAY_LENGTH - 1)
+              + "; got: "
+              + initialCapacity);
     }
     // NOTE: we add +1 because all access to heap is 1-based not 0-based.  heap[0] is unused.
-    final int heapSize = maxSize + 1;
-    this.maxSize = maxSize;
+    final int heapSize = initialCapacity + 1;
+    this.initialCapacity = initialCapacity;
     this.heap = new long[heapSize];
   }
 
@@ -83,13 +85,13 @@ public final class TernaryLongHeap {
 
   /**
    * Adds a value to an TernaryLongHeap in log(size) time. If the number of values would exceed the
-   * heap's maxSize, the least value is discarded.
+   * heap's initialCapacity, the least value is discarded.
    *
    * @return whether the value was added (unless the heap is full, or the new value is less than the
    *     top value)
    */
   public boolean insertWithOverflow(long value) {
-    if (size >= maxSize) {
+    if (size >= initialCapacity) {
       if (value < heap[1]) {
         return false;
       }

--- a/lucene/core/src/test/org/apache/lucene/util/TestTernaryLongHeap.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestTernaryLongHeap.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util;
+
+import java.util.ArrayList;
+import java.util.Random;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+
+public class TestTernaryLongHeap extends LuceneTestCase {
+
+  private static void checkValidity(TernaryLongHeap heap) {
+    long[] heapArray = heap.getHeapArray();
+    int d = 3;
+    int size = heap.size();
+    for (int parent = 1; parent <= size; parent++) {
+      int firstChild = d * (parent - 1) + 2;
+      int lastChild = Math.min(firstChild + d - 1, size);
+      for (int c = firstChild; c <= lastChild; c++) {
+        assert heapArray[parent] <= heapArray[c];
+      }
+    }
+  }
+
+  public void testPQ() {
+    testPQ(atLeast(10000), random());
+  }
+
+  public static void testPQ(int count, Random gen) {
+    TernaryLongHeap pq = new TernaryLongHeap(count);
+    long sum = 0, sum2 = 0;
+
+    for (int i = 0; i < count; i++) {
+      long next = gen.nextLong();
+      sum += next;
+      pq.push(next);
+    }
+
+    long last = Long.MIN_VALUE;
+    for (long i = 0; i < count; i++) {
+      long next = pq.pop();
+      assertTrue(next >= last);
+      last = next;
+      sum2 += last;
+    }
+
+    assertEquals(sum, sum2);
+  }
+
+  public void testClear() {
+    TernaryLongHeap pq = new TernaryLongHeap(3);
+    pq.push(2);
+    pq.push(3);
+    pq.push(1);
+    assertEquals(3, pq.size());
+    pq.clear();
+    assertEquals(0, pq.size());
+  }
+
+  public void testExceedBounds() {
+    TernaryLongHeap pq = new TernaryLongHeap(1);
+    pq.push(2);
+    pq.push(0);
+    assertEquals(2, pq.size()); // the heap has been extended to a new max size
+    assertEquals(0, pq.top());
+  }
+
+  public void testFixedSize() {
+    TernaryLongHeap pq = new TernaryLongHeap(3);
+    pq.insertWithOverflow(2);
+    pq.insertWithOverflow(3);
+    pq.insertWithOverflow(1);
+    pq.insertWithOverflow(5);
+    pq.insertWithOverflow(7);
+    pq.insertWithOverflow(1);
+    assertEquals(3, pq.size());
+    assertEquals(3, pq.top());
+  }
+
+  public void testDuplicateValues() {
+    TernaryLongHeap pq = new TernaryLongHeap(3);
+    pq.push(2);
+    pq.push(3);
+    pq.push(1);
+    assertEquals(1, pq.top());
+    pq.updateTop(3);
+    assertEquals(3, pq.size());
+    assertArrayEquals(new long[] {0, 2, 3, 3}, pq.getHeapArray());
+  }
+
+  public void testInsertions() {
+    Random random = random();
+    int numDocsInPQ = TestUtil.nextInt(random, 1, 100);
+    TernaryLongHeap pq = new TernaryLongHeap(numDocsInPQ);
+    Long lastLeast = null;
+
+    // Basic insertion of new content
+    ArrayList<Long> sds = new ArrayList<>(numDocsInPQ);
+    for (int i = 0; i < numDocsInPQ * 10; i++) {
+      long newEntry = Math.abs(random.nextLong());
+      sds.add(newEntry);
+      pq.insertWithOverflow(newEntry);
+      checkValidity(pq);
+      long newLeast = pq.top();
+      if ((lastLeast != null) && (newLeast != newEntry) && (newLeast != lastLeast)) {
+        // If there has been a change of least entry and it wasn't our new
+        // addition we expect the scores to increase
+        assertTrue(newLeast <= newEntry);
+        assertTrue(newLeast >= lastLeast);
+      }
+      lastLeast = newLeast;
+    }
+  }
+
+  public void testInvalid() {
+    expectThrows(IllegalArgumentException.class, () -> new TernaryLongHeap(-1));
+    expectThrows(IllegalArgumentException.class, () -> new TernaryLongHeap(0));
+    expectThrows(
+        IllegalArgumentException.class, () -> new TernaryLongHeap(ArrayUtil.MAX_ARRAY_LENGTH));
+  }
+
+  public void testUnbounded() {
+    int initialSize = random().nextInt(10) + 1;
+    TernaryLongHeap pq = new TernaryLongHeap(initialSize);
+    int num = random().nextInt(100) + 1;
+    long maxValue = Long.MIN_VALUE;
+    int count = 0;
+    for (int i = 0; i < num; i++) {
+      long value = random().nextLong();
+      if (random().nextBoolean()) {
+        pq.push(value);
+        count++;
+      } else {
+        boolean full = pq.size() >= initialSize;
+        if (pq.insertWithOverflow(value)) {
+          if (full == false) {
+            count++;
+          }
+        }
+      }
+      maxValue = Math.max(maxValue, value);
+    }
+    assertEquals(count, pq.size());
+    long last = Long.MIN_VALUE;
+    while (pq.size() > 0) {
+      long top = pq.top();
+      long next = pq.pop();
+      assertEquals(top, next);
+      --count;
+      assertTrue(next >= last);
+      last = next;
+    }
+    assertEquals(0, count);
+    assertEquals(maxValue, last);
+  }
+}


### PR DESCRIPTION
### Description
This PR updates LongHeap from a fixed 2-ary heap to a 3-ary heap (the code is generic with n-ary Heap). The change improves cache locality and reduces heap operations for larger heaps, which improves overall query performance.

### Benchmarks
Luceneutil has been run with TopN as 1000 (see https://github.com/mikemccand/luceneutil/pull/357) Benchmark machine: i3.8xlarge

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
     BrowseRandomLabelSSDVFacets        1.59     (13.0%)        1.52      (6.1%)   -4.4% ( -20% -   16%) 0.167
                HighSloppyPhrase       20.10      (9.3%)       19.52      (6.4%)   -2.9% ( -17% -   14%) 0.258
            BrowseDateSSDVFacets        0.51     (10.2%)        0.50     (10.4%)   -2.7% ( -21% -   20%) 0.415
     BrowseRandomLabelTaxoFacets        1.35     (15.1%)        1.32      (3.4%)   -2.4% ( -18% -   18%) 0.495
            BrowseDateTaxoFacets        1.83     (26.1%)        1.79      (9.0%)   -2.3% ( -29% -   44%) 0.705
               HighTermTitleSort       28.52      (2.9%)       27.98      (3.9%)   -1.9% (  -8% -    5%) 0.080
       BrowseDayOfYearTaxoFacets        1.88     (23.8%)        1.85      (9.3%)   -1.6% ( -27% -   41%) 0.777
            HighIntervalsOrdered        5.14      (6.0%)        5.08      (5.8%)   -1.2% ( -12% -   11%) 0.502
                     LowSpanNear       24.52      (6.3%)       24.29      (7.8%)   -0.9% ( -14% -   14%) 0.676
        AndHighHighDayTaxoFacets       19.61      (4.6%)       19.48      (5.2%)   -0.7% ( -10% -    9%) 0.673
           BrowseMonthTaxoFacets        1.96      (6.1%)        1.94      (6.3%)   -0.6% ( -12% -   12%) 0.748
            HighTermTitleBDVSort        6.95      (5.0%)        6.92      (5.8%)   -0.5% ( -10% -   10%) 0.785
                      TermDTSort       51.57      (4.6%)       51.36      (5.1%)   -0.4% (  -9% -    9%) 0.787
             LowIntervalsOrdered       72.91     (12.9%)       72.63     (15.0%)   -0.4% ( -25% -   31%) 0.933
             MedIntervalsOrdered        4.67      (5.2%)        4.66      (6.4%)   -0.3% ( -11% -   11%) 0.854
         AndHighMedDayTaxoFacets       27.57      (3.5%)       27.60      (3.9%)    0.1% (  -7% -    7%) 0.912
                 MedSloppyPhrase       11.49      (2.9%)       11.54      (2.7%)    0.4% (  -5% -    6%) 0.649
                      AndHighLow      676.59      (5.6%)      680.20      (4.4%)    0.5% (  -8% -   11%) 0.738
           HighTermDayOfYearSort       48.85      (6.8%)       49.18      (6.3%)    0.7% ( -11% -   14%) 0.748
                       LowPhrase       48.95      (4.5%)       49.52      (4.9%)    1.2% (  -7% -   11%) 0.429
          OrHighMedDayTaxoFacets        4.62      (7.1%)        4.68      (5.5%)    1.3% ( -10% -   14%) 0.512
                         Respell       21.00      (8.2%)       21.28      (6.3%)    1.3% ( -12% -   17%) 0.566
                 LowSloppyPhrase       18.02      (8.2%)       18.39      (6.0%)    2.0% ( -11% -   17%) 0.373
                      HighPhrase       26.79      (3.0%)       27.35      (2.5%)    2.1% (  -3% -    7%) 0.015
       BrowseDayOfYearSSDVFacets        2.44     (13.5%)        2.49     (10.8%)    2.2% ( -19% -   30%) 0.565
                          IntNRQ      124.80      (2.6%)      127.62      (2.7%)    2.3% (  -2% -    7%) 0.006
                     MedSpanNear       71.89      (3.3%)       73.63      (2.9%)    2.4% (  -3% -    8%) 0.014
                           range     2418.26      (7.8%)     2481.43      (6.2%)    2.6% ( -10% -   18%) 0.242
                          Fuzzy2       32.82      (6.2%)       33.72      (7.9%)    2.7% ( -10% -   17%) 0.222
                        PKLookup      124.86      (9.3%)      128.39      (9.8%)    2.8% ( -14% -   24%) 0.350
               HighTermMonthSort      109.23     (10.0%)      112.66     (11.5%)    3.1% ( -16% -   27%) 0.355
                    HighSpanNear       12.77     (10.1%)       13.23      (7.0%)    3.6% ( -12% -   23%) 0.189
            MedTermDayTaxoFacets       23.20      (7.2%)       24.08      (3.9%)    3.8% (  -6% -   16%) 0.039
                          IntSet      319.40      (7.9%)      332.99      (7.0%)    4.3% (  -9% -   20%) 0.070
                   OrHighNotHigh       63.45     (12.0%)       66.16     (11.1%)    4.3% ( -16% -   31%) 0.242
                    OrNotHighLow      653.14      (4.5%)      681.44      (5.5%)    4.3% (  -5% -   15%) 0.007
                          Fuzzy1       33.92      (9.6%)       35.47      (8.8%)    4.6% ( -12% -   25%) 0.116
                     AndHighHigh       72.73     (11.4%)       76.10     (12.0%)    4.6% ( -16% -   31%) 0.210
                        Wildcard      162.20      (3.9%)      169.92      (3.7%)    4.8% (  -2% -   12%) 0.000
                       MedPhrase      105.75      (5.3%)      111.28      (6.2%)    5.2% (  -5% -   17%) 0.004
                      AndHighMed      300.00      (3.5%)      317.31      (3.5%)    5.8% (  -1% -   13%) 0.000
                      OrHighHigh       81.99     (10.0%)       86.95     (11.8%)    6.1% ( -14% -   30%) 0.080
                   OrNotHighHigh       94.63      (8.0%)      100.89      (8.5%)    6.6% (  -9% -   25%) 0.011
                    OrNotHighMed      156.93      (5.2%)      167.46      (5.7%)    6.7% (  -3% -   18%) 0.000
                    OrHighNotLow      109.84     (12.4%)      118.15     (13.7%)    7.6% ( -16% -   38%) 0.067
                         Prefix3      298.72      (4.6%)      321.96      (4.8%)    7.8% (  -1% -   17%) 0.000
           BrowseMonthSSDVFacets        2.46      (8.4%)        2.66     (17.5%)    8.0% ( -16% -   37%) 0.066
                       OrHighMed      135.37      (5.3%)      147.30      (8.0%)    8.8% (  -4% -   23%) 0.000
                        HighTerm      169.55     (10.9%)      189.84     (15.3%)   12.0% ( -12% -   42%) 0.004
                       OrHighLow      182.04      (8.5%)      203.99     (10.4%)   12.1% (  -6% -   33%) 0.000
                         MedTerm      257.50      (9.8%)      297.02     (14.4%)   15.4% (  -8% -   43%) 0.000
                    OrHighNotMed      215.73      (6.5%)      249.31      (9.1%)   15.6% (   0% -   33%) 0.000
                         LowTerm      411.97      (8.6%)      481.02     (13.4%)   16.8% (  -4% -   42%) 0.000
```

