### PR TITLE
Add only forward links when repairing HNSW merge (fixes #15467)

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -351,15 +351,7 @@ public class HnswGraphBuilder implements HnswBuilder {
       UpdateableRandomVectorScorer scorer,
       boolean outOfOrderInsertion)
       throws IOException {
-    /* For each of the beamWidth nearest candidates (going from best to worst), select it only if it
-     * is closer to target than it is to any of the already-selected neighbors (ie selected in this method,
-     * since the node is new and has no prior neighbors).
-     */
-    NeighborArray neighbors = hnsw.getNeighbors(level, node);
-    int maxConnOnLevel = level == 0 ? M * 2 : M;
-    boolean[] mask =
-        selectAndLinkDiverse(
-            node, neighbors, candidates, maxConnOnLevel, scorer, outOfOrderInsertion);
+    boolean[] mask = addDiverseForward(level, node, candidates, scorer, outOfOrderInsertion);
 
     // Link the selected nodes to the new node, and the new node to the selected nodes (again
     // applying diversity heuristic)
@@ -384,6 +376,24 @@ public class HnswGraphBuilder implements HnswBuilder {
         nbrsOfNbr.addAndEnsureDiversity(node, candidates.getScores(i), nbr, scorer);
       }
     }
+  }
+
+  boolean[] addDiverseForward(
+      int level,
+      int node,
+      NeighborArray candidates,
+      UpdateableRandomVectorScorer scorer,
+      boolean outOfOrderInsertion) throws IOException {
+    /* For each of the beamWidth nearest candidates (going from best to worst), select it only if it
+     * is closer to target than it is to any of the already-selected neighbors (ie selected in this method,
+     * since the node is new and has no prior neighbors).
+     */
+    NeighborArray neighbors = hnsw.getNeighbors(level, node);
+    int maxConnOnLevel = level == 0 ? M * 2 : M;
+    boolean[] mask =
+        selectAndLinkDiverse(
+            node, neighbors, candidates, maxConnOnLevel, scorer, outOfOrderInsertion);
+    return mask;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -383,7 +383,8 @@ public class HnswGraphBuilder implements HnswBuilder {
       int node,
       NeighborArray candidates,
       UpdateableRandomVectorScorer scorer,
-      boolean outOfOrderInsertion) throws IOException {
+      boolean outOfOrderInsertion)
+      throws IOException {
     /* For each of the beamWidth nearest candidates (going from best to worst), select it only if it
      * is closer to target than it is to any of the already-selected neighbors (ie selected in this method,
      * since the node is new and has no prior neighbors).

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
@@ -327,7 +327,7 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
         // Add diverse neighbors using HNSW heuristic (prunes similar neighbors)
         addDiverseForward(level, node, scratchArray, scorer, true);
       } else {
-        // Node has no nighbors, add connections from scratch
+        // Node has no neighbors, add connections from scratch
         addConnections(node, level, scorer);
       }
 
@@ -441,7 +441,7 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
     popToScratch(candidates, scratchArray);
 
     // Add diverse neighbors and establish bidirectional connections
-    addDiverseForward(targetLevel, node, scratchArray, scorer, true);
+    addDiverseNeighbors(targetLevel, node, scratchArray, scorer, true);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
@@ -325,7 +325,7 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
         popToScratch(candidates, scratchArray);
 
         // Add diverse neighbors using HNSW heuristic (prunes similar neighbors)
-        addDiverseNeighbors(level, node, scratchArray, scorer, true);
+        addDiverseForward(level, node, scratchArray, scorer, true);
       } else {
         // Node has no nighbors, add connections from scratch
         addConnections(node, level, scorer);
@@ -441,7 +441,7 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
     popToScratch(candidates, scratchArray);
 
     // Add diverse neighbors and establish bidirectional connections
-    addDiverseNeighbors(targetLevel, node, scratchArray, scorer, true);
+    addDiverseForward(targetLevel, node, scratchArray, scorer, true);
   }
 
   @Override


### PR DESCRIPTION
This is what I was thinking -- when "repairing" only add links *from* the node being repaired and not back again.  This is needed because ordinarily we are adding nodes in order and each node is only added once, so there is no opportunity for duplication, but in this case we are effectively "re-adding" the node.  So we would have to check for duplicates when making links, or we can just forgo adding the reverse links. Is this good enough? I don't know, I haven't had time to do any extensive testing, but it at least gets rid of the duplicates.