### PR TITLE
Speed up TestNumericComparator

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/comparators/TestNumericComparator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/comparators/TestNumericComparator.java
@@ -64,8 +64,8 @@ public class TestNumericComparator extends LuceneTestCase {
           doc.add(new NumericDocValuesField("double_field_2", i));
 
           writer.addDocument(doc);
-          writer.forceMerge(1);
         }
+        writer.forceMerge(1);
         try (var reader = DirectoryReader.open(writer)) {
           assertEquals(1, reader.leaves().size());
           var leafContext = reader.leaves().get(0);


### PR DESCRIPTION
The test was force-merging after every document, instead of at the end
of indexing.  Moving the forceMerge() call takes this from ~17s to ~200ms
on my machine.