### PR TITLE
ci: disable concurrency-limits lint

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+---
+rules:
+  # Setting these limits causes failed builds which can be confusing
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
Disable this new lint from zizmor, the cure is worse than the disease.

Background of the check:
https://docs.zizmor.sh/audits/#concurrency-limits

Setting concurrency-limits will e.g. fail previous in-progress builds for the same branch/PR, including `main`. Such "cancelled" builds display and notify exactly as failures, when they really aren't. This can cause a lot of noise and confusion!

Given that maintainers must approve before actions are run from a new contributor, it doesn't seem like the best tradeoff to scan for this rule and cancel (fail) such builds. Better to ensure all workflows have timeouts better than the default (6h), if we want to prevent waste of actions minutes.
