### PR TITLE
build: enable ClassInitializationDeadlock, SuppressWarnings the problems

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ErrorPronePlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ErrorPronePlugin.java
@@ -323,7 +323,7 @@ public class ErrorPronePlugin extends LuceneGradlePlugin {
     "CheckReturnValue:OFF", // we don't use these annotations
     "CheckedExceptionNotThrown:OFF", // TODO: new, not checked if applicable to Lucene
     "ClassCanBeStatic:OFF", // noisy
-    "ClassInitializationDeadlock:OFF", // TODO: there are problems
+    "ClassInitializationDeadlock:ERROR",
     "ClassName:OFF", // TODO: new, not checked if applicable to Lucene
     "ClassNamedLikeTypeParameter:OFF", // TODO: new, not checked if applicable to Lucene
     "ClassNewInstance:WARN",

--- a/gradle/regenerate/moman/gen_BulkOperation.py
+++ b/gradle/regenerate/moman/gen_BulkOperation.py
@@ -285,6 +285,7 @@ if __name__ == '__main__':
  */\n''')
 
   f.write('abstract class BulkOperation implements PackedInts.Decoder, PackedInts.Encoder {\n')
+  f.write('  @SuppressWarnings("ClassInitializationDeadlock") // FIXME: may cause hangs!\n')
   f.write('  private static final BulkOperation[] packedBulkOps = new BulkOperation[] {\n')
 
   for bpv in range(1, 65):
@@ -310,6 +311,7 @@ if __name__ == '__main__':
   f.write('\n')
 
   f.write('  // NOTE: this is sparse (some entries are null):\n')
+  f.write('  @SuppressWarnings("ClassInitializationDeadlock") // FIXME: may cause hangs!\n')
   f.write('  private static final BulkOperation[] packedSingleBlockBulkOps = new BulkOperation[] {\n')
   for bpv in range(1, max(PACKED_64_SINGLE_BLOCK_BPV) + 1):
     if bpv in PACKED_64_SINGLE_BLOCK_BPV:

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/TrecDocParser.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/TrecDocParser.java
@@ -28,6 +28,7 @@ import java.util.Map;
  * Parser for trec doc content, invoked on doc text excluding &lt;DOC&gt; and &lt;DOCNO&gt; which
  * are handled in TrecContentSource. Required to be stateless and hence thread safe.
  */
+@SuppressWarnings("ClassInitializationDeadlock") // FIXME: may cause hangs!
 public abstract class TrecDocParser {
 
   /** Types of trec parse paths, */

--- a/lucene/core/src/generated/checksums/utilGenPacked.json
+++ b/lucene/core/src/generated/checksums/utilGenPacked.json
@@ -1,7 +1,7 @@
 {
-    "gradle/regenerate/moman/gen_BulkOperation.py": "d721930b5dae7f938b52a17700eb84b157930b2b",
+    "gradle/regenerate/moman/gen_BulkOperation.py": "da9eccf0c8dd33325df5f1e76a1de74226035734",
     "gradle/regenerate/moman/gen_Packed64SingleBlock.py": "0fd2a498c3edbd195a68c2d1d686be0aed51a104",
-    "lucene/core/src/java/org/apache/lucene/util/packed/BulkOperation.java": "c4e16930960a18e74802c56ee60f8e83bd8b6dd2",
+    "lucene/core/src/java/org/apache/lucene/util/packed/BulkOperation.java": "35a89e4f3dd37084cc059a784bcbeb384256773b",
     "lucene/core/src/java/org/apache/lucene/util/packed/BulkOperationPacked.java": "2b0d9226bae8a07ce4970bcaa9d4d0cd4fe2c79a",
     "lucene/core/src/java/org/apache/lucene/util/packed/BulkOperationPacked1.java": "c483aa35c275bacc1f3a010c5b879441be502108",
     "lucene/core/src/java/org/apache/lucene/util/packed/BulkOperationPacked10.java": "35fe8a9c9a91cd840b239af4ddd1e0de53ef1404",

--- a/lucene/core/src/java/org/apache/lucene/analysis/CharArrayMap.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/CharArrayMap.java
@@ -32,6 +32,7 @@ import org.apache.lucene.util.CharsRef;
  */
 public class CharArrayMap<V> extends AbstractMap<Object, V> {
   // private only because missing generics
+  @SuppressWarnings("ClassInitializationDeadlock") // FIXME: may cause hangs!
   private static final CharArrayMap<?> EMPTY_MAP = new EmptyCharArrayMap<>();
 
   private static final int INIT_SIZE = 8;

--- a/lucene/core/src/java/org/apache/lucene/index/TermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermsEnum.java
@@ -196,6 +196,7 @@ public abstract class TermsEnum implements BytesRefIterator {
    * Attributes to it. This should not be a problem, as the enum is always empty and the existence
    * of unused Attributes does not matter.
    */
+  @SuppressWarnings("ClassInitializationDeadlock") // FIXME: may cause hangs!
   public static final TermsEnum EMPTY =
       new BaseTermsEnum() {
 

--- a/lucene/core/src/java/org/apache/lucene/store/IOContext.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IOContext.java
@@ -50,6 +50,7 @@ public interface IOContext {
    * <p>It will use {@link ReadAdvice#RANDOM} by default, unless set by system property {@code
    * org.apache.lucene.store.defaultReadAdvice}.
    */
+  @SuppressWarnings("ClassInitializationDeadlock") // FIXME: may cause hangs!
   IOContext DEFAULT = new DefaultIOContext();
 
   /**
@@ -58,6 +59,7 @@ public interface IOContext {
    * <p>This context should only be used when the read operations will be performed in the same
    * thread as the thread that opens the underlying storage.
    */
+  @SuppressWarnings("ClassInitializationDeadlock") // FIXME: may cause hangs!
   IOContext READONCE = new DefaultIOContext(DataAccessHint.SEQUENTIAL, ReadOnceHint.INSTANCE);
 
   /** Returns an {@link IOContext} for merging with the specified {@link MergeInfo} */

--- a/lucene/core/src/java/org/apache/lucene/util/packed/BulkOperation.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/BulkOperation.java
@@ -20,6 +20,7 @@ package org.apache.lucene.util.packed;
 
 /** Efficient sequential read/write of packed integers. */
 abstract class BulkOperation implements PackedInts.Decoder, PackedInts.Encoder {
+  @SuppressWarnings("ClassInitializationDeadlock") // FIXME: may cause hangs!
   private static final BulkOperation[] packedBulkOps =
       new BulkOperation[] {
         new BulkOperationPacked1(),
@@ -89,6 +90,7 @@ abstract class BulkOperation implements PackedInts.Decoder, PackedInts.Encoder {
       };
 
   // NOTE: this is sparse (some entries are null):
+  @SuppressWarnings("ClassInitializationDeadlock") // FIXME: may cause hangs!
   private static final BulkOperation[] packedSingleBlockBulkOps =
       new BulkOperation[] {
         new BulkOperationPackedSingleBlock(1),

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/DistanceStyle.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/DistanceStyle.java
@@ -26,18 +26,23 @@ public interface DistanceStyle {
   // convenient access to built-in styles:
 
   /** Arc distance calculator */
+  @SuppressWarnings("ClassInitializationDeadlock") // FIXME: may cause hangs!
   public static final ArcDistance ARC = ArcDistance.INSTANCE;
 
   /** Linear distance calculator */
+  @SuppressWarnings("ClassInitializationDeadlock") // FIXME: may cause hangs!
   public static final LinearDistance LINEAR = LinearDistance.INSTANCE;
 
   /** Linear distance squared calculator */
+  @SuppressWarnings("ClassInitializationDeadlock") // FIXME: may cause hangs!
   public static final LinearSquaredDistance LINEAR_SQUARED = LinearSquaredDistance.INSTANCE;
 
   /** Normal distance calculator */
+  @SuppressWarnings("ClassInitializationDeadlock") // FIXME: may cause hangs!
   public static final NormalDistance NORMAL = NormalDistance.INSTANCE;
 
   /** Normal distance squared calculator */
+  @SuppressWarnings("ClassInitializationDeadlock") // FIXME: may cause hangs!
   public static final NormalSquaredDistance NORMAL_SQUARED = NormalSquaredDistance.INSTANCE;
 
   /**


### PR DESCRIPTION
Enable error-prone's ClassInitializationDeadlock check, which can statically detect bugs such as #15317

All problems were just suppressed with a 'FIXME' message, this check will at least prevent any new ones from showing up.

There aren't that many problems, it just happens that some are caused by generated code, so you get a violation for each bit-per-value.

