### PR TITLE
Fix `benchmark` programmatic/Sample.java

### DIFF
--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/programmatic/Sample.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/programmatic/Sample.java
@@ -73,7 +73,8 @@ public class Sample {
     p.setProperty("task.max.depth.log", "3");
     p.setProperty("max.buffered", "buf:10:10:100:100:10:10:100:100");
     p.setProperty("doc.maker", "org.apache.lucene.benchmark.byTask.feeds.DocMaker");
-    p.setProperty("content.source", "org.apache.lucene.benchmark.byTask.feeds.ReutersContentSource");
+    p.setProperty(
+        "content.source", "org.apache.lucene.benchmark.byTask.feeds.ReutersContentSource");
     p.setProperty("log.step", "2000");
     p.setProperty("doc.delete.step", "8");
     p.setProperty("analyzer", "org.apache.lucene.analysis.standard.StandardAnalyzer");

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/programmatic/Sample.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/programmatic/Sample.java
@@ -72,7 +72,8 @@ public class Sample {
     Properties p = new Properties();
     p.setProperty("task.max.depth.log", "3");
     p.setProperty("max.buffered", "buf:10:10:100:100:10:10:100:100");
-    p.setProperty("doc.maker", "org.apache.lucene.benchmark.byTask.feeds.ReutersContentSource");
+    p.setProperty("doc.maker", "org.apache.lucene.benchmark.byTask.feeds.DocMaker");
+    p.setProperty("content.source", "org.apache.lucene.benchmark.byTask.feeds.ReutersContentSource");
     p.setProperty("log.step", "2000");
     p.setProperty("doc.delete.step", "8");
     p.setProperty("analyzer", "org.apache.lucene.analysis.standard.StandardAnalyzer");


### PR DESCRIPTION
A slight change. Now it's failed with ClassCastException when attempting to cast ReutersContentSource to DocMaker

### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
