### PR TITLE
Remove unused method which does unsafe XML parsing

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -131,6 +131,9 @@ API Changes
   IDs at once, in particular by taking advantage of the new
   NumericDocValues#longValues API. (Adrien Grand)
 
+* GITHUB#15234: Remove unused method which does unsafe XML parsing.
+  (Uwe Schindler, Isaac David)
+
 New Features
 ---------------------
 * GITHUB#14565: Add ParentsChildrenBlockJoinQuery that supports parent and child filter in the same query

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/DOMUtils.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/DOMUtils.java
@@ -19,7 +19,11 @@ package org.apache.lucene.queryparser.xml;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
-/** Helper methods for parsing XML */
+/**
+ * Helper methods for parsing XML.
+ *
+ * @lucene.internal
+ */
 public class DOMUtils {
 
   public static Element getChildByTagOrFail(Element e, String name) throws ParserException {

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/DOMUtils.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/DOMUtils.java
@@ -26,6 +26,8 @@ import org.w3c.dom.Node;
  */
 public class DOMUtils {
 
+  private DOMUtils() {}
+
   public static Element getChildByTagOrFail(Element e, String name) throws ParserException {
     Element kid = getChildByTagName(e, name);
     if (null == kid) {

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/DOMUtils.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/DOMUtils.java
@@ -16,13 +16,8 @@
  */
 package org.apache.lucene.queryparser.xml;
 
-import java.io.Reader;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-import org.xml.sax.InputSource;
 
 /** Helper methods for parsing XML */
 public class DOMUtils {
@@ -173,33 +168,5 @@ public class DOMUtils {
           }
       }
     }
-  }
-
-  /**
-   * Helper method to parse an XML file into a DOM tree, given a reader.
-   *
-   * @param is reader of the XML file to be parsed
-   * @return an org.w3c.dom.Document object
-   */
-  public static Document loadXML(Reader is) {
-    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-    DocumentBuilder db = null;
-
-    try {
-      db = dbf.newDocumentBuilder();
-    } catch (Exception se) {
-      throw new RuntimeException("Parser configuration error", se);
-    }
-
-    // Step 3: parse the input file
-    org.w3c.dom.Document doc = null;
-    try {
-      doc = db.parse(new InputSource(is));
-      // doc = db.parse(is);
-    } catch (Exception se) {
-      throw new RuntimeException("Error parsing file:" + se, se);
-    }
-
-    return doc;
   }
 }


### PR DESCRIPTION
This method parses XML in an unsafe way (XXE risk). As it is not used, remove it completely.

I don't think deprecating is needed as such methods were not meant to be public at all. I added the `@lucene.internal` flag to the whole XMLUtils class and made the ctor private.