### PR TITLE
Enable configuration cache (test tasks)

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
@@ -91,12 +91,14 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
                           BuildOptionsPlugin.LOCAL_BUILD_OPTIONS_FILE + " file";
                     };
 
+                var seedValueProvider = testsSeedOption.asStringProvider();
+
                 task.doFirst(
                     t -> {
                       t.getLogger()
                           .lifecycle(
                               "Running tests with root randomization seed tests.seed="
-                                  + testsSeedOption.asStringProvider().get()
+                                  + seedValueProvider.get()
                                   + ", source: "
                                   + seedSource);
                     });

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/misc/HelpPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/misc/HelpPlugin.java
@@ -72,10 +72,11 @@ public class HelpPlugin extends LuceneGradlePlugin {
           task -> {
             task.setGroup("Help (developer guides and hints)");
             task.setDescription(helpEntry.description);
+            var helpFilePath = rootProject.file(helpEntry.path).toPath();
             task.doFirst(
                 _ -> {
                   try {
-                    println("\n" + Files.readString(rootProject.file(helpEntry.path).toPath()));
+                    println("\n" + Files.readString(helpFilePath));
                   } catch (IOException e) {
                     throw new UncheckedIOException(e);
                   }
@@ -88,12 +89,15 @@ public class HelpPlugin extends LuceneGradlePlugin {
         .named("help")
         .configure(
             task -> {
+              Object version = rootProject.getVersion();
+              String gradleVersion = rootProject.getGradle().getGradleVersion();
+
               task.doFirst(
                   _ -> {
                     printf("");
                     printf(
                         "This is Lucene %s build file (gradle %s). See some guidelines in files",
-                        rootProject.getVersion(), rootProject.getGradle().getGradleVersion());
+                        version, gradleVersion);
                     printf("found under the help/* folder or type any of these:");
                     printf("");
 

--- a/lucene/spatial-extras/build.gradle
+++ b/lucene/spatial-extras/build.gradle
@@ -42,5 +42,5 @@ dependencies {
 }
 
 sourceSets.test.extensions.configure("modularPaths", {
-  it.patchModule("spatial4j", project.providers.provider({ configurations.spatial4jTestPatch.singleFile }))
+  it.patchModule("spatial4j", configurations.spatial4jTestPatch)
 })


### PR DESCRIPTION
This PR allows running 'test' tasks with gradle's configuration cache enabled. This brings significant savings - even if you're running without a daemon - and is especially useful when working with gradle builds in an IDE (intellij for example).

You can enable the configuration cache in IntelliJ as it is explained here:

https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:ide:intellij

which translates to this template change:

<img width="2052" height="1408" alt="image" src="https://github.com/user-attachments/assets/cc8f85e6-6ab8-45d7-b9cb-e73e8296d403" />