### PR TITLE
Add asynchronous prefetch for DirectIO directory

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -49,6 +49,8 @@ New Features
 
 * GITHUB#14792: Introduced OffHeapQuantizedFloatVectorValues class to access float vectors when only quantized byte vectors are available in the index. (Pulkit Gupta)
 
+* GITHUB#15224: Add asynchronous prefetching to DirectIO directories. (Ben Trent)
+
 Improvements
 ---------------------
 

--- a/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
@@ -18,6 +18,7 @@ package org.apache.lucene.misc.store;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 
+import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -27,9 +28,16 @@ import java.nio.file.Files;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.Objects;
 import java.util.OptionalLong;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
 import org.apache.lucene.store.AlreadyClosedException;
@@ -175,7 +183,7 @@ public class DirectIODirectory extends FilterDirectory {
   public IndexInput openInput(String name, IOContext context) throws IOException {
     ensureOpen();
     if (useDirectIO(name, context, OptionalLong.of(fileLength(name)))) {
-      return new DirectIOIndexInput(getDirectory().resolve(name), blockSize, mergeBufferSize);
+      return new DirectIOIndexInput(getDirectory().resolve(name), blockSize, mergeBufferSize, 16);
     } else {
       return in.openInput(name, context);
     }
@@ -308,6 +316,7 @@ public class DirectIODirectory extends FilterDirectory {
     private final long length;
     private final boolean isClosable; // clones and slices are not closable
     private boolean isOpen;
+    private final DirectIOPrefetcher prefetcher;
     private long filePos;
 
     /**
@@ -318,11 +327,14 @@ public class DirectIODirectory extends FilterDirectory {
      * @throws IOException if the operating system or filesystem does not support support Direct I/O
      *     or a sufficient equivalent.
      */
-    public DirectIOIndexInput(Path path, int blockSize, int bufferSize) throws IOException {
+    public DirectIOIndexInput(Path path, int blockSize, int bufferSize, int maxPrefetches)
+        throws IOException {
       super("DirectIOIndexInput(path=\"" + path + "\")");
       this.channel = FileChannel.open(path, StandardOpenOption.READ, getDirectOpenOption());
       this.blockSize = blockSize;
       this.buffer = allocateBuffer(bufferSize, blockSize);
+      this.prefetcher =
+          new DirectIOPrefetcher(bufferSize, blockSize, channel, maxPrefetches, maxPrefetches * 32);
       this.isOpen = true;
       this.isClosable = true;
       this.length = channel.size();
@@ -340,6 +352,13 @@ public class DirectIODirectory extends FilterDirectory {
       this.buffer = allocateBuffer(bufferSize, other.blockSize);
       this.blockSize = other.blockSize;
       this.channel = other.channel;
+      this.prefetcher =
+          new DirectIOPrefetcher(
+              bufferSize,
+              blockSize,
+              channel,
+              other.prefetcher.maxConcurrentPrefetches,
+              other.prefetcher.maxTotalPrefetches);
       this.isOpen = true;
       this.isClosable = false;
       this.length = length;
@@ -348,14 +367,42 @@ public class DirectIODirectory extends FilterDirectory {
       buffer.limit(0);
     }
 
-    private static ByteBuffer allocateBuffer(int bufferSize, int blockSize) {
+    static ByteBuffer allocateBuffer(int bufferSize, int blockSize) {
       return ByteBuffer.allocateDirect(bufferSize + blockSize - 1)
           .alignedSlice(blockSize)
           .order(LITTLE_ENDIAN);
     }
 
+    /**
+     * Prefetches the given range of bytes. The range will be aligned to blockSize and will be
+     * chopped up into chunks of buffer size.
+     *
+     * @param pos the position to prefetch from, must be non-negative and within file length
+     * @param length the length to prefetch, must be non-negative. This length may cause multiple
+     *     prefetches to be issued, depending on the buffer size.
+     */
+    @Override
+    public void prefetch(long pos, long length) throws IOException {
+      if (pos < 0 || length < 0 || pos + length > this.length) {
+        throw new IllegalArgumentException(
+            "Invalid prefetch range: pos="
+                + pos
+                + ", length="
+                + length
+                + ", fileLength="
+                + this.length);
+      }
+      // check if our current buffer already contains the requested range
+      final long absPos = pos + offset;
+      final long alignedPos = absPos - (absPos % blockSize);
+      // we only prefetch into a single buffer, even if length exceeds buffer size
+      // maybe we should improve this...
+      prefetcher.prefetch(alignedPos, length);
+    }
+
     @Override
     public void close() throws IOException {
+      prefetcher.close();
       if (isOpen && isClosable) {
         channel.close();
         isOpen = false;
@@ -395,8 +442,12 @@ public class DirectIODirectory extends FilterDirectory {
       filePos = alignedPos - buffer.capacity();
 
       final int delta = (int) (absPos - alignedPos);
-      refill(delta);
-      buffer.position(delta);
+      refill(delta, delta);
+    }
+
+    private void refill(int bytesToRead) throws IOException {
+      assert filePos % blockSize == 0;
+      refill(bytesToRead, 0);
     }
 
     @Override
@@ -440,26 +491,37 @@ public class DirectIODirectory extends FilterDirectory {
       }
     }
 
-    private void refill(int bytesToRead) throws IOException {
-      filePos += buffer.capacity();
+    private void refill(int bytesToRead, int delta) throws IOException {
+      long nextFilePos = filePos + buffer.capacity();
 
       // BaseDirectoryTestCase#testSeekPastEOF test for consecutive read past EOF,
       // hence throwing EOFException early to maintain buffer state (position in particular)
-      if (filePos > offset + length || ((offset + length) - filePos < bytesToRead)) {
+      if (nextFilePos > offset + length || ((offset + length) - nextFilePos < bytesToRead)) {
+        filePos = nextFilePos;
         throw new EOFException("read past EOF: " + this);
       }
 
       buffer.clear();
       try {
+        if (prefetcher.readBytes(nextFilePos, buffer, delta)) {
+          // handle potentially differently aligned prefetch buffer
+          // this gets tricky as the prefetch buffer is always blockSize aligned
+          // but the prefetches might be aligned on an earlier block boundary
+          // so we need to adjust the filePos accordingly
+          long currentLogicalPos = nextFilePos + delta;
+          filePos = currentLogicalPos - buffer.position();
+          return;
+        }
+        filePos = nextFilePos;
         // read may return -1 here iff filePos == channel.size(), but that's ok as it just reaches
         // EOF
         // when filePos > channel.size(), an EOFException will be thrown from above
         channel.read(buffer, filePos);
+        buffer.flip();
+        buffer.position(delta);
       } catch (IOException ioe) {
         throw new IOException(ioe.getMessage() + ": " + this, ioe);
       }
-
-      buffer.flip();
     }
 
     @Override
@@ -540,6 +602,7 @@ public class DirectIODirectory extends FilterDirectory {
     public DirectIOIndexInput clone() {
       try {
         var clone = new DirectIOIndexInput("clone:" + this, this, offset, length);
+        // TODO figure out how to make this async
         clone.seekInternal(getFilePointer());
         return clone;
       } catch (IOException ioe) {
@@ -554,8 +617,178 @@ public class DirectIODirectory extends FilterDirectory {
             "slice() " + sliceDescription + " out of bounds: " + this);
       }
       var slice = new DirectIOIndexInput(sliceDescription, this, this.offset + offset, length);
+      // TODO figure out how to make this async
       slice.seekInternal(0L);
       return slice;
+    }
+  }
+
+  /** A prefetcher that can prefetch multiple chunks of data from a FileChannel using direct IO. */
+  private static class DirectIOPrefetcher implements Closeable {
+    private final int maxConcurrentPrefetches;
+    private final int maxTotalPrefetches;
+    private final int blockSize;
+    private final long[] prefetchPos;
+    private final Future<?>[] prefetchThreads;
+    private final TreeMap<Long, Integer> posToSlot;
+    private final Deque<Integer> slots;
+    private final ByteBuffer[] prefetchBuffers;
+    private final IOException[] prefetchExceptions;
+    private final int prefetchBytesSize;
+    private final Deque<Long> pendingPrefetches = new ArrayDeque<>();
+    private final FileChannel channel;
+    private final ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+
+    DirectIOPrefetcher(
+        int prefetchBytesSize,
+        int blockSize,
+        FileChannel channel,
+        int maxConcurrentPrefetches,
+        int maxTotalPrefetches) {
+      this.blockSize = blockSize;
+      this.maxConcurrentPrefetches = maxConcurrentPrefetches;
+      this.prefetchPos = new long[maxConcurrentPrefetches];
+      this.prefetchThreads = new Future<?>[maxConcurrentPrefetches];
+      this.posToSlot = new TreeMap<>();
+      this.slots = new ArrayDeque<>(maxConcurrentPrefetches);
+      for (int i = 0; i < maxConcurrentPrefetches; i++) {
+        slots.addLast(i);
+      }
+      this.prefetchExceptions = new IOException[maxConcurrentPrefetches];
+      this.prefetchBuffers = new ByteBuffer[maxConcurrentPrefetches];
+      this.prefetchBytesSize = prefetchBytesSize;
+      this.maxTotalPrefetches = maxTotalPrefetches;
+      this.channel = channel;
+    }
+
+    /**
+     * Initiate prefetch of the given range. The range will be aligned to blockSize and chopped up
+     * into chunks of prefetchBytesSize.
+     *
+     * @param pos the position to prefetch from, must be non-negative and within file length
+     * @param length the length to prefetch, must be non-negative.
+     */
+    void prefetch(long pos, long length) {
+      // first determine how many slots we need given the length
+      int numSlots =
+          (int)
+              Math.min((length + prefetchBytesSize - 1) / prefetchBytesSize, Integer.MAX_VALUE - 1);
+      while (numSlots > 0
+          && (this.posToSlot.size() + this.pendingPrefetches.size()) < maxTotalPrefetches) {
+        final int slot;
+        Integer existingSlot = this.posToSlot.get(pos);
+        if (existingSlot != null && prefetchThreads[existingSlot] != null) {
+          // already being prefetched and hasn't been consumed.
+          // return early
+          return;
+        }
+        if (this.posToSlot.size() < maxConcurrentPrefetches && slots.isEmpty() == false) {
+          slot = slots.removeFirst();
+          posToSlot.put(pos, slot);
+          prefetchPos[slot] = pos;
+        } else {
+          slot = -1;
+          pendingPrefetches.addLast(pos);
+        }
+        if (slot != -1) {
+          startPrefetch(pos, slot);
+        }
+        pos += prefetchBytesSize;
+        numSlots--;
+      }
+    }
+
+    /**
+     * Try to read the requested bytes from an already prefetched buffer. If the requested bytes are
+     * not in a prefetched buffer, return false.
+     *
+     * @param pos the absolute position to read from
+     * @param slice the buffer to read into, must be pre-sized to the required length
+     * @param delta an offset into the slice buffer to start writing at
+     * @return true if the requested bytes were read from a prefetched buffer, false otherwise
+     * @throws IOException if an I/O error occurs
+     */
+    boolean readBytes(long pos, ByteBuffer slice, int delta) throws IOException {
+      final var entry = this.posToSlot.floorEntry(pos + delta);
+      if (entry == null) {
+        return false;
+      }
+      final int slot = entry.getValue();
+      final long prefetchedPos = entry.getKey();
+      // determine if the requested pos is within the prefetched range
+      if (pos + delta >= prefetchedPos + prefetchBytesSize) {
+        return false;
+      }
+      final Future<?> thread = prefetchThreads[slot];
+      if (thread == null) {
+        // free slot and decrement active prefetches
+        clearSlotAndMaybeStartPending(slot);
+        return false;
+      }
+      try {
+        thread.get();
+      } catch (ExecutionException | InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException("interrupted while waiting for prefetch", e);
+      }
+      if (prefetchExceptions[slot] != null) {
+        IOException e = prefetchExceptions[slot];
+        clearSlotAndMaybeStartPending(slot);
+        throw e;
+      }
+      if (prefetchBuffers[slot] == null) {
+        clearSlotAndMaybeStartPending(slot);
+        return false;
+      }
+      // our buffer sizes are uniform, and match the required buffer size, however, the position
+      // here
+      // might be before the requested pos, so offset it
+      slice.put(prefetchBuffers[slot]);
+      slice.flip();
+      slice.position(Math.toIntExact(pos - prefetchedPos) + delta);
+      clearSlotAndMaybeStartPending(slot);
+      return true;
+    }
+
+    void clearSlotAndMaybeStartPending(int slot) {
+      prefetchExceptions[slot] = null;
+      prefetchThreads[slot] = null;
+      posToSlot.remove(prefetchPos[slot]);
+      if (pendingPrefetches.isEmpty()) {
+        slots.addLast(slot);
+        return;
+      }
+      final long req = pendingPrefetches.removeFirst();
+      posToSlot.put(req, slot);
+      startPrefetch(req, slot);
+    }
+
+    void startPrefetch(long pos, int slot) {
+      prefetchExceptions[slot] = null;
+      Future<?> future =
+          executor.submit(
+              () -> {
+                try {
+                  ByteBuffer prefetchBuffer = this.prefetchBuffers[slot];
+                  if (prefetchBuffer == null) {
+                    prefetchBuffer =
+                        DirectIOIndexInput.allocateBuffer(prefetchBytesSize, blockSize);
+                    this.prefetchBuffers[slot] = prefetchBuffer;
+                  } else {
+                    prefetchBuffer.clear();
+                  }
+                  channel.read(prefetchBuffer, pos);
+                  prefetchBuffer.flip();
+                } catch (IOException e) {
+                  prefetchExceptions[slot] = e;
+                }
+              });
+      prefetchThreads[slot] = future;
+    }
+
+    @Override
+    public void close() throws IOException {
+      executor.shutdownNow();
     }
   }
 }

--- a/lucene/misc/src/test/org/apache/lucene/misc/store/TestDirectIODirectory.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/store/TestDirectIODirectory.java
@@ -17,6 +17,8 @@
 package org.apache.lucene.misc.store;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomIntBetween;
+import static org.apache.lucene.misc.store.DirectIODirectory.DEFAULT_MERGE_BUFFER_SIZE;
+import static org.apache.lucene.misc.store.DirectIODirectory.DEFAULT_MIN_BYTES_DIRECT;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -59,7 +61,11 @@ public class TestDirectIODirectory extends BaseDirectoryTestCase {
   }
 
   private static DirectIODirectory open(Path path) throws IOException {
-    return new DirectIODirectory(FSDirectory.open(path)) {
+    return new DirectIODirectory(
+        FSDirectory.open(path),
+        DEFAULT_MERGE_BUFFER_SIZE,
+        DEFAULT_MIN_BYTES_DIRECT,
+        randomIntBetween(0, 32)) {
       @Override
       protected boolean useDirectIO(String name, IOContext context, OptionalLong fileLength) {
         return true;
@@ -163,9 +169,8 @@ public class TestDirectIODirectory extends BaseDirectoryTestCase {
   public void testUseDirectIODefaults() throws Exception {
     Path path = createTempDir("testUseDirectIODefaults");
     try (DirectIODirectory dir = new DirectIODirectory(FSDirectory.open(path))) {
-      long largeSize = DirectIODirectory.DEFAULT_MIN_BYTES_DIRECT + random().nextInt(10_000);
-      long smallSize =
-          random().nextInt(Math.toIntExact(DirectIODirectory.DEFAULT_MIN_BYTES_DIRECT));
+      long largeSize = DEFAULT_MIN_BYTES_DIRECT + random().nextInt(10_000);
+      long smallSize = random().nextInt(Math.toIntExact(DEFAULT_MIN_BYTES_DIRECT));
       int numDocs = random().nextInt(1000);
 
       assertFalse(dir.useDirectIO("dummy", IOContext.DEFAULT, OptionalLong.empty()));


### PR DESCRIPTION
This adds prefetching to directIO. The idea is pretty simple,

 - configure a number of "prefetch buffers" that are the same size as the directIO buffer
 - calling prefetch will start a prefetch virtual thread to fill an available buffer
 - On read, DirectIO will attempt to refill from any prefetched buffers that match the position before attempting to do directIO itself.

When doing many prefetches and handling things in batches, this can significantly improve throughput.