### PR TITLE
Fix SmartChinese to only deserialize data from classpath with a native array filter applied and never cache dictionaries from custom locations

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
@@ -441,9 +441,14 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
               task.systemProperty("jdk.map.althashing.threshold", "0");
 
               // disable any Java serialization without a filter
-              task.systemProperty(
-                  "jdk.serialFilterFactory",
-                  "org.apache.lucene.tests.util.TestObjectInputFilterFactory");
+              if (project.getPath().endsWith(".tests")) {
+                // LUCENE-10301: for now, do not use the serialization filter for modular tests
+                // (test framework is not available).
+              } else if (project.getPath().startsWith(":lucene")) {
+                task.systemProperty(
+                    "jdk.serialFilterFactory",
+                    "org.apache.lucene.tests.util.TestObjectInputFilterFactory");
+              }
 
               if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
                 task.systemProperty("java.security.egd", "file:/dev/./urandom");

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
@@ -440,7 +440,7 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
               task.systemProperty("java.awt.headless", "true");
               task.systemProperty("jdk.map.althashing.threshold", "0");
 
-              // disable any Java serialization without a filter
+              // disallow any Java serialization without a filter
               if (project.getPath().endsWith(".tests")) {
                 // LUCENE-10301: for now, do not use the serialization filter for modular tests
                 // (test framework is not available).

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
@@ -440,6 +440,11 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
               task.systemProperty("java.awt.headless", "true");
               task.systemProperty("jdk.map.althashing.threshold", "0");
 
+              // disable any Java serialization without a filter
+              task.systemProperty(
+                  "jdk.serialFilterFactory",
+                  "org.apache.lucene.tests.util.TestObjectInputFilterFactory");
+
               if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
                 task.systemProperty("java.security.egd", "file:/dev/./urandom");
               }

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -187,8 +187,8 @@ Bug Fixes
 
 Other
 ---------------------
-* GITHUB#15237: Fix SmartChinese to only serialize data from classpath with a native array filter
-  applied and never cache dictionaries from custom locations. (Uwe Schindler, Isaac David)
+* GITHUB#15237: Fix SmartChinese to only deserialize dictionary data from classpath with a native array
+  filter applied and never cache dictionaries from custom locations. (Uwe Schindler, Isaac David)
 
 ======================= Lucene 10.3.0 =======================
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -188,7 +188,9 @@ Bug Fixes
 Other
 ---------------------
 * GITHUB#15237: Fix SmartChinese to only deserialize dictionary data from classpath with a native array
-  filter applied and never cache dictionaries from custom locations. (Uwe Schindler, Isaac David)
+  filter applied and never cache dictionaries from custom locations. Also install a global deserialization
+  filter factory that disallows any unprotected deserialization while running tests.
+  (Uwe Schindler, Isaac David)
 
 ======================= Lucene 10.3.0 =======================
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -187,7 +187,8 @@ Bug Fixes
 
 Other
 ---------------------
-(No changes)
+* GITHUB#15237: Fix SmartChinese to only serialize data from classpath with a native array filter
+  applied and never cache dictionaries from custom locations. (Uwe Schindler, Isaac David)
 
 ======================= Lucene 10.3.0 =======================
 

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/AbstractDictionary.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/AbstractDictionary.java
@@ -16,6 +16,9 @@
  */
 package org.apache.lucene.analysis.cn.smart.hhmm;
 
+import java.io.ObjectInputFilter.FilterInfo;
+import java.io.ObjectInputFilter.Status;
+import java.io.ObjectInputStream;
 import java.io.UnsupportedEncodingException;
 
 /**
@@ -194,5 +197,17 @@ abstract class AbstractDictionary {
     }
 
     return hash;
+  }
+
+  /** Safety filter for {@link ObjectInputStream} to only allow arrays of primitive types. */
+  final Status filterObjectInputStream(FilterInfo info) {
+    var cl = info.serialClass();
+    if (cl == null) {
+      return Status.UNDECIDED;
+    }
+    while (cl.isArray()) {
+      cl = cl.getComponentType();
+    }
+    return cl.isPrimitive() ? Status.ALLOWED : Status.REJECTED;
   }
 }

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BigramDictionary.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BigramDictionary.java
@@ -114,6 +114,9 @@ class BigramDictionary extends AbstractDictionary {
       frequencyTable[i] = 0;
     }
     loadFromFile(bigramDictPath);
