### PR TITLE
Utilize iterator and not approximation in MaxScoreBulkScorer

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -224,6 +224,9 @@ Bug Fixes
 * GITHUB#15334: Fix NPE for MemoryIndex when using nearest neighbor search. MemoryIndex does not support
   nearest neighbor search, but it should not throw an NPE (Ben Trent)
 
+* GITHUB#15380: Fix potential EOF introduced by optimized filter iterations in MaxScoreBulkScorer. The
+  approximation and the match verification could get out of sync, resulting in an EOFException. (Ben Trent)
+
 Other
 ---------------------
 * GITHUB#15237: Fix SmartChinese to only deserialize dictionary data from classpath with a native array

--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionScorer.java
@@ -108,7 +108,7 @@ abstract class DisjunctionScorer extends Scorer {
     private boolean assertVerifiedMatchesApproximationDocID() {
       int docID = docID();
       for (DisiWrapper w = verifiedMatches; w != null; w = w.next) {
-        if (w.approximation.docID() != docID) {
+        if (w.doc != docID) {
           return false;
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionScorer.java
@@ -101,7 +101,18 @@ abstract class DisjunctionScorer extends Scorer {
         }
       }
       unverifiedMatches.clear();
+      assert assertVerifiedMatchesApproximationDocID();
       return verifiedMatches;
+    }
+
+    private boolean assertVerifiedMatchesApproximationDocID() {
+      int docID = docID();
+      for (DisiWrapper w = verifiedMatches; w != null; w = w.next) {
+        if (w.approximation.docID() != docID) {
+          return false;
+        }
+      }
+      return true;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
@@ -172,7 +172,7 @@ final class MaxScoreBulkScorer extends BulkScorer {
     assert top.doc < max;
     while (top.doc < filter.doc) {
       // Must use the iterator as `top` might be a two-phase iterator
-      top.doc = top.approximation.advance(filter.doc);
+      top.doc = top.iterator.advance(filter.doc);
       top = essentialQueue.updateTop();
     }
 

--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
@@ -171,7 +171,8 @@ final class MaxScoreBulkScorer extends BulkScorer {
     DisiWrapper top = essentialQueue.top();
     assert top.doc < max;
     while (top.doc < filter.doc) {
-      top.doc = top.approximation.advance(filter.doc);
+      // Must use the iterator as `top` might be a two-phase iterator
+      top.doc = top.iterator.advance(filter.doc);
       top = essentialQueue.updateTop();
     }
 

--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
@@ -172,7 +172,7 @@ final class MaxScoreBulkScorer extends BulkScorer {
     assert top.doc < max;
     while (top.doc < filter.doc) {
       // Must use the iterator as `top` might be a two-phase iterator
-      top.doc = top.iterator.advance(filter.doc);
+      top.doc = top.approximation.advance(filter.doc);
       top = essentialQueue.updateTop();
     }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanRewrites.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanRewrites.java
@@ -430,7 +430,6 @@ public class TestBooleanRewrites extends LuceneTestCase {
     assertEquals(expected, searcher.rewrite(bq));
   }
 
-  @com.carrotsearch.randomizedtesting.annotations.Repeat(iterations = 500)
   public void testRandom() throws IOException {
     Directory dir = newDirectory();
     RandomIndexWriter w = new RandomIndexWriter(random(), dir);
@@ -520,11 +519,13 @@ public class TestBooleanRewrites extends LuceneTestCase {
   }
 
   private Query randomWrapper(Random random, Query query) {
-    switch (random.nextInt(2)) {
+    switch (random.nextInt(3)) {
       case 0:
         return new BoostQuery(query, TestUtil.nextInt(random, 0, 4));
       case 1:
         return new ConstantScoreQuery(query);
+      case 2:
+        return new RandomApproximationQuery(query, random);
       default:
         throw new AssertionError();
     }
@@ -534,26 +535,22 @@ public class TestBooleanRewrites extends LuceneTestCase {
     if (random.nextInt(5) == 0) {
       return randomWrapper(random, randomQuery(random));
     }
-    Query inner =
-        switch (random.nextInt(7)) {
-          case 0 -> new MatchAllDocsQuery();
-          case 1 -> new TermQuery(new Term("body", "a"));
-          case 2 -> new TermQuery(new Term("body", "b"));
-          case 3 -> new TermQuery(new Term("body", "c"));
-          case 4 -> new TermQuery(new Term("body", "d"));
-          case 5 ->
-              new PhraseQuery.Builder()
-                  .add(new Term("body", "d"))
-                  .add(new Term("body", "c"))
-                  .setSlop(1)
-                  .build();
-          case 6 -> randomBooleanQuery(random);
-          default -> throw new AssertionError();
-        };
-    if (random.nextBoolean()) {
-      inner = new RandomApproximationQuery(inner, random);
+    switch (random().nextInt(6)) {
+      case 0:
+        return new MatchAllDocsQuery();
+      case 1:
+        return new TermQuery(new Term("body", "a"));
+      case 2:
+        return new TermQuery(new Term("body", "b"));
+      case 3:
+        return new TermQuery(new Term("body", "c"));
+      case 4:
+        return new TermQuery(new Term("body", "d"));
+      case 5:
+        return randomBooleanQuery(random);
+      default:
+        throw new AssertionError();
     }
-    return inner;
   }
 
   private void assertEquals(TopDocs td1, TopDocs td2) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanRewrites.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanRewrites.java
@@ -34,6 +34,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.search.RandomApproximationQuery;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 
@@ -429,6 +430,7 @@ public class TestBooleanRewrites extends LuceneTestCase {
     assertEquals(expected, searcher.rewrite(bq));
   }
 
+  @com.carrotsearch.randomizedtesting.annotations.Repeat(iterations = 500)
   public void testRandom() throws IOException {
     Directory dir = newDirectory();
     RandomIndexWriter w = new RandomIndexWriter(random(), dir);
@@ -532,22 +534,26 @@ public class TestBooleanRewrites extends LuceneTestCase {
     if (random.nextInt(5) == 0) {
       return randomWrapper(random, randomQuery(random));
     }
-    switch (random().nextInt(6)) {
-      case 0:
-        return new MatchAllDocsQuery();
-      case 1:
-        return new TermQuery(new Term("body", "a"));
-      case 2:
-        return new TermQuery(new Term("body", "b"));
-      case 3:
-        return new TermQuery(new Term("body", "c"));
-      case 4:
-        return new TermQuery(new Term("body", "d"));
-      case 5:
-        return randomBooleanQuery(random);
-      default:
-        throw new AssertionError();
+    Query inner =
+        switch (random.nextInt(7)) {
+          case 0 -> new MatchAllDocsQuery();
+          case 1 -> new TermQuery(new Term("body", "a"));
+          case 2 -> new TermQuery(new Term("body", "b"));
+          case 3 -> new TermQuery(new Term("body", "c"));
+          case 4 -> new TermQuery(new Term("body", "d"));
+          case 5 ->
+              new PhraseQuery.Builder()
+                  .add(new Term("body", "d"))
+                  .add(new Term("body", "c"))
+                  .setSlop(1)
+                  .build();
+          case 6 -> randomBooleanQuery(random);
+          default -> throw new AssertionError();
+        };
+    if (random.nextBoolean()) {
+      inner = new RandomApproximationQuery(inner, random);
     }
+    return inner;
   }
 
   private void assertEquals(TopDocs td1, TopDocs td2) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestMaxScoreBulkScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMaxScoreBulkScorer.java
@@ -32,6 +32,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.search.RandomApproximationQuery;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.Bits;
 
@@ -146,6 +147,10 @@ public class TestMaxScoreBulkScorer extends LuceneTestCase {
             new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2);
         Query clause2 = new ConstantScoreQuery(new TermQuery(new Term("foo", "C")));
         Query filter = new TermQuery(new Term("foo", "B"));
+        if (random().nextBoolean()) {
+          clause1 = new RandomApproximationQuery(clause1, random());
+          clause2 = new RandomApproximationQuery(clause2, random());
+        }
         LeafReaderContext context = searcher.getIndexReader().leaves().get(0);
         Scorer scorer1 =
             searcher
@@ -214,6 +219,10 @@ public class TestMaxScoreBulkScorer extends LuceneTestCase {
             new BoostQuery(new ConstantScoreQuery(new TermQuery(new Term("foo", "A"))), 2);
         Query clause2 = new ConstantScoreQuery(new TermQuery(new Term("foo", "C")));
         Query filter = new TermQuery(new Term("foo", "B"));
+        if (random().nextBoolean()) {
+          clause1 = new RandomApproximationQuery(clause1, random());
+          clause2 = new RandomApproximationQuery(clause2, random());
+        }
         LeafReaderContext context = searcher.getIndexReader().leaves().get(0);
         Scorer scorer1 =
             searcher


### PR DESCRIPTION
When we utilize the underlying approximation here, its possible that its provided by a TwoPhase iterator. Meaning, we never actually call `matches()` after advancing the approximation and thus the two can get out of sync. This can result in EOFs as described in the related issue.

The other way I could see to fix this is to force calling `matches()` on every item in the essential queue later in the while loop. However, since this was the ONLY place in all of `MaxScoreBulkScorer` that used the approximation for the scorers, I opted to just not use it and use an iterator. 

I welcome discussion, this took a long time to figure out as this part of the code is very interdependent with various other parts of the code :/ and have had many changes over the last couple of minor releases.

Still working on a test...maybe we should add assertions to the TwoPhase iterator that ensures `matches` is called...I am not sure.

closes: https://github.com/apache/lucene/issues/15324