### PR TITLE
ci: tune codeql for java to use default query pack

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
             queries: security-extended
           - language: java
             build-mode: none
-            queries: default # security-extended is very noisy for the java language
+            queries: codeql/java-queries # security-extended is very noisy for the java language
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,10 +27,13 @@ jobs:
         include:
           - language: actions
             build-mode: none
-          - language: java
-            build-mode: none
+            queries: security-extended
           - language: python
             build-mode: none
+            queries: security-extended
+          - language: java
+            build-mode: none
+            queries: default # security-extended is very noisy for the java language
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -46,7 +49,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-          queries: security-extended
+          queries: ${{ matrix.queries }}
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
             queries: security-extended
           - language: java
             build-mode: none
-            queries: codeql/java-queries # security-extended is very noisy for the java language
+            queries: "" # security-extended is very noisy for the java language
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Set security-extended queries only for actions and python.

Security-extended for java contains too many noisy checks (e.g. every single place an implicit narrowing cast happens from a compound assignment).

