### PR TITLE
Use bulk scoring new osq

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -235,6 +235,9 @@ Optimizations
 
 * GITHUB#15406: Improve round trip conversion of ValueSource <-> DoublesValueSource (hossman)
 
+* GITHUB#15474: Use bulk scoring provided by RandomVectorScorers for new scalar quantized formats provided through
+    Lucene104ScalarQuantizedVectorsFormat and Lucene104HnswScalarQuantizedVectorsFormat (Ben Trent)
+
 Bug Fixes
 ---------------------
 * GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsReader.java
@@ -50,7 +50,6 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.apache.lucene.util.hnsw.OrdinalTranslatedKnnCollector;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.quantization.OptimizedScalarQuantizer;
 import org.apache.lucene.util.quantization.QuantizedVectorsReader;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsReader.java
@@ -262,7 +262,6 @@ public class Lucene104ScalarQuantizedVectorsReader extends FlatVectorsReader
     if (knnCollector.k() == 0) return;
     final RandomVectorScorer scorer = getRandomVectorScorer(field, target);
     if (scorer == null) return;
-    knnCollector = new OrdinalTranslatedKnnCollector(knnCollector, scorer::ordToDoc);
     Bits acceptedOrds = scorer.getAcceptOrds(acceptDocs.bits());
     // if k is larger than the number of vectors we expect to visit in an HNSW search,
     // we can just iterate over all vectors and collect them.

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/OffHeapScalarQuantizedFloatVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/OffHeapScalarQuantizedFloatVectorValues.java
@@ -252,6 +252,11 @@ abstract class OffHeapScalarQuantizedFloatVectorValues extends FloatVectorValues
         public DocIdSetIterator iterator() {
           return iterator;
         }
+
+        @Override
+        public VectorScorer.Bulk bulk(DocIdSetIterator matchingDocs) {
+          return Bulk.fromRandomScorerDense(scorer, iterator, matchingDocs);
+        }
       };
     }
 
@@ -345,6 +350,11 @@ abstract class OffHeapScalarQuantizedFloatVectorValues extends FloatVectorValues
         @Override
         public DocIdSetIterator iterator() {
           return iterator;
+        }
+
+        @Override
+        public VectorScorer.Bulk bulk(DocIdSetIterator matchingDocs) {
+          return Bulk.fromRandomScorerSparse(scorer, iterator, matchingDocs);
         }
       };
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/OffHeapScalarQuantizedVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/OffHeapScalarQuantizedVectorValues.java
@@ -321,6 +321,11 @@ public abstract class OffHeapScalarQuantizedVectorValues extends QuantizedByteVe
         public DocIdSetIterator iterator() {
           return iterator;
         }
+
+        @Override
+        public VectorScorer.Bulk bulk(DocIdSetIterator matchingDocs) {
+          return Bulk.fromRandomScorerDense(scorer, iterator, matchingDocs);
+        }
       };
     }
 
@@ -429,6 +434,11 @@ public abstract class OffHeapScalarQuantizedVectorValues extends QuantizedByteVe
         @Override
         public DocIdSetIterator iterator() {
           return iterator;
+        }
+
+        @Override
+        public VectorScorer.Bulk bulk(DocIdSetIterator matchingDocs) {
+          return Bulk.fromRandomScorerSparse(scorer, iterator, matchingDocs);
         }
       };
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapByteVectorValues.java
@@ -172,6 +172,11 @@ public abstract class OffHeapByteVectorValues extends ByteVectorValues implement
         public DocIdSetIterator iterator() {
           return iterator;
         }
+
+        @Override
+        public VectorScorer.Bulk bulk(DocIdSetIterator matchingDocs) {
+          return Bulk.fromRandomScorerDense(scorer, iterator, matchingDocs);
+        }
       };
     }
   }
@@ -260,6 +265,7 @@ public abstract class OffHeapByteVectorValues extends ByteVectorValues implement
       SparseOffHeapVectorValues copy = copy();
       RandomVectorScorer scorer =
           flatVectorsScorer.getRandomVectorScorer(similarityFunction, copy, query);
