### PR TITLE
Optimize a bit two more prefix sums.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
@@ -204,10 +204,11 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
     }
   }
 
-  static void prefixSum(int[] buffer, int count, long base) {
-    buffer[0] += base;
-    for (int i = 1; i < count; ++i) {
-      buffer[i] += buffer[i - 1];
+  static void prefixSum(int[] buffer, int count, int base) {
+    int sum = base;
+    for (int i = 0; i < count; ++i) {
+      sum += buffer[i];
+      buffer[i] = sum;
     }
   }
 
@@ -617,9 +618,7 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
           for (int i = 0; i < numLongs - 1; ++i) {
             docCumulativeWordPopCounts[i] = Long.bitCount(docBitSet.getBits()[i]);
           }
-          for (int i = 1; i < numLongs - 1; ++i) {
-            docCumulativeWordPopCounts[i] += docCumulativeWordPopCounts[i - 1];
-          }
+          prefixSum(docCumulativeWordPopCounts, numLongs - 1, 0);
           docCumulativeWordPopCounts[numLongs - 1] = BLOCK_SIZE;
           assert docCumulativeWordPopCounts[numLongs - 2]
                   + Long.bitCount(docBitSet.getBits()[numLongs - 1])


### PR DESCRIPTION
This applies the same change as #14979 to two more prefix sums. I was not able to measure speedups (or slowdowns) with luceneutil, but I think it's still better to write our prefix sums this way.