### PR TITLE
Use appropriate return type for byte vector specific cosineBody* functions

### DIFF
--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -700,7 +700,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     // only vectorize if we'll at least enter the loop a single time
     if (a.length() >= 16) {
-      final float[] ret;
+      final int[] ret;
       if (VECTOR_BITSIZE >= 512) {
         i += BYTE_SPECIES.loopBound(a.length());
         ret = cosineBody512(a, b, i);
@@ -729,7 +729,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   }
 
   /** vectorized cosine body (512 bit vectors) */
-  private static float[] cosineBody512(ByteVectorLoader a, ByteVectorLoader b, int limit) {
+  private static int[] cosineBody512(ByteVectorLoader a, ByteVectorLoader b, int limit) {
     IntVector accSum = IntVector.zero(INT_SPECIES);
     IntVector accNorm1 = IntVector.zero(INT_SPECIES);
     IntVector accNorm2 = IntVector.zero(INT_SPECIES);
@@ -753,13 +753,13 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       accSum = accSum.add(prod32);
     }
     // reduce
-    return new float[] {
+    return new int[] {
       accSum.reduceLanes(ADD), accNorm1.reduceLanes(ADD), accNorm2.reduceLanes(ADD)
     };
   }
 
   /** vectorized cosine body (256 bit vectors) */
-  private static float[] cosineBody256(ByteVectorLoader a, ByteVectorLoader b, int limit) {
+  private static int[] cosineBody256(ByteVectorLoader a, ByteVectorLoader b, int limit) {
     IntVector accSum = IntVector.zero(IntVector.SPECIES_256);
     IntVector accNorm1 = IntVector.zero(IntVector.SPECIES_256);
     IntVector accNorm2 = IntVector.zero(IntVector.SPECIES_256);
@@ -778,13 +778,13 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       accSum = accSum.add(prod32);
     }
     // reduce
-    return new float[] {
+    return new int[] {
       accSum.reduceLanes(ADD), accNorm1.reduceLanes(ADD), accNorm2.reduceLanes(ADD)
     };
   }
 
   /** vectorized cosine body (128 bit vectors) */
-  private static float[] cosineBody128(ByteVectorLoader a, ByteVectorLoader b, int limit) {
+  private static int[] cosineBody128(ByteVectorLoader a, ByteVectorLoader b, int limit) {
     IntVector accSum = IntVector.zero(IntVector.SPECIES_128);
     IntVector accNorm1 = IntVector.zero(IntVector.SPECIES_128);
     IntVector accNorm2 = IntVector.zero(IntVector.SPECIES_128);
@@ -805,7 +805,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       accSum = accSum.add(prod16.convertShape(S2I, IntVector.SPECIES_128, 0));
     }
     // reduce
-    return new float[] {
+    return new int[] {
       accSum.reduceLanes(ADD), accNorm1.reduceLanes(ADD), accNorm2.reduceLanes(ADD)
     };
   }


### PR DESCRIPTION
### Description

Intermediate cast from `int` -> `float` -> `int` in the byte vector specific [`cosineBody`](https://github.com/apache/lucene/blob/a4ebe984087cf62e3f8d96a53b2e7ebe96172500/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java#L695) function(s) loses precision.

This happens for integers >= 2^24, because IEEE 754 single-precision floats use 24 bits to represent the integer part.

For example, when `16777217` is cast to `float` and back to `int`, it yields `16777216`.

This also avoids CPU cycles related to casting. [`VectorUtilBenchmark`](https://github.com/apache/lucene/blob/a4ebe984087cf62e3f8d96a53b2e7ebe96172500/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java#L46) shows minor but consistent speedup:

`main`

```
Benchmark                               (size)   Mode  Cnt  Score   Error   Units
VectorUtilBenchmark.binaryCosineVector    1024  thrpt   15  4.782 ± 0.007  ops/us
```

This PR

```
Benchmark                               (size)   Mode  Cnt  Score   Error   Units
VectorUtilBenchmark.binaryCosineVector    1024  thrpt   15  4.885 ± 0.002  ops/us
```