### PR TITLE
Speed up slow LegacyBaseDocValuesFormatTestCase tests (fixes #1544)

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene80/BaseLucene80DocValuesFormatTestCase.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene80/BaseLucene80DocValuesFormatTestCase.java
@@ -660,7 +660,7 @@ public abstract class BaseLucene80DocValuesFormatTestCase
     // IndexedDISI block skipping only activated if target >= current+2, so we need at least 5
     // blocks to trigger consecutive block skips
     final int maxDoc = atLeast(5 * 65536);
-    long start = System.currentTimeMillis();
+    long start = System.nanoTime();
     BaseDirectoryWrapper dir = newDirectory();
     dir.setCheckIndexOnClose(false);
     IndexWriter iw = createFastIndexWriter(dir, maxDoc);
@@ -687,18 +687,18 @@ public abstract class BaseLucene80DocValuesFormatTestCase
     iw.commit();
     iw.close();
     if (VERBOSE) {
-      System.out.println("index created " + (System.currentTimeMillis() - start) / 1000f + " s");
+      System.out.println("index created " + (System.nanoTime() - start) / 1e9 + " s");
     }
     start = System.currentTimeMillis();
     assertDVIterate(dir, 16);
     if (VERBOSE) {
-      System.out.println("assertDVIterate " + (System.currentTimeMillis() - start) / 1000f + " s");
+      System.out.println("assertDVIterate " + (System.nanoTime() - start) / 1e9 + " s");
     }
     start = System.currentTimeMillis();
     assertDVAdvance(
         dir, rarely() ? 1 : 7); // 1 is heavy (~20 s), so we do it rarely. 7 is a lot faster (8 s)
     if (VERBOSE) {
-      System.out.println("assertDVAdvance " + (System.currentTimeMillis() - start) / 1000f + " s");
+      System.out.println("assertDVAdvance " + (System.nanoTime() - start) / 1e9 + " s");
     }
     dir.close();
   }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene80/BaseLucene80DocValuesFormatTestCase.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene80/BaseLucene80DocValuesFormatTestCase.java
@@ -689,12 +689,12 @@ public abstract class BaseLucene80DocValuesFormatTestCase
     if (VERBOSE) {
       System.out.println("index created " + (System.nanoTime() - start) / 1e9 + " s");
     }
-    start = System.currentTimeMillis();
+    start = System.nanoTime();
     assertDVIterate(dir, 16);
     if (VERBOSE) {
       System.out.println("assertDVIterate " + (System.nanoTime() - start) / 1e9 + " s");
     }
-    start = System.currentTimeMillis();
+    start = System.nanoTime();
     assertDVAdvance(
         dir, rarely() ? 1 : 7); // 1 is heavy (~20 s), so we do it rarely. 7 is a lot faster (8 s)
     if (VERBOSE) {

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene80/BaseLucene80DocValuesFormatTestCase.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene80/BaseLucene80DocValuesFormatTestCase.java
@@ -66,6 +66,7 @@ import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.codecs.asserting.AssertingCodec;
 import org.apache.lucene.tests.index.LegacyBaseDocValuesFormatTestCase;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.store.BaseDirectoryWrapper;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
@@ -657,11 +658,11 @@ public abstract class BaseLucene80DocValuesFormatTestCase
   @Nightly
   public void testNumericFieldJumpTables() throws Exception {
     // IndexedDISI block skipping only activated if target >= current+2, so we need at least 5
-    // blocks to
-    // trigger consecutive block skips
+    // blocks to trigger consecutive block skips
     final int maxDoc = atLeast(5 * 65536);
-
-    Directory dir = newDirectory();
+    long start = System.currentTimeMillis();
+    BaseDirectoryWrapper dir = newDirectory();
+    dir.setCheckIndexOnClose(false);
     IndexWriter iw = createFastIndexWriter(dir, maxDoc);
 
     Field idField = newStringField("id", "", Field.Store.NO);
@@ -685,11 +686,20 @@ public abstract class BaseLucene80DocValuesFormatTestCase
     iw.forceMerge(1, true); // Single segment to force large enough structures
     iw.commit();
     iw.close();
-
-    assertDVIterate(dir);
+    if (VERBOSE) {
+      System.out.println("index created " + (System.currentTimeMillis() - start) / 1000f + " s");
+    }
+    start = System.currentTimeMillis();
+    assertDVIterate(dir, 16);
+    if (VERBOSE) {
+      System.out.println("assertDVIterate " + (System.currentTimeMillis() - start) / 1000f + " s");
+    }
+    start = System.currentTimeMillis();
     assertDVAdvance(
         dir, rarely() ? 1 : 7); // 1 is heavy (~20 s), so we do it rarely. 7 is a lot faster (8 s)
-
+    if (VERBOSE) {
+      System.out.println("assertDVAdvance " + (System.currentTimeMillis() - start) / 1000f + " s");
+    }
     dir.close();
   }
 
@@ -823,7 +833,7 @@ public abstract class BaseLucene80DocValuesFormatTestCase
     writer.close();
 
     // compare
-    assertDVIterate(dir);
+    assertDVIterate(dir, 1);
     assertDVAdvance(
         dir, 1); // Tests all jump-lengths from 1 to maxDoc (quite slow ~= 1 minute for 200K docs)
 
@@ -838,7 +848,7 @@ public abstract class BaseLucene80DocValuesFormatTestCase
       LeafReader r = context.reader();
       StoredFields storedFields = r.storedFields();
 
-      for (int jump = jumpStep; jump < r.maxDoc(); jump += jumpStep) {
+      for (int jump = jumpStep; jump < r.maxDoc(); jump += jumpStep * random().nextInt(1, 10)) {
         // Create a new instance each time to ensure jumps from the beginning
         NumericDocValues docValues = DocValues.getNumeric(r, "dv");
         for (int docID = 0; docID < r.maxDoc(); docID += jump) {
@@ -860,6 +870,13 @@ public abstract class BaseLucene80DocValuesFormatTestCase
                 "The doc value should be correct for " + base,
                 Long.parseLong(storedValue),
                 docValues.longValue());
+          }
+          if (random().nextInt(10) == 3) {
+            // sometimes skip more
+            int skip = (r.maxDoc() - docID) / 3;
+            if (skip > 0) {
+              docID += random().nextInt(skip);
+            }
           }
         }
       }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormat.java
