### PR TITLE
Adding support for passing an ExecutorService into DirectoryReader.open() to enable concurrent segment reader initialization

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -46,7 +46,6 @@ API Changes
 
 * GITHUB#15187: Restrict visibility of PerFieldKnnVectorsFormat.FieldsReader (Simon Cooper)
 
-* GITHUB##15428: Add support for ExecutorServices to be passed into DirectoryReader.open() API (Bryce Kane)
 
 New Features
 ---------------------
@@ -157,6 +156,8 @@ API Changes
 
 * GITHUB#15422: Add a new method in DirectWriter to compute how many bytes are written for encoding a number of values using a number of
   bits per value. (Ignacio Vera)
+
+* GITHUB##15428: Add support for ExecutorServices to be passed into DirectoryReader.open() and DirectoryReader.openIfChanged() APIs (Bryce Kane)
 
 New Features
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -46,6 +46,8 @@ API Changes
 
 * GITHUB#15187: Restrict visibility of PerFieldKnnVectorsFormat.FieldsReader (Simon Cooper)
 
+* GITHUB##15428: Add support for ExecutorServices to be passed into DirectoryReader.open() API (Bryce Kane)
+
 New Features
 ---------------------
 * GITHUB#14097: Binary partitioning merge policy over float-valued vector field. (Mike Sokolov)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -46,7 +46,6 @@ API Changes
 
 * GITHUB#15187: Restrict visibility of PerFieldKnnVectorsFormat.FieldsReader (Simon Cooper)
 
-
 New Features
 ---------------------
 * GITHUB#14097: Binary partitioning merge policy over float-valued vector field. (Mike Sokolov)

--- a/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
@@ -65,12 +65,12 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
    * Returns a IndexReader reading the index in the given Directory
    *
    * @param directory the index directory
-   * @param executor an executor service for processing the creation of segment readers
+   * @param executorService an executor service for processing the creation of segment readers
    * @throws IOException if there is a low-level IO error
    */
-  public static DirectoryReader open(final Directory directory, ExecutorService executor)
+  public static DirectoryReader open(final Directory directory, ExecutorService executorService)
       throws IOException {
-    return StandardDirectoryReader.open(directory, null, null, executor);
+    return StandardDirectoryReader.open(directory, null, null, executorService);
   }
 
   /**
@@ -100,14 +100,14 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
    *     leafSorter} should sort leaves according to this sort criteria. Providing leafSorter allows
    *     to speed up this particular type of sort queries by early terminating while iterating
    *     through segments and segments' documents.
-   * @param executor provies an executor service that will be utilized to intialize segment readers.
+   * @param executorService provies an executor service that will be utilized to intialize segment readers.
    *     Providing an executor is useful to parallelize
    * @throws IOException if there is a low-level IO error
    */
   public static DirectoryReader open(
-      final Directory directory, Comparator<LeafReader> leafSorter, ExecutorService executor)
+      final Directory directory, Comparator<LeafReader> leafSorter, ExecutorService executorService)
       throws IOException {
-    return StandardDirectoryReader.open(directory, null, leafSorter, executor);
+    return StandardDirectoryReader.open(directory, null, leafSorter, executorService);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
@@ -100,8 +100,8 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
    *     leafSorter} should sort leaves according to this sort criteria. Providing leafSorter allows
    *     to speed up this particular type of sort queries by early terminating while iterating
    *     through segments and segments' documents.
