### PR TITLE
Update code comment after bumping block size to 256.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104PostingsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104PostingsWriter.java
@@ -451,8 +451,8 @@ public class Lucene104PostingsWriter extends PushPostingsWriterBase {
           spareBitSet.set(s);
         }
         // We never use the bit set encoding when it requires more than Integer.SIZE=32 bits per
-        // value. So the bit set cannot have more than BLOCK_SIZE * Integer.SIZE / Long.SIZE = 64
-        // longs, which fits on a byte.
+        // value. So the bit set cannot have more than BLOCK_SIZE * Integer.SIZE / Long.SIZE = 128
+        // longs. -128 fits in a byte so we're good.
         assert numBitSetLongs <= BLOCK_SIZE / 2;
         level0Output.writeByte((byte) -numBitSetLongs);
         for (int i = 0; i < numBitSetLongs; ++i) {


### PR DESCRIPTION
The flag we store at the beginning of every block is either 0 if the block is dense, a positive integer storing the number of bits per value if encoded with FOR-delta, or a negative number storing the opposite of the number of longs required when encoded as a bit set.

This PR updates the comment that explains why we're guaranteed to not overflow a byte with the number of required longs.