### PR TITLE
Batch virtual calls from DefaultBulkScorer#scoreRange

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
@@ -145,7 +145,6 @@ public interface LeafCollector {
     for (int i = 0; i < count; ++i) {
       collect(docs[i]);
     }
-    ;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
@@ -126,30 +126,26 @@ public interface LeafCollector {
   /**
    * Bulk-collect doc IDs.
    *
-   * <p>Note: The provided int[] may be reused across calls and should be consumed
-   * immediately.
+   * <p>Note: The provided int[] may be reused across calls and should be consumed immediately.
    *
-   * <p>Note: The provided int[] typically only holds a small subset of query matches.
-   * This method may be called multiple times per segment.
+   * <p>Note: The provided int[] typically only holds a small subset of query matches. This method
+   * may be called multiple times per segment.
    *
    * <p>Like {@link #collect(int)}, it is guaranteed that doc IDs get collected in order, ie. doc
-   * IDs are collected in order within a int[], and if called twice, all doc IDs from
-   * the second int[] will be greater than all doc IDs from the first int[].
+   * IDs are collected in order within a int[], and if called twice, all doc IDs from the second
+   * int[] will be greater than all doc IDs from the first int[].
    *
-   * <p>It is legal for callers to mix calls to {@link #collect(int[])}, {@link #collect(DocIdStream)}
-   * and {@link #collect(int)}.
+   * <p>It is legal for callers to mix calls to {@link #collect(int[], int)}, {@link
+   * #collect(DocIdStream)} and {@link #collect(int)}.
    *
-   * <p>The default implementation calls
-   * {@code
-   * for(int i = 0; i < count; ++i) {
-   *  collect(docs[i]);
-   * };
-   * }.
+   * <p>The default implementation calls {@code for(int i = 0; i < count; ++i) { collect(docs[i]);
+   * }; }.
    */
   default void collect(int[] docs, int count) throws IOException {
-    for(int i = 0; i < count; ++i) {
+    for (int i = 0; i < count; ++i) {
       collect(docs[i]);
-    };
+    }
+    ;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
@@ -124,6 +124,35 @@ public interface LeafCollector {
   }
 
   /**
+   * Bulk-collect doc IDs.
+   *
+   * <p>Note: The provided int[] may be reused across calls and should be consumed
+   * immediately.
+   *
+   * <p>Note: The provided int[] typically only holds a small subset of query matches.
+   * This method may be called multiple times per segment.
+   *
+   * <p>Like {@link #collect(int)}, it is guaranteed that doc IDs get collected in order, ie. doc
+   * IDs are collected in order within a int[], and if called twice, all doc IDs from
+   * the second int[] will be greater than all doc IDs from the first int[].
+   *
+   * <p>It is legal for callers to mix calls to {@link #collect(int[])}, {@link #collect(DocIdStream)}
+   * and {@link #collect(int)}.
+   *
+   * <p>The default implementation calls
+   * {@code
+   * for(int i = 0; i < count; ++i) {
+   *  collect(docs[i]);
+   * };
+   * }.
+   */
+  default void collect(int[] docs, int count) throws IOException {
+    for(int i = 0; i < count; ++i) {
+      collect(docs[i]);
+    };
+  }
+
+  /**
    * Optionally returns an iterator over competitive documents.
    *
    * <p>Collectors should delegate this method to their comparators if their comparators provide the

--- a/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
@@ -128,8 +128,10 @@ public class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
       }
 
       @Override
-      public void collect(int[] docs, int count) {
-        collect(docs, count);
+      public void collect(int[] docs, int count) throws IOException {
+        for (int i = 0; i < count; ++i) {
+          collect(docs[i]);
+        }
       }
 
       private void collectCompetitiveHit(int doc, float score) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
@@ -127,6 +127,11 @@ public class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
         }
       }
 
+      @Override
+      public void collect(int[] docs, int count) {
+        collect(docs, count);
+      }
+
       private void collectCompetitiveHit(int doc, float score) throws IOException {
         final long code = DocScoreEncoder.encode(doc + docBase, score);
         topCode = heap.updateTop(code);

--- a/lucene/core/src/java/org/apache/lucene/search/Weight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Weight.java
@@ -284,7 +284,8 @@ public abstract class Weight implements SegmentCacheable {
       } else if (competitiveIterator == null) {
         scoreTwoPhaseIterator(collector, acceptDocs, iterator, twoPhase, max, docBuffer);
       } else if (twoPhase == null) {
-        scoreCompetitiveIterator(collector, acceptDocs, iterator, competitiveIterator, max, docBuffer);
+        scoreCompetitiveIterator(
+            collector, acceptDocs, iterator, competitiveIterator, max, docBuffer);
       } else {
         scoreTwoPhaseOrCompetitiveIterator(
             collector, acceptDocs, iterator, twoPhase, competitiveIterator, max, docBuffer);
@@ -383,7 +384,8 @@ public abstract class Weight implements SegmentCacheable {
       collect(collector, docs, count, -1);
     }
 
-    private static int collect(LeafCollector collector, int[] docs, int count, int docId) throws IOException {
+    private static int collect(LeafCollector collector, int[] docs, int count, int docId)
+        throws IOException {
       if (count == docs.length || docId == -1) {
         collector.collect(docs, count);
         count = 0;


### PR DESCRIPTION
### Description

Aims at reducing the overhead of virtual calls from bulk scorer by loading matching docIds into a buffer before flushing the doc buffer into the collector. Related issue #15381
