### PR TITLE
Add missing checkDimension check to Lucene104ScalarQuantizedVectorScorer#getRandomVectorScorer and some cleanup

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsScorer.java
@@ -67,4 +67,11 @@ public interface FlatVectorsScorer {
   RandomVectorScorer getRandomVectorScorer(
       VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, byte[] target)
       throws IOException;
+
+  static void checkDimensions(int queryLen, int fieldLen) {
+    if (queryLen != fieldLen) {
+      throw new IllegalArgumentException(
+          "vector query dimension: " + queryLen + " differs from field dimension: " + fieldLen);
+    }
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorScorer.java
@@ -39,13 +39,6 @@ public class Lucene104ScalarQuantizedVectorScorer implements FlatVectorsScorer {
     this.nonQuantizedDelegate = nonQuantizedDelegate;
   }
 
-  static void checkDimensions(int queryLen, int fieldLen) {
-    if (queryLen != fieldLen) {
-      throw new IllegalArgumentException(
-          "vector query dimension: " + queryLen + " differs from field dimension: " + fieldLen);
-    }
-  }
-
   @Override
   public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
       VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues)
@@ -62,7 +55,7 @@ public class Lucene104ScalarQuantizedVectorScorer implements FlatVectorsScorer {
       VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, float[] target)
       throws IOException {
     if (vectorValues instanceof QuantizedByteVectorValues qv) {
-      checkDimensions(target.length, qv.dimension());
+      FlatVectorsScorer.checkDimensions(target.length, qv.dimension());
       OptimizedScalarQuantizer quantizer = qv.getQuantizer();
       Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding scalarEncoding = qv.getScalarEncoding();
       byte[] scratch = new byte[scalarEncoding.getDiscreteDimensions(qv.dimension())];
@@ -103,6 +96,7 @@ public class Lucene104ScalarQuantizedVectorScorer implements FlatVectorsScorer {
   public RandomVectorScorer getRandomVectorScorer(
       VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, byte[] target)
       throws IOException {
+    FlatVectorsScorer.checkDimensions(target.length, vectorValues.dimension());
     return nonQuantizedDelegate.getRandomVectorScorer(similarityFunction, vectorValues, target);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
@@ -95,7 +95,7 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
       VectorSimilarityFunction sim,
       float constMultiplier,
       QuantizedByteVectorValues values) {
-    checkDimensions(targetBytes.length, values.dimension());
+    FlatVectorsScorer.checkDimensions(values.dimension(), targetBytes.length);
     return switch (sim) {
       case EUCLIDEAN -> new Euclidean(values, constMultiplier, targetBytes);
       case COSINE, DOT_PRODUCT ->
@@ -113,13 +113,6 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
               values,
               VectorUtil::scaleMaxInnerProductScore);
     };
-  }
-
-  static void checkDimensions(int queryLen, int fieldLen) {
-    if (queryLen != fieldLen) {
-      throw new IllegalArgumentException(
-          "vector query dimension: " + queryLen + " differs from field dimension: " + fieldLen);
-    }
   }
 
   private static UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFlatVectorsScorer.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFlatVectorsScorer.java
@@ -84,7 +84,7 @@ public class Lucene99MemorySegmentFlatVectorsScorer implements FlatVectorsScorer
   public RandomVectorScorer getRandomVectorScorer(
       VectorSimilarityFunction similarityType, KnnVectorValues vectorValues, float[] target)
       throws IOException {
-    checkDimensions(target.length, vectorValues.dimension());
+    FlatVectorsScorer.checkDimensions(target.length, vectorValues.dimension());
     if (vectorValues instanceof FloatVectorValues fvv
         && fvv instanceof HasIndexSlice floatVectorValues
         && floatVectorValues.getSlice() != null) {
@@ -102,7 +102,7 @@ public class Lucene99MemorySegmentFlatVectorsScorer implements FlatVectorsScorer
   public RandomVectorScorer getRandomVectorScorer(
       VectorSimilarityFunction similarityType, KnnVectorValues vectorValues, byte[] queryVector)
       throws IOException {
-    checkDimensions(queryVector.length, vectorValues.dimension());
+    FlatVectorsScorer.checkDimensions(queryVector.length, vectorValues.dimension());
     // a quantized values here is a wrapping or delegation issue
     assert !(vectorValues instanceof QuantizedByteVectorValues);
     if (vectorValues instanceof ByteVectorValues bvv
@@ -116,13 +116,6 @@ public class Lucene99MemorySegmentFlatVectorsScorer implements FlatVectorsScorer
       }
     }
     return delegate.getRandomVectorScorer(similarityType, vectorValues, queryVector);
-  }
-
-  static void checkDimensions(int queryLen, int fieldLen) {
-    if (queryLen != fieldLen) {
-      throw new IllegalArgumentException(
-          "vector query dimension: " + queryLen + " differs from field dimension: " + fieldLen);
-    }
   }
 
   @Override


### PR DESCRIPTION
### Description

Adds missing `checkDimension` check to `Lucene104ScalarQuantizedVectorScorer#getRandomVectorScorer` (similarly like its in `float[]` variant) and some cleanup for duplicate `checkDimension` helper function
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
