### PR TITLE
Return MergeObserver from IndexWriter.forceMergeDeletes() (#14515)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -69,12 +69,6 @@ Improvements
 
 * GITHUB#15124: Use RamUsageEstimator to calculate size for non-accountable queries. (Sagar Upadhyaya)
 
-* GITHUB#14515: IndexWriter.forceMergeDeletes() now returns MergePolicy.MergeObserver,
-  allowing applications to monitor merge progress, wait for completion (synchronously
-  via await() or asynchronously via CompletableFuture), and inspect individual merges.
-  Backward compatible - existing code that ignores the return value works unchanged.
-  (Salvatore Campagna)
-
 Optimizations
 ---------------------
 * GITHUB#14011: Reduce allocation rate in HNSW concurrent merge. (Viliam Durina)
@@ -150,6 +144,12 @@ API Changes
 
 * GITHUB#15234: Remove unused method which does unsafe XML parsing.
   (Uwe Schindler, Isaac David)
+
+* GITHUB#14515: IndexWriter.forceMergeDeletes() now returns MergePolicy.MergeObserver,
+  allowing applications to monitor merge progress and wait for completion. The observer
+  provides methods to query merge count, check completion status, and wait synchronously
+  (with optional timeout) or asynchronously via CompletableFuture. Backward compatible -
+  existing code that ignores the return value works unchanged. (Salvatore Campagna)
 
 New Features
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -69,6 +69,12 @@ Improvements
 
 * GITHUB#15124: Use RamUsageEstimator to calculate size for non-accountable queries. (Sagar Upadhyaya)
 
+* GITHUB#14515: IndexWriter.forceMergeDeletes() now returns MergePolicy.MergeObserver,
+  allowing applications to monitor merge progress, wait for completion (synchronously
+  via await() or asynchronously via CompletableFuture), and inspect individual merges.
+  Backward compatible - existing code that ignores the return value works unchanged.
+  (Salvatore Campagna)
+
 Optimizations
 ---------------------
 * GITHUB#14011: Reduce allocation rate in HNSW concurrent merge. (Viliam Durina)

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -966,6 +966,25 @@ public abstract class MergePolicy {
     }
 
     /**
+     * Returns the number of completed merges in this specification. Useful for tracking merge
+     * progress: {@code numCompletedMerges() / numMerges()}.
+     *
+     * @return number of completed merges
+     */
+    public int numCompletedMerges() {
+      if (spec == null) {
+        return 0;
+      }
+      int completed = 0;
+      for (OneMerge merge : spec.merges) {
+        if (merge.mergeCompleted.isDone()) {
+          completed++;
+        }
+      }
+      return completed;
+    }
+
+    /**
      * Waits for all merges in this specification to complete. Returns immediately if no merges were
      * scheduled.
      *
@@ -1003,7 +1022,11 @@ public abstract class MergePolicy {
 
     @Override
     public String toString() {
-      return spec == null ? "MergeObserver: no merges" : spec.toString();
+      if (spec == null) {
+        return "MergeObserver: no merges";
+      }
+      return String.format(
+          "MergeObserver: %d merges (%d completed)", numMerges(), numCompletedMerges());
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -1025,7 +1026,7 @@ public abstract class MergePolicy {
       if (spec == null) {
         return "MergeObserver: no merges";
       }
-      return String.format("MergeObserver: %d merges", numMerges());
+      return String.format(Locale.ROOT, "MergeObserver: %d merges", numMerges());
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -944,9 +944,8 @@ public abstract class MergePolicy {
    * Observer for merge operations returned by {@link IndexWriter#forceMergeDeletes(boolean)}.
    * Provides methods to query merge status and wait for completion.
    *
-   * <p>When no merges are needed, {@link #hasNewMerges()} returns {@code false} and {@link
-   * #numMerges()} returns 0. In this case, {@link #await()} returns {@code true} immediately since
-   * there is nothing to wait for.
+   * <p>When no merges are needed, {@link #numMerges()} returns 0. In this case, {@link #await()}
+   * returns {@code true} immediately since there is nothing to wait for.
    *
    * @lucene.experimental
    */
@@ -964,15 +963,6 @@ public abstract class MergePolicy {
      */
     public int numMerges() {
       return spec == null ? 0 : spec.merges.size();
-    }
-
-    /**
-     * Returns whether any new merges were scheduled.
-     *
-     * @return {@code true} if merges were scheduled, {@code false} if no merges needed
-     */
-    public boolean hasNewMerges() {
-      return spec != null;
     }
 
     /**

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -1025,8 +1025,7 @@ public abstract class MergePolicy {
       if (spec == null) {
         return "MergeObserver: no merges";
       }
-      return String.format(
-          "MergeObserver: %d merges (%d completed)", numMerges(), numCompletedMerges());
+      return String.format("MergeObserver: %d merges", numMerges());
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -1026,7 +1026,7 @@ public abstract class MergePolicy {
       if (spec == null) {
         return "MergeObserver: no merges";
       }
-      return String.format(Locale.ROOT, "MergeObserver: %d merges", numMerges());
+      return String.format(Locale.ROOT, "MergeObserver: %d merges\n%s", numMerges(), spec.toString());
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -1026,7 +1026,8 @@ public abstract class MergePolicy {
       if (spec == null) {
         return "MergeObserver: no merges";
       }
-      return String.format(Locale.ROOT, "MergeObserver: %d merges\n%s", numMerges(), spec.toString());
+      return String.format(
+          Locale.ROOT, "MergeObserver: %d merges\n%s", numMerges(), spec.toString());
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -939,4 +939,96 @@ public abstract class MergePolicy {
       this.hardLiveDocs = hardLiveDocs;
     }
   }
+
+  /**
+   * Observer for merge operations returned by {@link IndexWriter#forceMergeDeletes(boolean)}.
+   * Provides methods to query merge status and wait for completion.
+   *
+   * <p>When no merges are needed, {@link #hasNewMerges()} returns {@code false} and {@link
+   * #numMerges()} returns 0. In this case, {@link #await()} returns {@code true} immediately since
+   * there is nothing to wait for.
+   *
+   * @lucene.experimental
+   */
+  public static final class MergeObserver {
+    private final MergePolicy.MergeSpecification spec;
+
+    MergeObserver(MergePolicy.MergeSpecification spec) {
+      this.spec = spec;
+    }
+
+    /**
+     * Returns the number of merges in this specification.
+     *
+     * @return number of merges, or 0 if no merges were scheduled
+     */
+    public int numMerges() {
+      return spec == null ? 0 : spec.merges.size();
+    }
+
+    /**
+     * Returns whether any new merges were scheduled.
+     *
+     * @return {@code true} if merges were scheduled, {@code false} if no merges needed
+     */
+    public boolean hasNewMerges() {
+      return spec != null;
+    }
+
+    /**
+     * Waits for all merges in this specification to complete. Returns immediately if no merges were
+     * scheduled.
+     *
+     * @return {@code true} if all merges completed successfully or no merges were needed, {@code
+     *     false} on error
+     */
+    public boolean await() {
+      return spec == null || spec.await();
+    }
+
+    /**
+     * Waits for all merges in this specification to complete, with timeout. Returns immediately if
+     * no merges were scheduled.
+     *
+     * @param timeout maximum time to wait
+     * @param unit time unit for timeout
+     * @return {@code true} if all merges completed within timeout or no merges were needed, {@code
+     *     false} on timeout or error
+     */
+    public boolean await(long timeout, TimeUnit unit) {
+      return spec == null || spec.await(timeout, unit);
+    }
+
+    /**
+     * Returns a {@link CompletableFuture} that completes when all merges finish. Returns an
+     * already-completed future if no merges were scheduled.
+     *
+     * @return future that completes when merges finish
+     */
+    public CompletableFuture<Void> awaitAsync() {
+      return spec == null
+          ? CompletableFuture.completedFuture(null)
+          : spec.getMergeCompletedFutures();
+    }
+
+    @Override
+    public String toString() {
+      return spec == null ? "MergeObserver: no merges" : spec.toString();
+    }
+
+    /**
+     * Returns the merge at the specified index. Caller must ensure {@link #hasNewMerges()} returns
+     * {@code true} and index is within bounds.
+     *
+     * @param i merge index (0 to {@link #numMerges()} - 1)
+     * @return the merge at index i
+     * @throws IndexOutOfBoundsException if index is invalid or no merges exist
+     */
+    public MergePolicy.OneMerge getMerge(int i) {
+      if (spec == null) {
+        throw new IndexOutOfBoundsException("No merges available");
+      }
+      return spec.merges.get(i);
+    }
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -1015,20 +1015,5 @@ public abstract class MergePolicy {
     public String toString() {
       return spec == null ? "MergeObserver: no merges" : spec.toString();
     }
-
-    /**
-     * Returns the merge at the specified index. Caller must ensure {@link #hasNewMerges()} returns
-     * {@code true} and index is within bounds.
-     *
-     * @param i merge index (0 to {@link #numMerges()} - 1)
-     * @return the merge at index i
-     * @throws IndexOutOfBoundsException if index is invalid or no merges exist
-     */
-    public MergePolicy.OneMerge getMerge(int i) {
-      if (spec == null) {
-        throw new IndexOutOfBoundsException("No merges available");
-      }
-      return spec.merges.get(i);
-    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
@@ -387,8 +387,7 @@ public class TestIndexWriterMerging extends LuceneTestCase {
     assertTrue("Should have scheduled merges", observer.numMerges() > 0);
 
     assertTrue(
-        "Merges should complete within 30 seconds",
-        observer.await(30_000, TimeUnit.MILLISECONDS));
+        "Merges should complete within 30 seconds", observer.await(30_000, TimeUnit.MILLISECONDS));
 
     assertEquals(
         "All merges should be completed after await() returns true",
@@ -446,8 +445,7 @@ public class TestIndexWriterMerging extends LuceneTestCase {
     MergePolicy.MergeObserver observer = iw.forceMergeDeletes(false);
 
     assertTrue(
-        "Merges should complete within 30 seconds",
-        observer.await(30_000, TimeUnit.MILLISECONDS));
+        "Merges should complete within 30 seconds", observer.await(30_000, TimeUnit.MILLISECONDS));
 
     assertEquals(
         "All merges should be completed after await() returns true",

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
@@ -384,8 +384,7 @@ public class TestIndexWriterMerging extends LuceneTestCase {
     assertEquals(5, iw.getDocStats().numDocs);
     MergePolicy.MergeObserver observer = iw.forceMergeDeletes(false);
 
-    assertTrue(observer.hasNewMerges());
-    assertTrue(observer.numMerges() > 0);
+    assertTrue("Should have scheduled merges", observer.numMerges() > 0);
 
     // Measure time to detect stuck merges
     long startNanos = System.nanoTime();
@@ -419,7 +418,6 @@ public class TestIndexWriterMerging extends LuceneTestCase {
 
     MergePolicy.MergeObserver observer = writer.forceMergeDeletes(false);
 
-    assertFalse("Should have no merges when no deletions", observer.hasNewMerges());
     assertEquals("Should have zero merges", 0, observer.numMerges());
 
     writer.close();
@@ -506,7 +504,7 @@ public class TestIndexWriterMerging extends LuceneTestCase {
 
     MergePolicy.MergeObserver observer = indexer.forceMergeDeletes(false);
 
-    if (observer.hasNewMerges()) {
+    if (observer.numMerges() > 0) {
       mergeStarted.await();
       assertFalse("await should timeout", observer.await(10, TimeUnit.MILLISECONDS));
       allowMergeToFinish.countDown();
@@ -554,7 +552,6 @@ public class TestIndexWriterMerging extends LuceneTestCase {
     assertEquals(5, iw.getDocStats().numDocs);
 
     MergePolicy.MergeObserver observer = iw.forceMergeDeletes(true);
-    assertTrue("Should have scheduled merges", observer.hasNewMerges());
     assertTrue("Should have completed merges", observer.numMerges() > 0);
     assertTrue("await should return true immediately", observer.await());
 
@@ -579,7 +576,6 @@ public class TestIndexWriterMerging extends LuceneTestCase {
     iw.commit();
 
     MergePolicy.MergeObserver observer = iw.forceMergeDeletes(true);
-    assertFalse("Should have no merges", observer.hasNewMerges());
     assertEquals("Should have zero merges", 0, observer.numMerges());
     assertTrue("await with timeout should return true", observer.await(1, TimeUnit.SECONDS));
     assertTrue("await should return true", observer.await());

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
@@ -18,6 +18,9 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -28,6 +31,7 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.SuppressForbidden;
 
 public class TestIndexWriterMerging extends LuceneTestCase {
 
@@ -331,6 +335,326 @@ public class TestIndexWriterMerging extends LuceneTestCase {
 
     @Override
     public void close() {}
+  }
+
+  public void testForceMergeDeletesWithObserver() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter indexer =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random()))
+                .setMaxBufferedDocs(2)
+                .setRAMBufferSizeMB(IndexWriterConfig.DISABLE_AUTO_FLUSH));
+
+    for (int i = 0; i < 10; i++) {
+      Document doc = new Document();
+      Field idField = newStringField("id", "" + i, Field.Store.NO);
+      doc.add(idField);
+      indexer.addDocument(doc);
+    }
+    indexer.close();
+
+    IndexReader beforeDeleteReader = DirectoryReader.open(dir);
+    assertEquals(10, beforeDeleteReader.maxDoc());
+    assertEquals(10, beforeDeleteReader.numDocs());
+    beforeDeleteReader.close();
+
+    IndexWriter deleter =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random()))
+                .setMergePolicy(NoMergePolicy.INSTANCE));
+    for (int i = 0; i < 10; i++) {
+      if (i % 2 == 0) {
+        deleter.deleteDocuments(new Term("id", "" + i));
+      }
+    }
+    deleter.close();
+
+    IndexReader afterDeleteReader = DirectoryReader.open(dir);
+    assertEquals(10, afterDeleteReader.maxDoc());
+    assertEquals(5, afterDeleteReader.numDocs());
+    afterDeleteReader.close();
+
+    IndexWriter iw =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(newLogMergePolicy()));
+    assertEquals(10, iw.getDocStats().maxDoc);
+    assertEquals(5, iw.getDocStats().numDocs);
+    MergePolicy.MergeObserver observer = iw.forceMergeDeletes(false);
+
+    assertTrue(observer.hasNewMerges());
+    assertTrue(observer.numMerges() > 0);
+
+    observer.await();
+    assertEquals(5, iw.getDocStats().maxDoc);
+    assertEquals(5, iw.getDocStats().numDocs);
+
+    iw.waitForMerges();
+    iw.close();
+    dir.close();
+  }
+
+  public void testMergeObserverGetMerges() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter indexer =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random()))
+                .setMergePolicy(NoMergePolicy.INSTANCE));
+
+    for (int i = 0; i < 10; i++) {
+      Document doc = new Document();
+      Field idField = newStringField("id", "" + i, Field.Store.NO);
+      doc.add(idField);
+      indexer.addDocument(doc);
+    }
+    indexer.close();
+
+    IndexWriter deleter =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(newLogMergePolicy()));
+    for (int i = 0; i < 2; i++) {
+      deleter.deleteDocuments(new Term("id", "" + i));
+    }
+
+    MergePolicy.MergeObserver observer = deleter.forceMergeDeletes(false);
+    assertTrue(observer.hasNewMerges());
+    assertTrue(observer.numMerges() > 0);
+
+    int numMerges = observer.numMerges();
+    for (int j = 0; j < numMerges; j++) {
+      MergePolicy.OneMerge oneMerge = observer.getMerge(j);
+      assertNotNull(oneMerge);
+    }
+
+    try {
+      observer.getMerge(-1);
+      fail("Should throw IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException expected) {
+      String message = expected.getMessage();
+      assertTrue(
+          "Message should mention 'out of bounds', got: " + message,
+          message.contains("Index -1 out of bounds for length 1"));
+    }
+
+    try {
+      observer.getMerge(numMerges);
+      fail("Should throw IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException expected) {
+      String message = expected.getMessage();
+      assertTrue(
+          "Message should mention 'out of bounds', got: " + message,
+          message.contains("Index " + numMerges + " out of bounds for length 1"));
+    }
+
+    deleter.waitForMerges();
+    deleter.close();
+    dir.close();
+  }
+
+  public void testMergeObserverNoMerges() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter writer =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random()))
+                .setMergePolicy(NoMergePolicy.INSTANCE));
+
+    Document doc = new Document();
+    doc.add(newStringField("id", "1", Field.Store.NO));
+    writer.addDocument(doc);
+    writer.commit();
+
+    MergePolicy.MergeObserver observer = writer.forceMergeDeletes(false);
+
+    assertFalse("Should have no merges when no deletions", observer.hasNewMerges());
+    assertEquals("Should have zero merges", 0, observer.numMerges());
+
+    try {
+      observer.getMerge(0);
+      fail("Should throw IndexOutOfBoundsException when no merges");
+    } catch (IndexOutOfBoundsException expected) {
+      String message = expected.getMessage();
+      assertTrue(
+          "Message should mention 'no merges', got: " + message,
+          message.contains("No merges available"));
+    }
+
+    writer.close();
+    dir.close();
+  }
+
+  public void testMergeObserverAwaitWithTimeout() throws Exception {
+    Directory dir = newDirectory();
+    IndexWriter iw =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(newLogMergePolicy()));
+
+    for (int i = 0; i < 10; i++) {
+      Document doc = new Document();
+      doc.add(newStringField("id", "" + i, Field.Store.NO));
+      iw.addDocument(doc);
+    }
+    iw.commit();
+
+    iw.deleteDocuments(new Term("id", "0"));
+    iw.deleteDocuments(new Term("id", "1"));
+    iw.deleteDocuments(new Term("id", "2"));
+    iw.commit();
+
+    MergePolicy.MergeObserver observer = iw.forceMergeDeletes(false);
+
+    // Test that await(timeout, unit) returns true when merge completes successfully.
+    // Measure actual time to detect abnormally slow merges (potential deadlock/stuck merge).
+    long startNanos = System.nanoTime();
+    assertTrue("await should complete before timeout", observer.await(10, TimeUnit.MINUTES));
+    long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+
+    // This small merge should complete in ~1 second. Fail if it takes unreasonably long,
+    // which would indicate a performance regression or stuck merge.
+    assertTrue(
+        "Merge took too long: " + elapsedMillis + "ms (expected < 30000ms). "
+            + "Possible stuck merge or severe performance issue.",
+        elapsedMillis < 30_000);
+
+    iw.waitForMerges();
+    iw.close();
+    dir.close();
+  }
+
+  @SuppressForbidden(reason = "Thread sleep")
+  public void testMergeObserverAwaitTimeout() throws Exception {
+    Directory dir = newDirectory();
+
+    CountDownLatch mergeStarted = new CountDownLatch(1);
+    CountDownLatch allowMergeToFinish = new CountDownLatch(1);
+
+    ConcurrentMergeScheduler mergeScheduler =
+        new ConcurrentMergeScheduler() {
+          @Override
+          protected void doMerge(MergeSource mergeSource, MergePolicy.OneMerge merge)
+              throws IOException {
+            try {
+              mergeStarted.countDown();
+              // Block until test allows completion
+              allowMergeToFinish.await();
+              super.doMerge(mergeSource, merge);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              throw new IOException(e);
+            }
+          }
+        };
+
+    IndexWriter indexer =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random()))
+                .setMergePolicy(newLogMergePolicy())
+                .setMergeScheduler(mergeScheduler));
+
+    for (int i = 0; i < 20; i++) {
+      Document doc = new Document();
+      doc.add(newStringField("id", "" + i, Field.Store.NO));
+      indexer.addDocument(doc);
+    }
+    indexer.commit();
+
+    for (int i = 0; i < 10; i++) {
+      indexer.deleteDocuments(new Term("id", "" + i));
+    }
+    indexer.commit();
+
+    MergePolicy.MergeObserver observer = indexer.forceMergeDeletes(false);
+
+    if (observer.hasNewMerges()) {
+      mergeStarted.await();
+      assertFalse("await should timeout", observer.await(10, TimeUnit.MILLISECONDS));
+      allowMergeToFinish.countDown();
+    }
+
+    indexer.waitForMerges();
+    indexer.close();
+    dir.close();
+  }
+
+  public void testForceMergeDeletesBlockingWithObserver() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter indexer =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random()))
+                .setMaxBufferedDocs(2)
+                .setRAMBufferSizeMB(IndexWriterConfig.DISABLE_AUTO_FLUSH));
+
+    for (int i = 0; i < 10; i++) {
+      Document doc = new Document();
+      Field idField = newStringField("id", "" + i, Field.Store.NO);
+      doc.add(idField);
+      indexer.addDocument(doc);
+    }
+    indexer.close();
+
+    IndexWriter deleter =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random()))
+                .setMergePolicy(NoMergePolicy.INSTANCE));
+    for (int i = 0; i < 10; i++) {
+      if (i % 2 == 0) {
+        deleter.deleteDocuments(new Term("id", "" + i));
+      }
+    }
+    deleter.close();
+
+    IndexWriter iw =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(newLogMergePolicy()));
+    assertEquals(10, iw.getDocStats().maxDoc);
+    assertEquals(5, iw.getDocStats().numDocs);
+
+    MergePolicy.MergeObserver observer = iw.forceMergeDeletes(true);
+    assertTrue("Should have scheduled merges", observer.hasNewMerges());
+    assertTrue("Should have completed merges", observer.numMerges() > 0);
+    assertTrue("await should return true immediately", observer.await());
+
+    assertEquals(5, iw.getDocStats().maxDoc);
+    assertEquals(5, iw.getDocStats().numDocs);
+
+    iw.close();
+    dir.close();
+  }
+
+  public void testBlockingModeWithNoMerges() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter iw =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random()))
+                .setMergePolicy(NoMergePolicy.INSTANCE));
+
+    Document doc = new Document();
+    doc.add(newStringField("id", "1", Field.Store.NO));
+    iw.addDocument(doc);
+    iw.commit();
+
+    MergePolicy.MergeObserver observer = iw.forceMergeDeletes(true);
+    assertFalse("Should have no merges", observer.hasNewMerges());
+    assertEquals("Should have zero merges", 0, observer.numMerges());
+    assertTrue("await with timeout should return true", observer.await(1, TimeUnit.SECONDS));
+    assertTrue("await should return true", observer.await());
+
+    CompletableFuture<Void> future = observer.awaitAsync();
+    assertTrue("Future should be done", future.isDone());
+    assertFalse("Future should not be exceptional", future.isCompletedExceptionally());
+
+    iw.close();
+    dir.close();
   }
 
   // LUCENE-1013

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
@@ -386,14 +386,14 @@ public class TestIndexWriterMerging extends LuceneTestCase {
 
     assertTrue("Should have scheduled merges", observer.numMerges() > 0);
 
-    // Measure time to detect stuck merges
-    long startNanos = System.nanoTime();
-    observer.await();
-    long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
-
     assertTrue(
-        "Merge took too long: " + elapsedMillis + "ms (expected < 30000ms)",
-        elapsedMillis < 30_000);
+        "Merges should complete within 30 seconds",
+        observer.await(30_000, TimeUnit.MILLISECONDS));
+
+    assertEquals(
+        "All merges should be completed after await() returns true",
+        observer.numMerges(),
+        observer.numCompletedMerges());
 
     assertEquals(5, iw.getDocStats().maxDoc);
     assertEquals(5, iw.getDocStats().numDocs);
