### PR TITLE
Support `@SuppressAssertingFormats`

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -193,6 +193,8 @@ New Features
  * GITHUB#15415: Add fallback support to Lucene104ScalarQuantizedVectorsFormat getFloatVectorValues when there are
    no full-precision vectors present (Pulkit Gupta)
 
+ * GITHUB#15468: Add support for `@SuppressAssertingFormats` annotation for fine-grained control over `AssertingCodec` formats (Prudhvi Godithi)
+
 Improvements
 ---------------------
 * GITHUB#15148: Add support uint8 distance and allow 8 bit scalar quantization (Trevor McCulloch)

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingCodec.java
@@ -16,6 +16,9 @@
  */
 package org.apache.lucene.tests.codecs.asserting;
 
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
@@ -32,6 +35,29 @@ import org.apache.lucene.tests.util.TestUtil;
 
 /** Acts like the default codec but with additional asserts. */
 public class AssertingCodec extends FilterCodec {
+
+  /** Enum representing asserting format types that can be suppressed. */
+  public enum Format {
+    STORED_FIELDS,
+    TERM_VECTORS,
+    NORMS,
+    LIVE_DOCS,
+    POINTS,
+    KNN_VECTORS
+  }
+
+  @SuppressWarnings("NonFinalStaticField")
+  private static volatile Set<Format> suppressedFormats = Collections.emptySet();
+
+  /** Set the formats to suppress. */
+  public static void setSuppressedFormats(Set<Format> formats) {
+    suppressedFormats =
+        formats == null || formats.isEmpty() ? Collections.emptySet() : EnumSet.copyOf(formats);
+  }
+
+  private static boolean isSuppressed(Format format) {
+    return suppressedFormats.contains(format);
+  }
 
   static void assertThread(String object, Thread creationThread) {
     if (creationThread != Thread.currentThread()) {
@@ -90,12 +116,12 @@ public class AssertingCodec extends FilterCodec {
 
   @Override
   public TermVectorsFormat termVectorsFormat() {
-    return vectors;
+    return isSuppressed(Format.TERM_VECTORS) ? delegate.termVectorsFormat() : vectors;
   }
 
   @Override
   public StoredFieldsFormat storedFieldsFormat() {
-    return storedFields;
+    return isSuppressed(Format.STORED_FIELDS) ? delegate.storedFieldsFormat() : storedFields;
   }
 
   @Override
@@ -105,22 +131,22 @@ public class AssertingCodec extends FilterCodec {
 
   @Override
   public NormsFormat normsFormat() {
-    return norms;
+    return isSuppressed(Format.NORMS) ? delegate.normsFormat() : norms;
   }
 
   @Override
   public LiveDocsFormat liveDocsFormat() {
-    return liveDocs;
+    return isSuppressed(Format.LIVE_DOCS) ? delegate.liveDocsFormat() : liveDocs;
   }
 
   @Override
   public PointsFormat pointsFormat() {
-    return pointsFormat;
+    return isSuppressed(Format.POINTS) ? delegate.pointsFormat() : pointsFormat;
   }
 
   @Override
   public KnnVectorsFormat knnVectorsFormat() {
-    return knnVectorsFormat;
+    return isSuppressed(Format.KNN_VECTORS) ? delegate.knnVectorsFormat() : knnVectorsFormat;
   }
 
   @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -171,6 +171,7 @@ import org.apache.lucene.store.MergeInfo;
 import org.apache.lucene.store.NRTCachingDirectory;
 import org.apache.lucene.store.ReadOnceHint;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.apache.lucene.tests.codecs.asserting.AssertingCodec;
 import org.apache.lucene.tests.index.AlcoholicMergePolicy;
 import org.apache.lucene.tests.index.AssertingDirectoryReader;
 import org.apache.lucene.tests.index.AssertingLeafReader;
@@ -363,6 +364,18 @@ public abstract class LuceneTestCase extends Assert {
   @Target(ElementType.TYPE)
   public @interface SuppressFileSystems {
     String[] value();
+  }
+
+  /**
+   * Annotation for test classes that should avoid specific asserting formats within the Asserting
+   * codec (e.g., AssertingStoredFieldsFormat) while keeping other asserting formats active.
+   */
+  @Documented
+  @Inherited
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.TYPE)
+  public @interface SuppressAssertingFormats {
+    AssertingCodec.Format[] value();
   }
 
   /**

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -367,8 +367,10 @@ public abstract class LuceneTestCase extends Assert {
   }
 
   /**
-   * Annotation for test classes that should avoid specific asserting formats within the Asserting
-   * codec (e.g., AssertingStoredFieldsFormat) while keeping other asserting formats active.
+   * Annotation for test classes that should avoid specific asserting formats within the {@link
+   * AssertingCodec} while keeping other asserting formats active.
+   *
+   * @see org.apache.lucene.tests.codecs.asserting.AssertingCodec.Format
    */
   @Documented
   @Inherited

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
@@ -31,6 +31,7 @@ import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Random;
@@ -51,6 +52,7 @@ import org.apache.lucene.tests.index.RandomCodec;
 import org.apache.lucene.tests.search.similarities.AssertingSimilarity;
 import org.apache.lucene.tests.search.similarities.RandomSimilarity;
 import org.apache.lucene.tests.util.LuceneTestCase.LiveIWCFlushMode;
+import org.apache.lucene.tests.util.LuceneTestCase.SuppressAssertingFormats;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.PrintStreamInfoStream;
@@ -75,6 +77,11 @@ final class TestRuleSetupAndRestoreClassEnv extends AbstractBeforeAfterRule {
    * @see SuppressCodecs
    */
   HashSet<String> avoidCodecs;
+
+  /**
+   * @see LuceneTestCase.SuppressAssertingFormats
+   */
+  EnumSet<AssertingCodec.Format> avoidAssertingFormats;
 
   static class ThreadNameFixingPrintStreamInfoStream extends PrintStreamInfoStream {
     public ThreadNameFixingPrintStreamInfoStream(PrintStream out) {
@@ -126,6 +133,13 @@ final class TestRuleSetupAndRestoreClassEnv extends AbstractBeforeAfterRule {
       SuppressCodecs a = targetClass.getAnnotation(SuppressCodecs.class);
       avoidCodecs.addAll(Arrays.asList(a.value()));
     }
+
+    avoidAssertingFormats = EnumSet.noneOf(AssertingCodec.Format.class);
+    if (targetClass.isAnnotationPresent(SuppressAssertingFormats.class)) {
+      SuppressAssertingFormats a = targetClass.getAnnotation(SuppressAssertingFormats.class);
+      avoidAssertingFormats.addAll(Arrays.asList(a.value()));
+    }
+    AssertingCodec.setSuppressedFormats(avoidAssertingFormats);
 
     savedCodec = Codec.getDefault();
     int randomVal = random.nextInt(11);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
@@ -52,7 +52,6 @@ import org.apache.lucene.tests.index.RandomCodec;
 import org.apache.lucene.tests.search.similarities.AssertingSimilarity;
 import org.apache.lucene.tests.search.similarities.RandomSimilarity;
 import org.apache.lucene.tests.util.LuceneTestCase.LiveIWCFlushMode;
-import org.apache.lucene.tests.util.LuceneTestCase.SuppressAssertingFormats;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.PrintStreamInfoStream;
@@ -134,13 +133,6 @@ final class TestRuleSetupAndRestoreClassEnv extends AbstractBeforeAfterRule {
       avoidCodecs.addAll(Arrays.asList(a.value()));
     }
 
-    avoidAssertingFormats = EnumSet.noneOf(AssertingCodec.Format.class);
-    if (targetClass.isAnnotationPresent(SuppressAssertingFormats.class)) {
-      SuppressAssertingFormats a = targetClass.getAnnotation(SuppressAssertingFormats.class);
-      avoidAssertingFormats.addAll(Arrays.asList(a.value()));
-    }
-    AssertingCodec.setSuppressedFormats(avoidAssertingFormats);
-
     savedCodec = Codec.getDefault();
     int randomVal = random.nextInt(11);
     if ("default".equals(TEST_CODEC)) {
@@ -180,7 +172,7 @@ final class TestRuleSetupAndRestoreClassEnv extends AbstractBeforeAfterRule {
 
             @Override
             public String toString() {
-              return super.toString() + ": " + format.toString() + ", " + dvFormat.toString();
+              return super.toString() + ": " + format + ", " + dvFormat;
             }
           };
     } else if ("SimpleText".equals(TEST_CODEC)

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
@@ -77,11 +77,6 @@ final class TestRuleSetupAndRestoreClassEnv extends AbstractBeforeAfterRule {
    */
   HashSet<String> avoidCodecs;
 
-  /**
-   * @see LuceneTestCase.SuppressAssertingFormats
-   */
-  EnumSet<AssertingCodec.Format> avoidAssertingFormats;
-
   static class ThreadNameFixingPrintStreamInfoStream extends PrintStreamInfoStream {
     public ThreadNameFixingPrintStreamInfoStream(PrintStream out) {
       super(out);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleSetupAndRestoreClassEnv.java
@@ -31,7 +31,6 @@ import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import java.io.PrintStream;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Random;


### PR DESCRIPTION
### Description

Similar to https://github.com/apache/lucene/pull/15468 with suggestion from comment https://github.com/apache/lucene/pull/15468#issuecomment-3631098680.

@dweiss Since the newer error prone already allows this (from https://github.com/apache/lucene/issues/15489) and seeing the existing codebase https://github.com/search?q=repo%3Aapache%2Flucene%20%40SuppressWarnings(%22NonFinalStaticField%22)&type=code its better to use `NonFinalStaticField`.
