### PR TITLE
NumericComparator: immediately check whether a segment is competitive with the recorded bottom

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -213,6 +213,8 @@ Optimizations
 
 * GITHUB#14963: Bypass HNSW graph building for tiny segments. (Shubham Chaudhary, Ben Trent)
 
+* GITHUB#15397: NumericComparator: immediately check whether a segment is competitive with the recorded bottom (Martijn van Groningen)
+
 Bug Fixes
 ---------------------
 * GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -373,7 +373,7 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
      * @throws IOException i/o exception while fetching min and max values from point values
      */
     void postInitializeCompetitiveIterator() throws IOException {
-      if (queueFull) {
+      if (queueFull && hitsThresholdReached) {
         // if some documents have missing points, then check that missing values prohibits
         // optimization
         if (docCount() < maxDoc && isMissingValueCompetitive()) {
@@ -536,7 +536,7 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
      * iterator as competitive iterator.
      */
     void postInitializeCompetitiveIterator() {
-      if (queueFull) {
+      if (queueFull && hitsThresholdReached) {
         // if some documents have missing doc values, check that missing values prohibits
         // optimization
         if (docCount() < maxDoc && isMissingValueCompetitive()) {

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -374,6 +374,11 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
      */
     void postInitializeCompetitiveIterator() throws IOException {
       if (queueFull) {
+        // if some documents have missing points, then check that missing values prohibits
+        // optimization
+        if (docCount() < maxDoc && isMissingValueCompetitive()) {
+          return;
+        }
         long bottom = leafComparator.bottomAsComparableLong();
         long minValue = sortableBytesToLong(pointValues.getMinPackedValue());
         long maxValue = sortableBytesToLong(pointValues.getMaxPackedValue());
@@ -532,6 +537,11 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
      */
     void postInitializeCompetitiveIterator() {
       if (queueFull) {
+        // if some documents have missing doc values, check that missing values prohibits
+        // optimization
+        if (docCount() < maxDoc && isMissingValueCompetitive()) {
+          return;
+        }
         long bottom = leafComparator.bottomAsComparableLong();
         if (reverse == false && bottom < skipper.minValue()) {
           competitiveIterator.update(DocIdSetIterator.empty());

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -320,7 +320,8 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
     // helps to be conservative about increasing the sampling interval
     private int tryUpdateFailCount = 0;
 
-    public PointsCompetitiveDISIBuilder(PointValues pointValues, NumericLeafComparator comparator) {
+    PointsCompetitiveDISIBuilder(PointValues pointValues, NumericLeafComparator comparator)
+        throws IOException {
       super(comparator);
       LeafReaderContext context = comparator.context;
       FieldInfo info = context.reader().getFieldInfos().fieldInfo(field);
@@ -344,6 +345,7 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
                 + bytesCount);
       }
       this.pointValues = pointValues;
+      postInitializeCompetitiveIterator();
     }
 
     @Override
@@ -362,6 +364,25 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
     @Override
     int docCount() {
       return pointValues.getDocCount();
+    }
+
+    /**
+     * If queue is full and global min/max point values are not competitive with bottom then set an
+     * empty iterator as competitive iterator.
+     *
+     * @throws IOException i/o exception while fetching min and max values from point values
+     */
+    void postInitializeCompetitiveIterator() throws IOException {
+      if (queueFull) {
+        long bottom = leafComparator.bottomAsComparableLong();
+        long minValue = sortableBytesToLong(pointValues.getMinPackedValue());
+        long maxValue = sortableBytesToLong(pointValues.getMaxPackedValue());
+        if (reverse == false && bottom < minValue) {
+          competitiveIterator.update(DocIdSetIterator.empty());
+        } else if (reverse && bottom > maxValue) {
+          competitiveIterator.update(DocIdSetIterator.empty());
+        }
+      }
     }
 
     @Override
@@ -478,8 +499,8 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
     private final DocValuesSkipper skipper;
     private final TwoPhaseIterator innerTwoPhase;
 
-    public DVSkipperCompetitiveDISIBuilder(
-        DocValuesSkipper skipper, NumericLeafComparator leafComparator) throws IOException {
+    DVSkipperCompetitiveDISIBuilder(DocValuesSkipper skipper, NumericLeafComparator leafComparator)
+        throws IOException {
       super(leafComparator);
       this.skipper = skipper;
       NumericDocValues docValues =
@@ -497,11 +518,27 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
               return 2; // 2 comparisons
             }
           };
+      postInitializeCompetitiveIterator();
     }
 
     @Override
     int docCount() {
       return skipper.docCount();
+    }
+
+    /**
+     * If queue is full and global min/max skipper are not competitive with bottom then set an empty
+     * iterator as competitive iterator.
+     */
+    void postInitializeCompetitiveIterator() {
+      if (queueFull) {
+        long bottom = leafComparator.bottomAsComparableLong();
+        if (reverse == false && bottom < skipper.minValue()) {
+          competitiveIterator.update(DocIdSetIterator.empty());
+        } else if (reverse && bottom > skipper.maxValue()) {
+          competitiveIterator.update(DocIdSetIterator.empty());
+        }
+      }
     }
 
     @Override

--- a/lucene/core/src/test/org/apache/lucene/search/comparators/TestNumericComparator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/comparators/TestNumericComparator.java
@@ -166,7 +166,8 @@ public class TestNumericComparator extends LuceneTestCase {
   }
 
   public void testEmptyCompetitiveIteratorOptimizationAndHitsThresholdReached() throws Exception {
-    final int numDocs = TestUtil.nextInt(random(), 128, 512); // Below IndexSearcher.DEFAULT_HITS_THRESHOLD
+    final int numDocs =
+        TestUtil.nextInt(random(), 128, 512); // Below IndexSearcher.DEFAULT_HITS_THRESHOLD
     try (var dir = newDirectory()) {
       try (var writer =
           new IndexWriter(dir, new IndexWriterConfig().setMergePolicy(newLogMergePolicy()))) {

--- a/lucene/core/src/test/org/apache/lucene/search/comparators/TestNumericComparator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/comparators/TestNumericComparator.java
@@ -60,46 +60,46 @@ public class TestNumericComparator extends LuceneTestCase {
 
           writer.addDocument(doc);
           writer.forceMerge(1);
-          try (var reader = DirectoryReader.open(writer)) {
-            assertEquals(1, reader.leaves().size());
-            var leafContext = reader.leaves().get(0);
+        }
+        try (var reader = DirectoryReader.open(writer)) {
+          assertEquals(1, reader.leaves().size());
+          var leafContext = reader.leaves().get(0);
 
-            // long field 1 ascending:
-            assertLongField("long_field_1", false, -1, leafContext);
-            // long field 1 descending:
-            assertLongField("long_field_1", true, numDocs + 1, leafContext);
-            // long field 2 ascending:
-            assertLongField("long_field_2", false, -1, leafContext);
-            // long field 2 descending:
-            assertLongField("long_field_2", true, numDocs + 1, leafContext);
+          // long field 1 ascending:
+          assertLongField("long_field_1", false, -1, leafContext);
+          // long field 1 descending:
+          assertLongField("long_field_1", true, numDocs + 1, leafContext);
+          // long field 2 ascending:
+          assertLongField("long_field_2", false, -1, leafContext);
+          // long field 2 descending:
+          assertLongField("long_field_2", true, numDocs + 1, leafContext);
 
-            // int field 1 ascending:
-            assertIntField("int_field_1", false, -1, leafContext);
-            // int field 1 descending:
-            assertIntField("int_field_1", true, numDocs + 1, leafContext);
-            // int field 2 ascending:
-            assertIntField("int_field_2", false, -1, leafContext);
-            // int field 2 descending:
-            assertIntField("int_field_2", true, numDocs + 1, leafContext);
+          // int field 1 ascending:
+          assertIntField("int_field_1", false, -1, leafContext);
+          // int field 1 descending:
+          assertIntField("int_field_1", true, numDocs + 1, leafContext);
+          // int field 2 ascending:
+          assertIntField("int_field_2", false, -1, leafContext);
+          // int field 2 descending:
+          assertIntField("int_field_2", true, numDocs + 1, leafContext);
 
-            // float field 1 ascending:
-            assertFloatField("float_field_1", false, -1, leafContext);
-            // float field 1 descending:
-            assertFloatField("float_field_1", true, numDocs + 1, leafContext);
-            // float field 2 ascending:
-            assertFloatField("float_field_2", false, -1, leafContext);
-            // float field 2 descending:
-            assertFloatField("float_field_2", true, numDocs + 1, leafContext);
+          // float field 1 ascending:
+          assertFloatField("float_field_1", false, -1, leafContext);
+          // float field 1 descending:
+          assertFloatField("float_field_1", true, numDocs + 1, leafContext);
+          // float field 2 ascending:
+          assertFloatField("float_field_2", false, -1, leafContext);
+          // float field 2 descending:
+          assertFloatField("float_field_2", true, numDocs + 1, leafContext);
 
-            // double field 1 ascending:
-            assertDoubleField("double_field_1", false, -1, leafContext);
-            // double field 1 descending:
-            assertDoubleField("double_field_1", true, numDocs + 1, leafContext);
-            // double field 2 ascending:
-            assertDoubleField("double_field_2", false, -1, leafContext);
-            // double field 2 descending:
-            assertDoubleField("double_field_2", true, numDocs + 1, leafContext);
-          }
+          // double field 1 ascending:
+          assertDoubleField("double_field_1", false, -1, leafContext);
+          // double field 1 descending:
+          assertDoubleField("double_field_1", true, numDocs + 1, leafContext);
+          // double field 2 ascending:
+          assertDoubleField("double_field_2", false, -1, leafContext);
+          // double field 2 descending:
+          assertDoubleField("double_field_2", true, numDocs + 1, leafContext);
         }
       }
     }


### PR DESCRIPTION
When construction a new CompetitiveDISIBuilder, then check whether global min/max points or global min/max doc values skipper are comparative with the bottom. If so, then update competitiveIterator with an empty iterator, because no documents will have a value that is competitive with the current recorded bottom in the current segment.

Doing this at CompetitiveDISIBuilder construction is cheap and allows to immediately prune, instead of waiting until doUpdateCompetitiveIterator(...) is invoked.

~~I didn't add tests in this PR, because I think that `TestSortOptimization` provides sufficient coverage. But I'm happy to add more tests.~~