### PR TITLE
Avoid unnecessary sorting and instantiations in readMapOfStrings

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -69,6 +69,8 @@ Improvements
 
 * GITHUB#15124: Use RamUsageEstimator to calculate size for non-accountable queries. (Sagar Upadhyaya)
 
+* GITHUB#15453: Avoid unnecessary sorting and instantiations in readMapOfStrings. (Benjamin Lerer)
+
 Optimizations
 ---------------------
 * GITHUB#14011: Reduce allocation rate in HNSW concurrent merge. (Viliam Durina)

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
@@ -185,7 +185,6 @@ public abstract class PerFieldDocValuesFormat extends DocValuesFormat {
       }
       final String formatName = format.getName();
 
-      field.putAttribute(PER_FIELD_FORMAT_KEY, formatName);
       Integer suffix = null;
 
       ConsumerAndSuffix consumer = formats.get(format);
@@ -229,8 +228,8 @@ public abstract class PerFieldDocValuesFormat extends DocValuesFormat {
         assert suffixes.containsKey(formatName);
         suffix = consumer.suffix;
       }
-
-      field.putAttribute(PER_FIELD_SUFFIX_KEY, Integer.toString(suffix));
+      field.putAttributes(
+          Map.of(PER_FIELD_FORMAT_KEY, formatName, PER_FIELD_SUFFIX_KEY, Integer.toString(suffix)));
       // TODO: we should only provide the "slice" of FIS
       // that this DVF actually sees ...
       return consumer.consumer;

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
@@ -148,7 +148,6 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
       }
       final String formatName = format.getName();
 
-      field.putAttribute(PER_FIELD_FORMAT_KEY, formatName);
       Integer suffix;
 
       WriterAndSuffix writerAndSuffix = formats.get(format);
@@ -176,7 +175,8 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
         assert suffixes.containsKey(formatName);
         suffix = writerAndSuffix.suffix;
       }
-      field.putAttribute(PER_FIELD_SUFFIX_KEY, Integer.toString(suffix));
+      field.putAttributes(
+          Map.of(PER_FIELD_FORMAT_KEY, formatName, PER_FIELD_SUFFIX_KEY, Integer.toString(suffix)));
       return writerAndSuffix.writer;
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
@@ -245,8 +245,12 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
 
         groupBuilder.addField(field);
 
-        fieldInfo.putAttribute(PER_FIELD_FORMAT_KEY, formatName);
-        fieldInfo.putAttribute(PER_FIELD_SUFFIX_KEY, Integer.toString(groupBuilder.suffix));
+        fieldInfo.putAttributes(
+            Map.of(
+                PER_FIELD_FORMAT_KEY,
+                formatName,
+                PER_FIELD_SUFFIX_KEY,
+                Integer.toString(groupBuilder.suffix)));
       }
 
       Map<PostingsFormat, FieldsGroup> formatToGroups =

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.index;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -674,8 +675,22 @@ public final class FieldInfo {
     String oldValue = newMap.put(key, value);
     // This needs to be thread-safe as multiple threads may be updating (different) attributes
     // concurrently due to concurrent merging.
-    attributes = Map.copyOf(newMap);
+    attributes = Collections.unmodifiableMap(newMap);
     return oldValue;
+  }
+
+  /**
+   * Puts some codec attribute values.
+   *
+   * <p>If multiples attributes need to be added {@code putAttributes} is more efficient than
+   * calling {@code putAttribute} multiple times as it avoid unnecessary copies and synchronisation.
+   */
+  public synchronized void putAttributes(Map<String, String> map) {
+    HashMap<String, String> newMap = new HashMap<>(attributes);
+    newMap.putAll(map);
+    // This needs to be thread-safe as multiple threads may be updating (different) attributes
+    // concurrently due to concurrent merging.
+    attributes = Collections.unmodifiableMap(newMap);
   }
 
   /** Returns internal codec attributes map. */

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.index;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -113,7 +112,7 @@ public final class FieldInfo {
       this.omitNorms = false;
     }
     this.dvGen = dvGen;
