### PR TITLE
Add `@SuppressAssertingFormats` annotation for fine-grained control over `AssertingCodec` formats

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -186,6 +186,8 @@ New Features
  * GITHUB#15415: Add fallback support to Lucene104ScalarQuantizedVectorsFormat getFloatVectorValues when there are
    no full-precision vectors present (Pulkit Gupta)
 
+ * GITHUB#15468: Add support for `@SuppressAssertingFormats` annotation for fine-grained control over `AssertingCodec` formats (Prudhvi Godithi)
+
 Improvements
 ---------------------
 * GITHUB#15148: Add support uint8 distance and allow 8 bit scalar quantization (Trevor McCulloch)

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingCodec.java
@@ -16,6 +16,9 @@
  */
 package org.apache.lucene.tests.codecs.asserting;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
@@ -32,6 +35,22 @@ import org.apache.lucene.tests.util.TestUtil;
 
 /** Acts like the default codec but with additional asserts. */
 public class AssertingCodec extends FilterCodec {
+
+  private static volatile Set<String> suppressedFormats = Collections.emptySet();
+
+  /** Set the formats to suppress. Use simple class names like "AssertingStoredFieldsFormat". */
+  public static void setSuppressedFormats(Set<String> formats) {
+    suppressedFormats = new HashSet<>(formats);
+  }
+
+  /** Clear all suppressed formats. */
+  public static void clearSuppressedFormats() {
+    suppressedFormats = Collections.emptySet();
+  }
+
+  private static boolean isSuppressed(String formatName) {
+    return suppressedFormats.contains(formatName);
+  }
 
   static void assertThread(String object, Thread creationThread) {
     if (creationThread != Thread.currentThread()) {
@@ -90,12 +109,12 @@ public class AssertingCodec extends FilterCodec {
 
   @Override
   public TermVectorsFormat termVectorsFormat() {
-    return vectors;
+    return isSuppressed("AssertingTermVectorsFormat") ? delegate.termVectorsFormat() : vectors;
   }
 
   @Override
   public StoredFieldsFormat storedFieldsFormat() {
-    return storedFields;
+    return isSuppressed("AssertingStoredFieldsFormat") ? delegate.storedFieldsFormat() : storedFields;
   }
 
   @Override
@@ -105,22 +124,22 @@ public class AssertingCodec extends FilterCodec {
 
   @Override
   public NormsFormat normsFormat() {
-    return norms;
+    return isSuppressed("AssertingNormsFormat") ? delegate.normsFormat() : norms;
   }
 
   @Override
   public LiveDocsFormat liveDocsFormat() {
-    return liveDocs;
+    return isSuppressed("AssertingLiveDocsFormat") ? delegate.liveDocsFormat() : liveDocs;
   }
 
   @Override
   public PointsFormat pointsFormat() {
-    return pointsFormat;
+    return isSuppressed("AssertingPointsFormat") ? delegate.pointsFormat() : pointsFormat;
   }
 
   @Override
   public KnnVectorsFormat knnVectorsFormat() {
-    return knnVectorsFormat;
+    return isSuppressed("AssertingKnnVectorsFormat") ? delegate.knnVectorsFormat() : knnVectorsFormat;
   }
 
   @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingCodec.java
@@ -40,9 +40,8 @@ public class AssertingCodec extends FilterCodec {
 
   /** Set the formats to suppress. Use simple class names like "AssertingStoredFieldsFormat". */
   public static void setSuppressedFormats(Set<String> formats) {
-    suppressedFormats = formats == null || formats.isEmpty() 
-        ? Collections.emptySet() 
-        : new HashSet<>(formats);
+    suppressedFormats =
+        formats == null || formats.isEmpty() ? Collections.emptySet() : new HashSet<>(formats);
   }
 
   private static boolean isSuppressed(String formatName) {
@@ -111,7 +110,9 @@ public class AssertingCodec extends FilterCodec {
 
   @Override
   public StoredFieldsFormat storedFieldsFormat() {
-    return isSuppressed("AssertingStoredFieldsFormat") ? delegate.storedFieldsFormat() : storedFields;
+    return isSuppressed("AssertingStoredFieldsFormat")
+        ? delegate.storedFieldsFormat()
+        : storedFields;
   }
 
   @Override
@@ -136,7 +137,9 @@ public class AssertingCodec extends FilterCodec {
 
   @Override
   public KnnVectorsFormat knnVectorsFormat() {
-    return isSuppressed("AssertingKnnVectorsFormat") ? delegate.knnVectorsFormat() : knnVectorsFormat;
+    return isSuppressed("AssertingKnnVectorsFormat")
+        ? delegate.knnVectorsFormat()
+        : knnVectorsFormat;
   }
 
   @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingCodec.java
@@ -17,7 +17,7 @@
 package org.apache.lucene.tests.codecs.asserting;
 
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Set;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.FilterCodec;
@@ -36,16 +36,26 @@ import org.apache.lucene.tests.util.TestUtil;
 /** Acts like the default codec but with additional asserts. */
 public class AssertingCodec extends FilterCodec {
 
-  private static volatile Set<String> suppressedFormats = Collections.emptySet();
-
-  /** Set the formats to suppress. Use simple class names like "AssertingStoredFieldsFormat". */
-  public static void setSuppressedFormats(Set<String> formats) {
-    suppressedFormats =
-        formats == null || formats.isEmpty() ? Collections.emptySet() : new HashSet<>(formats);
+  /** Enum representing asserting format types that can be suppressed. */
+  public enum Format {
+    STORED_FIELDS,
+    TERM_VECTORS,
+    NORMS,
+    LIVE_DOCS,
+    POINTS,
+    KNN_VECTORS
   }
 
-  private static boolean isSuppressed(String formatName) {
-    return suppressedFormats.contains(formatName);
+  private static volatile Set<Format> suppressedFormats = Collections.emptySet();
+
+  /** Set the formats to suppress. */
+  public static void setSuppressedFormats(Set<Format> formats) {
+    suppressedFormats =
+        formats == null || formats.isEmpty() ? Collections.emptySet() : EnumSet.copyOf(formats);
+  }
+
+  private static boolean isSuppressed(Format format) {
+    return suppressedFormats.contains(format);
   }
 
   static void assertThread(String object, Thread creationThread) {
@@ -105,14 +115,12 @@ public class AssertingCodec extends FilterCodec {
 
   @Override
   public TermVectorsFormat termVectorsFormat() {
-    return isSuppressed("AssertingTermVectorsFormat") ? delegate.termVectorsFormat() : vectors;
+    return isSuppressed(Format.TERM_VECTORS) ? delegate.termVectorsFormat() : vectors;
   }
 
   @Override
   public StoredFieldsFormat storedFieldsFormat() {
-    return isSuppressed("AssertingStoredFieldsFormat")
-        ? delegate.storedFieldsFormat()
-        : storedFields;
+    return isSuppressed(Format.STORED_FIELDS) ? delegate.storedFieldsFormat() : storedFields;
   }
 
   @Override
@@ -122,24 +130,22 @@ public class AssertingCodec extends FilterCodec {
 
   @Override
   public NormsFormat normsFormat() {
-    return isSuppressed("AssertingNormsFormat") ? delegate.normsFormat() : norms;
+    return isSuppressed(Format.NORMS) ? delegate.normsFormat() : norms;
   }
 
   @Override
   public LiveDocsFormat liveDocsFormat() {
-    return isSuppressed("AssertingLiveDocsFormat") ? delegate.liveDocsFormat() : liveDocs;
+    return isSuppressed(Format.LIVE_DOCS) ? delegate.liveDocsFormat() : liveDocs;
   }
 
   @Override
   public PointsFormat pointsFormat() {
-    return isSuppressed("AssertingPointsFormat") ? delegate.pointsFormat() : pointsFormat;
+    return isSuppressed(Format.POINTS) ? delegate.pointsFormat() : pointsFormat;
   }
 
   @Override
   public KnnVectorsFormat knnVectorsFormat() {
-    return isSuppressed("AssertingKnnVectorsFormat")
-        ? delegate.knnVectorsFormat()
-        : knnVectorsFormat;
+    return isSuppressed(Format.KNN_VECTORS) ? delegate.knnVectorsFormat() : knnVectorsFormat;
   }
 
   @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingCodec.java
@@ -40,12 +40,9 @@ public class AssertingCodec extends FilterCodec {
 
   /** Set the formats to suppress. Use simple class names like "AssertingStoredFieldsFormat". */
   public static void setSuppressedFormats(Set<String> formats) {
-    suppressedFormats = new HashSet<>(formats);
-  }
-
-  /** Clear all suppressed formats. */
-  public static void clearSuppressedFormats() {
-    suppressedFormats = Collections.emptySet();
+    suppressedFormats = formats == null || formats.isEmpty() 
+        ? Collections.emptySet() 
+        : new HashSet<>(formats);
   }
 
   private static boolean isSuppressed(String formatName) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -351,6 +351,20 @@ public abstract class LuceneTestCase extends Assert {
   }
 
   /**
+   * Annotation for test classes that should avoid specific asserting formats within the Asserting
+   * codec (e.g., AssertingStoredFieldsFormat) while keeping other asserting formats active.
+   *
+   * <p>Use the simple class name of the format to suppress, e.g., "AssertingStoredFieldsFormat".
+   */
+  @Documented
+  @Inherited
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.TYPE)
+  public @interface SuppressAssertingFormats {
+    String[] value();
+  }
+
+  /**
    * Annotation for test classes that should avoid mock filesystem types (because they test a bug
    * that only happens on linux, for example).
    *

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -171,6 +171,7 @@ import org.apache.lucene.store.MergeInfo;
 import org.apache.lucene.store.NRTCachingDirectory;
 import org.apache.lucene.store.ReadOnceHint;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.apache.lucene.tests.codecs.asserting.AssertingCodec;
 import org.apache.lucene.tests.index.AlcoholicMergePolicy;
 import org.apache.lucene.tests.index.AssertingDirectoryReader;
 import org.apache.lucene.tests.index.AssertingLeafReader;
@@ -353,15 +354,13 @@ public abstract class LuceneTestCase extends Assert {
   /**
    * Annotation for test classes that should avoid specific asserting formats within the Asserting
    * codec (e.g., AssertingStoredFieldsFormat) while keeping other asserting formats active.
-   *
-   * <p>Use the simple class name of the format to suppress, e.g., "AssertingStoredFieldsFormat".
    */
   @Documented
   @Inherited
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.TYPE)
   public @interface SuppressAssertingFormats {
-    String[] value();
+    AssertingCodec.Format[] value();
   }
 
   /**

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
@@ -51,6 +51,7 @@ import org.apache.lucene.tests.index.RandomCodec;
 import org.apache.lucene.tests.search.similarities.AssertingSimilarity;
 import org.apache.lucene.tests.search.similarities.RandomSimilarity;
 import org.apache.lucene.tests.util.LuceneTestCase.LiveIWCFlushMode;
+import org.apache.lucene.tests.util.LuceneTestCase.SuppressAssertingFormats;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.PrintStreamInfoStream;
@@ -125,6 +126,14 @@ final class TestRuleSetupAndRestoreClassEnv extends AbstractBeforeAfterRule {
     if (targetClass.isAnnotationPresent(SuppressCodecs.class)) {
       SuppressCodecs a = targetClass.getAnnotation(SuppressCodecs.class);
       avoidCodecs.addAll(Arrays.asList(a.value()));
+    }
+
+    // Process SuppressAssertingFormats annotation
+    if (targetClass.isAnnotationPresent(SuppressAssertingFormats.class)) {
+      SuppressAssertingFormats a = targetClass.getAnnotation(SuppressAssertingFormats.class);
+      AssertingCodec.setSuppressedFormats(new HashSet<>(Arrays.asList(a.value())));
+    } else {
+      AssertingCodec.clearSuppressedFormats();
     }
 
     savedCodec = Codec.getDefault();

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
@@ -139,7 +139,6 @@ final class TestRuleSetupAndRestoreClassEnv extends AbstractBeforeAfterRule {
       avoidAssertingFormats.addAll(Arrays.asList(a.value()));
     }
 
-    // Set suppressed asserting formats before codec creation
     AssertingCodec.setSuppressedFormats(avoidAssertingFormats);
 
     savedCodec = Codec.getDefault();

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
@@ -31,6 +31,7 @@ import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Random;
@@ -80,7 +81,7 @@ final class TestRuleSetupAndRestoreClassEnv extends AbstractBeforeAfterRule {
   /**
    * @see SuppressAssertingFormats
    */
-  HashSet<String> avoidAssertingFormats;
+  EnumSet<AssertingCodec.Format> avoidAssertingFormats;
 
   static class ThreadNameFixingPrintStreamInfoStream extends PrintStreamInfoStream {
     public ThreadNameFixingPrintStreamInfoStream(PrintStream out) {
@@ -133,7 +134,7 @@ final class TestRuleSetupAndRestoreClassEnv extends AbstractBeforeAfterRule {
       avoidCodecs.addAll(Arrays.asList(a.value()));
     }
 
-    avoidAssertingFormats = new HashSet<>();
+    avoidAssertingFormats = EnumSet.noneOf(AssertingCodec.Format.class);
     if (targetClass.isAnnotationPresent(SuppressAssertingFormats.class)) {
       SuppressAssertingFormats a = targetClass.getAnnotation(SuppressAssertingFormats.class);
       avoidAssertingFormats.addAll(Arrays.asList(a.value()));

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
@@ -77,6 +77,11 @@ final class TestRuleSetupAndRestoreClassEnv extends AbstractBeforeAfterRule {
    */
   HashSet<String> avoidCodecs;
 
+  /**
+   * @see SuppressAssertingFormats
+   */
+  HashSet<String> avoidAssertingFormats;
+
   static class ThreadNameFixingPrintStreamInfoStream extends PrintStreamInfoStream {
     public ThreadNameFixingPrintStreamInfoStream(PrintStream out) {
       super(out);
@@ -128,13 +133,14 @@ final class TestRuleSetupAndRestoreClassEnv extends AbstractBeforeAfterRule {
       avoidCodecs.addAll(Arrays.asList(a.value()));
     }
 
-    // Process SuppressAssertingFormats annotation
+    avoidAssertingFormats = new HashSet<>();
     if (targetClass.isAnnotationPresent(SuppressAssertingFormats.class)) {
       SuppressAssertingFormats a = targetClass.getAnnotation(SuppressAssertingFormats.class);
-      AssertingCodec.setSuppressedFormats(new HashSet<>(Arrays.asList(a.value())));
-    } else {
-      AssertingCodec.clearSuppressedFormats();
+      avoidAssertingFormats.addAll(Arrays.asList(a.value()));
     }
+
+    // Set suppressed asserting formats before codec creation
+    AssertingCodec.setSuppressedFormats(avoidAssertingFormats);
 
     savedCodec = Codec.getDefault();
     int randomVal = random.nextInt(11);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
@@ -138,7 +138,6 @@ final class TestRuleSetupAndRestoreClassEnv extends AbstractBeforeAfterRule {
       SuppressAssertingFormats a = targetClass.getAnnotation(SuppressAssertingFormats.class);
       avoidAssertingFormats.addAll(Arrays.asList(a.value()));
     }
-
     AssertingCodec.setSuppressedFormats(avoidAssertingFormats);
 
     savedCodec = Codec.getDefault();


### PR DESCRIPTION
### Description
This PR introduces a new `@SuppressAssertingFormats` annotation that allows test classes to
suppress specific asserting formats within the `AssertingCodec` while keeping other asserting
formats active.

Currently, `@SuppressCodecs("Asserting")` disables the entire `AssertingCodec`, losing all
assertion checks. However, some tests have legitimate use cases to just suppress specific `AssertingFormats` and continue with `AssertingCodec`. 

Now With this we can use as `@LuceneTestCase.SuppressAssertingFormats("AssertingStoredFieldsFormat")` rather than `@SuppressCodecs("Asserting")`
