### PR TITLE
test: remove slow test for java 21 bug

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
@@ -18,11 +18,7 @@ package org.apache.lucene.util.bkd;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
-import org.apache.lucene.document.IntPoint;
-import org.apache.lucene.document.SortedNumericDocValuesField;
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.PointValues.IntersectVisitor;
 import org.apache.lucene.index.PointValues.Relation;
 import org.apache.lucene.store.Directory;
@@ -32,7 +28,6 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.CollectionUtil;
-import org.apache.lucene.util.Constants;
 
 public class TestDocIdsWriter extends LuceneTestCase {
 

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/TestDocIdsWriter.java
@@ -169,23 +169,4 @@ public class TestDocIdsWriter extends LuceneTestCase {
     }
     dir.deleteFile("tmp");
   }
-
-  // This simple test tickles a JVM C2 JIT crash on JDK's less than 21.0.1
-  // Crashes only when run with HotSpot C2.
-  // Regardless of whether C2 is enabled or not, the test should never fail.
-  public void testCrash() throws IOException {
-    assumeTrue(
-        "Requires HotSpot C2 compiler (won't work on client VM).",
-        Constants.IS_HOTSPOT_VM && !Constants.IS_CLIENT_VM);
-    int itrs = atLeast(100);
-    for (int i = 0; i < itrs; i++) {
-      try (Directory dir = newDirectory();
-          IndexWriter iw = new IndexWriter(dir, newIndexWriterConfig(null))) {
-        for (int d = 0; d < 20_000; d++) {
-          iw.addDocument(
-              List.of(new IntPoint("foo", 0), new SortedNumericDocValuesField("bar", 0)));
-        }
-      }
-    }
-  }
 }


### PR DESCRIPTION
This test never runs on my system (I never let tests get a C2, its too slow). But its very slow in CI: probably because it makes many writers, probably fsyncs a lot, etc. Given that `main` is on java 25 I think we can remove the java 21 test?
