### PR TITLE
add JavaDoc for expand8 in VectorUtil

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -492,6 +492,12 @@ public final class VectorUtil {
     return IMPL.filterByScore(docBuffer, scoreBuffer, minScoreInclusive, upTo);
   }
 
+  /**
+   * Expands 64 integers in-place into a 256-element array by extracting individual bytes. Each
+   * 32-bit integer is split into 4 bytes. Only works on arrays with 256 length.
+   *
+   * @param arr the array to expand in-place
+   */
   public static void expand8(int[] arr) {
     IMPL.expand8(arr);
   }


### PR DESCRIPTION
### Description 

Follow up from https://github.com/apache/lucene/pull/15198

Add JavaDoc for `expand8` in VectorUtil.java. 