### PR TITLE
Use TernaryLongHeap in NeighborQueue for faster vector search performance

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -129,6 +129,8 @@ Optimizations
 ---------------------
 * GITHUB#15140: Optimize TopScoreDocCollector with TernaryLongHeap for improved performance over Binary-LongHeap. (Ramakrishna Chilaka)
 
+* GITHUB#15163: Use TernaryLongHeap in NeighborQueue for faster vector search performance. (Ramakrishna Chilaka)
+
 * GITHUB#14998: Speed up flushing of live docs. (Adrien Grand)
 
 Bug Fixes

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborQueue.java
@@ -17,13 +17,13 @@
 
 package org.apache.lucene.util.hnsw;
 
-import org.apache.lucene.util.LongHeap;
 import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.TernaryLongHeap;
 
 /**
- * NeighborQueue uses a {@link LongHeap} to store lists of arcs in an HNSW graph, represented as a
- * neighbor node id with an associated score packed together as a sortable long, which is sorted
- * primarily by score. The queue provides both fixed-size and unbounded operations via {@link
+ * NeighborQueue uses a {@link TernaryLongHeap} to store lists of arcs in an HNSW graph, represented
+ * as a neighbor node id with an associated score packed together as a sortable long, which is
+ * sorted primarily by score. The queue provides both fixed-size and unbounded operations via {@link
  * #insertWithOverflow(int, float)} and {@link #add(int, float)}, and provides MIN and MAX heap
  * subclasses.
  */
@@ -48,7 +48,7 @@ public class NeighborQueue {
     abstract long apply(long v);
   }
 
-  private final LongHeap heap;
+  private final TernaryLongHeap heap;
   private final Order order;
 
   // Used to track the number of neighbors visited during a single graph traversal
@@ -57,7 +57,7 @@ public class NeighborQueue {
   private boolean incomplete;
 
   public NeighborQueue(int initialSize, boolean maxHeap) {
-    this.heap = new LongHeap(initialSize);
+    this.heap = new TernaryLongHeap(initialSize);
     this.order = maxHeap ? Order.MAX_HEAP : Order.MIN_HEAP;
   }
 


### PR DESCRIPTION
Follow-up to https://github.com/apache/lucene/pull/15140. For vector search, TopKNNCollector uses NeighborQueue. This PR replaces its underlying heap implementation from the binary LongHeap to the TernaryLongHeap.

### Performance Results

On c8g.8xlarge (Graviton) with topN = 1000:

```
                  TaskQPS baseline      StdDevQPS candidate      StdDev                Pct diff p-value
                        PKLookup      456.85      (1.4%)      459.33      (0.9%)    0.5% (  -1% -    2%) 0.139
               AndHighHighVector      114.90      (0.9%)      116.25      (0.6%)    1.2% (   0% -    2%) 0.000
                AndHighLowVector      119.86      (0.8%)      121.37      (0.7%)    1.3% (   0% -    2%) 0.000
                AndHighMedVector      112.55      (0.8%)      114.00      (0.7%)    1.3% (   0% -    2%) 0.000
                   MedTermVector      130.14      (0.8%)      131.91      (0.7%)    1.4% (   0% -    2%) 0.000
                  HighTermVector      138.60      (0.8%)      140.81      (0.6%)    1.6% (   0% -    3%) 0.000
                   LowTermVector      138.34      (0.7%)      140.74      (0.5%)    1.7% (   0% -    2%) 0.000
```

On i3.8xlarge with topN = 1000:
```
TaskQPS baseline      StdDevQPS candidate      StdDev                Pct diff p-value
                        PKLookup      218.10      (2.3%)      217.52      (2.3%)   -0.3% (  -4% -    4%) 0.712
                AndHighLowVector       75.39      (0.4%)       76.12      (0.4%)    1.0% (   0% -    1%) 0.000
               AndHighHighVector       74.40      (0.5%)       75.20      (0.4%)    1.1% (   0% -    1%) 0.000
                AndHighMedVector       79.06      (0.3%)       79.92      (0.5%)    1.1% (   0% -    1%) 0.000
                   MedTermVector       82.18      (0.4%)       83.17      (0.4%)    1.2% (   0% -    1%) 0.000
                  HighTermVector       87.32      (0.4%)       88.37      (0.4%)    1.2% (   0% -    2%) 0.000
                   LowTermVector       93.71      (0.4%)       95.05      (0.5%)    1.4% (   0% -    2%) 0.000
```

TLDR; The ternary heap implementation shows consistent performance improvements of 1.0-1.7% across vector search operations on both ARM (Graviton) and x86 architectures.
