### PR TITLE
Run the tests with assertions disabled ~25% of the time

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
@@ -223,7 +223,13 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
 
     Provider<Boolean> assertsOption =
         buildOptions.addBooleanOption(
-            "tests.asserts", "Enables or disables assertions mode.", true);
+            "tests.asserts",
+            "Enables or disables assertions mode.",
+            project.provider(
+                () -> {
+                  // Run with assertions for ~75% of all seeds.
+                  return new Random(buildGlobals.getProjectSeedAsLong().get()).nextInt(100) > 25;
+                }));
     optionsInheritedAsProperties.add("tests.asserts");
 
     buildOptions.addBooleanOption(

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -106,6 +106,8 @@ Changes in Runtime Behavior
 
 Build
 ---------------------
+* GITHUB#15325: Run the tests with assertions disabled ~25% of the time #15325 (Dawid Weiss)
+
 * GITHUB#14804: Detect and ban wildcard imports in Java (Robert Muir, Dawid Weiss)
 
 * GITHUB#14808: Add support for validating sources using ast-grep tool rules #14808

--- a/lucene/core/src/test/org/apache/lucene/TestAssertions.java
+++ b/lucene/core/src/test/org/apache/lucene/TestAssertions.java
@@ -46,13 +46,13 @@ public class TestAssertions extends LuceneTestCase {
   public void testTokenStreams() {
     new TestTokenStream1();
     new TestTokenStream2();
-    try {
-      new TestTokenStream3();
-      if (assertsAreEnabled) {
-        fail("TestTokenStream3 should fail assertion");
-      }
-    } catch (AssertionError _) {
-      // expected
+
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            new TestTokenStream3();
+          });
     }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestCharHashSet.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestCharHashSet.java
@@ -90,11 +90,13 @@ public class TestCharHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(set.indexGet(set.indexOf(keyE)), is(equalTo(keyE)));
     MatcherAssert.assertThat(set.indexGet(set.indexOf(key1)), is(equalTo(key1)));
 
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          set.indexGet(set.indexOf(key2));
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            set.indexGet(set.indexOf(key2));
+          });
+    }
 
     MatcherAssert.assertThat(set.indexReplace(set.indexOf(keyE), keyE), is(equalTo(keyE)));
     MatcherAssert.assertThat(set.indexReplace(set.indexOf(key1), key1), is(equalTo(key1)));

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestCharObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestCharObjectHashMap.java
@@ -177,11 +177,13 @@ public class TestCharObjectHashMap extends LuceneTestCase {
     assertEquals(value1, map.indexGet(map.indexOf(keyE)));
     assertEquals(value2, map.indexGet(map.indexOf(key1)));
 
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          map.indexGet(map.indexOf(key2));
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            map.indexGet(map.indexOf(key2));
+          });
+    }
 
     assertEquals(value1, map.indexReplace(map.indexOf(keyE), value3));
     assertEquals(value2, map.indexReplace(map.indexOf(key1), value4));

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntDoubleHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntDoubleHashMap.java
@@ -173,11 +173,13 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
     assertEquals2(value1, map.indexGet(map.indexOf(keyE)));
     assertEquals2(value2, map.indexGet(map.indexOf(key1)));
 
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          map.indexGet(map.indexOf(key2));
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            map.indexGet(map.indexOf(key2));
+          });
+    }
 
     assertEquals2(value1, map.indexReplace(map.indexOf(keyE), value3));
     assertEquals2(value2, map.indexReplace(map.indexOf(key1), value4));

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntFloatHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntFloatHashMap.java
@@ -173,11 +173,13 @@ public class TestIntFloatHashMap extends LuceneTestCase {
     assertEquals2(value1, map.indexGet(map.indexOf(keyE)));
     assertEquals2(value2, map.indexGet(map.indexOf(key1)));
 
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          map.indexGet(map.indexOf(key2));
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            map.indexGet(map.indexOf(key2));
+          });
+    }
 
     assertEquals2(value1, map.indexReplace(map.indexOf(keyE), value3));
     assertEquals2(value2, map.indexReplace(map.indexOf(key1), value4));

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntHashSet.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntHashSet.java
@@ -90,11 +90,13 @@ public class TestIntHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(set.indexGet(set.indexOf(keyE)), is(equalTo(keyE)));
     MatcherAssert.assertThat(set.indexGet(set.indexOf(key1)), is(equalTo(key1)));
 
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          set.indexGet(set.indexOf(key2));
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            set.indexGet(set.indexOf(key2));
+          });
+    }
 
     MatcherAssert.assertThat(set.indexReplace(set.indexOf(keyE), keyE), is(equalTo(keyE)));
     MatcherAssert.assertThat(set.indexReplace(set.indexOf(key1), key1), is(equalTo(key1)));

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntIntHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntIntHashMap.java
@@ -152,11 +152,13 @@ public class TestIntIntHashMap extends LuceneTestCase {
     assertEquals(value1, map.indexGet(map.indexOf(keyE)));
     assertEquals(value2, map.indexGet(map.indexOf(key1)));
 
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          map.indexGet(map.indexOf(key2));
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            map.indexGet(map.indexOf(key2));
+          });
+    }
 
     assertEquals(value1, map.indexReplace(map.indexOf(keyE), value3));
     assertEquals(value2, map.indexReplace(map.indexOf(key1), value4));

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntLongHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntLongHashMap.java
@@ -184,11 +184,13 @@ public class TestIntLongHashMap extends LuceneTestCase {
     assertEquals(value1, map.indexGet(map.indexOf(keyE)));
     assertEquals(value2, map.indexGet(map.indexOf(key1)));
 
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          map.indexGet(map.indexOf(key2));
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            map.indexGet(map.indexOf(key2));
+          });
+    }
 
     assertEquals(value1, map.indexReplace(map.indexOf(keyE), value3));
     assertEquals(value2, map.indexReplace(map.indexOf(key1), value4));

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntObjectHashMap.java
@@ -162,11 +162,13 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     assertEquals(value1, map.indexGet(map.indexOf(keyE)));
     assertEquals(value2, map.indexGet(map.indexOf(key1)));
 
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          map.indexGet(map.indexOf(key2));
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            map.indexGet(map.indexOf(key2));
+          });
+    }
 
     assertEquals(value1, map.indexReplace(map.indexOf(keyE), value3));
     assertEquals(value2, map.indexReplace(map.indexOf(key1), value4));

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongFloatHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongFloatHashMap.java
@@ -173,11 +173,13 @@ public class TestLongFloatHashMap extends LuceneTestCase {
     assertEquals2(value1, map.indexGet(map.indexOf(keyE)));
     assertEquals2(value2, map.indexGet(map.indexOf(key1)));
 
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          map.indexGet(map.indexOf(key2));
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            map.indexGet(map.indexOf(key2));
+          });
+    }
 
     assertEquals2(value1, map.indexReplace(map.indexOf(keyE), value3));
     assertEquals2(value2, map.indexReplace(map.indexOf(key1), value4));

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongHashSet.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongHashSet.java
@@ -90,11 +90,13 @@ public class TestLongHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(set.indexGet(set.indexOf(keyE)), is(equalTo(keyE)));
     MatcherAssert.assertThat(set.indexGet(set.indexOf(key1)), is(equalTo(key1)));
 
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          set.indexGet(set.indexOf(key2));
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            set.indexGet(set.indexOf(key2));
+          });
+    }
 
     MatcherAssert.assertThat(set.indexReplace(set.indexOf(keyE), keyE), is(equalTo(keyE)));
     MatcherAssert.assertThat(set.indexReplace(set.indexOf(key1), key1), is(equalTo(key1)));

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongIntHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongIntHashMap.java
@@ -161,11 +161,13 @@ public class TestLongIntHashMap extends LuceneTestCase {
     assertEquals(value1, map.indexGet(map.indexOf(keyE)));
     assertEquals(value2, map.indexGet(map.indexOf(key1)));
 
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          map.indexGet(map.indexOf(key2));
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            map.indexGet(map.indexOf(key2));
+          });
+    }
 
     assertEquals(value1, map.indexReplace(map.indexOf(keyE), value3));
     assertEquals(value2, map.indexReplace(map.indexOf(key1), value4));

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongObjectHashMap.java
@@ -159,11 +159,13 @@ public class TestLongObjectHashMap extends LuceneTestCase {
     assertEquals(value1, map.indexGet(map.indexOf(keyE)));
     assertEquals(value2, map.indexGet(map.indexOf(key1)));
 
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          map.indexGet(map.indexOf(key2));
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            map.indexGet(map.indexOf(key2));
+          });
+    }
 
     assertEquals(value1, map.indexReplace(map.indexOf(keyE), value3));
     assertEquals(value2, map.indexReplace(map.indexOf(key1), value4));

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestMaxSizedFloatArrayList.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestMaxSizedFloatArrayList.java
@@ -31,11 +31,13 @@ public class TestMaxSizedFloatArrayList extends TestFloatArrayList {
     assertEquals(MAX_SIZE, list.maxSize);
 
     // Test invalid maxSize (expectedElements > maxSize)
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          new MaxSizedFloatArrayList(2, 3);
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            new MaxSizedFloatArrayList(2, 3);
+          });
+    }
   }
 
   @Test

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestMaxSizedIntArrayList.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestMaxSizedIntArrayList.java
@@ -31,11 +31,13 @@ public class TestMaxSizedIntArrayList extends TestIntArrayList {
     assertEquals(MAX_SIZE, list.maxSize);
 
     // Test invalid maxSize (expectedElements > maxSize)
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          new MaxSizedIntArrayList(2, 3);
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            new MaxSizedIntArrayList(2, 3);
+          });
+    }
   }
 
   @Test

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanScorerSupplier.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanScorerSupplier.java
@@ -281,6 +281,8 @@ public class TestBooleanScorerSupplier extends LuceneTestCase {
 
   // test the tester...
   public void testFakeScorerSupplier() {
+    assumeTrue("Test designed to work only with assertions enabled.", TEST_ASSERTS_ENABLED);
+
     FakeScorerSupplier randomAccessSupplier =
         new FakeScorerSupplier(TestUtil.nextInt(random(), 31, 100), 30);
     expectThrows(AssertionError.class, () -> randomAccessSupplier.get(70));

--- a/lucene/core/src/test/org/apache/lucene/search/TestConjunctionDISI.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestConjunctionDISI.java
@@ -401,7 +401,8 @@ public class TestConjunctionDISI extends LuceneTestCase {
   }
 
   public void testIllegalAdvancementOfSubIteratorsTripsAssertion() throws IOException {
-    assumeTrue("Assertions must be enabled for this test!", LuceneTestCase.assertsAreEnabled);
+    assumeTrue("Assertions must be enabled for this test!", TEST_ASSERTS_ENABLED);
+
     int maxDoc = 100;
     final int numIterators = TestUtil.nextInt(random(), 2, 5);
     FixedBitSet set = randomSet(maxDoc);

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiCollector.java
@@ -402,13 +402,15 @@ public class TestMultiCollector extends LuceneTestCase {
 
     final LeafReaderContext ctx = reader.leaves().get(0);
 
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          collector(ScoreMode.COMPLETE_NO_SCORES, ScoreCachingWrappingScorer.class)
-              .getLeafCollector(ctx)
-              .setScorer(new SimpleScorable());
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            collector(ScoreMode.COMPLETE_NO_SCORES, ScoreCachingWrappingScorer.class)
+                .getLeafCollector(ctx)
+                .setScorer(new SimpleScorable());
+          });
+    }
 
     // no collector needs scores => no caching
     Collector c1 = collector(ScoreMode.COMPLETE_NO_SCORES, SimpleScorable.class);

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermScorer.java
@@ -208,11 +208,13 @@ public class TestTermScorer extends LuceneTestCase {
     IndexSearcher indexSearcher = new IndexSearcher(forbiddenNorms);
 
     Weight weight = indexSearcher.createWeight(termQuery, ScoreMode.COMPLETE, 1);
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          weight.scorer(forbiddenNorms.getContext()).iterator().nextDoc();
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            weight.scorer(forbiddenNorms.getContext()).iterator().nextDoc();
+          });
+    }
 
     Weight weight2 = indexSearcher.createWeight(termQuery, ScoreMode.COMPLETE_NO_SCORES, 1);
     // should not fail this time since norms are not necessary