+
+    /* Enable the following line to regenerate the serialized file: */
+    // saveToObj(Paths.get(dictRoot + "/bigramdict.mem"));
   }
 
   /**

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BigramDictionary.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BigramDictionary.java
@@ -77,20 +77,12 @@ class BigramDictionary extends AbstractDictionary {
     return singleInstance;
   }
 
-  private boolean loadFromObj(Path serialObj) {
-    try {
-      loadFromInputStream(Files.newInputStream(serialObj));
-      return true;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   @SuppressForbidden(
       reason = "TODO: fix code to serialize its own dictionary vs. a binary blob in the codebase")
   private void loadFromInputStream(InputStream serialObjectInputStream)
       throws IOException, ClassNotFoundException {
     try (ObjectInputStream input = new ObjectInputStream(serialObjectInputStream)) {
+      input.setObjectInputFilter(this::filterObjectInputStream);
       bigramHashTable = (long[]) input.readObject();
       frequencyTable = (int[]) input.readObject();
       // log.info("load bigram dict from serialization.");
@@ -114,26 +106,14 @@ class BigramDictionary extends AbstractDictionary {
 
   private void load(String dictRoot) throws IOException {
     String bigramDictPath = dictRoot + "/bigramdict.dct";
-
-    Path serialObj = Paths.get(dictRoot + "/bigramdict.mem");
-
-    if (Files.exists(serialObj) && loadFromObj(serialObj)) {
-
-    } else {
-      try {
-        bigramHashTable = new long[PRIME_BIGRAM_LENGTH];
-        frequencyTable = new int[PRIME_BIGRAM_LENGTH];
-        for (int i = 0; i < PRIME_BIGRAM_LENGTH; i++) {
-          // it is possible for a value to hash to 0, but the probability is extremely low
-          bigramHashTable[i] = 0;
-          frequencyTable[i] = 0;
-        }
-        loadFromFile(bigramDictPath);
-      } catch (IOException e) {
-        throw new RuntimeException(e.getMessage());
-      }
-      saveToObj(serialObj);
+    bigramHashTable = new long[PRIME_BIGRAM_LENGTH];
+    frequencyTable = new int[PRIME_BIGRAM_LENGTH];
+    for (int i = 0; i < PRIME_BIGRAM_LENGTH; i++) {
+      // it is possible for a value to hash to 0, but the probability is extremely low
+      bigramHashTable[i] = 0;
+      frequencyTable[i] = 0;
     }
+    loadFromFile(bigramDictPath);
   }
 
   /**

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/WordDictionary.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/WordDictionary.java
@@ -150,15 +150,13 @@ class WordDictionary extends AbstractDictionary {
 
   @SuppressForbidden(
       reason = "TODO: fix code to serialize its own dictionary vs. a binary blob in the codebase")
-  private void saveToObj(Path serialObj) {
+  private void saveToObj(Path serialObj) throws IOException {
     try (ObjectOutputStream output = new ObjectOutputStream(Files.newOutputStream(serialObj))) {
       output.writeObject(wordIndexTable);
       output.writeObject(charIndexTable);
       output.writeObject(wordItem_charArrayTable);
       output.writeObject(wordItem_frequencyTable);
       // log.info("serialize core dict.");
-    } catch (Exception _) {
-      // log.warn(e.getMessage());
     }
   }
 

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/WordDictionary.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/WordDictionary.java
@@ -122,6 +122,9 @@ class WordDictionary extends AbstractDictionary {
     mergeSameWords();
     sortEachItems();
     // log.info("load dictionary: " + dctFilePath + " total:" + total);
+
+    /* Enable the following line to regenerate the serialized file: */
+    // saveToObj(Paths.get(dctFileRoot + "/coredict.mem"));
   }
 
   /**

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/WordDictionary.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/WordDictionary.java
@@ -80,8 +80,20 @@ class WordDictionary extends AbstractDictionary {
       try {
         singleInstance.load();
       } catch (IOException _) {
-        String wordDictRoot = AnalyzerProfile.ANALYSIS_DATA_DIR;
-        singleInstance.load(wordDictRoot);
+        try {
+          singleInstance.load();
+        } catch (IOException e) {
+          String dictRoot = AnalyzerProfile.ANALYSIS_DATA_DIR;
+          try {
+            singleInstance.load(dictRoot);
+          } catch (IOException ioe) {
+            RuntimeException ex = new RuntimeException(ioe);
+            ex.addSuppressed(e);
+            throw ex;
+          }
+        } catch (ClassNotFoundException e) {
+          throw new RuntimeException(e);
+        }
       } catch (ClassNotFoundException e) {
         throw new RuntimeException(e);
       }
@@ -94,26 +106,22 @@ class WordDictionary extends AbstractDictionary {
    *
    * @param dctFileRoot path to dictionary directory
    */