-    this.attributes = Objects.requireNonNull(attributes);
+    this.attributes = Map.copyOf(Objects.requireNonNull(attributes));
     this.pointDimensionCount = pointDimensionCount;
     this.pointIndexDimensionCount = pointIndexDimensionCount;
     this.pointNumBytes = pointNumBytes;
@@ -675,7 +674,7 @@ public final class FieldInfo {
     String oldValue = newMap.put(key, value);
     // This needs to be thread-safe as multiple threads may be updating (different) attributes
     // concurrently due to concurrent merging.
-    attributes = Collections.unmodifiableMap(newMap);
+    attributes = Map.copyOf(newMap);
     return oldValue;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -775,7 +775,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
       if (curFi != null) {
         curFi.verifySameSchema(fi);
         if (fi.attributes() != null) {
-          fi.attributes().forEach((k, v) -> curFi.putAttribute(k, v));
+          curFi.putAttributes(fi.attributes());
         }
         if (fi.hasPayloads()) {
           curFi.setStorePayloads();

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
@@ -362,7 +362,7 @@ public final class SegmentInfo {
     // This needs to be thread-safe because multiple threads may be updating (different) attributes
     // at the same time due to concurrent merging, plus some threads may be calling toString() on
     // segment info while other threads are updating attributes.
-    attributes = Collections.unmodifiableMap(newMap);
+    attributes = Map.copyOf(newMap);
     return oldValue;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
@@ -362,7 +362,8 @@ public final class SegmentInfo {
     // This needs to be thread-safe because multiple threads may be updating (different) attributes
     // at the same time due to concurrent merging, plus some threads may be calling toString() on
     // segment info while other threads are updating attributes.
-    attributes = Map.copyOf(newMap);
+    // We use unmodifiableMap instead of Map.copyOf to avoid an unnecessary copy.
+    attributes = Collections.unmodifiableMap(newMap);
     return oldValue;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/store/DataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/DataInput.java
@@ -18,14 +18,9 @@ package org.apache.lucene.store;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
 import org.apache.lucene.util.BitUtil;
 
 /**
@@ -248,17 +243,17 @@ public abstract class DataInput implements Cloneable {
   public Map<String, String> readMapOfStrings() throws IOException {
     int count = readVInt();
     if (count == 0) {
-      return Collections.emptyMap();
+      return Map.of();
     } else if (count == 1) {
-      return Collections.singletonMap(readString(), readString());
+      return Map.of(readString(), readString());
     } else {
-      Map<String, String> map = count > 10 ? new HashMap<>() : new TreeMap<>();
+      @SuppressWarnings("unchecked")
+      Map.Entry<String, String>[] entries =
+          (Map.Entry<String, String>[]) new Map.Entry<?, ?>[count];
       for (int i = 0; i < count; i++) {
-        final String key = readString();
-        final String val = readString();
-        map.put(key, val);
+        entries[i] = Map.entry(readString(), readString());
       }
-      return Collections.unmodifiableMap(map);
+      return Map.ofEntries(entries);
     }
   }
 
@@ -270,15 +265,15 @@ public abstract class DataInput implements Cloneable {
   public Set<String> readSetOfStrings() throws IOException {
     int count = readVInt();
     if (count == 0) {
-      return Collections.emptySet();
+      return Set.of();
     } else if (count == 1) {
-      return Collections.singleton(readString());
+      return Set.of(readString());
     } else {
-      Set<String> set = count > 10 ? new HashSet<>() : new TreeSet<>();
+      String[] set = new String[count];
       for (int i = 0; i < count; i++) {
-        set.add(readString());
+        set[i] = readString();
       }
-      return Collections.unmodifiableSet(set);
+      return Set.of(set);
     }
   }
 


### PR DESCRIPTION
### Description
The patch remove the use of `TreeMap` from `readMapOfStrings` and the use of `TreeSet` from `readSetOfString` and return `ImmutableMaps` and `ImmutableSets` instead of `UnmodifiableMaps`. As the use of `Map.copyOf` on `ImmutableMap` is a noop the change also avoid the creation of a new map instance in `SegmentInfo`.

Closes #15453
