### PR TITLE
Use cached cardinality for AcceptDocs cost

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -200,6 +200,9 @@ Optimizations
 
 * GITHUB#15261: Implement longValues for MultiFieldNormValues to speedup CombinedQuery (Ge Song)
 
+* GITHUB#15343: Ensure that `AcceptDocs#cost()` only ever calls `BitSets#cardinality()`
+  once per instance to avoid redundant computation. (Ben Trent)
+
 Bug Fixes
 ---------------------
 * GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException

--- a/lucene/core/src/java/org/apache/lucene/search/AcceptDocs.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AcceptDocs.java
@@ -190,7 +190,7 @@ public abstract class AcceptDocs {
     @Override
     public int cost() throws IOException {
       createBitSetAcceptDocsIfNecessary();
-      return acceptBitSet.cardinality();
+      return cardinality;
     }
 
     @Override


### PR DESCRIPTION
We are unnecessarily calling `BitSet.cardinality` more than once when returning the cost from `AcceptDocs`.