### PR TITLE
add .envrc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ __pycache__
 
 # SDKMAN
 .sdkmanrc
+
+# Directenv
+.envrc


### PR DESCRIPTION
### Description

As a byproduct of https://github.com/apache/lucene/pull/15396, being able to set env variables via directenv(https://direnv.net/) can be useful.

For example, I used it to point to a different gradle home for opensource work.

This PR adds `.envrc ` to the gitignore list