-  public void load(String dctFileRoot) {
+  public void load(String dctFileRoot) throws IOException {
     String dctFilePath = dctFileRoot + "/coredict.dct";
-    try {
-      wordIndexTable = new short[PRIME_INDEX_LENGTH];
-      charIndexTable = new char[PRIME_INDEX_LENGTH];
-      for (int i = 0; i < PRIME_INDEX_LENGTH; i++) {
-        charIndexTable[i] = 0;
-        wordIndexTable[i] = -1;
-      }
-      wordItem_charArrayTable = new char[GB2312_CHAR_NUM][][];
-      wordItem_frequencyTable = new int[GB2312_CHAR_NUM][];
-      // int total =
-      loadMainDataFromFile(dctFilePath);
-      expandDelimiterData();
-      mergeSameWords();
-      sortEachItems();
-      // log.info("load dictionary: " + dctFilePath + " total:" + total);
-    } catch (IOException e) {
-      throw new RuntimeException(e.getMessage());
+    wordIndexTable = new short[PRIME_INDEX_LENGTH];
+    charIndexTable = new char[PRIME_INDEX_LENGTH];
+    for (int i = 0; i < PRIME_INDEX_LENGTH; i++) {
+      charIndexTable[i] = 0;
+      wordIndexTable[i] = -1;
     }
+    wordItem_charArrayTable = new char[GB2312_CHAR_NUM][][];
+    wordItem_frequencyTable = new int[GB2312_CHAR_NUM][];
+    // int total =
+    loadMainDataFromFile(dctFilePath);
+    expandDelimiterData();
+    mergeSameWords();
+    sortEachItems();
+    // log.info("load dictionary: " + dctFilePath + " total:" + total);
   }
 
   /**

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/WordDictionary.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/WordDictionary.java
@@ -90,38 +90,29 @@ class WordDictionary extends AbstractDictionary {
   }
 
   /**
-   * Attempt to load dictionary from provided directory, first trying coredict.mem, failing back on
-   * coredict.dct
+   * Attempt to load dictionary from provided path to coredict.dct
    *
    * @param dctFileRoot path to dictionary directory
    */
   public void load(String dctFileRoot) {
     String dctFilePath = dctFileRoot + "/coredict.dct";
-    Path serialObj = Paths.get(dctFileRoot + "/coredict.mem");
-
-    if (Files.exists(serialObj) && loadFromObj(serialObj)) {
-
-    } else {
-      try {
-        wordIndexTable = new short[PRIME_INDEX_LENGTH];
-        charIndexTable = new char[PRIME_INDEX_LENGTH];
-        for (int i = 0; i < PRIME_INDEX_LENGTH; i++) {
-          charIndexTable[i] = 0;
-          wordIndexTable[i] = -1;
-        }
-        wordItem_charArrayTable = new char[GB2312_CHAR_NUM][][];
-        wordItem_frequencyTable = new int[GB2312_CHAR_NUM][];
-        // int total =
-        loadMainDataFromFile(dctFilePath);
-        expandDelimiterData();
-        mergeSameWords();
-        sortEachItems();
-        // log.info("load dictionary: " + dctFilePath + " total:" + total);
-      } catch (IOException e) {
-        throw new RuntimeException(e.getMessage());
+    try {
+      wordIndexTable = new short[PRIME_INDEX_LENGTH];
+      charIndexTable = new char[PRIME_INDEX_LENGTH];
+      for (int i = 0; i < PRIME_INDEX_LENGTH; i++) {
+        charIndexTable[i] = 0;
+        wordIndexTable[i] = -1;
       }
-
-      saveToObj(serialObj);
+      wordItem_charArrayTable = new char[GB2312_CHAR_NUM][][];
+      wordItem_frequencyTable = new int[GB2312_CHAR_NUM][];
+      // int total =
+      loadMainDataFromFile(dctFilePath);
+      expandDelimiterData();
+      mergeSameWords();
+      sortEachItems();
+      // log.info("load dictionary: " + dctFilePath + " total:" + total);
+    } catch (IOException e) {
+      throw new RuntimeException(e.getMessage());
     }
   }
 
@@ -135,20 +126,12 @@ class WordDictionary extends AbstractDictionary {
     loadFromObjectInputStream(input);
   }
 
-  private boolean loadFromObj(Path serialObj) {
-    try {
-      loadFromObjectInputStream(Files.newInputStream(serialObj));
-      return true;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   @SuppressForbidden(
       reason = "TODO: fix code to serialize its own dictionary vs. a binary blob in the codebase")
   private void loadFromObjectInputStream(InputStream serialObjectInputStream)
       throws IOException, ClassNotFoundException {
     try (ObjectInputStream input = new ObjectInputStream(serialObjectInputStream)) {
+      input.setObjectInputFilter(this::filterObjectInputStream);
       wordIndexTable = (short[]) input.readObject();
       charIndexTable = (char[]) input.readObject();
       wordItem_charArrayTable = (char[][][]) input.readObject();

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -53,7 +53,6 @@ import java.io.Closeable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectInputFilter;
 import java.io.PrintStream;
 import java.lang.StackWalker.StackFrame;
 import java.lang.annotation.Documented;
@@ -497,14 +496,6 @@ public abstract class LuceneTestCase extends Assert {
       defaultValue |= systemPropertyAsBoolean(property, false);
     }
     LEAVE_TEMPORARY = defaultValue;
-  }
-
-  /* Make sure we do not allow Java serialization without custom filters anywhere while running tests.
-   * We could have activated that already in the test runner Gradle plugin, but Gradle itsself uses
-   * unfiltered serialization on startup.
-   */
-  static {
-    ObjectInputFilter.Config.setSerialFilter(_ -> ObjectInputFilter.Status.REJECTED);
   }
 
   /** Filesystem-based {@link Directory} implementations. */

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -53,6 +53,7 @@ import java.io.Closeable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectInputFilter;
 import java.io.PrintStream;
 import java.lang.StackWalker.StackFrame;
 import java.lang.annotation.Documented;
@@ -496,6 +497,14 @@ public abstract class LuceneTestCase extends Assert {
       defaultValue |= systemPropertyAsBoolean(property, false);
     }
     LEAVE_TEMPORARY = defaultValue;
+  }
+
+  /* Make sure we do not allow Java serialization without custom filters anywhere while running tests.
+   * We could have activated that already in the test runner Gradle plugin, but Gradle itsself uses
+   * unfiltered serialization on startup.
+   */
+  static {
+    ObjectInputFilter.Config.setSerialFilter(_ -> ObjectInputFilter.Status.REJECTED);
   }
 
   /** Filesystem-based {@link Directory} implementations. */

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestObjectInputFilterFactory.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestObjectInputFilterFactory.java
@@ -34,7 +34,7 @@ public final class TestObjectInputFilterFactory implements BinaryOperator<Object
 
   @Override
   public ObjectInputFilter apply(ObjectInputFilter curr, ObjectInputFilter next) {
-    // if Gradle's deserializer is on the stack, return next filter:
+    // if Gradle's deserializer is on the stack, return next filter (which is obviously null):
     if (StackWalker.getInstance()
         .walk(s -> s.anyMatch(TestObjectInputFilterFactory::isGradleSerializerStackFrame))) {
       return next;
@@ -43,12 +43,8 @@ public final class TestObjectInputFilterFactory implements BinaryOperator<Object
     if (curr == null && next == null) {
       return DENY_ALL_FILTER;
     }
-    // if code installs a new filter, but ours is active return only the new filter:
-    if (curr == DENY_ALL_FILTER) {
-      return next;
-    }
-    // otherwise merge filters:
-    return ObjectInputFilter.merge(next, curr);
+    // if code installs its own filter return it:
+    return next;
   }
 
   private static boolean isGradleSerializerStackFrame(StackFrame f) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestObjectInputFilterFactory.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestObjectInputFilterFactory.java
@@ -44,7 +44,7 @@ public final class TestObjectInputFilterFactory implements BinaryOperator<Object
     return ObjectInputFilter.merge(next, curr);
   }
 
-  private static ObjectInputFilter DENY_ALL_EXCEPT_GRADLE_FILTER =
+  private static final ObjectInputFilter DENY_ALL_EXCEPT_GRADLE_FILTER =
       _ -> {
         return (StackWalker.getInstance()
                 .walk(s -> s.anyMatch(TestObjectInputFilterFactory::isGradleSerializerStackFrame)))

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestObjectInputFilterFactory.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestObjectInputFilterFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.tests.util;
+
+import java.io.ObjectInputFilter;
+import java.io.ObjectInputFilter.Status;
+import java.lang.StackWalker.StackFrame;
+import java.util.function.BinaryOperator;
+
+/**
+ * Make sure we do not allow Java serialization without custom filters anywhere while running tests.
+ * This factory returns a "deny-all" deserialization filter if none was installed by the
+ * deserializer. To allow Gradle's test runner to serialize its config, all calls from Gradle are
+ * allowed.
+ */
+public final class TestObjectInputFilterFactory implements BinaryOperator<ObjectInputFilter> {
+
+  @Override
+  public ObjectInputFilter apply(ObjectInputFilter curr, ObjectInputFilter next) {
+    // if no filter was configured return our filter that rejects all deserialization and only
+    // allows Gradle deserializing test runner information:
+    if (curr == null && next == null) {
+      return DENY_ALL_EXCEPT_GRADLE_FILTER;
+    }
+    // if code installs a new filter, but ours is active return only the new filter:
+    if (curr == DENY_ALL_EXCEPT_GRADLE_FILTER) {
+      return next;
+    }
+    // merge filters:
+    return ObjectInputFilter.merge(next, curr);
+  }
+
+  private static ObjectInputFilter DENY_ALL_EXCEPT_GRADLE_FILTER =
+      _ -> {
+        return (StackWalker.getInstance()
+                .walk(s -> s.anyMatch(TestObjectInputFilterFactory::isGradleSerializerStackFrame)))
+            ? Status.ALLOWED
+            : Status.REJECTED;
+      };
+
+  private static boolean isGradleSerializerStackFrame(StackFrame f) {
+    final String methodName = f.getMethodName(), className = f.getClassName();
+    return ("deserializeWorker".equals(methodName)
+        && "org.gradle.process.internal.worker.messaging.WorkerConfigSerializer".equals(className));
+  }
+}

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestTestObjectInputFilterFactory.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestTestObjectInputFilterFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.tests.util;
+
+import static java.io.ObjectInputFilter.Config.getSerialFilterFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InvalidClassException;
+import java.io.ObjectInputFilter;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.HashMap;
+import org.apache.lucene.util.SuppressForbidden;
+import org.junit.BeforeClass;
+
+@SuppressForbidden(reason = "tests the forbidden code")
+public final class TestTestObjectInputFilterFactory extends LuceneTestCase {
+
+  @BeforeClass
+  public static void beforeClass() {
+    assumeTrue(
+        "Only works when TestObjectInputFilterFactory is installed in JVM",
+        getSerialFilterFactory() instanceof TestObjectInputFilterFactory);
+  }
+
+  private InputStream openStream() throws IOException {
+    var out = new ByteArrayOutputStream();
+    try (var oout = new ObjectOutputStream(out)) {
+      oout.writeObject(new HashMap<>());
+    }
+    return new ByteArrayInputStream(out.toByteArray());
+  }
+
+  public void testDeserializationWithoutFilter() throws Exception {
+    try (var oin = new ObjectInputStream(openStream())) {
+      // no filter set!
+      var ex = assertThrows(InvalidClassException.class, () -> oin.readObject());
+      assertTrue(ex.getMessage().contains("REJECTED"));
+    }
+  }
+
+  public void testDeserializationWithAllowFilter() throws Exception {
+    try (var oin = new ObjectInputStream(openStream())) {
+      oin.setObjectInputFilter(ObjectInputFilter.Config.createFilter("java.util.HashMap;!*"));
+      oin.readObject();
+    }
+  }
+
+  public void testDeserializationWithDenyFilter() throws Exception {
+    try (var oin = new ObjectInputStream(openStream())) {
+      oin.setObjectInputFilter(ObjectInputFilter.Config.createFilter("!*"));
+      var ex = assertThrows(InvalidClassException.class, () -> oin.readObject());
+      assertTrue(ex.getMessage().contains("REJECTED"));
+    }
+  }
+}

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestTestObjectInputFilterFactory.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestTestObjectInputFilterFactory.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.tests.util;
 
+import static java.io.ObjectInputFilter.Config.createFilter;
 import static java.io.ObjectInputFilter.Config.getSerialFilterFactory;
 
 import java.io.ByteArrayInputStream;
@@ -23,7 +24,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InvalidClassException;
-import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.HashMap;
@@ -58,16 +58,22 @@ public final class TestTestObjectInputFilterFactory extends LuceneTestCase {
 
   public void testDeserializationWithAllowFilter() throws Exception {
     try (var oin = new ObjectInputStream(openStream())) {
-      oin.setObjectInputFilter(ObjectInputFilter.Config.createFilter("java.util.HashMap;!*"));
+      oin.setObjectInputFilter(createFilter("java.util.HashMap;!*"));
       oin.readObject();
     }
   }
 
   public void testDeserializationWithDenyFilter() throws Exception {
     try (var oin = new ObjectInputStream(openStream())) {
-      oin.setObjectInputFilter(ObjectInputFilter.Config.createFilter("!*"));
+      oin.setObjectInputFilter(createFilter("!*"));
       var ex = assertThrows(InvalidClassException.class, () -> oin.readObject());
       assertTrue(ex.getMessage().contains("REJECTED"));
+    }
+  }
+
+  public void testBadCodeJustSettingNullFilter() throws Exception {
+    try (var oin = new ObjectInputStream(openStream())) {
+      assertThrows(IllegalStateException.class, () -> oin.setObjectInputFilter(null));
     }
   }
 }


### PR DESCRIPTION
This PR improves SmartChinese analyzer to only load Java serialized `.mem` files from classpath and never ever cache custom dictionaries in serialized form.

This also adds a filter to the `ObjectInputStream` used for loading the legacy dictionary format from classpath to only accept (arrays of) native types.

At a later stage we should completely remove the serialized data and also add the original sources of the dictionaries (bigram and core) to the Lucene repo and use `DataInput/DataOutput` to write our custom file format.