### PR TITLE
TestVectorUtilSupport increase delta for larger vector sizes

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
@@ -39,7 +39,7 @@ public class TestVectorUtilSupport extends BaseVectorizationTestCase {
   public TestVectorUtilSupport(int size) {
     this.size = size;
     // scale the delta with the size
-    this.delta = 1e-4 * size;
+    this.delta = 1e-5 * size;
   }
 
   @ParametersFactory
@@ -306,10 +306,10 @@ public class TestVectorUtilSupport extends BaseVectorizationTestCase {
   }
 
   private void assertFloatReturningProviders(ToDoubleFunction<VectorUtilSupport> func) {
-    assertEquals(
-        func.applyAsDouble(LUCENE_PROVIDER.getVectorUtilSupport()),
-        func.applyAsDouble(PANAMA_PROVIDER.getVectorUtilSupport()),
-        delta);
+    double luceneProviderResults = func.applyAsDouble(LUCENE_PROVIDER.getVectorUtilSupport());
+    double panamaProviderResults = func.applyAsDouble(PANAMA_PROVIDER.getVectorUtilSupport());
+    double delta = Math.max(this.delta, this.delta * Math.max(luceneProviderResults, panamaProviderResults));
+    assertEquals(luceneProviderResults, panamaProviderResults, Math.max(delta, this.delta));
   }
 
   private void assertIntReturningProviders(ToIntFunction<VectorUtilSupport> func) {

--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
@@ -310,7 +310,7 @@ public class TestVectorUtilSupport extends BaseVectorizationTestCase {
     double panamaProviderResults = func.applyAsDouble(PANAMA_PROVIDER.getVectorUtilSupport());
     double delta =
         Math.max(this.delta, this.delta * Math.max(luceneProviderResults, panamaProviderResults));
-    assertEquals(luceneProviderResults, panamaProviderResults, Math.max(delta, this.delta));
+    assertEquals(luceneProviderResults, panamaProviderResults, delta);
   }
 
   private void assertIntReturningProviders(ToIntFunction<VectorUtilSupport> func) {

--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
@@ -308,7 +308,8 @@ public class TestVectorUtilSupport extends BaseVectorizationTestCase {
   private void assertFloatReturningProviders(ToDoubleFunction<VectorUtilSupport> func) {
     double luceneProviderResults = func.applyAsDouble(LUCENE_PROVIDER.getVectorUtilSupport());
     double panamaProviderResults = func.applyAsDouble(PANAMA_PROVIDER.getVectorUtilSupport());
-    double delta = Math.max(this.delta, this.delta * Math.max(luceneProviderResults, panamaProviderResults));
+    double delta =
+        Math.max(this.delta, this.delta * Math.max(luceneProviderResults, panamaProviderResults));
     assertEquals(luceneProviderResults, panamaProviderResults, Math.max(delta, this.delta));
   }
 

--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
@@ -39,7 +39,7 @@ public class TestVectorUtilSupport extends BaseVectorizationTestCase {
   public TestVectorUtilSupport(int size) {
     this.size = size;
     // scale the delta with the size
-    this.delta = 1e-5 * size;
+    this.delta = 1e-4 * size;
   }
 
   @ParametersFactory


### PR DESCRIPTION
Comparing results of vector functions with and without Panama support might lead to larger discrepancies as the vector dimensionality grows.
For example:
```
./gradlew test --tests TestVectorUtilSupport.testMinMaxScalarQuantize -Dtests.seed=A315683B50AE2A0 -Dtests.locale=bho -Dtests.timezone=GMT -Dtests.asserts=true -Dtests.file.encoding=UTF-8
```

fails with:
```
TestVectorUtilSupport > testMinMaxScalarQuantize {p0=4096} FAILED
    java.lang.AssertionError: expected:<1770.3743896484375> but was:<1770.3133544921875>
        at __randomizedtesting.SeedInfo.seed([A315683B50AE2A0:B5176B347F30D775]:0)
...
```

