### PR TITLE
Fix encoding selection logic in Lucene104PostingsWriter

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104PostingsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104PostingsWriter.java
@@ -438,7 +438,7 @@ public class Lucene104PostingsWriter extends PushPostingsWriterBase {
       int numBitsNextBitsPerValue = Math.min(Integer.SIZE, bitsPerValue + 1) * BLOCK_SIZE;
       if (docRange == BLOCK_SIZE) {
         level0Output.writeByte((byte) 0);
-      } else if (numBitsNextBitsPerValue <= docRange) {
+      } else if (numBitsNextBitsPerValue <= (numBitSetLongs * Long.SIZE)) {
         level0Output.writeByte((byte) bitsPerValue);
         forUtil.encode(docDeltaBuffer, bitsPerValue, level0Output);
       } else {


### PR DESCRIPTION
The previous code compared `numBitsNextBitsPerValue ≤ docRange` to decide whether to store the doc-delta block with PackedInts or as a bit-set. docRange is the number of documents, not the number of bits the bit-set would occupy, so the test did not reflect the actual space that would be written. 

### Change
Replace the comparison with `numBitsNextBitsPerValue ≤ numBitSetLongs * Long.SIZE`
so the decision is based on the exact bit footprint of each alternative. The bit-set path is now taken only when it is strictly smaller on disk.

We can skip change-log as it is a marginal change, I will add it, if you prefer