### PR TITLE
ci: fix missing permission for the stale workflow

### DIFF
--- a/.github/workflows/mark-stale-PRs.yml
+++ b/.github/workflows/mark-stale-PRs.yml
@@ -19,6 +19,7 @@ jobs:
 
     permissions:
       pull-requests: write # must comment/label PRs
+      actions: write # must manipulate actions cache to split workload across multiple runs
 
     steps:
       - name: Run stale PR action


### PR DESCRIPTION
Permissions were restricted (following documentation of actions/stale) in c5d82423934db5e5512b83d6319944be3f33e221, but the `actions: write` is missing

This permission is only mentioned in the top of documentation along with many other "optional" permissions that depend upon which features you use... but it is needed for the action to manipulate the actions cache the way that it does.

When operations limit is exceeded, it "stops" and "picks up from where it left off" in the next run, and actions cache is used to do this.

