### PR TITLE
Backport #14607 to branch_10x (Index open performs version check on each segment, ignores indexCreatedVersionMajor)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -122,7 +122,7 @@ Other
   Applications using SecurityManager now need to grant SerializablePermission("serialFilter")
   to the analysis-smartcn module. (Uwe Schindler, Isaac David)
 
-* GITHUB#15431: Index open performs version check on each segment, ignores indexCreatedVersionMajor (Rahul Goswami)
+* GITHUB#15431: Index open performs version check on each segment, ignores indexCreatedVersionMajor (Rahul Goswami, Mike Sokolov)
 
 Build
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -122,6 +122,8 @@ Other
   Applications using SecurityManager now need to grant SerializablePermission("serialFilter")
   to the analysis-smartcn module. (Uwe Schindler, Isaac David)
 
+* GITHUB#14607: Index open performs version check on each segment, ignores indexCreatedVersionMajor (Rahul Goswami)
+
 Build
 ---------------------
 * Upgrade forbiddenapis to version 3.10.  (Uwe Schindler)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -122,7 +122,7 @@ Other
   Applications using SecurityManager now need to grant SerializablePermission("serialFilter")
   to the analysis-smartcn module. (Uwe Schindler, Isaac David)
 
-* GITHUB#14607: Index open performs version check on each segment, ignores indexCreatedVersionMajor (Rahul Goswami)
+* GITHUB#15431: Index open performs version check on each segment, ignores indexCreatedVersionMajor (Rahul Goswami)
 
 Build
 ---------------------

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestAncientIndicesCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestAncientIndicesCompatibility.java
@@ -45,7 +45,6 @@ import org.apache.lucene.tests.store.BaseDirectoryWrapper;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.IOUtils;
-import org.apache.lucene.util.Version;
 
 public class TestAncientIndicesCompatibility extends LuceneTestCase {
   static final Set<String> UNSUPPORTED_INDEXES;
@@ -199,7 +198,7 @@ public class TestAncientIndicesCompatibility extends LuceneTestCase {
       checker.setInfoStream(new PrintStream(bos, false, UTF_8));
       checker.setLevel(CheckIndex.Level.MIN_LEVEL_FOR_INTEGRITY_CHECKS);
       CheckIndex.Status indexStatus = checker.checkIndex();
-      if (getVersion(version).onOrAfter(Version.fromBits(8, 6, 0))) {
+      if (version.startsWith("8.")) {
         assertTrue(indexStatus.clean);
       } else {
         assertFalse(indexStatus.clean);
@@ -215,18 +214,6 @@ public class TestAncientIndicesCompatibility extends LuceneTestCase {
 
       dir.close();
     }
-  }
-
-  private Version getVersion(String version) {
-    if (version.startsWith("5x")) {
-      // couple of indices in unsupported_indices.txt start with "5x'
-      return Version.fromBits(5, 0, 0);
-    }
-    String[] versionBitsStr = version.split("[.\\-]");
-    return Version.fromBits(
-        Integer.parseInt(versionBitsStr[0]),
-        Integer.parseInt(versionBitsStr[1]),
-        Integer.parseInt(versionBitsStr[2]));
   }
 
   // #12895: test on a carefully crafted 9.8.0 index (from a small contiguous subset

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestAncientIndicesCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestAncientIndicesCompatibility.java
@@ -45,6 +45,7 @@ import org.apache.lucene.tests.store.BaseDirectoryWrapper;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.Version;
 
 public class TestAncientIndicesCompatibility extends LuceneTestCase {
   static final Set<String> UNSUPPORTED_INDEXES;
@@ -198,7 +199,7 @@ public class TestAncientIndicesCompatibility extends LuceneTestCase {
       checker.setInfoStream(new PrintStream(bos, false, UTF_8));
       checker.setLevel(CheckIndex.Level.MIN_LEVEL_FOR_INTEGRITY_CHECKS);
       CheckIndex.Status indexStatus = checker.checkIndex();
-      if (version.startsWith("8.")) {
+      if (getVersion(version).onOrAfter(Version.fromBits(8, 6, 0))) {
         assertTrue(indexStatus.clean);
       } else {
         assertFalse(indexStatus.clean);
@@ -214,6 +215,18 @@ public class TestAncientIndicesCompatibility extends LuceneTestCase {
 
       dir.close();
     }
+  }
+
+  private Version getVersion(String version) {
+    if (version.startsWith("5x")) {
+      // couple of indices in unsupported_indices.txt start with "5x'
+      return Version.fromBits(5, 0, 0);
+    }
+    String[] versionBitsStr = version.split("[.\\-]");
+    return Version.fromBits(
+        Integer.parseInt(versionBitsStr[0]),
+        Integer.parseInt(versionBitsStr[1]),
+        Integer.parseInt(versionBitsStr[2]));
   }
 
   // #12895: test on a carefully crafted 9.8.0 index (from a small contiguous subset

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBasicBackwardsCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBasicBackwardsCompatibility.java
@@ -861,7 +861,10 @@ public class TestBasicBackwardsCompatibility extends BackwardsCompatibilityTestB
             () -> StandardDirectoryReader.open(commit, Version.LATEST.major, null));
     assertTrue(
         ex.getMessage()
-            .contains("only supports reading from version " + Version.LATEST.major + " upwards."));
+            .contains(
+                "This Lucene version only supports indexes with major version "
+                    + Version.LATEST.major
+                    + " or later"));
     // now open with allowed min version
     StandardDirectoryReader.open(commit, Version.MIN_SUPPORTED_MAJOR, null).close();
   }

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -328,7 +328,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
         throw new IndexFormatTooOldException(
             input, magic, CodecUtil.CODEC_MAGIC, CodecUtil.CODEC_MAGIC);
       }
-      format = CodecUtil.checkHeaderNoMagic(input, "segments", VERSION_86, VERSION_CURRENT);
+      format = CodecUtil.checkHeaderNoMagic(input, "segments", VERSION_74, VERSION_CURRENT);
       byte[] id = new byte[StringHelper.ID_LENGTH];
       input.readBytes(id, 0, id.length);
       CodecUtil.checkIndexHeaderSuffix(input, Long.toString(generation, Character.MAX_RADIX));
@@ -529,11 +529,15 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
     } catch (IllegalArgumentException e) {
       // maybe it's an old default codec that moved
       if (name.startsWith("Lucene")) {
-        throw new IllegalArgumentException(
+        throw new IndexFormatTooOldException(
+            input,
             "Could not load codec '"
                 + name
-                + "'. Did you forget to add lucene-backward-codecs.jar?",
-            e);
+                + "'. "
+                + e.getMessage()
+                + ". This Lucene version only supports indexes with major version "
+                + Version.MIN_SUPPORTED_MAJOR
+                + " or later. Or did you forget to add lucene-backward-codecs.jar?");
       }
       throw e;
     }

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -535,9 +535,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
                 + name
                 + "'. "
                 + e.getMessage()
-                + ". This Lucene version only supports indexes with major version "
-                + Version.MIN_SUPPORTED_MAJOR
-                + " or later. Or did you forget to add lucene-backward-codecs.jar?");
+                + ". Did you forget to add lucene-backward-codecs.jar?");
       }
       throw e;
     }


### PR DESCRIPTION
### Description
Backport #14607 to branch_10x
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
