### PR TITLE
ci: further tune the codeql

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,10 @@
+---
+query-filters:
+  - exclude:
+      # Very noisy check which can also be accomplished with an ordinary linter.
+      # See: https://codeql.github.com/codeql-query-help/java/java-implicit-cast-in-compound-assignment/
+      id: java/implicit-cast-in-compound-assignment
+  - exclude:
+      # Very noisy check which can also be accomplished with an ordinary linter.
+      # See: https://codeql.github.com/codeql-query-help/java/java-comparison-with-wider-type/
+      id: java/comparison-with-wider-type

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,13 +27,10 @@ jobs:
         include:
           - language: actions
             build-mode: none
-            queries: security-extended
           - language: python
             build-mode: none
-            queries: security-extended
           - language: java
             build-mode: none
-            queries: "" # security-extended is very noisy for the java language
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -49,7 +46,8 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-          queries: ${{ matrix.queries }}
+          queries: security-extended
+          config-file: ./.github/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3


### PR DESCRIPTION
Some of the security-extended checks were actually useful, it only has one extremely noisy rule, just like the default queries have one extremely noisy rule.

Disable both of the noisy rules via configuration file instead.