-   * @param executorService provies an executor service that will be utilized to intialize segment readers.
-   *     Providing an executor is useful to parallelize
+   * @param executorService provies an executor service that will be utilized to intialize segment
+   *     readers. Providing an executor is useful to parallelize
    * @throws IOException if there is a low-level IO error
    */
   public static DirectoryReader open(

--- a/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
@@ -246,6 +246,31 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
   }
 
   /**
+   * If the index has changed since the provided reader was opened, open and return a new reader;
+   * else, return null. The new reader, if not null, will be the same type of reader as the previous
+   * one, ie an NRT reader will open a new NRT reader etc.
+   *
+   * <p>This method is typically far less costly than opening a fully new <code>DirectoryReader
+   * </code> as it shares resources (for example sub-readers) with the provided <code>
+   * DirectoryReader</code>, when possible.
+   *
+   * <p>The provided reader is not closed (you are responsible for doing so); if a new reader is
+   * returned you also must eventually close it. Be sure to never close a reader while other threads
+   * are still using it; see {@link SearcherManager} to simplify managing this.
+   *
+   * @throws CorruptIndexException if the index is corrupt
+   * @throws IOException if there is a low-level IO error
+   * @return null if there are no changes; else, a new DirectoryReader instance which you must
+   *     eventually close
+   */
+  public static DirectoryReader openIfChanged(
+      DirectoryReader oldReader, ExecutorService executorService) throws IOException {
+    final DirectoryReader newReader = oldReader.doOpenIfChanged(executorService);
+    assert newReader != oldReader;
+    return newReader;
+  }
+
+  /**
    * If the IndexCommit differs from what the provided reader is searching, open and return a new
    * reader; else, return null.
    *
@@ -254,6 +279,20 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
   public static DirectoryReader openIfChanged(DirectoryReader oldReader, IndexCommit commit)
       throws IOException {
     final DirectoryReader newReader = oldReader.doOpenIfChanged(commit);
+    assert newReader != oldReader;
+    return newReader;
+  }
+
+  /**
+   * If the IndexCommit differs from what the provided reader is searching, open and return a new
+   * reader; else, return null. Executor service provides intra-open concurrency.
+   *
+   * @see #openIfChanged(DirectoryReader)
+   */
+  public static DirectoryReader openIfChanged(
+      DirectoryReader oldReader, IndexCommit commit, ExecutorService executorService)
+      throws IOException {
+    final DirectoryReader newReader = oldReader.doOpenIfChanged(commit, executorService);
     assert newReader != oldReader;
     return newReader;
   }
