### PR TITLE
Revert required SegmentInfos min version in header check in readCommit to continue binary compatibility with 8.x indexes

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -132,6 +132,7 @@ Other
 * GITHUB#14817: Refactor some complex uses of PriorityQueue to use Comparators. (Simon Cooper)
 
 * GITHUB#14607: Index open performs version check on each segment, ignores indexCreatedVersionMajor (Rahul Goswami)
+* GITHUB#15454: Restore binary readability for 8.x indexes like previously and throw IndexFormatTooOldException for an older default codec not found on classpath (Rahul Goswami) 
 
 ======================= Lucene 10.4.0 =======================
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -132,7 +132,7 @@ Other
 * GITHUB#14817: Refactor some complex uses of PriorityQueue to use Comparators. (Simon Cooper)
 
 * GITHUB#14607: Index open performs version check on each segment, ignores indexCreatedVersionMajor (Rahul Goswami)
-* GITHUB#15454: Restore binary readability for 8.x indexes like previously and throw IndexFormatTooOldException for an older default codec not found on classpath (Rahul Goswami) 
+* GITHUB#15454: Restore binary readability for 8.x indexes like previously and throw IndexFormatTooOldException for an older default codec not found on classpath (Rahul Goswami)
 
 ======================= Lucene 10.4.0 =======================
 

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestAncientIndicesCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestAncientIndicesCompatibility.java
@@ -45,7 +45,6 @@ import org.apache.lucene.tests.store.BaseDirectoryWrapper;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.IOUtils;
-import org.apache.lucene.util.Version;
 
 public class TestAncientIndicesCompatibility extends LuceneTestCase {
   static final Set<String> UNSUPPORTED_INDEXES;
@@ -200,7 +199,7 @@ public class TestAncientIndicesCompatibility extends LuceneTestCase {
       checker.setInfoStream(new PrintStream(bos, false, UTF_8));
       checker.setLevel(CheckIndex.Level.MIN_LEVEL_FOR_INTEGRITY_CHECKS);
       CheckIndex.Status indexStatus = checker.checkIndex();
-      if (getVersion(version).onOrAfter(Version.fromBits(8, 6, 0))) {
+      if (version.startsWith("8.") || version.startsWith("9.")) {
         assertTrue(indexStatus.clean);
       } else {
         assertFalse(indexStatus.clean);
@@ -216,18 +215,6 @@ public class TestAncientIndicesCompatibility extends LuceneTestCase {
 
       dir.close();
     }
-  }
-
-  private Version getVersion(String version) {
-    if (version.startsWith("5x")) {
-      // couple of indices in unsupported_indices.txt start with "5x'
-      return Version.fromBits(5, 0, 0);
-    }
-    String[] versionBitsStr = version.split("[.\\-]");
-    return Version.fromBits(
-        Integer.parseInt(versionBitsStr[0]),
-        Integer.parseInt(versionBitsStr[1]),
-        Integer.parseInt(versionBitsStr[2]));
   }
 
   // #12895: test on a carefully crafted 9.8.0 index (from a small contiguous subset

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -328,7 +328,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
         throw new IndexFormatTooOldException(
             input, magic, CodecUtil.CODEC_MAGIC, CodecUtil.CODEC_MAGIC);
       }
-      format = CodecUtil.checkHeaderNoMagic(input, "segments", VERSION_86, VERSION_CURRENT);
+      format = CodecUtil.checkHeaderNoMagic(input, "segments", VERSION_74, VERSION_CURRENT);
       byte[] id = new byte[StringHelper.ID_LENGTH];
       input.readBytes(id, 0, id.length);
       CodecUtil.checkIndexHeaderSuffix(input, Long.toString(generation, Character.MAX_RADIX));
@@ -529,11 +529,13 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
     } catch (IllegalArgumentException e) {
       // maybe it's an old default codec that moved
       if (name.startsWith("Lucene")) {
-        throw new IllegalArgumentException(
+        throw new IndexFormatTooOldException(
+            input,
             "Could not load codec '"
                 + name
-                + "'. Did you forget to add lucene-backward-codecs.jar?",
-            e);
+                + "'. "
+                + e.getMessage()
+                + ". Did you forget to add lucene-backward-codecs.jar?");
       }
       throw e;
     }


### PR DESCRIPTION


### Description

#14607 advanced the SegmentInfos version to VERSION_86 (10) in header check during readCommit() to allow tests to find backward codecs until 9.x while throwing a graceful IndexFormatTooOldException for indexes < v8.6.0 (since by default anything < 10x is "too old"). 
Earlier with VERSION_74 (9), readCodec() would throw an IllegalArgumentException since readCommit now checks for segment level compatibility instead of looking at when the index was first created, and would find the 7.x codecs missing for some of the old indexes. This was causing some of the tests to fail. 

However  #15431 made me realize that we can afford to allow binary readability on 8.x indexes like was the case previously and also keep the tests happy., This change would also help keep the core logic and constraints consistent across 10x and main.
