### PR TITLE
Support JDK 25 in Panama Vectorization Provider

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -184,6 +184,8 @@ New Features
 
 * GITHUB#15110: PostingsDecodingUtil: interchange loops to enable better memory access and SIMD vectorisation. (Ramakrishna Chilaka)
 
+* GITHUB#15157: Support JDK 25 in Panama Vectorization Provider. (Chris Hegarty)
+
 Improvements
 ---------------------
 * GITHUB#14458: Add an IndexDeletion policy that retains the last N commits. (Owais Kazi)

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -64,7 +64,7 @@ public abstract class VectorizationProvider {
 
   private static final String UPPER_JAVA_FEATURE_VERSION_SYSPROP =
       "org.apache.lucene.vectorization.upperJavaFeatureVersion";
-  private static final int DEFAULT_UPPER_JAVA_FEATURE_VERSION = 24;
+  private static final int DEFAULT_UPPER_JAVA_FEATURE_VERSION = 25;
 
   private static int getUpperJavaFeatureVersion() {
     int runtimeVersion = DEFAULT_UPPER_JAVA_FEATURE_VERSION;


### PR DESCRIPTION
This commit updates the Vectorization Provider to support JDK 25. The API has not changed so the changes minimally bump the major JDK check, and enable the incubating API during testing.

JDK 25 is past rampdown phase 2.

I tested this locally with:
```
export RUNTIME_JAVA_HOME=/Users/chegar/binaries/jdk-25.jdk/Contents/Home/
export JAVA_HOME=/Users/chegar/binaries/jdk-24.0.2.jdk/Contents/Home/

CI=true ./gradlew check -Ptests.vectorsize="default" -Ptests.forceintegervectors=false 
```