### PR TITLE
Use vector bulk scoring in entry-point and filter hnsw search

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -256,6 +256,9 @@ Optimizations
 * GITHUB#15474: Use bulk scoring provided by RandomVectorScorers for new scalar quantized formats provided through
     Lucene104ScalarQuantizedVectorsFormat and Lucene104HnswScalarQuantizedVectorsFormat (Ben Trent)
 
+* GITHUB#15500: Use bulk scoring for filtered HNSW search and for entry-point scoring in the graph. This should
+  provide speed improvements when using vector scorers that satisfy the bulk scoring interface. (Ben Trent)
+
 Bug Fixes
 ---------------------
 * GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/AbstractHnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/AbstractHnswGraphSearcher.java
@@ -94,25 +94,15 @@ abstract class AbstractHnswGraphSearcher {
       throws IOException {
     assert eps != null && eps.length > 0;
     assert scores != null && scores.length >= eps.length;
-    if (eps.length == 1) {
-      visited.set(eps[0]);
-      float score = scorer.score(eps[0]);
-      results.incVisitedCount(1);
-      candidates.add(eps[0], score);
-      if (acceptOrds == null || acceptOrds.get(eps[0])) {
-        results.collect(eps[0], score);
-      }
-    } else {
-      scorer.bulkScore(eps, scores, eps.length);
-      results.incVisitedCount(eps.length);
-      for (int i = 0; i < eps.length; i++) {
-        float score = scores[i];
-        int ep = eps[i];
-        visited.set(ep);
-        candidates.add(ep, score);
-        if (acceptOrds == null || acceptOrds.get(ep)) {
-          results.collect(ep, score);
-        }
+    scorer.bulkScore(eps, scores, eps.length);
+    results.incVisitedCount(eps.length);
+    for (int i = 0; i < eps.length; i++) {
+      float score = scores[i];
+      int ep = eps[i];
+      visited.set(ep);
+      candidates.add(ep, score);
+      if (acceptOrds == null || acceptOrds.get(ep)) {
+        results.collect(ep, score);
       }
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/AbstractHnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/AbstractHnswGraphSearcher.java
@@ -18,6 +18,7 @@ package org.apache.lucene.util.hnsw;
 
 import java.io.IOException;
 import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.Bits;
 
 /**
@@ -80,5 +81,39 @@ abstract class AbstractHnswGraphSearcher {
       return;
     }
     searchLevel(results, scorer, 0, eps, graph, acceptOrds);
+  }
+
+  protected static void scoreEntryPoints(
+      KnnCollector results,
+      RandomVectorScorer scorer,
+      BitSet visited,
+      int[] eps,
+      Bits acceptOrds,
+      NeighborQueue candidates,
+      float[] scores)
+      throws IOException {
+    assert eps != null && eps.length > 0;
+    assert scores != null && scores.length >= eps.length;
+    if (eps.length == 1) {
+      visited.set(eps[0]);
+      float score = scorer.score(eps[0]);
+      results.incVisitedCount(1);
+      candidates.add(eps[0], score);
+      if (acceptOrds == null || acceptOrds.get(eps[0])) {
+        results.collect(eps[0], score);
+      }
+    } else {
+      scorer.bulkScore(eps, scores, eps.length);
+      results.incVisitedCount(eps.length);
+      for (int i = 0; i < eps.length; i++) {
+        float score = scores[i];
+        int ep = eps[i];
+        visited.set(ep);
+        candidates.add(ep, score);
+        if (acceptOrds == null || acceptOrds.get(ep)) {
+          results.collect(ep, score);
+        }
+      }
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/FilteredHnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/FilteredHnswGraphSearcher.java
@@ -122,6 +122,9 @@ public class FilteredHnswGraphSearcher extends HnswGraphSearcher {
       return;
     }
     scoreEntryPoints(results, scorer, visited, eps, acceptOrds, candidates, bulkScores);
+    if (results.earlyTerminated()) {
+      return;
+    }
     // Collect the vectors to score and potentially add as candidates
     IntArrayQueue toScore = new IntArrayQueue(graph.maxConn() * 2 * maxExplorationMultiplier);
     IntArrayQueue toExplore = new IntArrayQueue(graph.maxConn() * 2 * maxExplorationMultiplier);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -288,25 +288,13 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
     int size = getGraphSize(graph);
 
     prepareScratchState(size, graph.maxConn() * 2);
-
-    if (bulkNodes == null || bulkNodes.length < graph.maxConn() * 2) {
-      bulkNodes = new int[graph.maxConn() * 2];
-      bulkScores = new float[graph.maxConn() * 2];
+    if (bulkScores == null || bulkScores.length < eps.length) {
+      bulkScores = new float[eps.length];
     }
-
-    for (int ep : eps) {
-      if (visited.getAndSet(ep) == false) {
-        if (results.earlyTerminated()) {
-          break;
-        }
-        float score = scorer.score(ep);
-        results.incVisitedCount(1);
-        candidates.add(ep, score);
-        if (acceptOrds == null || acceptOrds.get(ep)) {
-          results.collect(ep, score);
-        }
-      }
+    if (results.earlyTerminated()) {
+      return;
     }
+    scoreEntryPoints(results, scorer, visited, eps, acceptOrds, candidates, bulkScores);
 
     // A bound that holds the minimum similarity to the query vector that a candidate vector must
     // have to be considered.

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -226,7 +226,7 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
       return new int[] {currentEp};
     }
     int size = getGraphSize(graph);
-    prepareScratchState(size);
+    prepareScratchState(size, graph.maxConn() * 2);
     float currentScore = scorer.score(currentEp);
     collector.incVisitedCount(1);
     boolean foundBetter;
@@ -238,6 +238,7 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
         foundBetter = false;
         graphSeek(graph, level, currentEp);
         int friendOrd;
+        int numNodes = 0;
         while ((friendOrd = graphNextNeighbor(graph)) != NO_MORE_DOCS) {
           assert friendOrd < size : "friendOrd=" + friendOrd + "; size=" + size;
           if (visited.getAndSet(friendOrd)) {
@@ -246,12 +247,21 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
           if (collector.earlyTerminated()) {
             return new int[] {UNK_EP};
           }
-          float friendSimilarity = scorer.score(friendOrd);
-          collector.incVisitedCount(1);
-          if (friendSimilarity > currentScore) {
-            currentScore = friendSimilarity;
-            currentEp = friendOrd;
-            foundBetter = true;
+          bulkNodes[numNodes++] = friendOrd;
+        }
+        float maxScore =
+            numNodes > 0
+                ? scorer.bulkScore(bulkNodes, bulkScores, numNodes)
+                : Float.NEGATIVE_INFINITY;
+        collector.incVisitedCount(numNodes);
+        if (maxScore > currentScore) {
+          for (int i = 0; i < numNodes; i++) {
+            float score = bulkScores[i];
+            if (score > currentScore) {
+              currentScore = score;
+              currentEp = bulkNodes[i];
+              foundBetter = true;
+            }
           }
         }
       }
@@ -277,7 +287,7 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
 
     int size = getGraphSize(graph);
 
-    prepareScratchState(size);
+    prepareScratchState(size, graph.maxConn() * 2);
 
     if (bulkNodes == null || bulkNodes.length < graph.maxConn() * 2) {
       bulkNodes = new int[graph.maxConn() * 2];
@@ -335,7 +345,7 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
         bulkNodes[numNodes++] = friendOrd;
       }
 
-      numNodes = (int) Math.min((long) numNodes, results.visitLimit() - results.visitedCount());
+      numNodes = (int) Math.min(numNodes, results.visitLimit() - results.visitedCount());
       results.incVisitedCount(numNodes);
       if (numNodes > 0
           && scorer.bulkScore(bulkNodes, bulkScores, numNodes)
@@ -365,12 +375,16 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
     }
   }
 
-  private void prepareScratchState(int capacity) {
+  private void prepareScratchState(int capacity, int bulkScoreSize) {
     candidates.clear();
     if (visited.length() < capacity) {
       visited = FixedBitSet.ensureCapacity((FixedBitSet) visited, capacity);
     }
     visited.clear();
+    if (bulkNodes == null || bulkNodes.length < bulkScoreSize) {
+      bulkNodes = new int[bulkScoreSize];
+      bulkScores = new float[bulkScoreSize];
+    }
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -295,6 +295,9 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
       return;
     }
     scoreEntryPoints(results, scorer, visited, eps, acceptOrds, candidates, bulkScores);
+    if (results.earlyTerminated()) {
+      return;
+    }
 
     // A bound that holds the minimum similarity to the query vector that a candidate vector must
     // have to be considered.

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -1503,10 +1503,13 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
                       visitedLimit);
           assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, results.totalHits.relation());
           int size = Lucene99HnswVectorsReader.EXHAUSTIVE_BULK_SCORE_ORDS;
+          // visit limit is a "best effort" limit given our bulk scoring logic; assert that we are
+          // within
+          // reasonable bounds
           assertTrue(
-              visitedLimit == results.totalHits.value()
-                  || ((visitedLimit + size - 1) / size) * ((long) size)
-                      == results.totalHits.value());
+              results.totalHits.value() == visitedLimit
+                  || results.totalHits.value()
+                      <= ((visitedLimit + size - 1) / size) * ((long) size));
 
           // check the limit is not hit when it clearly exceeds the number of vectors
           k = vectorValues.size();


### PR DESCRIPTION
We currently use the bulk scoring interface on the lowest HNSW level, but there isn't any technical reason why we cannot use bulk scoring on higher levels to find the entry point. For highly connected graphs with many levels, this could provide a small speed improvement.

Additionally, I noticed that we were not doing bulk scoring when using the Filtered hnsw searcher. Again, we should be using bulk scoring even when using the filter optimized HNSW scorer.