### PR TITLE
Vectorise expand8 in ForUtil using JDK Vector API

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -150,6 +150,8 @@ Optimizations
 * GITHUB#15160: Increased the size used for blocks of postings from 128 to 256.
   This gives a noticeable speedup to many queries. (Adrien Grand)
 
+* GITHUB#15198: Optimize ForUtil.expand8 using the JDK Vector API. (Ramakrishna Chilaka)
+
 * GITHUB#14863: Perform scoring for 4, 7, 8 bit quantized vectors off-heap. (Kaival Parikh)
 
 Bug Fixes

--- a/lucene/core/src/generated/checksums/generateForUtil.json
+++ b/lucene/core/src/generated/checksums/generateForUtil.json
@@ -1,4 +1,4 @@
 {
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene104/ForUtil.java": "5dda079c68e6060217f29010618c7fd807583056",
-    "lucene/core/src/java/org/apache/lucene/codecs/lucene104/gen_ForUtil.py": "4692fed62d9f79554647c5423b96b9e60c9f30eb"
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene104/ForUtil.java": "bf1168dbc05311c2e49b652391e01cb01d3f9133",
+    "lucene/core/src/java/org/apache/lucene/codecs/lucene104/gen_ForUtil.py": "e87e420e633601f6f751b6777d7c094ebc66c3e7"
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/ForUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/ForUtil.java
@@ -21,6 +21,7 @@ package org.apache.lucene.codecs.lucene104;
 import java.io.IOException;
 import org.apache.lucene.internal.vectorization.PostingDecodingUtil;
 import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.VectorUtil;
 
 /**
  * Inspired from https://fulmicoton.com/posts/bitpacking/ Encodes multiple integers in one to get
@@ -55,13 +56,7 @@ public final class ForUtil {
   }
 
   static void expand8(int[] arr) {
-    for (int i = 0; i < 64; ++i) {
-      int l = arr[i];
-      arr[i] = (l >>> 24) & 0xFF;
-      arr[64 + i] = (l >>> 16) & 0xFF;
-      arr[128 + i] = (l >>> 8) & 0xFF;
-      arr[192 + i] = l & 0xFF;
-    }
+    VectorUtil.expand8(arr);
   }
 
   static void collapse8(int[] arr) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/gen_ForUtil.py
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/gen_ForUtil.py
@@ -45,6 +45,7 @@ package org.apache.lucene.codecs.lucene104;
 import java.io.IOException;
 import org.apache.lucene.internal.vectorization.PostingDecodingUtil;
 import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.VectorUtil;
 
 /**
  * Inspired from https://fulmicoton.com/posts/bitpacking/
@@ -80,13 +81,7 @@ public final class ForUtil {
   }
 
   static void expand8(int[] arr) {
-    for (int i = 0; i < 64; ++i) {
-      int l = arr[i];
-      arr[i] = (l >>> 24) & 0xFF;
-      arr[64 + i] = (l >>> 16) & 0xFF;
-      arr[128 + i] = (l >>> 8) & 0xFF;
-      arr[192 + i] = l & 0xFF;
-    }
+    VectorUtil.expand8(arr);
   }
 
   static void collapse8(int[] arr) {

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
@@ -415,4 +415,16 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
     }
     return v;
   }
+
+  @Override
+  public void expand8(int[] arr) {
+    // BLOCK_SIZE is 256
+    for (int i = 0; i < 64; ++i) {
+      int l = arr[i];
+      arr[i] = (l >>> 24) & 0xFF;
+      arr[64 + i] = (l >>> 16) & 0xFF;
+      arr[128 + i] = (l >>> 8) & 0xFF;
+      arr[192 + i] = l & 0xFF;
+    }
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
@@ -145,5 +145,11 @@ public interface VectorUtilSupport {
 
   float[] l2normalize(float[] v, boolean throwOnZero);
 
+  /**
+   * Expands a 64-element integer array into a 256-element array by extracting individual bytes.
+   * Each 32-bit integer is split into 4 bytes, expanding the array from 64 to 256 elements.
+   * Only works on arrays with exactly 256 items (64 integers expanded to 256 bytes).
+   * Vectorization is beneficial here because the block size is 256.
+   */
   void expand8(int[] arr);
 }

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
@@ -144,4 +144,6 @@ public interface VectorUtilSupport {
   int filterByScore(int[] docBuffer, double[] scoreBuffer, double minScoreInclusive, int upTo);
 
   float[] l2normalize(float[] v, boolean throwOnZero);
+
+  void expand8(int[] arr);
 }

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
@@ -147,9 +147,9 @@ public interface VectorUtilSupport {
 
   /**
    * Expands a 64-element integer array into a 256-element array by extracting individual bytes.
-   * Each 32-bit integer is split into 4 bytes, expanding the array from 64 to 256 elements.
-   * Only works on arrays with exactly 256 items (64 integers expanded to 256 bytes).
-   * Vectorization is beneficial here because the block size is 256.
+   * Each 32-bit integer is split into 4 bytes, expanding the array from 64 to 256 elements. Only
+   * works on arrays with exactly 256 items (64 integers expanded to 256 bytes). Vectorization is
+   * beneficial here because the block size is 256.
    */
   void expand8(int[] arr);
 }

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -484,4 +484,8 @@ public final class VectorUtil {
     }
     return IMPL.filterByScore(docBuffer, scoreBuffer, minScoreInclusive, upTo);
   }
