### PR TITLE
ci: enable zizmor online checks at night

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,6 +11,8 @@ on:
       - main
     paths:
       - '.github/**'
+  schedule:
+    - cron: '22 2 * * *'
 
 permissions: {}
 
@@ -43,8 +45,8 @@ jobs:
         run: uvx zizmor --pedantic --format=sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # TODO: offline checks only to avoid any rate-limiting issues, maybe enable nightly?
-          ZIZMOR_OFFLINE: true
+          # run offline for branches and PRs to avoid rate limits
+          ZIZMOR_OFFLINE: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
         with:


### PR DESCRIPTION
Previously the tool was always run in the offline mode. Allow it to make API requests at night or via manual dispatch.

