### PR TITLE
Add a getImplementationName method to VectorizationProvider that returns the name of the selected implementation

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -96,6 +96,11 @@ public abstract class VectorizationProvider {
         Holder.INSTANCE, "call to getInstance() from subclass of VectorizationProvider");
   }
 
+  /** Returns the name of the {@code VectorizationProvider}'s implementation that's being used. */
+  public static String getImplementationName() {
+    return Objects.requireNonNull(Holder.INSTANCE).getName();
+  }
+
   VectorizationProvider() {
     // no instance/subclass except from this package
   }
@@ -222,6 +227,10 @@ public abstract class VectorizationProvider {
       throw new UnsupportedOperationException(
           "VectorizationProvider is internal and can only be used by known Lucene classes.");
     }
+  }
+
+  public String getName() {
+    return this.getClass().getSimpleName();
   }
 
   /** This static holder class prevents classloading deadlock. */

--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorizationProvider.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorizationProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.internal.vectorization;
 
+import java.util.Set;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestVectorizationProvider extends LuceneTestCase {
@@ -25,7 +26,12 @@ public class TestVectorizationProvider extends LuceneTestCase {
   }
 
   public void testGetProviderName() {
-    assertEquals("DefaultVectorizationProvider", VectorizationProvider.getImplementationName());
+    Set<String> knownVectorizationProviders =
+        Set.of("DefaultVectorizationProvider", "PanamaVectorizationProvider");
+    String currentVectorizationProvider = VectorizationProvider.getImplementationName();
+    assertTrue(
+        "Unknown Vectorization provider: " + currentVectorizationProvider,
+        knownVectorizationProviders.contains(currentVectorizationProvider));
   }
 
   private static void illegalCaller() {

--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorizationProvider.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorizationProvider.java
@@ -24,6 +24,10 @@ public class TestVectorizationProvider extends LuceneTestCase {
     expectThrows(UnsupportedOperationException.class, TestVectorizationProvider::illegalCaller);
   }
 
+  public void testGetProviderName() {
+    assertEquals("DefaultVectorizationProvider", VectorizationProvider.getImplementationName());
+  }
+
   private static void illegalCaller() {
     VectorizationProvider.getInstance();
   }


### PR DESCRIPTION
### Description
This PR is a possible solution for #15292. I implemented the `getName()` as the simple class name, but could also be just a string that represents the class, like `default`/`panama`.
With this new method, the initialization of the `Holder.INSTANCE` could happen from a caller that's not in the `VALID_CALLERS`. It would not be returned though, I'm not sure if that's a problem. getInstance would still require valid callers.
An alternative approach could be to refactor the `lookup` method in a way that the `getImplementationName` could use to determine the implementation without actually initializing it.