+
+  public static void expand8(int[] arr) {
+    IMPL.expand8(arr);
+  }
 }

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -1409,4 +1409,28 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       FloatVector.fromArray(FLOAT_SPECIES, v, i).mul(invNormVector).intoArray(v, i);
     }
   }
+
+  private static final boolean EXPAND_8_VECTOR_OPTIMIZATION = INT_SPECIES.length() >= 4;
+
+  @Override
+  public void expand8(int[] arr) {
+    if (EXPAND_8_VECTOR_OPTIMIZATION) {
+      for (int i = 0; i < 64; i += INT_SPECIES.length()) {
+        IntVector v = IntVector.fromArray(INT_SPECIES, arr, i);
+
+        v.lanewise(LSHR, 24).intoArray(arr, i);
+        v.lanewise(LSHR, 16).and(0xFF).intoArray(arr, 64 + i);
+        v.lanewise(LSHR, 8).and(0xFF).intoArray(arr, 128 + i);
+        v.and(0xFF).intoArray(arr, 192 + i);
+      }
+    } else {
+      for (int i = 0; i < 64; ++i) {
+        int l = arr[i];
+        arr[i] = (l >>> 24) & 0xFF;
+        arr[64 + i] = (l >>> 16) & 0xFF;
+        arr[128 + i] = (l >>> 8) & 0xFF;
+        arr[192 + i] = l & 0xFF;
+      }
+    }
+  }
 }

