### PR TITLE
Fix test bug in TestTopDocsCollector and TestTopFieldCollector

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
@@ -321,7 +321,7 @@ public class TestTopDocsCollector extends LuceneTestCase {
     IndexWriter w =
         new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE));
     Document doc = new Document();
-    w.addDocuments(Arrays.asList(doc, doc, doc, doc));
+    w.addDocuments(Arrays.asList(doc, doc, doc, doc, doc));
     w.flush();
     w.addDocuments(Arrays.asList(doc, doc));
     w.flush();
@@ -432,7 +432,7 @@ public class TestTopDocsCollector extends LuceneTestCase {
       leafCollector.setScorer(scorer);
 
       scorer.score = 3;
-      leafCollector.collect(1);
+      leafCollector.collect(0);
 
       scorer.score = 4;
       leafCollector.collect(1);

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
@@ -222,13 +222,13 @@ public class TestTopFieldCollector extends LuceneTestCase {
 
         scorer.score = 3;
         if (totalHitsThreshold < 3) {
-          expectThrows(CollectionTerminatedException.class, () -> leafCollector2.collect(1));
+          expectThrows(CollectionTerminatedException.class, () -> leafCollector2.collect(0));
           TopDocs topDocs = collector.topDocs();
           assertEquals(
               new TotalHits(3, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO), topDocs.totalHits);
           continue;
         } else {
-          leafCollector2.collect(1);
+          leafCollector2.collect(0);
         }
 
         scorer.score = 4;
@@ -271,7 +271,7 @@ public class TestTopFieldCollector extends LuceneTestCase {
     IndexWriter w =
         new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE));
     Document doc = new Document();
-    w.addDocuments(Arrays.asList(doc, doc, doc, doc));
+    w.addDocuments(Arrays.asList(doc, doc, doc, doc, doc));
     w.flush();
     w.addDocuments(Arrays.asList(doc, doc));
     w.flush();


### PR DESCRIPTION
Fix the following bugs in TestTopDocsCollector and TestTopFieldCollector:
1. If `leafCollector.collect(4)`, the documents count in this segment should be greater than 4.
2. For a new leafCollector, the collected doc id should starts from 0 and then 1, and same doc id shouldn't be collected again.

The test result won't be changed, but this PR makes the test cases more clear.