### PR TITLE
build: vscode improvements and devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
+  "name": "Apache Lucene",
+  "service": "lucene",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "25",
+      "installMaven": "false",
+      "installGradle": "false"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "redhat.java",
+        "editorconfig.editorconfig"
+      ],
+      "settings": {
+        "extensions.allowed": {
+          "vscjava.vscode-java-pack": false,
+          "vscjava.vscode-gradle": false,
+          "*": true
+        }
+      }
+    }
+  },
+  "updateContentCommand": "cd ${containerWorkspaceFolder} && rm -f .classpath && ./gradlew eclipse"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,7 @@
 {
   "recommendations": [
     "redhat.java",
-    "editorconfig.editorconfig",
-    "ast-grep.ast-grep-vscode"
+    "editorconfig.editorconfig"
   ],
   "unwantedRecommendations": [
     "vscjava.vscode-java-pack",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,13 @@
 {
+  "java.server.launchMode": "Standard",
   "java.import.gradle.enabled": false,
   "java.import.maven.enabled": false,
   "java.jdt.ls.lombokSupport.enabled": false,
   "java.compile.nullAnalysis.mode": "disabled",
   "java.completion.maxResults": 500,
+  "java.completion.favoriteStaticMembers": [ "none.*" ],
   "java.inlayHints.parameterNames.enabled": "all",
-  "astGrep.configPath": "gradle/validation/ast-grep/sgconfig.yml"
+  "java.inlayHints.parameterTypes.enabled": true,
+  "java.inlayHints.variableTypes.enabled": true,
+  "redhat.telemetry.enabled": false
 }

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -209,7 +209,6 @@ public class WrapperDownloader {
     }
   }
 
-  @SuppressForbidden(reason = "Valid use of thread.sleep.")
   private static void sleep(long millis) throws InterruptedException {
     Thread.sleep(millis);
   }

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -209,6 +209,7 @@ public class WrapperDownloader {
     }
   }
 
+  @SuppressForbidden(reason = "Valid use of thread.sleep.")
   private static void sleep(long millis) throws InterruptedException {
     Thread.sleep(millis);
   }

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/licenses/CheckLicensesPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/licenses/CheckLicensesPlugin.java
@@ -83,6 +83,9 @@ public class CheckLicensesPlugin extends LuceneGradlePlugin {
                 "**/*.xls",
                 "**/*.zip",
 
+                // JSON doesn't support comments
+                "**/*.json",
+
                 // Ignore build infrastructure and misc utility files.
                 ".asf.yaml",
                 ".dir-locals.el",

--- a/gradlew
+++ b/gradlew
@@ -228,7 +228,7 @@ if [ ! -e "$GRADLE_WRAPPER_JAR" ] || ! ( cd "$APP_HOME/gradle/wrapper" && "$shas
     "$JAVACMD" $JAVA_OPTS "$APP_HOME/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java" "$GRADLE_WRAPPER_JAR"
     WRAPPER_STATUS=$?
     if [ "$WRAPPER_STATUS" -eq 1 ]; then
-        echo "ERROR: Something went wrong. Make sure you're using Java version of exactly 23."
+        echo "ERROR: Something went wrong. Make sure you're using Java version of exactly 25."
         exit $WRAPPER_STATUS
     elif [ "$WRAPPER_STATUS" -ne 0 ]; then
         exit $WRAPPER_STATUS

--- a/help/IDEs.txt
+++ b/help/IDEs.txt
@@ -29,6 +29,16 @@ Run the following to set up Eclipse project files:
 
 Open the lucene checkout in VSCode.
 
+GitHub Codespaces
+=====
+
+Fork the apache/lucene repository
+
+Browse to https://github.com/codespaces/new
+
+Repository: yourfork/lucene
+Click "Create codespace"
+
 Neovim
 ======
 


### PR DESCRIPTION
Add devcontainer.json to support one-click development environment. It installs java 25, runs `gradlew eclipse`, and installs the correct extensions. No popups or confirmations required. Only GitHub codespaces has been tested.

Set "Standard" launch mode, the "Lightweight" mode initially started by the default "Hybrid" setup will spew nonsensical diagnostic errors. This is very confusing as it makes the setup appear broken, for a potentially long time, until the "Standard" server is finished indexing (takes ~5mins on my machine).

Improve the completion speed, by reducing the amount of auto-imported stuff (favorite static members).

Enable inlay hints for inferred variable types (`var` keyword), and inferred parameter types (lambdas).

Remove telemetry popup for Red Hat Language Server. Local VSCode user must still deal with 3 popups. but 3 is better than 4.

Remove ast-grep extension which errors-out if the binary isn't installed locally. User can install themselves if wanted.

Fix outdated 'java 23' in gradlew error code.

<img width="935" height="640" alt="Screen_Shot_2025-11-02_at_18 38 56" src="https://github.com/user-attachments/assets/580a1c43-8a28-46d2-a992-c46c47ebc32b" />

<img width="1914" height="1015" alt="Screen_Shot_2025-11-02_at_18 58 14" src="https://github.com/user-attachments/assets/b8fc612c-f29b-4a8c-8e62-3abd6142e461" />

<img width="1917" height="1022" alt="Screen_Shot_2025-11-02_at_19 03 33" src="https://github.com/user-attachments/assets/780e1ea7-453c-4800-82e4-ece764741a86" />