--- a/lucene/core/src/test/org/apache/lucene/util/TestArrayUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestArrayUtil.java
@@ -372,9 +372,11 @@ public class TestArrayUtil extends LuceneTestCase {
     int[] array = new int[] {1, 2, 3};
 
     // If minLength is negative, maxLength does not matter
-    expectThrows(AssertionError.class, () -> growInRange(array, -1, 4));
-    expectThrows(AssertionError.class, () -> growInRange(array, -1, 0));
-    expectThrows(AssertionError.class, () -> growInRange(array, -1, -1));
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(AssertionError.class, () -> growInRange(array, -1, 4));
+      expectThrows(AssertionError.class, () -> growInRange(array, -1, 0));
+      expectThrows(AssertionError.class, () -> growInRange(array, -1, -1));
+    }
 
     // If minLength > maxLength, we throw an exception
     expectThrows(IllegalArgumentException.class, () -> growInRange(array, 1, 0));
@@ -402,9 +404,11 @@ public class TestArrayUtil extends LuceneTestCase {
     float[] array = new float[] {1f, 2f, 3f};
 
     // If minLength is negative, maxLength does not matter
-    expectThrows(AssertionError.class, () -> growInRange(array, -1, 4));
-    expectThrows(AssertionError.class, () -> growInRange(array, -1, 0));
-    expectThrows(AssertionError.class, () -> growInRange(array, -1, -1));
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(AssertionError.class, () -> growInRange(array, -1, 4));
+      expectThrows(AssertionError.class, () -> growInRange(array, -1, 0));
+      expectThrows(AssertionError.class, () -> growInRange(array, -1, -1));
+    }
 
     // If minLength > maxLength, we throw an exception
     expectThrows(IllegalArgumentException.class, () -> growInRange(array, 1, 0));

