### PR TITLE
Enabling wrapped collectors in MultiCollector to collectRange

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -235,6 +235,8 @@ Optimizations
 
 * GITHUB#15406: Improve round trip conversion of ValueSource <-> DoublesValueSource (hossman)
 
+* GITHUB#15475: Enabling wrapped collectors in MultiCollector to collectRange (Ankit Jain)
+
 Bug Fixes
 ---------------------
 * GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException

--- a/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
@@ -234,7 +234,7 @@ public class MultiCollector implements Collector {
         final LeafCollector collector = collectors[i];
         if (collector != null) {
           try {
-              collector.collectRange(min, max);
+            collector.collectRange(min, max);
           } catch (
               @SuppressWarnings("unused")
               CollectionTerminatedException e) {

--- a/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
@@ -229,6 +229,26 @@ public class MultiCollector implements Collector {
     }
 
     @Override
+    public void collectRange(int min, int max) throws IOException {
+      for (int i = 0; i < collectors.length; i++) {
+        final LeafCollector collector = collectors[i];
+        if (collector != null) {
+          try {
+              collector.collectRange(min, max);
+          } catch (
+              @SuppressWarnings("unused")
+              CollectionTerminatedException e) {
+            collectors[i].finish();
+            collectors[i] = null;
+            if (allCollectorsTerminated()) {
+              throw new CollectionTerminatedException();
+            }
+          }
+        }
+      }
+    }
+
+    @Override
     public void finish() throws IOException {
       for (LeafCollector collector : collectors) {
         if (collector != null) {


### PR DESCRIPTION
### Description

Currently, `MultiLeafCollector` does not allow the wrapped collectors to take advantage of bulk collection using `collectRange` method. This PR enables wrapped collectors in `MultiCollector` to bulk collect documents if they provide efficient implementation for `collectRange`
