### PR TITLE
Dynamic pruning for SORTED(_SET) fields with doc values skipper

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -270,6 +270,8 @@ Optimizations
 
 * GITHUB#15498: ExitableDirectoryReader keeps singleton SortedSetDocValues or SortedNumericDocValues as singletons. (Houston Putman)
 
+* GITHUB#15511: Dynamic pruning for SORTED(_SET) fields with doc values skipper (Pan Guixin)
+
 Bug Fixes
 ---------------------
 * GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException

--- a/lucene/core/src/java/org/apache/lucene/search/DocValuesRangeIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocValuesRangeIterator.java
@@ -197,8 +197,7 @@ public final class DocValuesRangeIterator extends TwoPhaseIterator {
   @Override
   public final boolean matches() throws IOException {
     return switch (approximation.match) {
-      case YES -> true;
-      case IF_DOC_HAS_VALUE -> true;
+      case YES, IF_DOC_HAS_VALUE -> true;
       case MAYBE -> innerTwoPhase.matches();
       case NO -> throw new IllegalStateException("Unpositioned approximation");
     };


### PR DESCRIPTION
### Description
Similar to #14672, this commit takes advantage of doc values skipper to do the dynamic pruning for SORTED(_SET) fields.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
