### PR TITLE
When doing something with gradle, don't reuse any caches

### DIFF
--- a/.github/actions/prepare-for-build/action.yml
+++ b/.github/actions/prepare-for-build/action.yml
@@ -15,6 +15,11 @@ inputs:
     default: "temurin"
     description: "The default JDK distribution type"
 
+  use-cache:
+    required: false
+    default: true
+    description: "Use setup-gradle for dependency caching"
+
 runs:
   using: "composite"
   steps:
@@ -33,6 +38,7 @@ runs:
 
     # This includes "smart" caching of gradle dependencies.
     - name: Set up Gradle
+      if: ${{ inputs.use-cache }}
       uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
       with:
         # increase expiry time for the temp. develocity token.

--- a/.github/actions/prepare-for-build/action.yml
+++ b/.github/actions/prepare-for-build/action.yml
@@ -31,6 +31,7 @@ runs:
         java-package: jdk
 
     - name: Cache gradle-wrapper.jar
+      if: ${{ fromJSON(inputs.use-cache) }}
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: gradle/wrapper/gradle-wrapper.jar

--- a/.github/actions/prepare-for-build/action.yml
+++ b/.github/actions/prepare-for-build/action.yml
@@ -38,7 +38,7 @@ runs:
 
     # This includes "smart" caching of gradle dependencies.
     - name: Set up Gradle
-      if: ${{ inputs.use-cache }}
+      if: ${{ fromJSON(inputs.use-cache) }}
       uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
       with:
         # increase expiry time for the temp. develocity token.

--- a/.github/workflows/run-checks-gradle-upgrade.yml
+++ b/.github/workflows/run-checks-gradle-upgrade.yml
@@ -49,6 +49,7 @@ jobs:
       - uses: ./.github/actions/prepare-for-build
         with:
           java-version: ${{ matrix.java-version }}
+          use-cache: false
 
       - name: Set up RUNTIME_JAVA_HOME variable
         if: ${{ matrix.uses-alt-java }}


### PR DESCRIPTION
This should ensure a 'clean' environment (with no cached dependencies, etc.) runs properly.