@@ -301,6 +340,50 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
   }
 
   /**
+   * Expert: If there changes (committed or not) in the {@link IndexWriter} versus what the provided
+   * reader is searching, then open and return a new IndexReader searching both committed and
+   * uncommitted changes from the writer; else, return null (though, the current implementation
+   * never returns null).
+   *
+   * <p>This provides "near real-time" searching, in that changes made during an {@link IndexWriter}
+   * session can be quickly made available for searching without closing the writer or calling
+   * {@link IndexWriter#commit}.
+   *
+   * <p>It's <i>near</i> real-time because there is no hard guarantee on how quickly you can get a
+   * new reader after making changes with IndexWriter. You'll have to experiment in your situation
+   * to determine if it's fast enough. As this is a new and experimental feature, please report back
+   * on your findings so we can learn, improve and iterate.
+   *
+   * <p>The very first time this method is called, this writer instance will make every effort to
+   * pool the readers that it opens for doing merges, applying deletes, etc. This means additional
+   * resources (RAM, file descriptors, CPU time) will be consumed.
+   *
+   * <p>For lower latency on reopening a reader, you should call {@link
+   * IndexWriterConfig#setMergedSegmentWarmer} to pre-warm a newly merged segment before it's
+   * committed to the index. This is important for minimizing index-to-search delay after a large
+   * merge.
+   *
+   * <p>If an addIndexes* call is running in another thread, then this reader will only search those
+   * segments from the foreign index that have been successfully copied over, so far.
+   *
+   * <p><b>NOTE</b>: Once the writer is closed, any outstanding readers may continue to be used.
+   * However, if you attempt to reopen any of those readers, you'll hit an {@link
+   * org.apache.lucene.store.AlreadyClosedException}.
+   *
+   * @return DirectoryReader that covers entire index plus all changes made so far by this
+   *     IndexWriter instance, or null if there are no new changes
+   * @param writer The IndexWriter to open from
+   * @param executorService Provides intra-open concurrency
+   * @throws IOException if there is a low-level IO error
+   * @lucene.experimental
+   */
+  public static DirectoryReader openIfChanged(
+      DirectoryReader oldReader, IndexWriter writer, ExecutorService executorService)
+      throws IOException {
+    return openIfChanged(oldReader, writer, true, executorService);
+  }
+
+  /**
    * Expert: Opens a new reader, if there are any changes, controlling whether past deletions should
    * be applied.
    *
@@ -317,6 +400,33 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
   public static DirectoryReader openIfChanged(
       DirectoryReader oldReader, IndexWriter writer, boolean applyAllDeletes) throws IOException {
     final DirectoryReader newReader = oldReader.doOpenIfChanged(writer, applyAllDeletes);
+    assert newReader != oldReader;
+    return newReader;
+  }
+
+  /**
+   * Expert: Opens a new reader, if there are any changes, controlling whether past deletions should
+   * be applied.
+   *
+   * @see #openIfChanged(DirectoryReader,IndexWriter)
+   * @param writer The IndexWriter to open from
+   * @param applyAllDeletes If true, all buffered deletes will be applied (made visible) in the
+   *     returned reader. If false, the deletes are not applied but remain buffered (in IndexWriter)
+   *     so that they will be applied in the future. Applying deletes can be costly, so if your app
+   *     can tolerate deleted documents being returned you might gain some performance by passing
+   *     false.
+   * @param executorService Provides intra-open concurrency
+   * @throws IOException if there is a low-level IO error
+   * @lucene.experimental
+   */
+  public static DirectoryReader openIfChanged(
+      DirectoryReader oldReader,
+      IndexWriter writer,
+      boolean applyAllDeletes,
+      ExecutorService executorService)
+      throws IOException {
+    final DirectoryReader newReader =
+        oldReader.doOpenIfChanged(writer, applyAllDeletes, executorService);
     assert newReader != oldReader;
     return newReader;
   }
@@ -446,6 +556,18 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
   protected abstract DirectoryReader doOpenIfChanged() throws IOException;
 
   /**
+   * Implement this method to support {@link #openIfChanged(DirectoryReader)}. If this reader does
+   * not support reopen, return {@code null}, so client code is happy. This should be consistent
+   * with {@link #isCurrent} (should always return {@code true}) if reopen is not supported.
+   * ExecutorService provides intra-opening concurrency.
+   *
+   * @throws IOException if there is a low-level IO error
+   * @return null if there are no changes; else, a new DirectoryReader instance.
+   */
+  protected abstract DirectoryReader doOpenIfChanged(ExecutorService executorService)
+      throws IOException;
+
+  /**
    * Implement this method to support {@link #openIfChanged(DirectoryReader,IndexCommit)}. If this
    * reader does not support reopen from a specific {@link IndexCommit}, throw {@link
    * UnsupportedOperationException}.
@@ -456,6 +578,17 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
   protected abstract DirectoryReader doOpenIfChanged(final IndexCommit commit) throws IOException;
 
   /**
+   * Implement this method to support {@link #openIfChanged(DirectoryReader,IndexCommit)}. If this
+   * reader does not support reopen from a specific {@link IndexCommit}, throw {@link
+   * UnsupportedOperationException}. ExecutorService provides intra-opening concurrency.
+   *
+   * @throws IOException if there is a low-level IO error
+   * @return null if there are no changes; else, a new DirectoryReader instance.
+   */
+  protected abstract DirectoryReader doOpenIfChanged(
+      final IndexCommit commit, ExecutorService executorService) throws IOException;
+
+  /**
    * Implement this method to support {@link #openIfChanged(DirectoryReader,IndexWriter,boolean)}.
    * If this reader does not support reopen from {@link IndexWriter}, throw {@link
    * UnsupportedOperationException}.
@@ -464,6 +597,18 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
    * @return null if there are no changes; else, a new DirectoryReader instance.
    */
   protected abstract DirectoryReader doOpenIfChanged(IndexWriter writer, boolean applyAllDeletes)
