### PR TITLE
Fix testGraphMergeWithDeletes test case to have atleast one vector

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -212,7 +212,7 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     int M = 4;
     int beamWidth = 20;
     String vectorFieldName = "vec1";
-    int numVectors = random().nextInt(1000);
+    int numVectors = random().nextInt(1000) + 1;
     int deletionProbaility = random().nextInt(100);
     int dim = random().nextInt(64) + 1;
     if (dim % 2 == 1) {


### PR DESCRIPTION
### Description

Fixes #15485. The test was failing due to a zero-length array error. This occurred when certain random seed values resulted in numVectors being initialized to zero, causing the array instantiation to fail.