### PR TITLE
Add PhraseQuery.Builder.setMaxTerms() method to limit the maximum number of terms and excessive memory use

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -174,6 +174,8 @@ Improvements
 
 * GITHUB#15184: Refactoring internal HNSWGraphBuilder's APIs and avoid creating new scorer for each call (Patrick Zhai)
 
+* GITHUB#15332: Solve the problem of excessive memory usage in ultra-long text search case (linyunanit)
+
 Optimizations
 ---------------------
 * GITHUB#15140: Optimize TopScoreDocCollector with TernaryLongHeap for improved performance over Binary-LongHeap. (Ramakrishna Chilaka)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -174,7 +174,7 @@ Improvements
 
 * GITHUB#15184: Refactoring internal HNSWGraphBuilder's APIs and avoid creating new scorer for each call (Patrick Zhai)
 
-* GITHUB#15332: Solve the problem of excessive memory usage in ultra-long text search case (linyunanit)
+* GITHUB#15332: Add PhraseQuery.Builder.setMaxTerms() method to limit the maximum number of terms and excessive memory use (linyunanit)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
@@ -74,12 +74,14 @@ public class PhraseQuery extends Query {
   public static class Builder {
 
     private int slop;
+    private int termLimit;
     private final List<Term> terms;
     private final IntArrayList positions;
 
     /** Sole constructor. */
     public Builder() {
       slop = 0;
+      termLimit = -1;
       terms = new ArrayList<>();
       positions = new IntArrayList();
     }
@@ -91,6 +93,14 @@ public class PhraseQuery extends Query {
      */
     public Builder setSlop(int slop) {
       this.slop = slop;
+      return this;
+    }
+
+    /**
+     * Set the term limit.
+     */
+    public Builder setTermLimit(int value) {
+      this.termLimit = value;
       return this;
     }
 
@@ -127,6 +137,10 @@ public class PhraseQuery extends Query {
                 + term.field()
                 + " and "
                 + terms.get(0).field());
+      }
+      if (termLimit > 0 && terms.size() >= termLimit) {
+        throw new IllegalArgumentException("The current value of terms is " +
+            terms.size() + ", which exceeds the limit of " + termLimit);
       }
       terms.add(term);
       positions.add(position);

--- a/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
@@ -97,7 +97,7 @@ public class PhraseQuery extends Query {
     }
 
     /**
-     * Set the term limit.
+     * Set the term threshold.
      */
     public Builder setTermThreshold(int value) {
       this.termThreshold = value;

--- a/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
@@ -74,14 +74,14 @@ public class PhraseQuery extends Query {
   public static class Builder {
 
     private int slop;
-    private int termThreshold;
+    private int maxTerms;
     private final List<Term> terms;
     private final IntArrayList positions;
 
     /** Sole constructor. */
     public Builder() {
       slop = 0;
-      termThreshold = -1;
+      maxTerms = -1;
       terms = new ArrayList<>();
       positions = new IntArrayList();
     }
@@ -96,9 +96,15 @@ public class PhraseQuery extends Query {
       return this;
     }
 
-    /** Set the term threshold. */
-    public Builder setTermThreshold(int value) {
-      this.termThreshold = value;
+    /**
+     * Set the maximum number of terms allowed in the phrase query.
+     * This helps prevent excessive memory usage for very long phrases.
+     *
+     * <p>If the number of terms added via {@link #add(Term)} or {@link #add(Term, int)}
+     * exceeds this threshold, an {@link IllegalArgumentException} will be thrown.
+     */
+    public Builder setMaxTerms(int maxTerms) {
+      this.maxTerms = maxTerms;
       return this;
     }
 
@@ -136,12 +142,12 @@ public class PhraseQuery extends Query {
                 + " and "
                 + terms.get(0).field());
       }
-      if (termThreshold > 0 && terms.size() >= termThreshold) {
+      if (maxTerms > 0 && terms.size() >= maxTerms) {
         throw new IllegalArgumentException(
             "The current number of terms is "
                 + terms.size()
                 + ", which exceeds the limit of "
-                + termThreshold);
+                + maxTerms);
       }
       terms.add(term);
       positions.add(position);

--- a/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
@@ -138,7 +138,7 @@ public class PhraseQuery extends Query {
       }
       if (termThreshold > 0 && terms.size() >= termThreshold) {
         throw new IllegalArgumentException(
-            "The current value of terms is "
+            "The current number of terms is "
                 + terms.size()
                 + ", which exceeds the limit of "
                 + termThreshold);

--- a/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
@@ -96,9 +96,7 @@ public class PhraseQuery extends Query {
       return this;
     }
 
-    /**
-     * Set the term threshold.
-     */
+    /** Set the term threshold. */
     public Builder setTermThreshold(int value) {
       this.termThreshold = value;
       return this;
@@ -139,8 +137,11 @@ public class PhraseQuery extends Query {
                 + terms.get(0).field());
       }
       if (termThreshold > 0 && terms.size() >= termThreshold) {
-        throw new IllegalArgumentException("The current value of terms is " +
-            terms.size() + ", which exceeds the limit of " + termThreshold);
+        throw new IllegalArgumentException(
+            "The current value of terms is "
+                + terms.size()
+                + ", which exceeds the limit of "
+                + termThreshold);
       }
       terms.add(term);
       positions.add(position);

--- a/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
@@ -97,11 +97,11 @@ public class PhraseQuery extends Query {
     }
 
     /**
-     * Set the maximum number of terms allowed in the phrase query.
-     * This helps prevent excessive memory usage for very long phrases.
+     * Set the maximum number of terms allowed in the phrase query. This helps prevent excessive
+     * memory usage for very long phrases.
      *
-     * <p>If the number of terms added via {@link #add(Term)} or {@link #add(Term, int)}
-     * exceeds this threshold, an {@link IllegalArgumentException} will be thrown.
+     * <p>If the number of terms added via {@link #add(Term)} or {@link #add(Term, int)} exceeds
+     * this threshold, an {@link IllegalArgumentException} will be thrown.
      */
     public Builder setMaxTerms(int maxTerms) {
       this.maxTerms = maxTerms;

--- a/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
@@ -74,14 +74,14 @@ public class PhraseQuery extends Query {
   public static class Builder {
 
     private int slop;
-    private int termLimit;
+    private int termThreshold;
     private final List<Term> terms;
     private final IntArrayList positions;
 
     /** Sole constructor. */
     public Builder() {
       slop = 0;
-      termLimit = -1;
+      termThreshold = -1;
       terms = new ArrayList<>();
       positions = new IntArrayList();
     }
@@ -99,8 +99,8 @@ public class PhraseQuery extends Query {
     /**
      * Set the term limit.
      */
-    public Builder setTermLimit(int value) {
-      this.termLimit = value;
+    public Builder setTermThreshold(int value) {
+      this.termThreshold = value;
       return this;
     }
 
@@ -138,9 +138,9 @@ public class PhraseQuery extends Query {
                 + " and "
                 + terms.get(0).field());
       }
-      if (termLimit > 0 && terms.size() >= termLimit) {
+      if (termThreshold > 0 && terms.size() >= termThreshold) {
         throw new IllegalArgumentException("The current value of terms is " +
-            terms.size() + ", which exceeds the limit of " + termLimit);
+            terms.size() + ", which exceeds the limit of " + termThreshold);
       }
       terms.add(term);
       positions.add(position);

--- a/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
@@ -743,10 +743,10 @@ public class TestPhraseQuery extends LuceneTestCase {
         });
   }
 
-  public void testPhraseQueryTermLimit() throws Exception {
+  public void testPhraseQueryMaxTerms() throws Exception {
     PhraseQuery.Builder builder = new PhraseQuery.Builder();
     int termThreshold = 5;
-    builder.setTermThreshold(termThreshold);
+    builder.setMaxTerms(termThreshold);
     for (int i = 0; i < termThreshold; i++) {
       builder.add(new Term("field", "one" + i), i);
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
@@ -743,6 +743,20 @@ public class TestPhraseQuery extends LuceneTestCase {
         });
   }
 
+  public void testPhraseQueryTermLimit() throws Exception {
+    PhraseQuery.Builder builder = new PhraseQuery.Builder();
+    int termLimit = 1000;
+    builder.setTermLimit(termLimit);
+    for (int i = 0; i < termLimit; i++) {
+      builder.add(new Term("field", "one" + i), i + 1);
+    }
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          builder.add(new Term("field", "three"), termLimit + 1);
+        });
+  }
+
   private static final String[] DOCS =
       new String[] {
         "a b c d e f g h",

--- a/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
@@ -745,15 +745,15 @@ public class TestPhraseQuery extends LuceneTestCase {
 
   public void testPhraseQueryTermLimit() throws Exception {
     PhraseQuery.Builder builder = new PhraseQuery.Builder();
-    int termLimit = 1000;
-    builder.setTermThreshold(termLimit);
-    for (int i = 0; i < termLimit; i++) {
-      builder.add(new Term("field", "one" + i), i + 1);
+    int termThreshold = 5;
+    builder.setTermThreshold(termThreshold);
+    for (int i = 0; i < termThreshold; i++) {
+      builder.add(new Term("field", "one" + i), i);
     }
     expectThrows(
         IllegalArgumentException.class,
         () -> {
-          builder.add(new Term("field", "three"), termLimit + 1);
+          builder.add(new Term("field", "three"), termThreshold);
         });
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
@@ -746,7 +746,7 @@ public class TestPhraseQuery extends LuceneTestCase {
   public void testPhraseQueryTermLimit() throws Exception {
     PhraseQuery.Builder builder = new PhraseQuery.Builder();
     int termLimit = 1000;
-    builder.setTermLimit(termLimit);
+    builder.setTermThreshold(termLimit);
     for (int i = 0; i < termLimit; i++) {
       builder.add(new Term("field", "one" + i), i + 1);
     }


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
Add configurable term threshold for PhraseQuery#Builder to solve the problem of excessive memory usage in ultra-long text search case.

### Key Changes
- Add termThreshold variables  in PhraseQuery.Builder.
- Check whether the current terms size reaches the threshold.
