### PR TITLE
Prevent zero radius in BaseXYPointTestCase

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/geo/BaseXYPointTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/geo/BaseXYPointTestCase.java
@@ -920,8 +920,11 @@ public abstract class BaseXYPointTestCase extends LuceneTestCase {
       final float centerX = nextX();
       final float centerY = nextY();
 
-      // So the query can cover at most 50% of the cartesian space:
-      final float radius = random().nextFloat() * Float.MAX_VALUE / 2;
+      float radius = 0f;
+      while (radius == 0f) {
+        // So the query can cover at most 50% of the cartesian space:
+        radius = random().nextFloat() * Float.MAX_VALUE / 2;
+      }
 
       if (VERBOSE) {
         final DecimalFormat df =
@@ -953,6 +956,7 @@ public abstract class BaseXYPointTestCase extends LuceneTestCase {
         }
 
         if (hits.get(docID) != expected) {
+          final float finalRadius = radius;
           Consumer<StringBuilder> explain =
               (b) -> {
                 if (Double.isNaN(xs[id]) == false) {
@@ -964,7 +968,7 @@ public abstract class BaseXYPointTestCase extends LuceneTestCase {
                       .append(" distance=")
                       .append(distance)
                       .append(" vs radius=")
-                      .append(radius);
+                      .append(finalRadius);
                 }
               };
           buildError(docID, expected, id, xs, ys, query, liveDocs, explain);


### PR DESCRIPTION
Fixes the following CI error:

```
TestXYPointQueries > testRandomMedium {seed=[3C55FEBBB310DF4C:818BC913F275BC2A]} FAILED
    java.lang.IllegalArgumentException: radius must be bigger than 0, got 0.0
        at __randomizedtesting.SeedInfo.seed([3C55FEBBB310DF4C:818BC913F275BC2A]:0)
        at org.apache.lucene.geo.XYCircle.<init>(XYCircle.java:46)
        at org.apache.lucene.document.XYPointField.newDistanceQuery(XYPointField.java:178)
        at org.apache.lucene.search.TestXYPointQueries.newDistanceQuery(TestXYPointQueries.java:39)
        at org.apache.lucene.tests.geo.BaseXYPointTestCase.verifyRandomDistances(BaseXYPointTestCase.java:932)
        at org.apache.lucene.tests.geo.BaseXYPointTestCase.verify(BaseXYPointTestCase.java:792)
        at org.apache.lucene.tests.geo.BaseXYPointTestCase.doTestRandom(BaseXYPointTestCase.java:761)
        at org.apache.lucene.tests.geo.BaseXYPointTestCase.testRandomMedium(BaseXYPointTestCase.java:673)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
```

