### PR TITLE
Failing test for early termination in DrillSideways

### DIFF
--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -29,6 +29,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -978,6 +980,83 @@ public class TestDrillSideways extends FacetTestCase {
 
     writer.close();
     IOUtils.close(searcher.getIndexReader(), taxoReader, taxoWriter, dir, taxoDir);
+  }
+
+
+  public void testEarlyTermination() throws Exception {
+    Directory dir = newDirectory();
+    Directory taxoDir = newDirectory();
+
+    // Writes facet ords to a separate directory from the
+    // main index:
+    DirectoryTaxonomyWriter taxoWriter =
+        new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode.CREATE);
+
+    FacetsConfig config = new FacetsConfig();
+
+    RandomIndexWriter writer = new RandomIndexWriter(random(), dir);
+
+    Document doc = new Document();
+    doc.add(new FacetField("Author", "Bob"));
+    writer.addDocument(config.build(taxoWriter, doc));
+
+    for (int i = 0 ; i < 5 ; i++) {
+      doc = new Document();
+      doc.add(new FacetField("Author", "Lisa"));
+      writer.addDocument(config.build(taxoWriter, doc));
+    }
+
+    // NRT open
+    IndexSearcher searcher = getNewSearcher(writer.getReader());
+
+    // NRT open
+    TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoWriter);
+
+    // Run all the basic test cases with a standard DrillSideways implementation:
+    DrillSideways ds = getNewDrillSideways(searcher, config, taxoReader);
+    DrillDownQuery ddq = new DrillDownQuery(config);
+    ddq.add("Author", "Lisa");
+    AtomicInteger docsCollected = new AtomicInteger(0);
+    AtomicBoolean earlyTerminated = new AtomicBoolean(false);
+    int maxDocsForEarlyTermination = 3;
+    DrillSidewaysResult result = ds.search(ddq, new SimpleCollectorManager(2, Comparator.comparing(cr -> cr.docAndScore.doc)) {
+      @Override
+      public SimpleCollector newCollector() {
+        return new SimpleCollector(ScoreMode.COMPLETE_NO_SCORES) {
+          @Override
+          public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+            return new SimpleLeafCollector() {
+              int numCollects = 0;
+              @Override
+              public void setScorer(Scorable scorer) {
+                super.scorer = scorer;
+              }
+
+              @Override
+              public void collect(int doc) throws IOException {
+                numCollects++;
+                docsCollected.incrementAndGet();
+                if (numCollects >= maxDocsForEarlyTermination) {
+                  earlyTerminated.set(true);
+                  throw new CollectionTerminatedException();
+                }
+              }
+            };
+          }
+        };
+      }
+    });
+    // sanity check that the hits collector early terminated at 3
+    assertTrue("Expecting early termination", earlyTerminated.get());
+    assertEquals("Expecting num docs collected to be 3", maxDocsForEarlyTermination, docsCollected.get());
+
+    // Facets should have early terminated
+    System.out.println(result.facets.getTopChildren(10, "Author").value);
+    assertEquals("Early termination didn't stop facet collection", maxDocsForEarlyTermination, result.facets.getTopChildren(10, "Author").value);
+
+    writer.close();
+    IOUtils.close(searcher.getIndexReader(), taxoReader, taxoWriter, dir, taxoDir);
+
   }
 
   private static class Doc implements Comparable<Doc> {

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestParallelDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestParallelDrillSideways.java
@@ -55,6 +55,11 @@ public class TestParallelDrillSideways extends TestDrillSideways {
     return new DrillSideways(searcher, config, taxoReader, null, executor);
   }
 
+  protected DrillSideways getNewDrillSidewaysWithEarlyTermination(
+      IndexSearcher searcher, FacetsConfig config, TaxonomyReader taxoReader) {
+    return new DrillSideways(searcher, config, taxoReader, null, executor, true);
+  }
+
   @Override
   protected DrillSideways getNewDrillSidewaysScoreSubdocsAtOnce(
       IndexSearcher searcher, FacetsConfig config, TaxonomyReader taxoReader) {


### PR DESCRIPTION
### Description
Failing test that shows there is no early termination in DrillSideways when the hit collector throws `CollectionTerminatedException`. This test would pass in Lucene 8.10. Related to #15220