### PR TITLE
Apply HNSW merge optimizations when there are "no deleted vectors" instead of "no deleted documents"?

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -189,6 +189,9 @@ Improvements
 
 * GITHUB#15425: Refactoring internal HnswGraph.NodesIterator to avoid unneeded copying and sorting (Mike Sokolov)
 
+* GITHUB#15429: Make the criteria to re-use per-segment HNSW graph information in merge optimizations more appropriate,
+  from "no deleted documents" to "no deleted vectors". (Kaival Parikh)
+
 Optimizations
 ---------------------
 * GITHUB#15140: Optimize TopScoreDocCollector with TernaryLongHeap for improved performance over Binary-LongHeap. (Ramakrishna Chilaka)


### PR DESCRIPTION
### Description

While merging vectors across multiple segments, we can [re-use information from earlier HNSW graphs](https://github.com/apache/lucene/blob/d3bd7c7947387881145d1c20e8c1c5b74f9a55a8/lucene/core/src/java/org/apache/lucene/util/hnsw/IncrementalHnswGraphMerger.java#L68-L103) -- either an entire graph as a starting point, or previous connections as seeds for insertion!

These nice optimizations are used only if there are [no deleted documents](https://github.com/apache/lucene/blob/d3bd7c7947387881145d1c20e8c1c5b74f9a55a8/lucene/core/src/java/org/apache/lucene/util/hnsw/IncrementalHnswGraphMerger.java#L195-L206) (#15003 is a nice PR that allows re-using some information even _with_ deletes, which is how I got to looking at this class).

However, should the gating flag be "no deleted vectors" instead of "no deleted documents"?

This has two benefits:
- Optimizations kick in more frequently (when a segment has deleted documents, but none of those had vectors)
- Checking _whether_ the optimizations can be applied is sped up too (only need to check for "liveness" of documents with vectors, instead of "liveness" of all documents)