+      DocIndexIterator iterator = copy.iterator();
       return new VectorScorer() {
         @Override
         public float score() throws IOException {
@@ -268,7 +274,12 @@ public abstract class OffHeapByteVectorValues extends ByteVectorValues implement
 
         @Override
         public DocIdSetIterator iterator() {
-          return copy.disi;
+          return iterator;
+        }
+
+        @Override
+        public VectorScorer.Bulk bulk(DocIdSetIterator matchingDocs) {
+          return Bulk.fromRandomScorerSparse(scorer, iterator, matchingDocs);
         }
       };
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloatVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloatVectorValues.java
@@ -18,19 +18,15 @@
 package org.apache.lucene.codecs.lucene95;
 
 import java.io.IOException;
-import java.util.List;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.codecs.lucene90.IndexedDISI;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
-import org.apache.lucene.search.ConjunctionUtils;
-import org.apache.lucene.search.DocAndFloatFeatureBuffer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.VectorScorer;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RandomAccessInput;
-import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.packed.DirectMonotonicReader;
@@ -180,26 +176,7 @@ public abstract class OffHeapFloatVectorValues extends FloatVectorValues impleme
 
         @Override
         public VectorScorer.Bulk bulk(DocIdSetIterator matchingDocs) {
-          final DocIdSetIterator matches =
-              matchingDocs == null
-                  ? iterator
-                  : ConjunctionUtils.createConjunction(List.of(matchingDocs, iterator), List.of());
-          return (nextCount, liveDocs, buffer) -> {
-            if (matches.docID() == -1) {
-              matches.nextDoc();
-            }
-            buffer.growNoCopy(nextCount);
-            int size = 0;
-            for (int doc = matches.docID();
-                doc != DocIdSetIterator.NO_MORE_DOCS && size < nextCount;
-                doc = matches.nextDoc()) {
-              if (liveDocs == null || liveDocs.get(doc)) {
-                buffer.docs[size++] = doc;
-              }
-            }
-            buffer.size = size;
-            return randomVectorScorer.bulkScore(buffer.docs, buffer.features, size);
-          };
+          return Bulk.fromRandomScorerDense(randomVectorScorer, iterator, matchingDocs);
         }
       };
     }
@@ -297,39 +274,7 @@ public abstract class OffHeapFloatVectorValues extends FloatVectorValues impleme
 
         @Override
         public VectorScorer.Bulk bulk(DocIdSetIterator matchingDocs) {
-          return new Bulk() {
-            final DocIdSetIterator matches =
-                matchingDocs == null
-                    ? iterator
-                    : ConjunctionUtils.createConjunction(
-                        List.of(matchingDocs, iterator), List.of());
-            int[] docIds = new int[0];
-
-            @Override
-            public float nextDocsAndScores(
-                int nextCount, Bits liveDocs, DocAndFloatFeatureBuffer buffer) throws IOException {
-              if (matches.docID() == -1) {
-                matches.nextDoc();
-              }
-              buffer.growNoCopy(nextCount);
-              docIds = ArrayUtil.growNoCopy(docIds, nextCount);
-              int size = 0;
-              for (int doc = matches.docID();
-                  doc != DocIdSetIterator.NO_MORE_DOCS && size < nextCount;
-                  doc = matches.nextDoc()) {
-                if (liveDocs == null || liveDocs.get(doc)) {
-                  buffer.docs[size] = iterator.index();
-                  docIds[size] = doc;
-                  ++size;
-                }
-              }
-              buffer.size = size;
-              float maxScore = randomVectorScorer.bulkScore(buffer.docs, buffer.features, size);
-              // copy back the real doc IDs
-              System.arraycopy(docIds, 0, buffer.docs, 0, size);
-              return maxScore;
-            }
-          };
+          return Bulk.fromRandomScorerSparse(randomVectorScorer, iterator, matchingDocs);
         }
       };
     }


### PR DESCRIPTION
Even though they aren't written yet, we should be utilizing the bulk scoring implementations for quantized scoring.

This also refactors some of the implementations to simplify the code.