### PR TITLE
Avoid static dependency from TermsEnum to one of its subclasses

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -199,7 +199,7 @@ Bug Fixes
   removing co-planar points to do it once after all holes are removed instead of doing it for each
   removed hole.
 
-* GITHUB#15319: Fix potential hang initialisation TermsEnum and BaseTermsEnum (Chris Hegarty)
+* GITHUB#15319: Fix potential hang in initialisation of TermsEnum and BaseTermsEnum (Chris Hegarty)
 
 Other
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -199,6 +199,8 @@ Bug Fixes
   removing co-planar points to do it once after all holes are removed instead of doing it for each
   removed hole.
 
+* GITHUB#15319: Fix potential hang initialisation TermsEnum and BaseTermsEnum (Chris Hegarty)
+
 Other
 ---------------------
 * GITHUB#15237: Fix SmartChinese to only deserialize dictionary data from classpath with a native array

--- a/lucene/core/src/java/org/apache/lucene/index/TermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermsEnum.java
@@ -197,7 +197,27 @@ public abstract class TermsEnum implements BytesRefIterator {
    * of unused Attributes does not matter.
    */
   public static final TermsEnum EMPTY =
-      new BaseTermsEnum() {
+      new TermsEnum() {
+
+        private AttributeSource atts;
+
+        @Override
+        public AttributeSource attributes() {
+          if (atts == null) {
+            atts = new AttributeSource();
+          }
+          return atts;
+        }
+
+        @Override
+        public boolean seekExact(BytesRef text) {
+          return seekCeil(text) == SeekStatus.FOUND;
+        }
+
+        @Override
+        public IOBooleanSupplier prepareSeekExact(BytesRef text) {
+          return () -> seekExact(text);
+        }
 
         @Override
         public SeekStatus seekCeil(BytesRef term) {

--- a/lucene/core/src/java/org/apache/lucene/index/TermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermsEnum.java
@@ -196,6 +196,8 @@ public abstract class TermsEnum implements BytesRefIterator {
    * Attributes to it. This should not be a problem, as the enum is always empty and the existence
    * of unused Attributes does not matter.
    */
+  // Avoid refactoring that results in a dependency on a subclass, like BaseTermsEnum.
+  // See: https://github.com/apache/lucene/issues/15317
   public static final TermsEnum EMPTY =
       new TermsEnum() {
 


### PR DESCRIPTION
Fixes a potential hang with initialisation of TermsEnum and BaseTermsEnum, by simply removing the dependency and replicating the small amount of code.

Problem description: the static `TermsEnum.EMPTY` initialises to an implementation of `BaseTermsEnum`. `TermsEnum` is a superclass of `BaseTermsEnum`, so there is a clear dependency between these classes. If a subclass of `BaseTermsEnum` is initialising it may grab the lock on `BaseTermsEnum`, and prevent `TermsEnum` from initialising. E.g.

```
"main" #3 [8963] prio=5 os_prio=31 cpu=30.57ms elapsed=2.19s tid=0x0000000123815a00 nid=8963 in Object.wait()  [0x000000016b24e000]
   java.lang.Thread.State: RUNNABLE
	at TermsEnumClinitHang.main(TermsEnumClinitHang.java:22)
	- waiting on the Class initialization monitor for org.apache.lucene.index.TermsEnum

"TEST_THREAD" #25 [27395] prio=5 os_prio=31 cpu=1.54ms elapsed=2.17s tid=0x000000012382e800 nid=27395 in Object.wait()  [0x000000016d632000]
   java.lang.Thread.State: RUNNABLE
	at org.apache.lucene.index.TermsEnum.<clinit>(TermsEnum.java:199)
	- waiting on the Class initialization monitor for org.apache.lucene.index.BaseTermsEnum
	at TermsEnumClinitHang$1.run(TermsEnumClinitHang.java:15)
...
```

fixes #15317