@@ -601,7 +601,7 @@ public class TestLucene90DocValuesFormat extends BaseCompressingDocValuesFormatT
     iw.commit();
     iw.close();
 
-    assertDVIterate(dir);
+    assertDVIterate(dir, 4);
     assertDVAdvance(
         dir, rarely() ? 1 : 7); // 1 is heavy (~20 s), so we do it rarely. 7 is a lot faster (8 s)
 
@@ -740,7 +740,7 @@ public class TestLucene90DocValuesFormat extends BaseCompressingDocValuesFormatT
     writer.close();
 
     // compare
-    assertDVIterate(dir);
+    assertDVIterate(dir, 4);
     assertDVAdvance(
         dir, 1); // Tests all jump-lengths from 1 to maxDoc (quite slow ~= 1 minute for 200K docs)
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/LegacyBaseDocValuesFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/LegacyBaseDocValuesFormatTestCase.java
@@ -1386,12 +1386,13 @@ public abstract class LegacyBaseDocValuesFormatTestCase extends BaseIndexFileFor
 
     writer.close();
     // compare
-    assertDVIterate(dir);
+    int skip = minDocs < 1000 ? 0 : minDocs < 10000 ? 1 : 2;
+    assertDVIterate(dir, skip);
     dir.close();
   }
 
   // Asserts equality of stored value vs. DocValue by iterating DocValues one at a time
-  protected void assertDVIterate(Directory dir) throws IOException {
+  protected void assertDVIterate(Directory dir, int skip) throws IOException {
     DirectoryReader ir = maybeWrapWithMergingReader(DirectoryReader.open(dir));
     TestUtil.checkReader(ir);
     for (LeafReaderContext context : ir.leaves()) {
@@ -1407,6 +1408,14 @@ public abstract class LegacyBaseDocValuesFormatTestCase extends BaseIndexFileFor
           assertEquals(i, docValues.docID());
           assertEquals(Long.parseLong(storedValue), docValues.longValue());
           docValues.nextDoc();
+        }
+        if (random().nextInt(10) == 3) {
+          // Sometimes skip ahead. We used to exhaustively check every doc, but it is too time-consuming
+          int skipAmount = skip * (r.maxDoc() - i) / 10;
+          if (skipAmount > 0) {
+            i += random().nextInt(skipAmount);
+            docValues.advance(i + 1);
+          }
         }
       }
       assertEquals(DocIdSetIterator.NO_MORE_DOCS, docValues.docID());

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/LegacyBaseDocValuesFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/LegacyBaseDocValuesFormatTestCase.java
@@ -1410,7 +1410,8 @@ public abstract class LegacyBaseDocValuesFormatTestCase extends BaseIndexFileFor
           docValues.nextDoc();
         }
         if (random().nextInt(10) == 3) {
-          // Sometimes skip ahead. We used to exhaustively check every doc, but it is too time-consuming
+          // Sometimes skip ahead. We used to exhaustively check every doc, but it is too
+          // time-consuming
           int skipAmount = skip * (r.maxDoc() - i) / 10;
           if (skipAmount > 0) {
             i += random().nextInt(skipAmount);


### PR DESCRIPTION
I added some random skipping (using advance) to tests that were exhaustively checking every document in a large index.

I also disabled checkIndex for these very large indexes.

On the slow seed I found, a 10+minute run went to 3m30s