### PR TITLE
Performance regression in vector computations due to call site pollution

### DIFF
--- a/lucene/benchmark-jmh/src/resources/vector-directives.json
+++ b/lucene/benchmark-jmh/src/resources/vector-directives.json
@@ -1,0 +1,9 @@
+[
+  {
+    "match": [ "org.apache.lucene.internal.vectorization.PanamaVectorUtilSupport::*" ],
+    "inline": [
+      "-org.apache.lucene.internal.vectorization.PanamaVectorUtilSupport$ArrayLoader::*",
+      "-org.apache.lucene.internal.vectorization.PanamaVectorUtilSupport$MemorySegmentLoader::*"
+    ]
+  }
+]


### PR DESCRIPTION
I was trying to figure out why #14863 adversely affected indexing performance of byte quantized vectors in nightly benchmarks (see https://github.com/apache/lucene/pull/14863#issuecomment-3318974886), when it was supposed to speed things up by doing vector computations off-heap -- and _may_ have found something interesting!