### PR TITLE
Add a public NumericDocValuesRangeQuery class

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -196,6 +196,8 @@ Improvements
 
 * GITHUB#15425: Refactoring internal HnswGraph.NodesIterator to avoid unneeded copying and sorting (Mike Sokolov)
 
+* GITHUB#15479: Add NumericDocValueRangeQuery base class to add accessor methods for field, lower and upper values (Alan Woodward)
+
 Optimizations
 ---------------------
 * GITHUB#15140: Optimize TopScoreDocCollector with TernaryLongHeap for improved performance over Binary-LongHeap. (Ramakrishna Chilaka)

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -33,6 +33,7 @@ import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.NumericDocValuesRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
@@ -41,16 +42,10 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 
-final class SortedNumericDocValuesRangeQuery extends Query {
-
-  private final String field;
-  private final long lowerValue;
-  private final long upperValue;
+final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery {
 
   SortedNumericDocValuesRangeQuery(String field, long lowerValue, long upperValue) {
-    this.field = Objects.requireNonNull(field);
-    this.lowerValue = lowerValue;
-    this.upperValue = upperValue;
+    super(field, lowerValue, upperValue);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -66,11 +66,8 @@ import org.apache.lucene.util.ArrayUtil.ByteArrayComparator;
  *
  * @lucene.experimental
  */
-public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
+public class IndexSortSortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery {
 
-  private final String field;
-  private final long lowerValue;
-  private final long upperValue;
   private final Query fallbackQuery;
 
   /**
@@ -83,9 +80,7 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
    */
   public IndexSortSortedNumericDocValuesRangeQuery(
       String field, long lowerValue, long upperValue, Query fallbackQuery) {
-    this.field = Objects.requireNonNull(field);
-    this.lowerValue = lowerValue;
-    this.upperValue = upperValue;
+    super(field, lowerValue, upperValue);
     this.fallbackQuery = fallbackQuery;
   }
 
@@ -628,7 +623,7 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
     int compare(int docID) throws IOException;
   }
 
-  private static ValueComparator loadComparator(
+  private static ValueComparator  loadComparator(
       SortField sortField, SortField.Type type, long topValue, LeafReaderContext context)
       throws IOException {
     @SuppressWarnings("unchecked")

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -623,7 +623,7 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends NumericDocValuesR
     int compare(int docID) throws IOException;
   }
 
-  private static ValueComparator  loadComparator(
+  private static ValueComparator loadComparator(
       SortField sortField, SortField.Type type, long topValue, LeafReaderContext context)
       throws IOException {
     @SuppressWarnings("unchecked")

--- a/lucene/core/src/java/org/apache/lucene/search/NumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/NumericDocValuesRangeQuery.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search;
+
+import java.util.Objects;
+
+/**
+ * A Query over a range of long values
+ */
+public abstract class NumericDocValuesRangeQuery extends Query {
+
+  protected final String field;
+  protected final long lowerValue;
+  protected final long upperValue;
+
+  protected NumericDocValuesRangeQuery(String field, long lowerValue, long upperValue) {
+    this.field = Objects.requireNonNull(field);
+    this.lowerValue = lowerValue;
+    this.upperValue = upperValue;
+  }
+
+  /**
+   * @return the field this Query applies to
+   */
+  public final String getField() {
+    return field;
+  }
+
+  /**
+   * @return the lower bound value
+   */
+  public final long lowerValue() {
+    return lowerValue;
+  }
+
+  /**
+   * @return the upper bound value
+   */
+  public final long upperValue() {
+    return upperValue;
+  }
+
+}

--- a/lucene/core/src/java/org/apache/lucene/search/NumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/NumericDocValuesRangeQuery.java
@@ -19,9 +19,7 @@ package org.apache.lucene.search;
 
 import java.util.Objects;
 
-/**
- * A Query over a range of long values
- */
+/** A Query over a range of long values */
 public abstract class NumericDocValuesRangeQuery extends Query {
 
   protected final String field;
@@ -54,5 +52,4 @@ public abstract class NumericDocValuesRangeQuery extends Query {
   public final long upperValue() {
     return upperValue;
   }
-
 }


### PR DESCRIPTION
SortedNumericDocValuesRangeQuery and IndexSortSortedNumericDocValuesRangeQuery 
both implement queries over ranges of numeric doc values, but they cannot be easily 
introspected. This commit adds a common base class which exposes the field, lowerValue 
and upperValue of the query.

This can be useful for things like queryparsers which can automatically rewrite multiple
overlapping queries into single instances.