### PR TITLE
Replace conditional logic in add(), subtract() with bit manipulation

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/NumericUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/NumericUtils.java
@@ -96,13 +96,10 @@ public final class NumericUtils {
     int end = start + bytesPerDim;
     int borrow = 0;
     for (int i = end - 1; i >= start; i--) {
+      // diff is always in the range [-256, 255]
       int diff = (a[i] & 0xff) - (b[i] & 0xff) - borrow;
-      if (diff < 0) {
-        diff += 256;
-        borrow = 1;
-      } else {
-        borrow = 0;
-      }
+      borrow = (diff >>> 31); // Extract sign bit as borrow
+      diff += (borrow << 8);
       result[i - start] = (byte) diff;
     }
     if (borrow != 0) {
@@ -120,12 +117,9 @@ public final class NumericUtils {
     int carry = 0;
     for (int i = end - 1; i >= start; i--) {
       int digitSum = (a[i] & 0xff) + (b[i] & 0xff) + carry;
-      if (digitSum > 255) {
-        digitSum -= 256;
-        carry = 1;
-      } else {
-        carry = 0;
-      }
+      // Below is safe as digitSum can be at most 511(255 * 2 + 1), so never exceeds 9 bits
+      carry = digitSum >>> 8;
+      digitSum &= 0xFF;
       result[i - start] = (byte) digitSum;
     }
     if (carry != 0) {


### PR DESCRIPTION
### Description

I came across this logic in add(), subtract() in NumericUtils where we have branching logic to extract carry/borrow.
Seems like we can better replace it with bitwise logic, and it would be faster.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
