### PR TITLE
ci: populate missing job timeout-minutes, fail build if missing

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,6 +18,7 @@ jobs:
   actionlint:
     name: Run actionlint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -30,6 +31,7 @@ jobs:
   zizmor:
     name: Run zizmor
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       security-events: write # integration with github advanced security
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,7 @@ jobs:
     name: Analyze (${{ matrix.language }})
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       security-events: write # integrate with Github Advanced Security
 

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -15,6 +15,7 @@ jobs:
   dependency-submission:
     name: Submit gradle dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write # see action's documentation
     steps:

--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -26,6 +26,7 @@ jobs:
       pull-requests: write # manipulate existing labels
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Run Labeler action

--- a/.github/workflows/mark-stale-PRs.yml
+++ b/.github/workflows/mark-stale-PRs.yml
@@ -21,6 +21,8 @@ jobs:
       pull-requests: write # must comment/label PRs
       actions: write # must manipulate actions cache to split workload across multiple runs
 
+    timeout-minutes: 15
+
     steps:
       - name: Run stale PR action
         uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0

--- a/.github/workflows/run-nightly-smoketester.yml
+++ b/.github/workflows/run-nightly-smoketester.yml
@@ -25,6 +25,7 @@ jobs:
         java-version: [ '25' ]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     env:
       LUCENE_RELEASE_DIR: /tmp/lucene-release-dir

--- a/.github/workflows/verify-changelog-and-set-milestone.yml
+++ b/.github/workflows/verify-changelog-and-set-milestone.yml
@@ -8,6 +8,7 @@ permissions: {}
 jobs:
   changelog-verifier-and-milestone-setter:
     name: Verify Change Log Entry and Set Milestone
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     permissions:

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/astgrep/AstGrepPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/astgrep/AstGrepPlugin.java
@@ -70,9 +70,16 @@ public class AstGrepPlugin implements Plugin<Project> {
               }
 
               var args = new ArrayList<String>();
-              // fail on any rule match regardless of severity level
+              // fail on any rule match regardless of severity level. Scan hidden files/directories
+              // too.
               args.addAll(
-                  List.of("scan", "-c", "gradle/validation/ast-grep/sgconfig.yml", "--error"));
+                  List.of(
+                      "scan",
+                      "-c",
+                      "gradle/validation/ast-grep/sgconfig.yml",
+                      "--error",
+                      "--no-ignore",
+                      "hidden"));
               // use the github format when being run as a workflow
               if (System.getenv("CI") != null && System.getenv("GITHUB_WORKFLOW") != null) {
                 args.addAll(List.of("--format", "github"));

--- a/gradle/validation/ast-grep/rules/actions.yml
+++ b/gradle/validation/ast-grep/rules/actions.yml
@@ -1,0 +1,50 @@
+# Checks for github actions
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/refs/heads/main/schemas/yaml_rule.json
+id: missing-job-timeout
+language: yaml
+files:
+  - ".github/workflows/**.yml"
+rule:
+  kind: block_mapping_pair
+  all:
+    - has:
+        kind: flow_node
+        field: key
+        pattern: $JOBNAME
+    - has:
+        kind: block_node
+        field: value
+        has:
+          kind: block_mapping
+          # doesn't have timeout minutes
+          not:
+            has:
+              kind: block_mapping_pair
+              has:
+                field: key
+                kind: flow_node
+                has:
+                  pattern: timeout-minutes
+                  stopBy: end
+  inside:
+    kind: block_mapping
+    inside:
+      kind: block_node
+      inside:
+        # top-level "jobs:"
+        kind: block_mapping_pair
+        inside:
+          kind: block_mapping
+          inside:
+            kind: block_node
+            inside:
+              kind: document
+        has:
+          field: key
+          kind: flow_node
+          has:
+            pattern: jobs
+            stopBy: end
+severity: error
+message: workflow job `$JOBNAME` missing `timeout-minutes:`

--- a/gradle/validation/ast-grep/tests/actions.yml
+++ b/gradle/validation/ast-grep/tests/actions.yml
@@ -1,0 +1,18 @@
+---
+id: missing-job-timeout
+invalid:
+  - |
+    jobs:
+      foobar:
+        runs-on: supercomputer
+valid:
+  - |
+    jobs:
+      foobar:
+        runs-on: supercomputer
+        timeout-minutes: 30
+  - |
+    somethingelse:
+      jobs:
+        foobar:
+          unrelated: stuff


### PR DESCRIPTION
Ensure all workflow jobs have explicit `timeout-minutes` set

