### PR TITLE
Empty Terms's prepareSeekExact'get()  always false

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/TermStates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermStates.java
@@ -101,7 +101,10 @@ public final class TermStates {
     if (needsStats) {
       PendingTermLookup[] pendingTermLookups = new PendingTermLookup[0];
       for (LeafReaderContext ctx : context.leaves()) {
-        Terms terms = Terms.getTerms(ctx.reader(), term.field());
+        Terms terms = ctx.reader().terms(term.field());
+        if (terms == null) {
+          continue;
+        }
         TermsEnum termsEnum = terms.iterator();
         // Schedule the I/O in the terms dictionary in the background.
         IOBooleanSupplier termExistsSupplier = termsEnum.prepareSeekExact(term.bytes());


### PR DESCRIPTION
When constructing TermStats, if a segment does not contain the target field, we don’t need to return an empty Term, because in the second loop the corresponding `prepareSeekExact` method will always return false

