### PR TITLE
ExitableDirectoryReader should not cover-up singletons

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -256,6 +256,8 @@ Optimizations
 * GITHUB#15474: Use bulk scoring provided by RandomVectorScorers for new scalar quantized formats provided through
     Lucene104ScalarQuantizedVectorsFormat and Lucene104HnswScalarQuantizedVectorsFormat (Ben Trent)
 
+* GITHUB#15498: ExitableDirectoryReader keeps singleton SortedSetDocValues or SortedNumericDocValues as singletons. (Houston Putman)
+
 Bug Fixes
 ---------------------
 * GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -109,7 +109,10 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
 
     @Override
     public NumericDocValues getNumericDocValues(String field) throws IOException {
-      final NumericDocValues numericDocValues = super.getNumericDocValues(field);
+      return wrapNumericDocValues(super.getNumericDocValues(field));
+    }
+
+    private NumericDocValues wrapNumericDocValues(final NumericDocValues numericDocValues) {
       if (numericDocValues == null) {
         return null;
       }
@@ -191,7 +194,10 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
 
     @Override
     public SortedDocValues getSortedDocValues(String field) throws IOException {
-      final SortedDocValues sortedDocValues = super.getSortedDocValues(field);
+      return wrapSortedDocValues(super.getSortedDocValues(field));
+    }
+
+    private SortedDocValues wrapSortedDocValues(final SortedDocValues sortedDocValues) {
       if (sortedDocValues == null) {
         return null;
       }
@@ -234,6 +240,10 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     @Override
     public SortedNumericDocValues getSortedNumericDocValues(String field) throws IOException {
       final SortedNumericDocValues sortedNumericDocValues = super.getSortedNumericDocValues(field);
+      final NumericDocValues numericDocValues = DocValues.unwrapSingleton(sortedNumericDocValues);
+      if (numericDocValues != null) {
+        return DocValues.singleton(wrapNumericDocValues(numericDocValues));
+      }
       if (sortedNumericDocValues == null) {
         return null;
       }
@@ -278,6 +288,10 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
       final SortedSetDocValues sortedSetDocValues = super.getSortedSetDocValues(field);
       if (sortedSetDocValues == null) {
         return null;
+      }
+      final SortedDocValues sortedDocValues = DocValues.unwrapSingleton(sortedSetDocValues);
+      if (sortedDocValues != null) {
+        return DocValues.singleton(wrapSortedDocValues(sortedDocValues));
       }
       return new FilterSortedSetDocValues(sortedSetDocValues) {
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
@@ -45,6 +45,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOFunction;
 import org.apache.lucene.util.SuppressForbidden;
 import org.apache.lucene.util.TestVectorUtil;
+import org.hamcrest.Matchers;
 
 /**
  * Test that uses a default/lucene Implementation of {@link QueryTimeout} to exit out long running
@@ -338,71 +339,88 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
   }
 
   public void testDocValues() throws IOException {
-    Directory directory = newDirectory();
-    IndexWriter writer =
-        new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+    try (Directory directory = newDirectory()) {
+      IndexWriter writer =
+          new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
 
-    Document d1 = new Document();
-    addDVs(d1, 10);
-    writer.addDocument(d1);
+      Document d1 = new Document();
+      addDVs(d1, 10);
+      writer.addDocument(d1);
 
-    Document d2 = new Document();
-    addDVs(d2, 100);
-    writer.addDocument(d2);
+      Document d2 = new Document();
+      addDVs(d2, 100);
+      writer.addDocument(d2);
 
-    Document d3 = new Document();
-    addDVs(d3, 1000);
-    writer.addDocument(d3);
+      Document d3 = new Document();
+      addDVs(d3, 1000);
+      writer.addDocument(d3);
 
-    writer.forceMerge(1);
-    writer.commit();
-    writer.close();
+      writer.forceMerge(1);
+      writer.commit();
+      writer.close();
 
-    DirectoryReader directoryReader;
-    DirectoryReader exitableDirectoryReader;
+      DirectoryReader directoryReader;
+      DirectoryReader exitableDirectoryReader;
 
-    for (IOFunction<LeafReader, DocValuesIterator> dvFactory :
-        Arrays.<IOFunction<LeafReader, DocValuesIterator>>asList(
-            (r) -> r.getSortedDocValues("sorted"),
-            (r) -> r.getSortedSetDocValues("sortedset"),
-            (r) -> r.getSortedNumericDocValues("sortednumeric"),
-            (r) -> r.getNumericDocValues("numeric"),
-            (r) -> r.getBinaryDocValues("binary"))) {
-      directoryReader = DirectoryReader.open(directory);
-      exitableDirectoryReader =
-          new ExitableDirectoryReader(directoryReader, immediateQueryTimeout());
+      for (IOFunction<LeafReader, DocValuesIterator> dvFactory :
+          Arrays.<IOFunction<LeafReader, DocValuesIterator>>asList(
+              (r) -> r.getSortedDocValues("sorted"),
+              (r) -> r.getSortedSetDocValues("sortedset"),
+              (r) -> r.getSortedNumericDocValues("sortednumeric"),
+              (r) -> r.getNumericDocValues("numeric"),
+              (r) -> r.getBinaryDocValues("binary"))) {
+        directoryReader = DirectoryReader.open(directory);
+        exitableDirectoryReader =
+            new ExitableDirectoryReader(directoryReader, immediateQueryTimeout());
 
-      {
-        IndexReader reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
+        try (IndexReader reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader))) {
+          expectThrows(
+              ExitingReaderException.class,
+              () -> {
+                LeafReader leaf = reader.leaves().get(0).reader();
+                DocValuesIterator iter = dvFactory.apply(leaf);
+                scan(leaf, iter);
+              });
+        }
 
-        expectThrows(
-            ExitingReaderException.class,
-            () -> {
-              LeafReader leaf = reader.leaves().get(0).reader();
-              DocValuesIterator iter = dvFactory.apply(leaf);
-              scan(leaf, iter);
-            });
-        reader.close();
+        directoryReader = DirectoryReader.open(directory);
+        exitableDirectoryReader =
+            new ExitableDirectoryReader(directoryReader, infiniteQueryTimeout());
+        try (IndexReader reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader))) {
+          final LeafReader leaf = reader.leaves().get(0).reader();
+          scan(leaf, dvFactory.apply(leaf));
+          assertNull(leaf.getNumericDocValues("absent"));
+          assertNull(leaf.getBinaryDocValues("absent"));
+          assertNull(leaf.getSortedDocValues("absent"));
+          assertNull(leaf.getSortedNumericDocValues("absent"));
+          assertNull(leaf.getSortedSetDocValues("absent"));
+        }
       }
 
+      // Test that singleton docValues stay as singleton docValues after filtering
       directoryReader = DirectoryReader.open(directory);
+      try (IndexReader reader = new TestReader(getOnlyLeafReader(directoryReader))) {
+        LeafReader leafReader = reader.leaves().getFirst().reader();
+        assertThat(
+            leafReader.getSortedSetDocValues("sortedset"),
+            Matchers.instanceOf(SingletonSortedSetDocValues.class));
+        assertThat(
+            leafReader.getSortedNumericDocValues("sortednumeric"),
+            Matchers.instanceOf(SingletonSortedNumericDocValues.class));
+      }
       exitableDirectoryReader =
-          new ExitableDirectoryReader(directoryReader, infiniteQueryTimeout());
-      {
-        IndexReader reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
-        final LeafReader leaf = reader.leaves().get(0).reader();
-        scan(leaf, dvFactory.apply(leaf));
-        assertNull(leaf.getNumericDocValues("absent"));
-        assertNull(leaf.getBinaryDocValues("absent"));
-        assertNull(leaf.getSortedDocValues("absent"));
-        assertNull(leaf.getSortedNumericDocValues("absent"));
-        assertNull(leaf.getSortedSetDocValues("absent"));
-
-        reader.close();
+          new ExitableDirectoryReader(DirectoryReader.open(directory), infiniteQueryTimeout());
+      try (IndexReader extitableReader =
+          new TestReader(getOnlyLeafReader(exitableDirectoryReader))) {
+        LeafReader exitableLeafReader = extitableReader.leaves().getFirst().reader();
+        assertThat(
+            exitableLeafReader.getSortedSetDocValues("sortedset"),
+            Matchers.instanceOf(SingletonSortedSetDocValues.class));
+        assertThat(
+            exitableLeafReader.getSortedNumericDocValues("sortednumeric"),
+            Matchers.instanceOf(SingletonSortedNumericDocValues.class));
       }
     }
-
-    directory.close();
   }
 
   public void testFloatVectorValues() throws IOException {


### PR DESCRIPTION
### Description

Currently using the `ExitableDirectoryReader` will render some optimizations for Singleton Numeric/SortedDocValues useless since it covers up whether the returned `SortedSetDocValues` or `SortedNumericDocValues` are singletons.

The fix is to check if they are singletons, and if so then filter the unwrapped singleton and then re-wrap it.
