### PR TITLE
Fix TestIndexWriterWithThreads exceeding max file handles.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/ThreadInterruptedException.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ThreadInterruptedException.java
@@ -18,7 +18,7 @@ package org.apache.lucene.util;
 
 /**
  * Thrown by lucene on detecting that Thread.interrupt() had been called. Unlike Java's
- * InterruptedException, this exception is not checked..
+ * InterruptedException, this exception is not checked.
  */
 public final class ThreadInterruptedException extends RuntimeException {
   public ThreadInterruptedException(InterruptedException ie) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -981,7 +981,7 @@ public abstract class LuceneTestCase extends Assert {
   public static IndexWriterConfig newIndexWriterConfig(Random r, Analyzer a) {
     IndexWriterConfig c = new IndexWriterConfig(a);
     c.setSimilarity(classEnvRule.similarity);
-    if (VERBOSE) {
+    if (INFOSTREAM) {
       // Even though TestRuleSetupAndRestoreClassEnv calls
       // InfoStream.setDefault, we do it again here so that
       // the PrintStreamInfoStream.messageID increments so

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleTemporaryFilesCleanup.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleTemporaryFilesCleanup.java
@@ -117,7 +117,7 @@ final class TestRuleTemporaryFilesCleanup extends TestRuleAdapter {
       avoid.addAll(Arrays.asList(a.value()));
     }
     FileSystem fs = FileSystems.getDefault();
-    if (LuceneTestCase.VERBOSE && allowed(avoid, VerboseFS.class)) {
+    if (LuceneTestCase.INFOSTREAM && allowed(avoid, VerboseFS.class)) {
       fs =
           new VerboseFS(
                   fs,


### PR DESCRIPTION
TestIndexWriterWithThreads.testCloseWithThreads occasionally throws "Too many open files" from HandleLimitFS. This test is designed to run multiple threads in parallel, each thread adding documents and performing merges, while the main thread closes the index writer forcefully.

I rewrote the test slightly but didn't want to add too much thread coordination. I also bumped the HandleLimitFS to 4x the default limit. The test passes for me with `-Ptests.iters=100` with no problems after that.