### PR TITLE
Specify deltas when checking float values for corrections for Lucene102BinaryQuantizedVectorsFormat

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene102/TestLucene102BinaryQuantizedVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene102/TestLucene102BinaryQuantizedVectorsFormat.java
@@ -173,7 +173,14 @@ public class TestLucene102BinaryQuantizedVectorsFormat extends BaseKnnVectorsFor
                     centroid);
             packAsBinary(quantizedVector, expectedVector);
             assertArrayEquals(expectedVector, qvectorValues.vectorValue(docIndexIterator.index()));
-            assertEquals(corrections, qvectorValues.getCorrectiveTerms(docIndexIterator.index()));
+
+            var actualCorrections = qvectorValues.getCorrectiveTerms(docIndexIterator.index());
+            assertEquals(corrections.lowerInterval(), actualCorrections.lowerInterval(), 1e-5);
+            assertEquals(corrections.upperInterval(), actualCorrections.upperInterval(), 1e-5);
+            assertEquals(
+                corrections.additionalCorrection(), actualCorrections.additionalCorrection(), 1e-5);
+            assertEquals(
+                corrections.quantizedComponentSum(), actualCorrections.quantizedComponentSum());
           }
         }
       }


### PR DESCRIPTION
This fixes test failures such as https://jenkins.thetaphi.de/job/Lucene-main-Linux/58769/testReport/junit/org.apache.lucene.codecs.lucene102/TestLucene102BinaryQuantizedVectorsFormat/testQuantizedVectorsWriteAndRead/ when floats are out slightly. This matches what has been done already in `TestLucene104ScalarQuantizedVectorsFormat`