+      throws IOException;
+
+  /**
+   * Implement this method to support {@link #openIfChanged(DirectoryReader,IndexWriter,boolean)}.
+   * If this reader does not support reopen from {@link IndexWriter}, throw {@link
+   * UnsupportedOperationException}. ExecutorService provides intra-opening concurrency.
+   *
+   * @throws IOException if there is a low-level IO error
+   * @return null if there are no changes; else, a new DirectoryReader instance.
+   */
+  protected abstract DirectoryReader doOpenIfChanged(
+      IndexWriter writer, boolean applyAllDeletes, ExecutorService executorService)
       throws IOException;
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
@@ -65,7 +65,7 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
    * Returns a IndexReader reading the index in the given Directory
    *
    * @param directory the index directory
-   * @param executorService an executor service for processing the creation of segment readers
+   * @param executorService used to open segment readers in parallel
    * @throws IOException if there is a low-level IO error
    */
   public static DirectoryReader open(final Directory directory, ExecutorService executorService)
@@ -100,8 +100,7 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
    *     leafSorter} should sort leaves according to this sort criteria. Providing leafSorter allows
    *     to speed up this particular type of sort queries by early terminating while iterating
    *     through segments and segments' documents.
-   * @param executorService provies an executor service that will be utilized to intialize segment
-   *     readers. Providing an executor is useful to parallelize
+   * @param executorService used to open segment readers in parallel
    * @throws IOException if there is a low-level IO error
    */
   public static DirectoryReader open(
@@ -159,7 +158,7 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
    * Expert: returns an IndexReader reading the index in the given {@link IndexCommit}.
    *
    * @param commit the commit point to open
-   * @param executorService executor provided for intra-open parallelization
+   * @param executorService used to open segment readers in parallel
    * @throws IOException if there is a low-level IO error
    */
   public static DirectoryReader open(final IndexCommit commit, ExecutorService executorService)
@@ -208,7 +207,7 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
    *     leafSorter} should sort leaves according to this sort criteria. Providing leafSorter allows
    *     to speed up this particular type of sort queries by early terminating while iterating
    *     through segments and segments' documents
