### PR TITLE
use intoBitSet to speed up scoreIterator

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -75,6 +75,8 @@ Optimizations
 
 * GITHUB#15085, GITHUB#15092: Hunspell suggestions: Ensure candidate roots are not worse before updating. (Ilia Permiashkin)
 
+* GITHUB#15230: Use intoBitSet to speed up scoreIterator. (Ke Wei)
+
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero

--- a/lucene/core/src/java/org/apache/lucene/search/BitSetDocIdStream.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BitSetDocIdStream.java
@@ -28,10 +28,14 @@ final class BitSetDocIdStream extends DocIdStream {
   private int upTo;
 
   BitSetDocIdStream(FixedBitSet bitSet, int offset) {
+    this(bitSet, offset, offset, Integer.MAX_VALUE);
+  }
+
+  BitSetDocIdStream(FixedBitSet bitSet, int offset, int upTo, int max) {
     this.bitSet = bitSet;
     this.offset = offset;
-    upTo = offset;
-    max = MathUtil.unsignedMin(Integer.MAX_VALUE, offset + bitSet.length());
+    this.upTo = upTo;
+    this.max = MathUtil.unsignedMin(max, offset + bitSet.length());
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/ConstantScoreScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ConstantScoreScorer.java
@@ -27,11 +27,11 @@ import org.apache.lucene.util.Bits;
  */
 public final class ConstantScoreScorer extends Scorer {
 
-  private class DocIdSetIteratorWrapper extends DocIdSetIterator {
+  class DocIdSetIteratorWrapper extends DocIdSetIterator {
     int doc = -1;
     DocIdSetIterator delegate;
 
-    DocIdSetIteratorWrapper(DocIdSetIterator delegate) {
+    public DocIdSetIteratorWrapper(DocIdSetIterator delegate) {
       this.delegate = delegate;
     }
 
@@ -53,6 +53,13 @@ public final class ConstantScoreScorer extends Scorer {
     @Override
     public long cost() {
       return delegate.cost();
+    }
+
+    public static DocIdSetIterator unWrapper(DocIdSetIterator iterator) {
+      if (iterator instanceof DocIdSetIteratorWrapper) {
+        return ((DocIdSetIteratorWrapper) iterator).delegate;
+      }
+      return iterator;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/Weight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Weight.java
@@ -21,7 +21,9 @@ import java.util.Objects;
 import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
 
 /**
  * Expert: Calculate query weights and build query scorers.
@@ -293,6 +295,16 @@ public abstract class Weight implements SegmentCacheable {
     private static void scoreIterator(
         LeafCollector collector, Bits acceptDocs, DocIdSetIterator iterator, int max)
         throws IOException {
+      if (acceptDocs == null) {
+        FixedBitSet fixedBitSet =
+            BitSetIterator.getFixedBitSetOrNull(
+                ConstantScoreScorer.DocIdSetIteratorWrapper.unWrapper(iterator));
+        if (fixedBitSet != null && iterator.docID() < max) {
+          collector.collect(new BitSetDocIdStream(fixedBitSet, 0, iterator.docID(), max));
+          iterator.advance(max);
+          return;
+        }
+      }
       for (int doc = iterator.docID(); doc < max; doc = iterator.nextDoc()) {
         if (acceptDocs == null || acceptDocs.get(doc)) {
           collector.collect(doc);

--- a/lucene/core/src/test/org/apache/lucene/search/TestWeight.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestWeight.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestWeight extends LuceneTestCase {
+
+  public void testBasics() throws Exception {
+    Directory dir = newDirectory();
+    RandomIndexWriter w =
+        new RandomIndexWriter(
+            random(), dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE));
+    for (int i = 0; i < 200; ++i) {
+      Document doc = new Document();
+      if (i == 42) {
+        doc.add(new StringField("f1", "bar", Field.Store.NO));
+        doc.add(new LongPoint("f2", 42L));
+        doc.add(new NumericDocValuesField("f2", 42L));
+      } else if (i == 100) {
+        doc.add(new StringField("f1", "foo", Field.Store.NO));
+        doc.add(new LongPoint("f2", 2L));
+        doc.add(new NumericDocValuesField("f2", 2L));
+      } else {
+        doc.add(new StringField("f1", "bar", Field.Store.NO));
+        doc.add(new LongPoint("f2", 2L));
+        doc.add(new NumericDocValuesField("f2", 2L));
+      }
+      w.addDocument(doc);
+    }
+    w.forceMerge(1);
+
+    IndexReader reader = w.getReader();
+    IndexSearcher searcher = newSearcher(reader);
+    w.close();
+
+    final Query boolQuery =
+        new BooleanQuery.Builder()
+            .add(
+                new IndexOrDocValuesQuery(
+                    LongPoint.newExactQuery("f2", 2),
+                    NumericDocValuesField.newSlowRangeQuery("f2", 2L, 2L)),
+                BooleanClause.Occur.MUST)
+            .build();
+
+    TopDocs topDocs = searcher.search(boolQuery, 300);
+    assertEquals(199, topDocs.totalHits.value());
+    reader.close();
+    dir.close();
+  }
+}


### PR DESCRIPTION
### Description

When no documents have been deleted, we can leverage the intoBitSet within the scoreIterator to accelerate the document collector.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
