### PR TITLE
Adds new simplified rescorer API to [Float|Byte]VectorValues

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene102/Lucene102BinaryQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene102/Lucene102BinaryQuantizedVectorsReader.java
@@ -431,6 +431,11 @@ class Lucene102BinaryQuantizedVectorsReader extends FlatVectorsReader {
       return quantizedVectorValues.scorer(query);
     }
 
+    @Override
+    public VectorScorer rescorer(float[] query) throws IOException {
+      return rawVectorValues.rescorer(query);
+    }
+
     BinarizedByteVectorValues getQuantizedVectorValues() throws IOException {
       return quantizedVectorValues;
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
@@ -460,6 +460,11 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
     }
 
     @Override
+    public VectorScorer rescorer(float[] query) throws IOException {
+      return rawVectorValues.rescorer(query);
+    }
+
+    @Override
     public DocIndexIterator iterator() {
       return rawVectorValues.iterator();
     }

--- a/lucene/core/src/java/org/apache/lucene/index/ByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ByteVectorValues.java
@@ -65,13 +65,31 @@ public abstract class ByteVectorValues extends KnnVectorValues {
   }
 
   /**
-   * Return a {@link VectorScorer} for the given query vector.
+   * Return a {@link VectorScorer} for the given query vector. When the underlying format quantizes
+   * the vectors, this will return a {@link VectorScorer} that scores against the quantized vectors.
    *
    * @param query the query vector
    * @return a {@link VectorScorer} instance or null
    */
   public VectorScorer scorer(byte[] query) throws IOException {
     throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Rescore using the given query vector and the current {@link ByteVectorValues}. This is unique
+   * from scorer() in that it is explicitly for rescoring an existing set of hits and thus will
+   * often utilize the highest fidelity scoring algorithm available. This is useful when the initial
+   * search used a quantized index or an approximate scoring algorithm, and now we want to rescore
+   * the hits using the full fidelity vectors. The default implementation is to call {@link
+   * #scorer(byte[])} assuming that the scorer is already the highest fidelity implementation
+   * available.
+   *
+   * @param target the query vector
+   * @return a {@link VectorScorer} instance or null
+   * @throws IOException if an I/O error occurs
+   */
+  public VectorScorer rescorer(byte[] target) throws IOException {
+    return scorer(target);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/FloatVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FloatVectorValues.java
@@ -66,13 +66,31 @@ public abstract class FloatVectorValues extends KnnVectorValues {
 
   /**
    * Return a {@link VectorScorer} for the given query vector and the current {@link
-   * FloatVectorValues}.
+   * FloatVectorValues}. When the underlying format quantizes the vectors, this will return a {@link
+   * VectorScorer} that scores against the quantized vectors.
    *
    * @param target the query vector
    * @return a {@link VectorScorer} instance or null
    */
   public VectorScorer scorer(float[] target) throws IOException {
     throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Rescore using the given query vector and the current {@link FloatVectorValues}. This is unique
+   * from scorer() in that it is explicitly for rescoring an existing set of hits and thus will
+   * often utilize the highest fidelity scoring algorithm available. This is useful when the initial
+   * search used a quantized index or an approximate search algorithm, and now we want to rescore
+   * the hits using the full fidelity vectors. The default implementation is to call {@link
+   * #scorer(float[])} assuming that the scorer is already the highest fidelity implementation
+   * available.
+   *
+   * @param target the query vector
+   * @return a {@link VectorScorer} instance or null
+   * @throws IOException if an I/O error occurs
+   */
+  public VectorScorer rescorer(float[] target) throws IOException {
+    return scorer(target);
   }
 
   @Override


### PR DESCRIPTION
Rescoring against a vector field should be simple and allow for lower level bulk scoring optimizations (e.g. scoring floating point values off heap, possibly bulk prefetching, etc.).

However, the current API always returns a scorer against the fastest fidelity vectors, not the most accurate. 

I thought a simple `rescorer` method that also just used the `VectorScorer` object would suffice. While our `DoubleValues` logic cannot take advantage of bulk scoring yet, it might be able to one day.


The other API idea I had in mind was adding something like `VectorScorer#asRescorer` instead. But it didn't seem any better than just adding a simple hook on our `KnnVectorValues` implementations.