### PR TITLE
[10.3] Fix returned Impacts when frequencies are not indexed

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,7 +7,9 @@ http://s.apache.org/luceneversions
 
 Bug Fixes
 ---------------------
-(No changes)
+* GITHUB#15263: Fix the returned Impact returned from Lucene103PostingsReader when frequencies
+  are not indexed. It was returning a wrong frequency in that case affecting scoring which
+  might led to performance issues. (Ignacio Vera)
 
 ======================= Lucene 10.3.0 =======================
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/Lucene103PostingsReader.java
@@ -68,12 +68,9 @@ import org.apache.lucene.util.VectorUtil;
 public final class Lucene103PostingsReader extends PostingsReaderBase {
 
   static final VectorizationProvider VECTORIZATION_PROVIDER = VectorizationProvider.getInstance();
-  // Dummy impacts, composed of the maximum possible term frequency and the lowest possible
-  // (unsigned) norm value. This is typically used on tail blocks, which don't actually record
-  // impacts as the storage overhead would not be worth any query evaluation speedup, since there's
-  // less than 128 docs left to evaluate anyway.
-  private static final List<Impact> DUMMY_IMPACTS =
-      Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L));
+
+  private static final List<Impact> DUMMY_IMPACTS_NO_FREQ =
+      Collections.singletonList(new Impact(1, 1L));
 
   private final IndexInput docIn;
   private final IndexInput posIn;
@@ -1382,7 +1379,8 @@ public final class Lucene103PostingsReader extends PostingsReaderBase {
                 return readImpacts(level1SerializedImpacts, level1Impacts);
               }
             }
-            return DUMMY_IMPACTS;
+            // Max freq is 1 since freqs are not indexed
+            return DUMMY_IMPACTS_NO_FREQ;
           }
 
           private List<Impact> readImpacts(BytesRef serialized, MutableImpactList impactsList) {


### PR DESCRIPTION
Return an Impact object with freqs equal to 1 instead of Integer.MAX_VALUE.

Note that this bug does not exists in main as it was fixed in https://github.com/apache/lucene/pull/15151

Iam working on adding a test
