### PR TITLE
Remove the scorer on FlatVectorsReader

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -46,6 +46,8 @@ API Changes
 
 * GITHUB#15187: Restrict visibility of PerFieldKnnVectorsFormat.FieldsReader (Simon Cooper)
 
+* GITHUB#15316: Remove FlatVectorsReader#getFlatVectorScorer and constructor parameter (Simon Cooper)
+
 New Features
 ---------------------
 * GITHUB#14097: Binary partitioning merge policy over float-valued vector field. (Mike Sokolov)

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
@@ -66,13 +66,14 @@ final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReader
   private final IntObjectHashMap<FieldEntry> fields = new IntObjectHashMap<>();
   private final IndexInput quantizedVectorData;
   private final FlatVectorsReader rawVectorsReader;
+  private final FlatVectorsScorer vectorScorer;
   private final FieldInfos fieldInfos;
 
   Lucene99ScalarQuantizedVectorsReader(
       SegmentReadState state, FlatVectorsReader rawVectorsReader, FlatVectorsScorer scorer)
       throws IOException {
-    super(scorer);
     this.rawVectorsReader = rawVectorsReader;
+    this.vectorScorer = scorer;
     this.fieldInfos = state.fieldInfos;
     int versionMeta = -1;
     String metaFileName =

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsReader.java
@@ -40,21 +40,6 @@ import org.apache.lucene.util.hnsw.RandomVectorScorer;
  */
 public abstract class FlatVectorsReader extends KnnVectorsReader implements Accountable {
 
-  /** Scorer for flat vectors */
-  protected final FlatVectorsScorer vectorScorer;
-
-  /** Sole constructor */
-  protected FlatVectorsReader(FlatVectorsScorer vectorsScorer) {
-    this.vectorScorer = vectorsScorer;
-  }
-
-  /**
-   * @return the {@link FlatVectorsScorer} for this reader.
-   */
-  public FlatVectorsScorer getFlatVectorScorer() {
-    return vectorScorer;
-  }
-
   @Override
   public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene102/Lucene102BinaryQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene102/Lucene102BinaryQuantizedVectorsReader.java
@@ -70,7 +70,6 @@ class Lucene102BinaryQuantizedVectorsReader extends FlatVectorsReader {
       FlatVectorsReader rawVectorsReader,
       Lucene102BinaryFlatVectorsScorer vectorsScorer)
       throws IOException {
-    super(vectorsScorer);
     this.vectorScorer = vectorsScorer;
     this.rawVectorsReader = rawVectorsReader;
     int versionMeta = -1;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsReader.java
@@ -73,7 +73,6 @@ class Lucene104ScalarQuantizedVectorsReader extends FlatVectorsReader
       FlatVectorsReader rawVectorsReader,
       Lucene104ScalarQuantizedVectorScorer vectorsScorer)
       throws IOException {
-    super(vectorsScorer);
     this.vectorScorer = vectorsScorer;
     this.rawVectorsReader = rawVectorsReader;
     int versionMeta = -1;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
@@ -58,15 +58,16 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
   private static final long SHALLOW_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(Lucene99FlatVectorsFormat.class);
 
+  private final FlatVectorsScorer vectorScorer;
   private final IntObjectHashMap<FieldEntry> fields = new IntObjectHashMap<>();
   private final IndexInput vectorData;
   private final FieldInfos fieldInfos;
   private final IOContext dataContext;
 
-  public Lucene99FlatVectorsReader(SegmentReadState state, FlatVectorsScorer scorer)
+  public Lucene99FlatVectorsReader(SegmentReadState state, FlatVectorsScorer vectorScorer)
       throws IOException {
-    super(scorer);
     int versionMeta = readMetadata(state);
+    this.vectorScorer = vectorScorer;
     this.fieldInfos = state.fieldInfos;
     // Flat formats are used to randomly access vectors from their node ID that is stored
     // in the HNSW graph.


### PR DESCRIPTION
Turns out the scorer isn't actual used by `FlatVectorsReader` directly, only on specific subclasses