### PR TITLE
 Gradle 9.1+ doesn't allow exclusiveContent in pluginManagement repositories

### DIFF
--- a/build-tools/build-infra/ecj-source.gradle
+++ b/build-tools/build-infra/ecj-source.gradle
@@ -24,20 +24,16 @@
 boolean useDropMirrorForEcj = true
 if (useDropMirrorForEcj) {
   repositories {
-    exclusiveContent {
-      forRepository {
-        ivy {
-          url = 'https://s3.amazonaws.com/lucene-testdata/temp-repo/ecj/'
-          patternLayout {
-            artifact "[artifact]-[revision](.[ext])"
-            m2compatible = true
-          }
-          metadataSources {
-            it.artifact()
-          }
-        }
+    ivy {
+      url = 'https://s3.amazonaws.com/lucene-testdata/temp-repo/ecj/'
+      patternLayout {
+        artifact "[artifact]-[revision](.[ext])"
+        m2compatible = true
       }
-      filter {
+      metadataSources {
+        it.artifact()
+      }
+      content {
         includeGroup "org.eclipse.jdt"
       }
     }


### PR DESCRIPTION
### Description

 Gradle 9.1+ doesn't allow exclusiveContent in pluginManagement repositories. I recently cloned the repo on my work laptop, and was unable to run any gradle tasks.


```

java -version
openjdk version "25" 2025-09-16 LTS
...

./gradlew
Starting a Gradle Daemon (subsequent builds will be faster)

[Incubating] Problems report is available at: file:///Users/varunthacker/code/lucene/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'lucene-root'.
> When using exclusive repository content in 'settings.pluginManagement.repositories', you cannot add repositories to 'buildscript.repositories'.
  For more information, please refer to https://docs.gradle.org/9.1.0/userguide/declaring_repositories.html#declaring_content_exclusively_found_in_one_repository in the Gradle documentation.
```