### PR TITLE
Introduce support for pruning and skipping to FirstPassGroupingCollector

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -75,6 +75,8 @@ Optimizations
 
 * GITHUB#15085, GITHUB#15092: Hunspell suggestions: Ensure candidate roots are not worse before updating. (Ilia Permiashkin)
 
+* GITHUB#15210: Enable pruning and skipping support for FirstPassGroupingCollector (Alexander Mueller)
+
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero

--- a/lucene/core/src/java/org/apache/lucene/search/CachingCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/CachingCollector.java
@@ -155,6 +155,17 @@ public abstract class CachingCollector extends FilterCollector {
     }
   }
 
+  private static class NoSkippingScorable extends FilterScorable {
+    public NoSkippingScorable(Scorable in) {
+      super(in);
+    }
+
+    @Override
+    public void setMinCompetitiveScore(float minScore) {
+      // ignore to enforce exhaustive hits
+    }
+  }
+
   private class NoScoreCachingLeafCollector extends FilterLeafCollector {
 
     final int maxDocsToCache;
@@ -183,6 +194,11 @@ public abstract class CachingCollector extends FilterCollector {
 
     protected void buffer(int doc) throws IOException {
       docs[docCount] = doc;
+    }
+
+    @Override
+    public void setScorer(Scorable scorer) throws IOException {
+      super.setScorer(new NoSkippingScorable(scorer));
     }
 
     @Override

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
@@ -1375,13 +1375,6 @@ public class TestGrouping extends LuceneTestCase {
               + canUseIDV);
     }
     // Run 1st pass collector to get top groups per shard
-    final Weight w =
-        topSearcher.createWeight(
-            topSearcher.rewrite(query),
-            groupSort.needsScores() || docSort.needsScores() || getMaxScores
-                ? ScoreMode.COMPLETE
-                : ScoreMode.COMPLETE_NO_SCORES,
-            1);
     final List<Collection<SearchGroup<BytesRef>>> shardGroups = new ArrayList<>();
     List<FirstPassGroupingCollector<?>> firstPassGroupingCollectors = new ArrayList<>();
     FirstPassGroupingCollector<?> firstPassCollector = null;
@@ -1405,6 +1398,10 @@ public class TestGrouping extends LuceneTestCase {
         System.out.println("    1st pass collector=" + firstPassCollector);
       }
       firstPassGroupingCollectors.add(firstPassCollector);
+
+      final Weight w =
+          topSearcher.createWeight(topSearcher.rewrite(query), firstPassCollector.scoreMode(), 1);
+
       subSearchers[shardIDX].search(w, firstPassCollector);
       final Collection<SearchGroup<BytesRef>> topGroups = getSearchGroups(firstPassCollector, 0);
       if (topGroups != null) {
@@ -1462,6 +1459,11 @@ public class TestGrouping extends LuceneTestCase {
                 docSort,
                 docOffset + topNDocs,
                 getMaxScores);
+
+        final Weight w =
+            topSearcher.createWeight(
+                topSearcher.rewrite(query), secondPassCollector.scoreMode(), 1);
+
         subSearchers[shardIDX].search(w, secondPassCollector);
         shardTopGroups[shardIDX] = getTopGroups(secondPassCollector, 0);
         if (VERBOSE) {

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.search.grouping;
 
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1520,14 +1522,14 @@ public class TestGrouping extends LuceneTestCase {
         "expected.groups.length != actual.groups.length",
         expected.groups.length,
         actual.groups.length);
-    assertEquals(
-        "expected.totalHitCount != actual.totalHitCount",
-        expected.totalHitCount,
-        actual.totalHitCount);
-    assertEquals(
-        "expected.totalGroupedHitCount != actual.totalGroupedHitCount",
-        expected.totalGroupedHitCount,
-        actual.totalGroupedHitCount);
+    assertThat(
+        "expected.totalHitCount >= actual.totalHitCount",
+        actual.totalHitCount,
+        lessThanOrEqualTo(expected.totalHitCount));
+    assertThat(
+        "expected.totalGroupedHitCount >= actual.totalGroupedHitCount",
+        actual.totalGroupedHitCount,
+        lessThanOrEqualTo(expected.totalGroupedHitCount));
     if (expected.totalGroupCount != null && verifyTotalGroupCount) {
       assertEquals(
           "expected.totalGroupCount != actual.totalGroupCount",
@@ -1556,7 +1558,10 @@ public class TestGrouping extends LuceneTestCase {
 
       // TODO
       // assertEquals(expectedGroup.maxScore, actualGroup.maxScore);
-      assertEquals(expectedGroup.totalHits().value(), actualGroup.totalHits().value());
+      assertThat(
+          "expectedGroup.totalHits().value() >= actualGroup.totalHits().value()",
+          actualGroup.totalHits().value(),
+          lessThanOrEqualTo(expectedGroup.totalHits().value()));
 
       final ScoreDoc[] expectedFDs = expectedGroup.scoreDocs();
       final ScoreDoc[] actualFDs = actualGroup.scoreDocs();


### PR DESCRIPTION
### Description

Extends the `FirstPassGroupingCollector` to support pruning (for numeric sort fields using `competitiveIterator`) and skipping of non-competitive documents (for relevance score sorting using `Scorable#setMinCompetitiveScore`).

Both optimizations are enabled automatically, thereby reducing the hit count of the collector if circumstances allow.

@jainankitk Are we fine with enabling this by default, or do we need this configurable (e.g. configurable hit threshold)?

Benchmark results using `luceneutils` for the `TermBGroup1M` scenario (combines first and second pass grouping) using a modified `wikimedium.10M.nostopwords.tasks` job. This scenario uses sort by relevance score.

```
> grep TermBGroup1M tasks/wikimedium500.tasks > tasks/wikimedium.10M.nostopwords.tasks
> python src/python/localrun.py -source wikimediumall 
```

Running on `m6a.2xlarge` using Corretto 24:

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                        PKLookup      161.09     (12.8%)      156.56     (11.2%)   -2.8% ( -23% -   24%) 0.460
                    TermBGroup1M       11.47     (14.8%)       13.44     (13.7%)   17.1% (  -9% -   53%) 0.000
```

=> ~17% overall performance improvement (first+second pass).

@jpountz I'm getting some rare test failures for `TestGrouping` caused by the `assert canSetMinCompetitiveScore` assertion in `AssertingScorer#setMinCompetitiveScore`, even though the `FirstPassGroupingCollector` uses `ScoreMode.TOP_SCORES` in all configurations when it calls `Scorable#setMinCompetitiveScore`. Is this a known issue?

Reproduce with: `gradlew test --tests TestGrouping.testRandom -Dtests.seed=EC2EC279F564DD82 -Dtests.locale=de-AT -Dtests.timezone=America/St_Thomas -Dtests.asserts=true -Dtests.file.encoding=UTF-8`

edit//Seems to be caused by the `Weight` that gets instantiated by the unit tests with either `ScoreMode.COMPLETE` or `ScoreMode.COMPLETE_NO_SCORES` regardless of the actual collectors. I updated the code to instantiate a new `Weight` instance for every collector that is in line with the collector `ScoreMode`.
