### PR TITLE
build: require Python 3.12+, add smoke-test Make target

### DIFF
--- a/dev-tools/scripts/Makefile
+++ b/dev-tools/scripts/Makefile
@@ -13,11 +13,14 @@ export PYTHONDONTWRITEBYTECODE=true
 # don't self-check, don't ask questions
 PIP_INSTALL_ARGS=--disable-pip-version-check --no-input --upgrade
 
+# override to specific python executable if you need
+PYTHON?=python3
+
 # venv with dependencies in the standard location
 VENV=${PWD}/.venv
 
 # don't behave strangely if these files exist
-.PHONY: lint format reformat autofix ruff ruff-fix pyright env clean
+.PHONY: lint format reformat autofix ruff ruff-fix pyright env clean smoke-test
 
 # list of directories we check
 SOURCES=$(wildcard *.py)
@@ -57,13 +60,22 @@ pyright: env
 	# type-check sources with basedpyright
 	$(VENV)/bin/basedpyright $(SOURCES)
 
+# runs smoketester against a release
+smoke-test: env
+	# ensure that you provided URL so that we know what to test
+	# run this command like: make smoke-test URL=https://dist.apache.org/...
+	test -n "$(URL)"
+	$(VENV)/bin/python smokeTestRelease.py $(URL)
+
 # rebuild venv if dependencies change
 env: $(VENV)/bin/activate
-$(VENV)/bin/activate: requirements.txt
+$(VENV)/bin/activate: requirements.txt Makefile
 	# remove any existing venv
 	rm -rf $(VENV)
-	# create new venv
-	python3 -m venv $(VENV)
+	# check that python meets minimum version requirements
+	$(PYTHON) -c "import sys; assert sys.version_info[0] == 3 and sys.version_info[1] >= 12, 'UPGRADE PYTHON'"
+	# create virtual environment
+	$(PYTHON) -m venv $(VENV)
 	# install dependencies into venv
 	$(VENV)/bin/pip install $(PIP_INSTALL_ARGS) -r requirements.txt
 	# adjust timestamp for safety

--- a/dev-tools/scripts/README.md
+++ b/dev-tools/scripts/README.md
@@ -20,9 +20,10 @@
 This folder contains various useful scripts for developers, mostly related to
 releasing new versions of Lucene and testing those.
 
-Python scripts require Python 3.6 or above. To install necessary python modules, please run:
+Python scripts require Python 3.12 or above. To install necessary python modules, please run:
 
-    pip3 install -r requirements.txt
+    make env
+    source .env/bin/activate
 
 ## Scripts description
 
@@ -62,7 +63,7 @@ the full tests.
       --download-only       Only perform download and sha hash check steps
 
     Example usage:
-    python3 -u dev-tools/scripts/smokeTestRelease.py https://dist.apache.org/repos/dist/dev/lucene/lucene-9.0.1-RC2-revc7510a0...
+    make smoke-test URL=https://dist.apache.org/repos/dist/dev/lucene/lucene-9.0.1-RC2-revc7510a0...
 
 ### releaseWizard.py
 


### PR DESCRIPTION
Update Makefile and README to require Python 3.12 or newer, allow configurable Python executable, and add a 'smoke-test' target for smoketester. Update setup instructions and usage examples accordingly.

Closes #14556

Example error (with minimum bumped to 3.14):

<img width="944" height="223" alt="Screen_Shot_2025-09-05_at_14 40 29" src="https://github.com/user-attachments/assets/446850fa-aa3f-4e4d-9f5d-f49bcccd15c4" />


If we can just use the `make` command, it will make life easier than user having to install python dependencies. It also won't mess up any other python stuff on their computer because it uses a virtual environment, etc.

