### PR TITLE
Fix off by one error in Lucene99MemorySegmentFloatVectorScorer

### DIFF
--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFloatVectorScorer.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFloatVectorScorer.java
@@ -114,7 +114,7 @@ abstract sealed class Lucene99MemorySegmentFloatVectorScorer
       }
       if (remaining > 2) {
         scores[i + 2] = normalizeRawScore(scratchScores[2]);
-        maxScore = Math.max(maxScore, scores[i + 1]);
+        maxScore = Math.max(maxScore, scores[i + 2]);
       }
     }
     return maxScore;


### PR DESCRIPTION
This was introduced in #15021 where we don't correctly account the max score when there are 3 remaining
vectors in a bulk scoring call.

Fixed #15180