### PR TITLE
Disable bypassing graph creation for HnswGraphTestCase#testReadWrite

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -242,7 +242,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
       IndexWriterConfig iwc =
           new IndexWriterConfig()
               .setCodec(
-                  TestUtil.alwaysKnnVectorsFormat(new Lucene99HnswVectorsFormat(M, beamWidth)));
+                  TestUtil.alwaysKnnVectorsFormat(new Lucene99HnswVectorsFormat(M, beamWidth, 0)));
       try (IndexWriter iw = new IndexWriter(dir, iwc)) {
         KnnVectorValues.DocIndexIterator it2 = v2.iterator();
         while (it2.nextDoc() != NO_MORE_DOCS) {
@@ -271,9 +271,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
               ((Lucene99HnswVectorsReader)
                       ((CodecReader) ctx.reader()).getVectorReader().unwrapReaderForField("field"))
                   .getGraph("field");
-          if (graphValues.size() > 0) {
-            assertGraphEqual(hnsw, graphValues);
-          }
+          assertGraphEqual(hnsw, graphValues);
         }
       }
     }


### PR DESCRIPTION
### Description

Improves the test coverage by always checking two graphs are same. See https://github.com/apache/lucene/issues/13447#issuecomment-3523731716

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
