### PR TITLE
Bulk write Ints in ForUtil's encode

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -133,6 +133,8 @@ Optimizations
 
 * GITHUB#15165: Optimize PForUtil.encode() with histogram-based bit selection. (Ramakrishna Chilaka)
 
+* GITHUB#15170: Bulk write Ints in ForUtil's encode (Ramakrishna Chilaka)
+
 * GITHUB#15151: Use `SimScorer#score` bulk API to compute impact scores per
   block of postings. (Adrien Grand)
 

--- a/lucene/core/src/generated/checksums/generateForUtil.json
+++ b/lucene/core/src/generated/checksums/generateForUtil.json
@@ -1,4 +1,4 @@
 {
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene103/ForUtil.java": "1ea2dac2a26be521a70cf74c37fe9134f7b42cb7",
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene103/gen_ForUtil.py": "cd186fe09ceeedb4e2dd3be191d7461e67fa1c2b"
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene103/ForUtil.java": "133a59aa21567e31f627c7c57ea627656b06852e",
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene103/gen_ForUtil.py": "d792f929f9a9af681c0d805a38517f5461c02efe"
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/ForUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/ForUtil.java
@@ -153,9 +153,7 @@ public final class ForUtil {
       }
     }
 
-    for (int i = 0; i < numIntsPerShift; ++i) {
-      out.writeInt(tmp[i]);
-    }
+    out.writeInts(tmp, 0, numIntsPerShift);
   }
 
   /** Number of bytes required to encode 128 integers of {@code bitsPerValue} bits per value. */

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/gen_ForUtil.py
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/gen_ForUtil.py
@@ -182,9 +182,7 @@ public final class ForUtil {
       }
     }
 
-    for (int i = 0; i < numIntsPerShift; ++i) {
-      out.writeInt(tmp[i]);
-    }
+    out.writeInts(tmp, 0, numIntsPerShift);
   }
 
   /** Number of bytes required to encode 128 integers of {@code bitsPerValue} bits per value. */

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
@@ -397,6 +397,27 @@ public final class ByteBuffersDataOutput extends DataOutput implements Accountab
   }
 
   @Override
+  public void writeInts(int[] src, int offset, int length) {
+    while (length > 0) {
+      if (!currentBlock.hasRemaining()) {
+        appendBlock();
+      }
+
+      int intsToWrite = Math.min(currentBlock.remaining() / Integer.BYTES, length);
+      if (intsToWrite > 0) {
+        currentBlock.asIntBuffer().put(src, offset, intsToWrite);
+        currentBlock.position(currentBlock.position() + intsToWrite * Integer.BYTES);
+        offset += intsToWrite;
+        length -= intsToWrite;
+      } else {
+        // Less than 4 bytes remaining, write individual int
+        writeInt(src[offset++]);
+        length--;
+      }
+    }
+  }
+
+  @Override
   public void writeLong(long v) {
     try {
       if (currentBlock.remaining() >= Long.BYTES) {

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersIndexOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersIndexOutput.java
@@ -119,6 +119,12 @@ public final class ByteBuffersIndexOutput extends IndexOutput {
   }
 
   @Override
+  public void writeInts(int[] src, int offset, int length) {
+    ensureOpen();
+    delegate.writeInts(src, offset, length);
+  }
+
+  @Override
   public void writeShort(short i) throws IOException {
     ensureOpen();
     delegate.writeShort(i);

--- a/lucene/core/src/java/org/apache/lucene/store/DataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/DataOutput.java
@@ -89,6 +89,20 @@ public abstract class DataOutput {
   }
 
   /**
+   * Writes a specified number of ints from an array at the specified offset.
+   *
+   * @param src the array to write ints from
+   * @param offset the offset in the array to start reading ints
+   * @param length the number of ints to write
+   * @see DataInput#readInts(int[], int, int)
+   */
+  public void writeInts(int[] src, int offset, int length) throws IOException {
+    for (int i = 0; i < length; ++i) {
+      writeInt(src[offset + i]);
+    }
+  }
+
+  /**
    * Writes an int in a variable-length format. Writes between one and five bytes. Smaller values
    * take fewer bytes. Negative numbers are supported, but should be avoided.
    *


### PR DESCRIPTION
In this PR, we are bulk writing packed ints in ForUtil's encode. Inorder to do this,  a new `writeInts(int[], int, int)` method is added to DataOutput API.

#### Changes:
- Add `writeInts(int[], offset, length)` method to DataOutput base class and default method which calls `writeInt` in a loop.
- Implement writeInts in  `ByteBuffersDataOutput`, which writes directly to `bytebuffer`.
- Implement writeInts in `ByteBuffersIndexOutput`, delegates to `ByteBuffersDataOutput`.
- Optimize ForUtil postings compression to use bulk writeInts instead of individual `writeInt` calls in a loop.



