### PR TITLE
Failing workflow instead of comment on missing changelog entry

### DIFF
--- a/.github/workflows/verify-changelog-and-set-milestone.yml
+++ b/.github/workflows/verify-changelog-and-set-milestone.yml
@@ -57,8 +57,7 @@ jobs:
           echo "Diff:"
           if git diff --exit-code --name-only "$BASE_COMMIT" HEAD -- "$CHANGE_LOG_FILE"; then
             echo "Change log file:$CHANGE_LOG_FILE does not contains an entry corresponding to changes introduced in PR. Please add a changelog entry."
-            gh pr comment "$PR_NUMBER" --body "This PR does not have an entry in lucene/CHANGES.txt. Consider adding one. If the PR doesn't need a changelog entry, then add the skip-changelog label to it and you will stop receiving this reminder on future updates to the PR."
-            exit 0
+            exit 1
           else
             echo "$CHANGE_LOG_FILE contains change log entry. Proceeding with next steps."
           fi

--- a/.github/workflows/verify-changelog-and-set-milestone.yml
+++ b/.github/workflows/verify-changelog-and-set-milestone.yml
@@ -56,7 +56,7 @@ jobs:
 
           echo "Diff:"
           if git diff --exit-code --name-only "$BASE_COMMIT" HEAD -- "$CHANGE_LOG_FILE"; then
-            echo "Change log file:$CHANGE_LOG_FILE does not contains an entry corresponding to changes introduced in PR. Please add a changelog entry."
+            echo "::error ::Change log file:$CHANGE_LOG_FILE does not contains an entry corresponding to changes introduced in PR. Please add a changelog entry."
             exit 1
           else
             echo "$CHANGE_LOG_FILE contains change log entry. Proceeding with next steps."


### PR DESCRIPTION
### Description
Fails workflow instead of comment on missing changelog entry to not have numerous comments in the PR.

Fixes https://github.com/apache/lucene/issues/15405
