### PR TITLE
LUCENE-15108 commit writer before opening DirectoryReader to fix test

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -96,6 +96,8 @@ Bug Fixes
 * GITHUB#14847: Allow Faiss vector format to index >2GB of vectors per-field per-segment by using MemorySegment APIs
   (instead of ByteBuffer) to copy bytes to native memory. (Kaival Parikh)
 
+* GITHUB#15108: Fixed test failure caused by DirectoryReader.open() reading an index with uncommitted changes. (Vivek Kumar)
+
 * GITHUB#15213: Don't normalize centroids with zero samples, which caused divide-by-zero. (Mike Sokolov)
 
 * GITHUB#15125: Handle inconsistent schema on flush with index sorts (Nhat Nguyen)

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/LegacyBaseDocValuesFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/LegacyBaseDocValuesFormatTestCase.java
@@ -1544,14 +1544,14 @@ public abstract class LegacyBaseDocValuesFormatTestCase extends BaseIndexFileFor
       int id = random().nextInt(numDocs);
       writer.deleteDocuments(new Term("id", Integer.toString(id)));
     }
-    try (DirectoryReader reader = maybeWrapWithMergingReader(DirectoryReader.open(dir))) {
+    try (DirectoryReader reader = maybeWrapWithMergingReader(writer.getReader())) {
       TestUtil.checkReader(reader);
       compareStoredFieldWithSortedNumericsDV(reader, "stored", "dv");
     }
     // merge some segments and ensure that at least one of them has more than
     // 256 values
     writer.forceMerge(numDocs / 256);
-    try (DirectoryReader reader = maybeWrapWithMergingReader(DirectoryReader.open(dir))) {
+    try (DirectoryReader reader = maybeWrapWithMergingReader(writer.getReader())) {
       TestUtil.checkReader(reader);
       compareStoredFieldWithSortedNumericsDV(reader, "stored", "dv");
     }


### PR DESCRIPTION
### Description

The test failed because DirectoryReader.open() tried to read the index while there were still uncommitted changes in the writer.

The fix is to call writer.commit() after we have made all the changes and before opening the reader. That makes sure the reader can actually see a proper index.

PS: This is my first commit. Please comment if I need to make any changes, and I will update the PR accordingly. Thank you.