### PR TITLE
Fix the build on missing .git

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/gitinfo/GitInfoPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/gitinfo/GitInfoPlugin.java
@@ -46,6 +46,13 @@ public class GitInfoPlugin extends LuceneGradlePlugin {
                       project.getRootProject().getLayout().getProjectDirectory();
                   Path gitLocation = projectDirectory.getAsFile().toPath().resolve(".git");
                   if (!Files.exists(gitLocation)) {
+                    project
+                        .getLogger()
+                        .warn(
+                            "This seems to be a source bundle of Lucene (not a git clone). Some tasks may be "
+                                + "skipped as they rely on .git to be present (you can run 'git init' if you "
+                                + "like or use a full git clone).");
+
                     // don't return anything from the provider if we can't locate the .git
                     // folder. This will result in the property returning false from isPresent.
                     return null;
@@ -61,7 +68,7 @@ public class GitInfoPlugin extends LuceneGradlePlugin {
                             + gitLocation.toAbsolutePath());
                   }
                 }))
-        .finalizeValueOnRead();
+        .finalizeValue();
 
     var gitExec =
         project.getExtensions().getByType(LuceneBuildGlobalsExtension.class).externalTool("git");

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/gitinfo/GitInfoValueSource.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/gitinfo/GitInfoValueSource.java
@@ -37,6 +37,14 @@ public abstract class GitInfoValueSource
 
   @Override
   public Map<String, String> obtain() {
+    if (!getParameters().getDotDir().isPresent()) {
+      return Map.ofEntries(
+          Map.entry("git.commit", "unknown"),
+          Map.entry("git.commit-short", "unknown"),
+          Map.entry("git.clean", "false"),
+          Map.entry("git.changed-files", "not a git checkout"));
+    }
+
     try (var baos = new ByteArrayOutputStream();
         var out = new BufferedOutputStream(baos)) {
       var result =

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/licenses/CheckLicensesPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/licenses/CheckLicensesPlugin.java
@@ -55,8 +55,11 @@ public class CheckLicensesPlugin extends LuceneGradlePlugin {
     Project project = task.getProject();
 
     assert project.getRootProject() == project;
-    var allNonIgnoredFiles =
-        project.getExtensions().getByType(GitInfoExtension.class).getAllNonIgnoredProjectFiles();
+    GitInfoExtension gitInfoExt = project.getExtensions().getByType(GitInfoExtension.class);
+
+    task.setEnabled(gitInfoExt.getDotGitDir().isPresent());
+
+    var allNonIgnoredFiles = gitInfoExt.getAllNonIgnoredProjectFiles();
 
     task.getReportFile().set(project.getLayout().getBuildDirectory().file("licenses-report.txt"));
 


### PR DESCRIPTION
This makes the build pass when .git is missing (source bundles) (failed
https://github.com/apache/lucene/actions/workflows/run-nightly-smoketester.yml).