### PR TITLE
ci: disable errorprone during "tests" job

### DIFF
--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -88,7 +88,7 @@ jobs:
         uses: ./.github/actions/prepare-for-build
 
       - name: Run gradle tests
-        run: ./gradlew test "-Ptask.times=true" --max-workers 2
+        run: ./gradlew test -Ptask.times=true -Pvalidation.errorprone=false --max-workers 2
 
       - name: List automatically-initialized gradle.properties
         run: cat gradle.properties

--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -88,7 +88,7 @@ jobs:
         uses: ./.github/actions/prepare-for-build
 
       - name: Run gradle tests
-        run: ./gradlew test -Ptask.times=true -Pvalidation.errorprone=false --max-workers 2
+        run: ./gradlew test "-Ptask.times=true" "-Pvalidation.errorprone=false" --max-workers 2
 
       - name: List automatically-initialized gradle.properties
         run: cat gradle.properties

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ErrorPronePlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ErrorPronePlugin.java
@@ -100,8 +100,7 @@ public class ErrorPronePlugin extends LuceneGradlePlugin {
           skipReason = null;
         } else {
           if (buildGlobals.isCIBuild) {
-            throw new GradleException(
-                "Odd, errorprone linting should always be enabled on CI builds?");
+            skipReason = "skipped explicitly on a CI build it seems";
           } else {
             skipReason =
                 "skipped on builds not running inside CI environments, pass -P"


### PR DESCRIPTION
Errorprone is only needed for "checks without tests". The idea is to speed up compilation for the "tests" job, which focuses on executing tests. Any errorprone issues will be found by the "checks without tests" job.
