### PR TITLE
Remove PriorityQueue.remove

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,6 +7,9 @@ http://s.apache.org/luceneversions
 
 API Changes
 ---------------------
+* GITHUB#15309: PriorityQueue.remove method has been removed entirely. If you need remove(), implement
+  it yourself in a subclass (heap access and size, upHeap and downHeap are protected members of PQ). (Dawid Weiss)
+
 * GITHUB#15215: Switch to Java 25 as the minimum required platform. Upgrade to gradle 9.1.0.
   (Robert Muir, Kaival Parikh, Dawid Weiss)
 

--- a/lucene/core/src/java/org/apache/lucene/util/PriorityQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/PriorityQueue.java
@@ -26,8 +26,7 @@ import java.util.function.Supplier;
 
 /**
  * A priority queue maintains a partial ordering of its elements such that the least element can
- * always be found in constant time. Put()'s and pop()'s require log(size) time but the remove()
- * cost implemented here is linear.
+ * always be found in constant time. Put()'s and pop()'s require log(size) time.
  *
  * <p><b>NOTE</b>: This class pre-allocates an array of length {@code maxSize+1} and pre-fills it
  * with elements if instantiated via the {@link #PriorityQueue(int,LessThan,Supplier)} constructor.
@@ -68,7 +67,7 @@ public class PriorityQueue<T> implements Iterable<T> {
         maxSize, (a, b) -> comparator.compare(a, b) < 0, sentinelObjectSupplier);
   }
 
-  private int size = 0;
+  protected int size = 0;
   private final int maxSize;
   private final T[] heap;
   private final LessThan<? super T> lessThan;
@@ -275,28 +274,6 @@ public class PriorityQueue<T> implements Iterable<T> {
   }
 
   /**
-   * Removes an existing element currently stored in the PriorityQueue. Cost is linear with the size
-   * of the queue. (A specialization of PriorityQueue which tracks element positions would provide a
-   * constant remove time but the trade-off would be extra cost to all additions/insertions)
-   */
-  public final boolean remove(T element) {
-    for (int i = 1; i <= size; i++) {
-      if (heap[i] == element) {
-        heap[i] = heap[size];
-        heap[size] = null; // permit GC of objects
-        size--;
-        if (i <= size) {
-          if (!upHeap(i)) {
-            downHeap(i);
-          }
-        }
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
    * Moves the contents of this queue into a new array created by {@code newArray}, lowest items
    * first
    */
@@ -320,7 +297,7 @@ public class PriorityQueue<T> implements Iterable<T> {
     return array;
   }
 
-  private boolean upHeap(int origPos) {
+  protected boolean upHeap(int origPos) {
     int i = origPos;
     T node = heap[i]; // save bottom node
     int j = i >>> 1;
@@ -333,7 +310,7 @@ public class PriorityQueue<T> implements Iterable<T> {
     return i != origPos;
   }
 
-  private void downHeap(int i) {
+  protected void downHeap(int i) {
     T node = heap[i]; // save top node
     int j = i << 1; // find smaller child
     int k = j + 1;

--- a/lucene/core/src/test/org/apache/lucene/util/TestPriorityQueue.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestPriorityQueue.java
@@ -208,9 +208,9 @@ public class TestPriorityQueue extends LuceneTestCase {
         () -> pq.addAll(list));
   }
 
-  /** Randomly add and remove elements, comparing against the reference java.util.PriorityQueue. */
-  public void testRemovalsAndInsertions() {
-    int maxElement = RandomNumbers.randomIntBetween(random(), 1, 10_000);
+  /** Randomly add some elements, comparing against the reference java.util.PriorityQueue. */
+  public void testRandomAdditionsAgainstJavaPq() {
+    int maxElement = RandomNumbers.randomIntBetween(random(), 1, 500);
     int size = maxElement / 2 + 1;
 
     var reference = new java.util.PriorityQueue<Integer>();
@@ -226,25 +226,18 @@ public class TestPriorityQueue extends LuceneTestCase {
     for (int i = 0, iters = size * 2; i < iters; i++) {
       Integer element = ints.computeIfAbsent(localRandom.nextInt(maxElement), k -> k);
 
-      var action = localRandom.nextInt(100);
-      if (action < 25) {
-        // removals, possibly misses.
-        assertEquals("remove() difference: " + i, reference.remove(element), pq.remove(element));
+      // additions.
+      var dropped = pq.insertWithOverflow(element);
+
+      reference.add(element);
+      Integer droppedReference;
+      if (reference.size() > size) {
+        droppedReference = reference.remove();
       } else {
-        // additions.
-        var dropped = pq.insertWithOverflow(element);
-
-        reference.add(element);
-        Integer droppedReference;
-        if (reference.size() > size) {
-          droppedReference = reference.remove();
-        } else {
-          droppedReference = null;
-        }
-
-        assertEquals("insertWithOverflow() difference.", dropped, droppedReference);
+        droppedReference = null;
       }
 
+      assertEquals("insertWithOverflow() difference.", dropped, droppedReference);
       assertEquals("insertWithOverflow() size difference?", reference.size(), pq.size());
       assertEquals("top() difference?", reference.peek(), pq.top());
     }


### PR DESCRIPTION
Fixes #15309. 

I've removed the public, linear, remove() method from PriorityQueue. I also made some methods protected which - in case somebody really wants to - can be used to implement the linear remove() in the way it was implemented before. This is actually also the workaround I used for DiversifiedTopDocsCollector. 

Non-linear remove(element) on a PriorityQueue is not an easy thing to do without somehow tracking positions on the heap, which would make everything slower. Let's keep the essentials that are fast instead.

This patch makes certain PQ members protected (size, upHeap, downHeap). I think it makes sense to do so because we already expose the heap buffer and allow subclassing. Seems like the above are necessary ingredients for implementing something reasonable in a subclass.