### PR TITLE
Proposal for alternate way to traverse BKD tree with prefetching matching leaves for IO concurrency

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -984,6 +984,8 @@ API Changes
 * GITHUB#13820, GITHUB#13825, GITHUB#13830: Corrects DataInput.readGroupVInts to be public and not-final, removes the protected
   DataInput.readGroupVInt method. (Zhang Chao, Robert Muir, Uwe Schindler, Dawid Weiss)
 
+* GITHUB#15376, GITHUB#15197: Added prefetching in bkd tree traversal, couple of new api in PointValues visitDocIDs from a position and prepareOrVisitDocIDs to prefetch the IO before visiting docIds (Saurabh Singh)
+
 New Features
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -3194,7 +3194,7 @@ public final class CheckIndex implements Closeable {
    *
    * @lucene.internal
    */
-  public static class VerifyPointsVisitor implements PointValues.IntersectVisitor {
+  public static class VerifyPointsVisitor implements IntersectVisitor {
     private long pointCountSeen;
     private int lastDocID = -1;
     private final FixedBitSet docsSeen;

--- a/lucene/core/src/java/org/apache/lucene/index/PointValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PointValues.java
@@ -345,13 +345,15 @@ public abstract class PointValues {
    * Finds all documents and points matching the provided visitor. This method does not enforce live
    * documents, so it's up to the caller to test whether each document is deleted, if necessary.
    */
-  public final void intersect(IntersectVisitor visitor) throws IOException {
+  public void intersect(IntersectVisitor visitor) throws IOException {
     final PointTree pointTree = getPointTree();
     intersect(visitor, pointTree);
     assert pointTree.moveToParent() == false;
   }
 
-  private static void intersect(IntersectVisitor visitor, PointTree pointTree) throws IOException {
+  /** Finds all documents and points matching the provided visitor for the provided point tree. */
+  protected static void intersect(IntersectVisitor visitor, PointTree pointTree)
+      throws IOException {
     while (true) {
       Relation compare =
           visitor.compare(pointTree.getMinPackedValue(), pointTree.getMaxPackedValue());


### PR DESCRIPTION
### Description

I would appreciate feedback on BKD traversal with prefetching. 

At a high level, this is what I am doing:

Start traversing the BKD tree as is,

If cell is inside the query
a) Call goes to prepareDocIDs method variation where if isLeaf is true. 
b) Do not read the leaf node yet. Instead, get the leafOrdinal, if this leaf ordinal is in continuation to last matching leaf ordinal (which I am storing in visitor) i.e leafOrdinal == visitor.lastMatchingLeafOrdinal() + 1. Do not call prefetch as this should be hopefully taken care by kernel readaheads. Otherwise if its not a continuous match i.e leafOrdinal != visitor.lastMatchingLeafOrdinal() + 1, then call prefetch on this leaf node file pointer. Also store this leaf node fp in visitor for visting matching doc IDs later.
c) If its not a leafNode continue with recursion as is.
d) Visit the cached leaf node file pointers after recursion.

For remaining traversal code remains unchanged.


[Related Issue](https://github.com/apache/lucene/issues/15197)