### PR TITLE
Corrects the VectorScorer.Bulk interface to be iterator friendly

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -176,7 +176,7 @@ New Features
 * GITHUB#14565: Add ParentsChildrenBlockJoinQuery that supports parent and child filter in the same query
   along with limiting number of child documents to retrieve per parent. (Jinny Wang)
 
-* GITHUB#15171: Add `VectorScorer.Bulk` for bulk iteration and scoring of vectors. This new interface is now
+* GITHUB#15171, GITHUB#15496: Add `VectorScorer.Bulk` for bulk iteration and scoring of vectors. This new interface is now
   used in AbstractKnnVectorQuery to make exact matches faster. (Ben Trent)
 
 * GITHUB#15176: Add `[Float|Byte]VectorValues#rescorer(element[])` interface to allow optimized rescoring of vectors.

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -316,17 +316,16 @@ abstract class AbstractKnnVectorQuery extends Query {
     HitQueue queue = new HitQueue(queueSize, true);
     TotalHits.Relation relation = TotalHits.Relation.EQUAL_TO;
     ScoreDoc topDoc = queue.top();
-    DocIdSetIterator vectorIterator = vectorScorer.iterator();
     DocAndFloatFeatureBuffer buffer = new DocAndFloatFeatureBuffer();
     VectorScorer.Bulk bulkScorer = vectorScorer.bulk(acceptIterator);
-    while (vectorIterator.docID() != DocIdSetIterator.NO_MORE_DOCS) {
+    for (float maxScore = bulkScorer.nextDocsAndScores(DocIdSetIterator.NO_MORE_DOCS, null, buffer);
+        buffer.size > 0;
+        maxScore = bulkScorer.nextDocsAndScores(DocIdSetIterator.NO_MORE_DOCS, null, buffer)) {
       // Mark results as partial if timeout is met
       if (queryTimeout != null && queryTimeout.shouldExit()) {
         relation = TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
         break;
       }
-      // iterator already takes live docs into account
-      float maxScore = bulkScorer.nextDocsAndScores(64, null, buffer);
       if (maxScore < topDoc.score) {
         // all the scores in this batch are too low, skip
         continue;

--- a/lucene/core/src/java/org/apache/lucene/search/VectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/VectorScorer.java
@@ -83,7 +83,7 @@ public interface VectorScorer {
     @Override
     public float nextDocsAndScores(int upTo, Bits liveDocs, DocAndFloatFeatureBuffer buffer)
         throws IOException {
-      assert upTo > 0 && upTo <= DocIdSetIterator.NO_MORE_DOCS;
+      assert upTo > 0;
       buffer.growNoCopy(DEFAULT_BULK_BATCH_SIZE);
       int size = 0;
       float maxScore = Float.NEGATIVE_INFINITY;
@@ -130,7 +130,7 @@ public interface VectorScorer {
               ? iterator
               : ConjunctionUtils.createConjunction(List.of(matchingDocs, iterator), List.of());
       return (upTo, liveDocs, buffer) -> {
-        assert upTo > 0 && upTo <= DocIdSetIterator.NO_MORE_DOCS;
+        assert upTo > 0;
         if (matches.docID() == -1) {
           matches.nextDoc();
         }
@@ -162,7 +162,7 @@ public interface VectorScorer {
         @Override
         public float nextDocsAndScores(int upTo, Bits liveDocs, DocAndFloatFeatureBuffer buffer)
             throws IOException {
-          assert upTo > 0 && upTo <= DocIdSetIterator.NO_MORE_DOCS;
+          assert upTo > 0;
           if (matches.docID() == -1) {
             matches.nextDoc();
           }

--- a/lucene/core/src/java/org/apache/lucene/search/VectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/VectorScorer.java
@@ -30,6 +30,7 @@ import org.apache.lucene.util.hnsw.RandomVectorScorer;
  * @lucene.experimental
  */
 public interface VectorScorer {
+  int DEFAULT_BULK_BATCH_SIZE = 64;
 
   /**
    * Compute the score for the current document ID.
@@ -52,36 +53,53 @@ public interface VectorScorer {
    * Additionally, if the iterators are unpositioned (docID() == -1), this method should position
    * them to the first document.
    *
-   * @param matchingDocs the documents to score
+   * @param matchingDocs Optional filter to iterate over the documents to score
    * @return a {@link Bulk} scorer
    * @throws IOException if an exception occurs during bulk scorer creation
    * @lucene.experimental
    */
   default Bulk bulk(DocIdSetIterator matchingDocs) throws IOException {
-    final DocIdSetIterator iterator =
-        matchingDocs == null
-            ? iterator()
-            : ConjunctionUtils.createConjunction(List.of(matchingDocs, iterator()), List.of());
-    if (iterator.docID() == -1) {
-      iterator.nextDoc();
+    return new DefaultBulkScorer(matchingDocs, this);
+  }
+
+  class DefaultBulkScorer implements Bulk {
+    private final VectorScorer vectorScorer;
+    private final DocIdSetIterator iterator;
+
+    public DefaultBulkScorer(DocIdSetIterator matchingDocs, VectorScorer vectorScorer)
+        throws IOException {
+      final DocIdSetIterator iterator =
+          matchingDocs == null
+              ? vectorScorer.iterator()
+              : ConjunctionUtils.createConjunction(
+                  List.of(matchingDocs, vectorScorer.iterator()), List.of());
+      if (iterator.docID() == -1) {
+        iterator.nextDoc();
+      }
+      this.vectorScorer = vectorScorer;
+      this.iterator = iterator;
     }
-    return (nextCount, liveDocs, buffer) -> {
-      buffer.growNoCopy(nextCount);
+
+    @Override
+    public float nextDocsAndScores(int upTo, Bits liveDocs, DocAndFloatFeatureBuffer buffer)
+        throws IOException {
+      assert upTo > 0 && upTo <= DocIdSetIterator.NO_MORE_DOCS;
+      buffer.growNoCopy(DEFAULT_BULK_BATCH_SIZE);
       int size = 0;
       float maxScore = Float.NEGATIVE_INFINITY;
       for (int doc = iterator.docID();
-          doc != DocIdSetIterator.NO_MORE_DOCS && size < nextCount;
+          doc < upTo && size < DEFAULT_BULK_BATCH_SIZE;
           doc = iterator.nextDoc()) {
         if (liveDocs == null || liveDocs.get(doc)) {
           buffer.docs[size] = doc;
-          buffer.features[size] = score();
+          buffer.features[size] = vectorScorer.score();
           maxScore = Math.max(maxScore, buffer.features[size]);
           ++size;
         }
       }
       buffer.size = size;
       return maxScore;
-    };
+    }
   }
 
   /**
@@ -91,16 +109,16 @@ public interface VectorScorer {
    */
   interface Bulk {
     /**
-     * Score up to nextCount documents, store the results in the provided buffer. Behaves similarly
-     * to {@link Scorer#nextDocsAndScores(int, Bits, DocAndFloatFeatureBuffer)}
+     * Score docs ids iterating to upTo documents, store the results in the provided buffer. Behaves
+     * similarly to {@link Scorer#nextDocsAndScores(int, Bits, DocAndFloatFeatureBuffer)}
      *
-     * @param nextCount the maximum number of documents to score
+     * @param upTo the maximum doc ID to score
      * @param liveDocs the live docs, or null if all docs are live
      * @param buffer the buffer to store the results
      * @return the max score of the scored documents
      * @throws IOException if an exception occurs during scoring
      */
-    float nextDocsAndScores(int nextCount, Bits liveDocs, DocAndFloatFeatureBuffer buffer)
+    float nextDocsAndScores(int upTo, Bits liveDocs, DocAndFloatFeatureBuffer buffer)
         throws IOException;
 
     static Bulk fromRandomScorerDense(
@@ -111,14 +129,15 @@ public interface VectorScorer {
           matchingDocs == null
               ? iterator
               : ConjunctionUtils.createConjunction(List.of(matchingDocs, iterator), List.of());
-      return (nextCount, liveDocs, buffer) -> {
+      return (upTo, liveDocs, buffer) -> {
+        assert upTo > 0 && upTo <= DocIdSetIterator.NO_MORE_DOCS;
         if (matches.docID() == -1) {
           matches.nextDoc();
         }
-        buffer.growNoCopy(nextCount);
+        buffer.growNoCopy(DEFAULT_BULK_BATCH_SIZE);
         int size = 0;
         for (int doc = matches.docID();
-            doc != DocIdSetIterator.NO_MORE_DOCS && size < nextCount;
+            doc < upTo && size < DEFAULT_BULK_BATCH_SIZE;
             doc = matches.nextDoc()) {
           if (liveDocs == null || liveDocs.get(doc)) {
             buffer.docs[size++] = doc;
@@ -141,16 +160,17 @@ public interface VectorScorer {
         int[] docIds = new int[0];
 
         @Override
-        public float nextDocsAndScores(
-            int nextCount, Bits liveDocs, DocAndFloatFeatureBuffer buffer) throws IOException {
+        public float nextDocsAndScores(int upTo, Bits liveDocs, DocAndFloatFeatureBuffer buffer)
+            throws IOException {
+          assert upTo > 0 && upTo <= DocIdSetIterator.NO_MORE_DOCS;
           if (matches.docID() == -1) {
             matches.nextDoc();
           }
-          buffer.growNoCopy(nextCount);
-          docIds = ArrayUtil.growNoCopy(docIds, nextCount);
+          buffer.growNoCopy(DEFAULT_BULK_BATCH_SIZE);
+          docIds = ArrayUtil.growNoCopy(docIds, DEFAULT_BULK_BATCH_SIZE);
           int size = 0;
           for (int doc = matches.docID();
-              doc != DocIdSetIterator.NO_MORE_DOCS && size < nextCount;
+              doc < upTo && size < DEFAULT_BULK_BATCH_SIZE;
               doc = matches.nextDoc()) {
             if (liveDocs == null || liveDocs.get(doc)) {
               buffer.docs[size] = iterator.index();


### PR DESCRIPTION
Back when I originally added the `VectorScorer.Bulk` interface, I was just sort of assuming it would only ever be used with some pre-filter applied iterator. 

However, this doesn't make sense when being like a `BulkScorer` (see `BatchScoreBulkScorer` as a nice example).

Consequently, I am adjusting the iteration to instead have the interface of `int upTo` as the "up to this next doc" to score instead of the original "count" score, which effectively assumes you always provide some "pre-filter" iterator in the construction of the object.

This still allows for a "pre-filter" type of iteration (which means, the user constructs the iterator and provides and scores everything). This is still useful for RandomVectorScorer things as we can bulk score many ordinals at once that aren't directly next to each other and get nice speed improvements.