### PR TITLE
ci: configure dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     commit-message:
       prefix: ci
     labels: [dependencies, skip-changelog]
+    cooldown:
+      default-days: 7
 
   # python dependencies in /dev-tools/scripts
   - package-ecosystem: pip
@@ -18,6 +20,8 @@ updates:
     commit-message:
       prefix: build(deps)
     labels: [dependencies, skip-changelog]
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gradle
     directory: /
@@ -28,3 +32,5 @@ updates:
     commit-message:
       prefix: deps(java)
     labels: [dependencies, skip-changelog]
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Addresses the new zizmor alerts around this issue.

Waits a configurable number of days for a dependency to be released, before creating a pull request for it. This is helpful when there are supply chain security issues such as the recent NPM incidents.

https://docs.zizmor.sh/audits/#dependabot-cooldown