--- a/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java24/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -1414,6 +1414,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
   @Override
   public void expand8(int[] arr) {
+    // BLOCK_SIZE is 256
     if (EXPAND_8_VECTOR_OPTIMIZATION) {
       for (int i = 0; i < 64; i += INT_SPECIES.length()) {
         IntVector v = IntVector.fromArray(INT_SPECIES, arr, i);


### PR DESCRIPTION
This PR optimizes the expand8 routine by leveraging the JDK Vector API. 

#### Benchmarks
I have validated performance using a standalone benchmark (see [postings_expand_benchmark](https://github.com/RamakrishnaChilaka/-postings_expand_benchmark)) for block_size: 256. Key take-aways are as follows. Benchmarks ran on i5-13600k and 256 bit vectors.

| Benchmark                     | Mode | Cnt |   Score   |  Error  | Units |
|-------------------------------|------|-----|-----------|---------|-------|
| expand16 (Scalar)             | thrpt|  5  | 112.842   | ± 0.221 | ops/us |
| expand16 (Vector)             | thrpt|  5  | 105.594   | ± 1.307 | ops/us |
| expand8 (Scalar)              | thrpt|  5  |  66.726   | ± 0.452 | ops/us |
| expand8 (Vector)              | thrpt|  5  | 105.821   | ± 0.272 | ops/us |

* **expand8**: Vectorized version is ~59% faster than scalar (66.7 → 105.8 ops/us).
* **expand16**: Scalar slightly outperforms vector (112.8 vs 105.6 ops/us).

### Lucene Microbenchmarks

```

baseline
Benchmark                                (bpv)   Mode  Cnt   Score   Error   Units
PostingIndexInputBenchmark.decode            2  thrpt   15  35.409 ± 0.120  ops/us
PostingIndexInputBenchmark.decode            3  thrpt   15  29.128 ± 0.017  ops/us
PostingIndexInputBenchmark.decode            4  thrpt   15  41.492 ± 0.305  ops/us
PostingIndexInputBenchmark.decode            5  thrpt   15  32.205 ± 0.350  ops/us
PostingIndexInputBenchmark.decode            6  thrpt   15  31.237 ± 0.245  ops/us
PostingIndexInputBenchmark.decode            7  thrpt   15  29.984 ± 0.582  ops/us
PostingIndexInputBenchmark.decode            8  thrpt   15  56.366 ± 0.134  ops/us
PostingIndexInputBenchmark.decode            9  thrpt   15  22.802 ± 0.077  ops/us
PostingIndexInputBenchmark.decode           10  thrpt   15  23.502 ± 0.037  ops/us
PostingIndexInputBenchmark.decodeVector      2  thrpt   15  53.151 ± 0.070  ops/us
PostingIndexInputBenchmark.decodeVector      3  thrpt   15  48.863 ± 1.455  ops/us
PostingIndexInputBenchmark.decodeVector      4  thrpt   15  54.284 ± 2.195  ops/us
PostingIndexInputBenchmark.decodeVector      5  thrpt   15  39.302 ± 0.659  ops/us
PostingIndexInputBenchmark.decodeVector      6  thrpt   15  38.414 ± 0.830  ops/us
PostingIndexInputBenchmark.decodeVector      7  thrpt   15  39.609 ± 0.551  ops/us
PostingIndexInputBenchmark.decodeVector      8  thrpt   15  56.373 ± 0.118  ops/us
PostingIndexInputBenchmark.decodeVector      9  thrpt   15  27.295 ± 0.351  ops/us
PostingIndexInputBenchmark.decodeVector     10  thrpt   15  30.058 ± 0.172  ops/us


contender
Benchmark                                (bpv)   Mode  Cnt   Score   Error   Units
PostingIndexInputBenchmark.decode            2  thrpt   15  35.238 ± 0.209  ops/us
PostingIndexInputBenchmark.decode            3  thrpt   15  29.214 ± 0.098  ops/us
PostingIndexInputBenchmark.decode            4  thrpt   15  41.559 ± 0.580  ops/us
PostingIndexInputBenchmark.decode            5  thrpt   15  32.543 ± 0.175  ops/us
PostingIndexInputBenchmark.decode            6  thrpt   15  31.323 ± 0.061  ops/us
PostingIndexInputBenchmark.decode            7  thrpt   15  29.525 ± 0.315  ops/us
PostingIndexInputBenchmark.decode            8  thrpt   15  52.348 ± 0.079  ops/us
PostingIndexInputBenchmark.decode            9  thrpt   15  24.919 ± 0.056  ops/us
PostingIndexInputBenchmark.decode           10  thrpt   15  26.581 ± 0.049  ops/us
PostingIndexInputBenchmark.decodeVector      2  thrpt   15  71.223 ± 6.921  ops/us
PostingIndexInputBenchmark.decodeVector      3  thrpt   15  53.237 ± 1.962  ops/us
PostingIndexInputBenchmark.decodeVector      4  thrpt   15  73.437 ± 0.284  ops/us
PostingIndexInputBenchmark.decodeVector      5  thrpt   15  41.201 ± 2.067  ops/us
PostingIndexInputBenchmark.decodeVector      6  thrpt   15  46.622 ± 0.289  ops/us
PostingIndexInputBenchmark.decodeVector      7  thrpt   15  45.505 ± 1.044  ops/us
PostingIndexInputBenchmark.decodeVector      8  thrpt   15  58.368 ± 0.977  ops/us
PostingIndexInputBenchmark.decodeVector      9  thrpt   15  27.243 ± 0.358  ops/us
PostingIndexInputBenchmark.decodeVector     10  thrpt   15  30.059 ± 0.105  ops/us
``` 

### Summary
bpv -9,10 uses primitive size as 16, hence no change in performance.

|   bpv | baseline vector (ops/μs) | contender vector (ops/μs) |          Δ |
| ----: | -----------------------: | ------------------------: | ---------: |
|     2 |                     53.2 |                      71.2 |    +33.8 % |
|     3 |                     48.9 |                      53.2 |     +8.8 % |
|     4 |                     54.3 |                      73.4 |    +35.2 % |
|     5 |                     39.3 |                      41.2 |     +4.8 % |
|     6 |                     38.4 |                      46.6 |    +21.4 % |
|     7 |                     39.6 |                      45.5 |    +14.9 % |
| 8    |                 56.3 |                  58.4 | +3.7 % |
|     9 |                     27.3 |                      27.2 |     –0.4 % |
|    10 |                     30.1 |                      30.1 |      0.0 % |

