### PR TITLE
Refactor FirstPassGroupingCollector to improve readability. (#15136)

### DIFF
--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/FirstPassGroupingCollector.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/FirstPassGroupingCollector.java
@@ -233,7 +233,7 @@ public class FirstPassGroupingCollector<T> extends SimpleCollector {
       }
       groupMap.put(sg.groupValue, sg);
 
-      if (isGroupMapFull()) {
+      if (isGroupMapFull() == true) {
         // End of startup transient: we now have max
         // number of groups; from here on we will drop
         // bottom group when we insert new one:

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/FirstPassGroupingCollector.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/FirstPassGroupingCollector.java
@@ -217,7 +217,7 @@ public class FirstPassGroupingCollector<T> extends SimpleCollector {
     // it before but it fell out of the top N and is now
     // coming back
 
-    if (!isGroupMapFull()) {
+    if (isGroupMapFull() == false) {
 
       // Still in startup transient: we have not
       // seen enough unique groups to start pruning them;


### PR DESCRIPTION
### Description

Clean up the collector a bit before submitting additional changes to introduce skipping/pruning and early termination.

No functional change.

