### PR TITLE
Fix segment-specific TermInSetQuery rewrites thrashing caching policy

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/AbstractMultiTermQueryConstantScoreWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractMultiTermQueryConstantScoreWrapper.java
@@ -164,7 +164,8 @@ abstract class AbstractMultiTermQueryConstantScoreWrapper<Q extends MultiTermQue
         bq.add(new TermQuery(new Term(q.field, t.term), termStates), BooleanClause.Occur.SHOULD);
       }
       Query q = new ConstantScoreQuery(bq.build());
-      final Weight weight = nonCachingSearcher.rewrite(q).createWeight(nonCachingSearcher, scoreMode, score());
+      final Weight weight =
+          nonCachingSearcher.rewrite(q).createWeight(nonCachingSearcher, scoreMode, score());
       return new WeightOrDocIdSetIterator(weight);
     }
 

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -242,6 +242,14 @@ public class IndexSearcher {
     this(context, null);
   }
 
+  public IndexSearcher(IndexSearcher searcher) {
+    this(searcher.getTopReaderContext(), searcher.getExecutor());
+    this.similarity = searcher.getSimilarity();
+    this.queryCache = searcher.getQueryCache();
+    this.queryCachingPolicy = searcher.getQueryCachingPolicy();
+    this.queryTimeout = searcher.getTimeout();
+  }
+
   /**
    * Return the maximum number of clauses permitted, 1024 by default. Attempts to add more than the
    * permitted number of clauses cause {@link TooManyClauses} to be thrown.

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -242,8 +242,9 @@ public class IndexSearcher {
     this(context, null);
   }
 
+  /** Copies everything except the executor */
   public IndexSearcher(IndexSearcher searcher) {
-    this(searcher.getTopReaderContext(), searcher.getExecutor());
+    this(searcher.getTopReaderContext());
     this.similarity = searcher.getSimilarity();
     this.queryCache = searcher.getQueryCache();
     this.queryCachingPolicy = searcher.getQueryCachingPolicy();

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -242,7 +242,7 @@ public class IndexSearcher {
     this(context, null);
   }
 
-  /** Copies everything except the executor */
+  /** Reuses everything except the executor */
   public IndexSearcher(IndexSearcher searcher) {
     this(searcher.getTopReaderContext());
     this.similarity = searcher.getSimilarity();

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
@@ -62,7 +62,8 @@ public class TestTermInSetQuery extends LuceneTestCase {
     Directory dir = newDirectory();
     RandomIndexWriter iw = new RandomIndexWriter(random(), dir);
     // Use few enough terms to trigger the BooleanQuery rewrite logic (≤ threshold)
-    final int numTerms = AbstractMultiTermQueryConstantScoreWrapper.BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD;
+    final int numTerms =
+        AbstractMultiTermQueryConstantScoreWrapper.BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD;
     List<BytesRef> terms = new ArrayList<>();
     for (int i = 0; i < numTerms; ++i) {
       String term = "term" + i;
@@ -78,18 +79,19 @@ public class TestTermInSetQuery extends LuceneTestCase {
 
     final AtomicInteger onUseCount = new AtomicInteger(0);
     final Set<Query> seenQueries = new HashSet<>();
-    QueryCachingPolicy policy = new QueryCachingPolicy() {
-      @Override
-      public void onUse(Query query) {
-        onUseCount.incrementAndGet();
-        seenQueries.add(query);
-      }
+    QueryCachingPolicy policy =
+        new QueryCachingPolicy() {
+          @Override
+          public void onUse(Query query) {
+            onUseCount.incrementAndGet();
+            seenQueries.add(query);
+          }
 
-      @Override
-      public boolean shouldCache(Query query) throws IOException {
-        return true;
-      }
-    };
+          @Override
+          public boolean shouldCache(Query query) throws IOException {
+            return true;
+          }
+        };
 
     searcher.setQueryCache(new LRUQueryCache(100, 10000));
     searcher.setQueryCachingPolicy(policy);
@@ -111,8 +113,9 @@ public class TestTermInSetQuery extends LuceneTestCase {
         "ConstantScoreQuery wrapping BooleanQuery should not be tracked",
         seenQueries.stream()
             .anyMatch(
-                q -> q instanceof ConstantScoreQuery
-                    && ((ConstantScoreQuery) q).getQuery() instanceof BooleanQuery));
+                q ->
+                    q instanceof ConstantScoreQuery
+                        && ((ConstantScoreQuery) q).getQuery() instanceof BooleanQuery));
     // The TermInSetQuery itself should be tracked
     assertTrue("TermInSetQuery should be tracked", seenQueries.contains(query));
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
@@ -58,6 +58,68 @@ import org.apache.lucene.util.automaton.ByteRunAutomaton;
 
 public class TestTermInSetQuery extends LuceneTestCase {
 
+  public void testCachingPolicyInteraction() throws IOException {
+    Directory dir = newDirectory();
+    RandomIndexWriter iw = new RandomIndexWriter(random(), dir);
+    // Use few enough terms to trigger the BooleanQuery rewrite logic (≤ threshold)
+    final int numTerms = AbstractMultiTermQueryConstantScoreWrapper.BOOLEAN_REWRITE_TERM_COUNT_THRESHOLD;
+    List<BytesRef> terms = new ArrayList<>();
+    for (int i = 0; i < numTerms; ++i) {
+      String term = "term" + i;
+      terms.add(newBytesRef(term));
+      Document doc = new Document();
+      doc.add(new StringField("field", term, Store.NO));
+      iw.addDocument(doc);
+    }
+    iw.commit();
+    IndexReader reader = iw.getReader();
+    IndexSearcher searcher = newSearcher(reader);
+    iw.close();
+
+    final AtomicInteger onUseCount = new AtomicInteger(0);
+    final Set<Query> seenQueries = new HashSet<>();
+    QueryCachingPolicy policy = new QueryCachingPolicy() {
+      @Override
+      public void onUse(Query query) {
+        onUseCount.incrementAndGet();
+        seenQueries.add(query);
+      }
+
+      @Override
+      public boolean shouldCache(Query query) throws IOException {
+        return true;
+      }
+    };
+
+    searcher.setQueryCache(new LRUQueryCache(100, 10000));
+    searcher.setQueryCachingPolicy(policy);
+
+    TermInSetQuery query = new TermInSetQuery("field", terms);
+    // use count() to ensure scores are not needed, which triggers caching logic
+    searcher.count(query);
+
+    // We expect only the top-level TermInSetQuery to be tracked.
+    // The inner rewrites (ConstantScoreQuery wrapping BooleanQuery) should
+    // effectively bypass the
+    // cache because they are executed by the non-caching private searcher.
+    // Verify that no BooleanQuery or ConstantScoreQuery wrapping BooleanQuery was
+    // tracked
+    assertFalse(
+        "Segment-specific BooleanQuery rewrites should not be tracked",
+        seenQueries.stream().anyMatch(q -> q instanceof BooleanQuery));
+    assertFalse(
+        "ConstantScoreQuery wrapping BooleanQuery should not be tracked",
+        seenQueries.stream()
+            .anyMatch(
+                q -> q instanceof ConstantScoreQuery
+                    && ((ConstantScoreQuery) q).getQuery() instanceof BooleanQuery));
+    // The TermInSetQuery itself should be tracked
+    assertTrue("TermInSetQuery should be tracked", seenQueries.contains(query));
+
+    reader.close();
+    dir.close();
+  }
+
   public void testAllDocsInFieldTerm() throws IOException {
     Directory dir = newDirectory();
     RandomIndexWriter iw = new RandomIndexWriter(random(), dir);


### PR DESCRIPTION
### Description
Fixes https://github.com/apache/lucene/issues/14986.

A `TermInSetQuery` with `rewriteMethod = MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE` creates a `RewritingWeight`. Getting a scorer from this `RewritingWeight` for a segment could involve rewriting to a `BooleanQuery` of multiple `TermQuery` with only the terms present in that particular segment.

These segment-specific `BooleanQuery` rewrites all thrash the `UsageTrackingQueryCachingPolicy` ring buffer, which is shared across all segments of the index. The expectation is that we mark a query only once per shard in this ring buffer - [ref](https://github.com/apache/lucene/blob/a3fa283cfd6aefbcc5a4983e065da0ce7d3209fe/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java#L686-L688)

In this change: When initializing `AbstractMultiTermQueryConstantScoreWrapper.RewritingWeight`, we copy the supplied indexSearcher but with `setQueryCache(null)` and pass it along for the segment-specific rewrites. The subsequent rewrites into BooleanQuery of TermQuery don't go through the query cache (The idea is that these should be cached as the parent TermInSet query itself)
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
