### PR TITLE
ci: use ubuntu-arm on every PR/push, use macos at night

### DIFF
--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -12,6 +12,9 @@ on:
       - 'main'
       - 'branch_10x'
 
+  schedule:
+    - cron: '44 1 * * *'
+
 permissions: {}
 
 env:
@@ -69,8 +72,15 @@ jobs:
     strategy:
       matrix:
         # Operating systems to run on.
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest ]
         java: [ '25' ]
+        trigger:
+          - ${{ github.event_name }}
+        exclude:
+          - os: macos-latest
+            trigger: push
+          - os: macos-latest
+            trigger: pull_request
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -106,7 +106,7 @@ jobs:
           echo "tests.workDir=/tmp/tmpfs/lucene" >> build-options.local.properties
 
       - name: Run gradle tests
-        run: ./gradlew test "-Ptask.times=true" "-Pvalidation.errorprone=false"
+        run: ./gradlew displayGradleDiagnostics allOptions test "-Ptask.times=true" "-Pvalidation.errorprone=false"
         env:
           # Set to the defaults to override the "CI"-based logic that would enable C2
           # we can't afford C2 on github runners.

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ErrorPronePlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ErrorPronePlugin.java
@@ -895,7 +895,7 @@ public class ErrorPronePlugin extends LuceneGradlePlugin {
         .withType(JavaCompile.class)
         .configureEach(
             t -> {
-              t.dependsOn(":" + CheckEnvironmentPlugin.CHECK_JDK_INTERNALS_EXPOSED_TO_GRADLE_TASK);
+              t.dependsOn(":" + CheckEnvironmentPlugin.TASK_CHECK_JDK_INTERNALS_EXPOSED_TO_GRADLE);
 
               var epOptions =
                   ((ExtensionAware) t.getOptions())

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/spotless/GoogleJavaFormatPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/spotless/GoogleJavaFormatPlugin.java
@@ -71,7 +71,7 @@ public class GoogleJavaFormatPlugin extends LuceneGradlePlugin {
       t.configure(
           task -> {
             task.getBatchSize().set(batchSizeOption);
-            task.dependsOn(":" + CheckEnvironmentPlugin.CHECK_JDK_INTERNALS_EXPOSED_TO_GRADLE_TASK);
+            task.dependsOn(":" + CheckEnvironmentPlugin.TASK_CHECK_JDK_INTERNALS_EXPOSED_TO_GRADLE);
           });
     }
 


### PR DESCRIPTION
* Gives us a 10 minute CI system
* Expand test coverage to "arm on linux", which is a real use-case
* Replaces slowest runner (20 minutes) with fastest runner (5 minutes)
* Still tests with macos-arm at night
* Policeman Jenkins still tests macos many times a day (and more reliably)

