### PR TITLE
Fix potential NPE for KnnVectorQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -212,6 +212,9 @@ Bug Fixes
 
 * GITHUB#15319: Fix potential hang in initialisation of TermsEnum and BaseTermsEnum (Chris Hegarty)
 
+* GITHUB#15334: Fix NPE for MemoryIndex when using nearest neighbor search. MemoryIndex does not support
+  nearest neighbor search, but it should not throw an NPE (Ben Trent)
+
 Other
 ---------------------
 * GITHUB#15237: Fix SmartChinese to only deserialize dictionary data from classpath with a native array

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -262,6 +262,7 @@ abstract class AbstractKnnVectorQuery extends Query {
         int visitedLimit, KnnSearchStrategy searchStrategy, LeafReaderContext context)
         throws IOException {
       // The delegate supports optimistic collection
+      // ctx.parent could be null if this is a MemoryIndex
       if (delegate.isOptimistic() && context.parent != null) {
         @SuppressWarnings("resource")
         float leafProportion = context.reader().maxDoc() / (float) context.parent.reader().maxDoc();

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -211,8 +211,15 @@ abstract class AbstractKnnVectorQuery extends Query {
     final int cost = acceptDocs.cost();
     QueryTimeout queryTimeout = timeLimitingKnnCollectorManager.getQueryTimeout();
 
-    float leafProportion = ctx.reader().maxDoc() / (float) ctx.parent.reader().maxDoc();
-    int perLeafTopK = perLeafTopKCalculation(k, leafProportion);
+    final int perLeafTopK;
+    // ctx.parent could be null if this is a MemoryIndex
+    if (ctx.parent != null) {
+      float leafProportion = ctx.reader().maxDoc() / (float) ctx.parent.reader().maxDoc();
+      perLeafTopK = perLeafTopKCalculation(k, leafProportion);
+      // We don't have a good way to estimate perLeafTopK here, so just do approximate search
+    } else {
+      perLeafTopK = k;
+    }
 
     if (cost <= perLeafTopK) {
       // If there are <= perLeafTopK possible matches, short-circuit and perform exact search, since
@@ -255,7 +262,7 @@ abstract class AbstractKnnVectorQuery extends Query {
         int visitedLimit, KnnSearchStrategy searchStrategy, LeafReaderContext context)
         throws IOException {
       // The delegate supports optimistic collection
-      if (delegate.isOptimistic()) {
+      if (delegate.isOptimistic() && context.parent != null) {
         @SuppressWarnings("resource")
         float leafProportion = context.reader().maxDoc() / (float) context.parent.reader().maxDoc();
         int perLeafTopK = perLeafTopKCalculation(k, leafProportion);

--- a/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
+++ b/lucene/memory/src/test/org/apache/lucene/index/memory/TestMemoryIndex.java
@@ -870,14 +870,6 @@ public class TestMemoryIndex extends LuceneTestCase {
     assertEquals(DocIdSetIterator.NO_MORE_DOCS, iterator.nextDoc());
   }
 
-  private static void doKnnSearch(MemoryIndex mi, String fieldName, float[] queryVector)
-      throws IOException {
-    IndexSearcher searcher = mi.createSearcher();
-    Query knnQuery = new KnnFloatVectorQuery(fieldName, queryVector, 1);
-    TopDocs topDocs = searcher.search(knnQuery, 10);
-    assertEquals(0, topDocs.scoreDocs[0].doc);
-  }
-
   private static void assertFloatVectorScore(
       MemoryIndex mi, String fieldName, float[] queryVector, float expectedScore)
       throws IOException {


### PR DESCRIPTION
When using a particular leaf reader (possibly for a MemoryIndex), `parent` can be `null`. 

Let's verify that and prevent an NPE