### PR TITLE
Fix NPE in PerFieldKnnVectorsFormat.getGraph

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
@@ -319,9 +319,13 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
     @Override
     public HnswGraph getGraph(String field) throws IOException {
       final FieldInfo info = fieldInfos.fieldInfo(field);
+      if (info == null) {
+        return null;
+      }
+
       KnnVectorsReader knnVectorsReader = fields.get(info.number);
-      if (knnVectorsReader instanceof HnswGraphProvider) {
-        return ((HnswGraphProvider) knnVectorsReader).getGraph(field);
+      if (knnVectorsReader instanceof HnswGraphProvider hnswGraphProvider) {
+        return hnswGraphProvider.getGraph(field);
       } else {
         return null;
       }


### PR DESCRIPTION
Fixes occasional test failures:
```
Stack Trace:
java.lang.NullPointerException: Cannot read field "number" because "info" is null
        at __randomizedtesting.SeedInfo.seed([7F1D9331344693F5:8AA61B73099B4704]:0)
        at org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat$FieldsReader.getGraph(PerFieldKnnVectorsFormat.java:322)
        at org.apache.lucene.index.TestKnnGraph.assertConsistentGraph(TestKnnGraph.java:385)
        at org.apache.lucene.index.TestKnnGraph.testMultipleVectorFields(TestKnnGraph.java:193)
```