-   * @param executorService executor provided for intra-open parallelization
+   * @param executorService used to open segment readers in parallel
    * @throws IOException if there is a low-level IO error
    */
   public static DirectoryReader open(
@@ -285,7 +284,7 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
 
   /**
    * If the IndexCommit differs from what the provided reader is searching, open and return a new
-   * reader; else, return null. Executor service provides intra-open concurrency.
+   * reader; else, return null. Executor service used to open segment readers in parallel.
    *
    * @see #openIfChanged(DirectoryReader)
    */
@@ -373,7 +372,7 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
    * @return DirectoryReader that covers entire index plus all changes made so far by this
    *     IndexWriter instance, or null if there are no new changes
    * @param writer The IndexWriter to open from
-   * @param executorService Provides intra-open concurrency
+   * @param executorService used to open segment readers in parallel
    * @throws IOException if there is a low-level IO error
    * @lucene.experimental
    */
@@ -415,7 +414,7 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
    *     so that they will be applied in the future. Applying deletes can be costly, so if your app
    *     can tolerate deleted documents being returned you might gain some performance by passing
    *     false.
-   * @param executorService Provides intra-open concurrency
+   * @param executorService used to open segment readers in parallel
    * @throws IOException if there is a low-level IO error
    * @lucene.experimental
    */
@@ -602,7 +601,7 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
   /**
    * Implement this method to support {@link #openIfChanged(DirectoryReader,IndexWriter,boolean)}.
    * If this reader does not support reopen from {@link IndexWriter}, throw {@link
-   * UnsupportedOperationException}. ExecutorService provides intra-opening concurrency.
+   * UnsupportedOperationException}. ExecutorService used to open segment readers in parallel.
    *
    * @throws IOException if there is a low-level IO error
    * @return null if there are no changes; else, a new DirectoryReader instance.

--- a/lucene/core/src/java/org/apache/lucene/index/FilterDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterDirectoryReader.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 /**
  * A FilterDirectoryReader wraps another DirectoryReader, allowing implementations to transform or
@@ -113,14 +114,33 @@ public abstract class FilterDirectoryReader extends DirectoryReader {
   }
 
   @Override
+  protected final DirectoryReader doOpenIfChanged(ExecutorService executorService)
+      throws IOException {
+    return wrapDirectoryReader(in.doOpenIfChanged(executorService));
+  }
+
+  @Override
   protected final DirectoryReader doOpenIfChanged(IndexCommit commit) throws IOException {
     return wrapDirectoryReader(in.doOpenIfChanged(commit));
+  }
+
+  @Override
+  protected final DirectoryReader doOpenIfChanged(
+      IndexCommit commit, ExecutorService executorService) throws IOException {
+    return wrapDirectoryReader(in.doOpenIfChanged(commit, executorService));
   }
 
   @Override
   protected final DirectoryReader doOpenIfChanged(IndexWriter writer, boolean applyAllDeletes)
       throws IOException {
     return wrapDirectoryReader(in.doOpenIfChanged(writer, applyAllDeletes));
+  }
+
+  @Override
+  protected final DirectoryReader doOpenIfChanged(
+      IndexWriter writer, boolean applyAllDeletes, ExecutorService executorService)
+      throws IOException {
+    return wrapDirectoryReader(in.doOpenIfChanged(writer, applyAllDeletes, executorService));
   }
 
   @Override

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/SegmentInfosSearcherManager.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/SegmentInfosSearcherManager.java
@@ -60,7 +60,9 @@ class SegmentInfosSearcherManager extends ReferenceManager<IndexSearcher> {
     node.message("SegmentInfosSearcherManager.init: use incoming infos=" + infosIn.toString());
     current =
         SearcherManager.getSearcher(
-            searcherFactory, StandardDirectoryReader.open(dir, currentInfos, null, null), null);
+            searcherFactory,
+            StandardDirectoryReader.open(dir, currentInfos, null, null, null),
+            null);
     addReaderClosedListener(current.getIndexReader());
   }
 
@@ -111,7 +113,7 @@ class SegmentInfosSearcherManager extends ReferenceManager<IndexSearcher> {
     }
 
     // Open a new reader, sharing any common segment readers with the old one:
-    DirectoryReader r = StandardDirectoryReader.open(dir, currentInfos, subs, null);
+    DirectoryReader r = StandardDirectoryReader.open(dir, currentInfos, subs, null, null);
     addReaderClosedListener(r);
     node.message("refreshed to version=" + currentInfos.getVersion() + " r=" + r);
     return SearcherManager.getSearcher(searcherFactory, r, old.getIndexReader());


### PR DESCRIPTION
### Description
Currently, as part of DirectoryReader.open() Lucene will [sequentially create segment readers for each segment](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java#L91-L95). 

This can be a very slow operation due to the I/O on the SegmentReader creation. By adding support for an ExecutorService to be passed in to DirectoryReader.open() we can submit the segment reader creations into the threadpool and achieve significant performance gains in DirectoryReader.open() times. The implementation is fully backwards compatible and allows for the users to pass in their own executor services. 

I have tested the changes and validated the performance improvement that can be possible by utilizing parallelism for the opening of the directory readers. 

| Optimization | P50 (ms)  | P90 (ms) | P99 (ms)| P50 Reduction %|
|----------|----------|----------|------------------| ---------------|                                                                                                                                                                                                                                                                                    
| Baseline   | 995    | 1020    |       1041 |   N/A                                                                                                                                                                                                                                                                            
| Concurrent SegmentReader Initialization  | 171    | 178     |  188| 82.81%| 

Fixes #15387 
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