--- a/lucene/core/src/test/org/apache/lucene/util/fst/TestFSTs.java
+++ b/lucene/core/src/test/org/apache/lucene/util/fst/TestFSTs.java
@@ -1706,7 +1706,7 @@ public class TestFSTs extends LuceneTestCase {
   }
 
   public void testIllegallyModifyRootArc() throws Exception {
-    assumeTrue("test relies on assertions", assertsAreEnabled);
+    assumeTrue("test relies on assertions", TEST_ASSERTS_ENABLED);
 
     Set<BytesRef> terms = new HashSet<>();
     for (int i = 0; i < 100; i++) {

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
@@ -28,8 +28,11 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addInOrder(0, 1);
     neighbors.addInOrder(1, 0.8f);
 
-    AssertionError ex = expectThrows(AssertionError.class, () -> neighbors.addInOrder(2, 0.9f));
-    assert ex.getMessage().startsWith("Nodes are added in the incorrect order!") : ex.getMessage();
+    if (TEST_ASSERTS_ENABLED) {
+      AssertionError ex = expectThrows(AssertionError.class, () -> neighbors.addInOrder(2, 0.9f));
+      assert ex.getMessage().startsWith("Nodes are added in the incorrect order!")
+          : ex.getMessage();
+    }
 
     neighbors.insertSorted(3, 0.9f);
     assertScoresEqual(new float[] {1, 0.9f, 0.8f}, neighbors);
@@ -77,8 +80,11 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addInOrder(0, 0.1f);
     neighbors.addInOrder(1, 0.3f);
 
-    AssertionError ex = expectThrows(AssertionError.class, () -> neighbors.addInOrder(2, 0.15f));
-    assert ex.getMessage().startsWith("Nodes are added in the incorrect order!") : ex.getMessage();
+    if (TEST_ASSERTS_ENABLED) {
+      AssertionError ex = expectThrows(AssertionError.class, () -> neighbors.addInOrder(2, 0.15f));
+      assert ex.getMessage().startsWith("Nodes are added in the incorrect order!")
+          : ex.getMessage();
+    }
 
     neighbors.insertSorted(3, 0.3f);
     assertScoresEqual(new float[] {0.1f, 0.3f, 0.3f}, neighbors);
@@ -125,7 +131,9 @@ public class TestNeighborArray extends LuceneTestCase {
     NeighborArray neighbors = new NeighborArray(10, false);
     neighbors.addOutOfOrder(1, 2);
     // we disallow calling addInOrder after addOutOfOrder even if they're actual in order
-    expectThrows(AssertionError.class, () -> neighbors.addInOrder(1, 2));
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(AssertionError.class, () -> neighbors.addInOrder(1, 2));
+    }
     neighbors.addOutOfOrder(2, 3);
     neighbors.addOutOfOrder(5, 6);
     neighbors.addOutOfOrder(3, 4);
@@ -155,7 +163,9 @@ public class TestNeighborArray extends LuceneTestCase {
     NeighborArray neighbors = new NeighborArray(10, true);
     neighbors.addOutOfOrder(1, 7);
     // we disallow calling addInOrder after addOutOfOrder even if they're actual in order
-    expectThrows(AssertionError.class, () -> neighbors.addInOrder(1, 2));
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(AssertionError.class, () -> neighbors.addInOrder(1, 2));
+    }
     neighbors.addOutOfOrder(2, 6);
     neighbors.addOutOfOrder(5, 3);
     neighbors.addOutOfOrder(3, 5);
@@ -184,7 +194,9 @@ public class TestNeighborArray extends LuceneTestCase {
   public void testAddwithScoringFunction() throws IOException {
     NeighborArray neighbors = new NeighborArray(10, true);
     neighbors.addOutOfOrder(1, Float.NaN);
-    expectThrows(AssertionError.class, () -> neighbors.addInOrder(1, 2));
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(AssertionError.class, () -> neighbors.addInOrder(1, 2));
+    }
     neighbors.addOutOfOrder(2, Float.NaN);
     neighbors.addOutOfOrder(5, Float.NaN);
     neighbors.addOutOfOrder(3, Float.NaN);
@@ -200,7 +212,9 @@ public class TestNeighborArray extends LuceneTestCase {
   public void testAddwithScoringFunctionLargeOrd() throws IOException {
     NeighborArray neighbors = new NeighborArray(10, true);
     neighbors.addOutOfOrder(11, Float.NaN);
-    expectThrows(AssertionError.class, () -> neighbors.addInOrder(1, 2));
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(AssertionError.class, () -> neighbors.addInOrder(1, 2));
+    }
     neighbors.addOutOfOrder(12, Float.NaN);
     neighbors.addOutOfOrder(15, Float.NaN);
     neighbors.addOutOfOrder(13, Float.NaN);
@@ -264,7 +278,9 @@ public class TestNeighborArray extends LuceneTestCase {
     neighbors.addOutOfOrder(1, 0.8f);
 
     // Try to add third node in order - should fail because we used addOutOfOrder
-    expectThrows(AssertionError.class, () -> neighbors.addInOrder(2, 0.6f));
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(AssertionError.class, () -> neighbors.addInOrder(2, 0.6f));
+    }
 
     // Add third node out of order
     neighbors.addOutOfOrder(2, 0.6f);

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestOnHeapHnswGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestOnHeapHnswGraph.java
@@ -38,7 +38,9 @@ public class TestOnHeapHnswGraph extends LuceneTestCase {
   public void testAddLevelOutOfOrder() {
     OnHeapHnswGraph graph = new OnHeapHnswGraph(10, -1);
     graph.addNode(0, 0);
-    expectThrows(AssertionError.class, () -> graph.addNode(1, 0));
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(AssertionError.class, () -> graph.addNode(1, 0));
+    }
   }
 
   /* assert exception will be thrown when we call getNodeOnLevel for an incomplete graph */

--- a/lucene/facet/src/test/org/apache/lucene/facet/facetset/TestMatchingFacetSetsCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/facetset/TestMatchingFacetSetsCounts.java
@@ -69,6 +69,8 @@ public class TestMatchingFacetSetsCounts extends FacetTestCase {
   }
 
   public void testInconsistentNumOfIndexedDimensions() throws IOException {
+    assumeTrue("Test designed to work only with assertions enabled.", TEST_ASSERTS_ENABLED);
+
     Directory d = newDirectory();
     RandomIndexWriter w = new RandomIndexWriter(random(), d);
 

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestKnnVectorSimilarityFunctions.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestKnnVectorSimilarityFunctions.java
@@ -192,6 +192,8 @@ public class TestKnnVectorSimilarityFunctions extends LuceneTestCase {
 
   @Test
   public void vectorSimilarity_twoVectorsWithDifferentDimensions_shouldRaiseException() {
+    assumeTrue("Test designed to work only with assertions enabled.", TEST_ASSERTS_ENABLED);
+
     ValueSource v1 = new ConstKnnByteVectorValueSource(new byte[] {1, 2, 3, 4});
     ValueSource v2 = new ByteKnnVectorFieldSource("knnByteField1");
     ByteVectorSimilarityFunction byteDenseVectorSimilarityFunction =

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/facet/TestTaxonomyFacet.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/facet/TestTaxonomyFacet.java
@@ -163,11 +163,13 @@ public class TestTaxonomyFacet extends SandboxFacetTestCase {
               new FacetLabel("Author", "Bob"),
             }));
 
-    expectThrows(
-        AssertionError.class,
-        () -> {
-          getTopChildrenByCount(countRecorder2, taxoReader, 10, "Non exitent dim");
-        });
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(
+          AssertionError.class,
+          () -> {
+            getTopChildrenByCount(countRecorder2, taxoReader, 10, "Non exitent dim");
+          });
+    }
 
     writer.close();
     IOUtils.close(taxoWriter, searcher.getIndexReader(), taxoReader, taxoDir, dir);

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestPhraseWildcardQuery.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestPhraseWildcardQuery.java
@@ -628,7 +628,9 @@ public class TestPhraseWildcardQuery extends LuceneTestCase {
     // Only verify test counters if the number of segments is 2 as expected.
     // If the randomization produced a different number of segments,
     // then just ignore test counters.
-    return reader.leaves().size() == 2 ? new AssertCounters() : AssertCounters.NO_OP;
+    return reader.leaves().size() == 2 && TEST_ASSERTS_ENABLED
+        ? new AssertCounters()
+        : AssertCounters.NO_OP;
   }
 
   /** Fluent API to assert {@link TestCounters}. */

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/tree/TestDateRangePrefixTree.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/tree/TestDateRangePrefixTree.java
@@ -183,6 +183,11 @@ public class TestDateRangePrefixTree extends LuceneTestCase {
   };
 
   private void roundTrip(Calendar calOrig) throws ParseException {
+    if (!TEST_ASSERTS_ENABLED) {
+      // If we're running without assertions, this test won't trigger.
+      return;
+    }
+
     Calendar cal = (Calendar) calOrig.clone();
     while (true) {
       String calString;
@@ -227,7 +232,9 @@ public class TestDateRangePrefixTree extends LuceneTestCase {
       try {
         tree.clearFieldsAfter(cal, prevPrecField);
       } catch (AssertionError e) {
-        if (e.getMessage().equals("Calendar underflow")) return;
+        if (e.getMessage().equals("Calendar underflow")) {
+          return;
+        }
         throw e;
       }
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
@@ -518,7 +518,10 @@ public abstract class BaseTermVectorsFormatTestCase extends BaseIndexFileFormatT
             assertTrue(foundPayload);
           }
         }
-        expectThrows(getReadPastLastPositionExceptionClass(), docsAndPositionsEnum::nextPosition);
+        Class<? extends Throwable> exClass = getReadPastLastPositionExceptionClass();
+        if (AssertionError.class.isAssignableFrom(exClass) && TEST_ASSERTS_ENABLED) {
+          expectThrows(exClass, docsAndPositionsEnum::nextPosition);
+        }
         assertEquals(PostingsEnum.NO_MORE_DOCS, docsAndPositionsEnum.nextDoc());
       }
       this.docsEnum.set(docsAndPositionsEnum);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/BaseDocIdSetTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/BaseDocIdSetTestCase.java
@@ -238,12 +238,16 @@ public abstract class BaseDocIdSetTestCase<T extends DocIdSet> extends LuceneTes
     it2.advance(from);
     // This call is not legal, since there is one bit that is set beyond the end of the target bit
     // set
-    expectThrows(Throwable.class, () -> it2.intoBitSet(to, dest2, offset));
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(Throwable.class, () -> it2.intoBitSet(to, dest2, offset));
+    }
 
     FixedBitSet dest3 = new FixedBitSet(42 - offset + 1);
     DocIdSetIterator it3 = copy.iterator();
     it3.advance(from);
     // This call is not legal, since offset is greater than the current doc
-    expectThrows(Throwable.class, () -> it3.intoBitSet(to, dest3, 21));
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(Throwable.class, () -> it3.intoBitSet(to, dest3, 21));
+    }
   }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -414,7 +414,12 @@ public abstract class LuceneTestCase extends Assert {
   /** Enables or disables dumping of {@link InfoStream} messages. */
   public static final boolean INFOSTREAM = systemPropertyAsBoolean("tests.infostream", VERBOSE);
 
-  public static final boolean TEST_ASSERTS_ENABLED = systemPropertyAsBoolean("tests.asserts", true);
+  /**
+   * True if {@code tests.asserts} is enabled (either explicitly via the build option or, if not
+   * present, by the default assertion status on this class).
+   */
+  public static final boolean TEST_ASSERTS_ENABLED =
+      systemPropertyAsBoolean("tests.asserts", LuceneTestCase.class.desiredAssertionStatus());
 
   /**
    * The default (embedded resource) lines file.
@@ -3107,15 +3112,6 @@ public abstract class LuceneTestCase extends Assert {
     }
 
     return Files.readAllLines(forkArgsPath, StandardCharsets.UTF_8);
-  }
-
-  /** True if assertions (-ea) are enabled (at least for this class). */
-  public static final boolean assertsAreEnabled;
-
-  static {
-    boolean enabled = false;
-    assert (enabled = true) == true; // Intentional side-effect!!!
-    assertsAreEnabled = enabled;
   }
 
   /**

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/RunListenerPrintReproduceInfo.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/RunListenerPrintReproduceInfo.java
@@ -216,7 +216,7 @@ public final class RunListenerPrintReproduceInfo extends RunListener {
       }
     }
 
-    if (LuceneTestCase.assertsAreEnabled) {
+    if (LuceneTestCase.TEST_ASSERTS_ENABLED) {
       addVmOpt(b, "tests.asserts", "true");
     } else {
       addVmOpt(b, "tests.asserts", "false");

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleAssertionsRequired.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleAssertionsRequired.java
@@ -29,9 +29,10 @@ public class TestRuleAssertionsRequired implements TestRule {
       public void evaluate() throws Throwable {
         try {
           // Make sure -ea matches -Dtests.asserts, to catch accidental mis-use:
-          if (LuceneTestCase.assertsAreEnabled != LuceneTestCase.TEST_ASSERTS_ENABLED) {
+          var assertsEnabled = LuceneTestCase.class.desiredAssertionStatus();
+          if (assertsEnabled != LuceneTestCase.TEST_ASSERTS_ENABLED) {
             String msg = "Assertions mismatch: ";
-            if (LuceneTestCase.assertsAreEnabled) {
+            if (assertsEnabled) {
               msg += "-ea was specified";
             } else {
               msg += "-ea was not specified";


### PR DESCRIPTION
We have ```tests.asserts``` which can be used to run the tests with or without assertions. We should occasionally run _without_ assertions though so that all code paths are covered.

This patch changes the default tests.asserts from true to a value computed based on the current tests.seed. About 25% of the time tests will run _without_ assertions enabled.

It also fixes those tests that hard-relied on assertions being always enabled.