### PR TITLE
fix: Typo in the error message

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/ConjunctionDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ConjunctionDISI.java
@@ -201,7 +201,7 @@ final class ConjunctionDISI extends FilterDocIdSetIterator {
   @Override
   public int advance(int target) throws IOException {
     assert assertItersOnSameDoc()
-        : "Sub-iterators of ConjunctionDISI are not one the same document!";
+        : "Sub-iterators of ConjunctionDISI are not on the same document!";
     return doNext(lead1.advance(target));
   }
 


### PR DESCRIPTION
### Description

Fix the typo in the error message of org.apache.lucene.search.ConjunctionDISI#advance(), it should be '... not on the same ...' instead of '... not one the same ...'.