@@ -445,14 +445,14 @@ public class TestIndexWriterMerging extends LuceneTestCase {
 
     MergePolicy.MergeObserver observer = iw.forceMergeDeletes(false);
 
-    // Measure time to detect stuck merges
-    long startNanos = System.nanoTime();
-    assertTrue("await should complete before timeout", observer.await(10, TimeUnit.MINUTES));
-    long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
-
     assertTrue(
-        "Merge took too long: " + elapsedMillis + "ms (expected < 30000ms)",
-        elapsedMillis < 30_000);
+        "Merges should complete within 30 seconds",
+        observer.await(30_000, TimeUnit.MILLISECONDS));
+
+    assertEquals(
+        "All merges should be completed after await() returns true",
+        observer.numMerges(),
+        observer.numCompletedMerges());
 
     iw.waitForMerges();
     iw.close();

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomIndexWriter.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomIndexWriter.java
@@ -32,6 +32,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LiveIndexWriterConfig;
+import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.SoftDeletesDirectoryReaderWrapper;
 import org.apache.lucene.index.Term;
@@ -430,14 +431,20 @@ public class RandomIndexWriter implements Closeable {
   private boolean doRandomForceMerge;
   private boolean doRandomForceMergeAssert;
 
-  public void forceMergeDeletes(boolean doWait) throws IOException {
+  /**
+   * @see IndexWriter#forceMergeDeletes(boolean)
+   */
+  public MergePolicy.MergeObserver forceMergeDeletes(boolean doWait) throws IOException {
     LuceneTestCase.maybeChangeLiveIndexWriterConfig(r, config);
-    w.forceMergeDeletes(doWait);
+    return w.forceMergeDeletes(doWait);
   }
 
-  public void forceMergeDeletes() throws IOException {
+  /**
+   * @see IndexWriter#forceMergeDeletes()
+   */
+  public MergePolicy.MergeObserver forceMergeDeletes() throws IOException {
     LuceneTestCase.maybeChangeLiveIndexWriterConfig(r, config);
-    w.forceMergeDeletes();
+    return w.forceMergeDeletes();
   }
 
   public void setDoRandomForceMerge(boolean v) {


### PR DESCRIPTION
## Summary

Changes `IndexWriter.forceMergeDeletes()` to return `MergePolicy.MergeObserver` instead of void, allowing applications to monitor merge progress and wait for completion without exposing mutable internal objects.

Fixes #14515

## Motivation

Currently when calling `forceMergeDeletes(false)`, there's no way to monitor whether merges were scheduled or wait for them to complete. This makes it difficult to coordinate merge completion with other operations or implement custom scheduling strategies.

## Changes

Added `MergePolicy.MergeObserver` as a new public API with methods to:
- Query merge count (`numMerges()`)
- Track completion progress (`numCompletedMerges()`)
- Wait synchronously with optional timeout (`await()`, `await(timeout, unit)`)
- Wait asynchronously via CompletableFuture (`awaitAsync()`)

The observer is thread-safe and handles cases where no merges are needed. It provides observability without exposing mutable `OneMerge` objects, maintaining proper encapsulation.

Updated `IndexWriter.forceMergeDeletes()` methods to return the observer instead of void. Also updated `RandomIndexWriter` to propagate the new return type.

## Testing

Added comprehensive tests covering:
- Blocking and non-blocking merge modes
- Timeout handling with proper assertions
- Completion status verification
- Null spec cases (no merges needed)
- Progress tracking via `numCompletedMerges()`

All tests pass with randomized seeds across multiple iterations.

## Backward Compatibility

Fully backward compatible. Existing code that ignores the return value continues to work unchanged. Changing void to a return type is not a breaking change in Java.

## Files Modified

- `MergePolicy.java` - New MergeObserver class with progress tracking
- `IndexWriter.java` - Updated return types and javadoc
- `RandomIndexWriter.java` - Propagated return type
- `TestIndexWriterMerging.java` - Comprehensive test coverage
- `CHANGES.txt` - Added entry under 10.4.0 API Changes
