### PR TITLE
Refactor DocValuesSkipper stat methods to accept IndexReader instead of IndexSearcher

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -177,6 +177,8 @@ API Changes
 
 * GITHUB#15501: Introduce optional access to backing vector values from the scorer  (Chris Hegarty)
 
+* GITHUB#15514: Refactor DocValuesSkipper stat methods to accept IndexReader instead of IndexSearcher (Pan Guixin)
+
 New Features
 ---------------------
 * GITHUB#15328: VectorSimilarityFunction.getValues() now implements doubleVal allowing its

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -93,14 +93,14 @@ final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery 
     if (lowerValue > upperValue) {
       return MatchNoDocsQuery.INSTANCE;
     }
-    long globalMin = DocValuesSkipper.globalMinValue(indexSearcher, field);
-    long globalMax = DocValuesSkipper.globalMaxValue(indexSearcher, field);
+    long globalMin = DocValuesSkipper.globalMinValue(indexSearcher.getIndexReader(), field);
+    long globalMax = DocValuesSkipper.globalMaxValue(indexSearcher.getIndexReader(), field);
     if (lowerValue > globalMax || upperValue < globalMin) {
       return MatchNoDocsQuery.INSTANCE;
     }
     if (lowerValue <= globalMin
         && upperValue >= globalMax
-        && DocValuesSkipper.globalDocCount(indexSearcher, field)
+        && DocValuesSkipper.globalDocCount(indexSearcher.getIndexReader(), field)
             == indexSearcher.getIndexReader().maxDoc()) {
       return MatchAllDocsQuery.INSTANCE;
     }

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
@@ -127,7 +127,7 @@ public abstract class DocValuesSkipper {
    * Returns the minimum value for a field across all segments, or {@link Long#MIN_VALUE} if not
    * available
    *
-   * @param reader the index reader to be stated
+   * @param reader the index reader to be queried
    * @param field the field to retrieve values for
    */
   public static long globalMinValue(IndexReader reader, String field) throws IOException {
@@ -151,7 +151,7 @@ public abstract class DocValuesSkipper {
    * Returns the maximum value for a field across all segments, or {@link Long#MIN_VALUE} if not
    * available
    *
-   * @param reader the index reader to be stated
+   * @param reader the index reader to be queried
    * @param field the field to retrieve values for
    */
   public static long globalMaxValue(IndexReader reader, String field) throws IOException {
@@ -174,7 +174,7 @@ public abstract class DocValuesSkipper {
   /**
    * Returns the total skipper document count for a field across all segments
    *
-   * @param reader the index reader to be stated
+   * @param reader the index reader to be queried
    * @param field the field to retrieve values for
    */
   public static int globalDocCount(IndexReader reader, String field) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
@@ -18,7 +18,6 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.IndexSearcher;
 
 /**
  * Skipper for {@link DocValues}.
@@ -128,12 +127,12 @@ public abstract class DocValuesSkipper {
    * Returns the minimum value for a field across all segments, or {@link Long#MIN_VALUE} if not
    * available
    *
-   * @param searcher a searcher over the index
+   * @param reader the index reader to be stated
    * @param field the field to retrieve values for
    */
-  public static long globalMinValue(IndexSearcher searcher, String field) throws IOException {
+  public static long globalMinValue(IndexReader reader, String field) throws IOException {
     long minValue = Long.MAX_VALUE;
-    for (LeafReaderContext ctx : searcher.getLeafContexts()) {
+    for (LeafReaderContext ctx : reader.leaves()) {
       if (ctx.reader().getFieldInfos().fieldInfo(field) == null) {
         continue; // no field values in this segment, so we can ignore it
       }
@@ -152,12 +151,12 @@ public abstract class DocValuesSkipper {
    * Returns the maximum value for a field across all segments, or {@link Long#MIN_VALUE} if not
    * available
    *
-   * @param searcher a searcher over the index
+   * @param reader the index reader to be stated
    * @param field the field to retrieve values for
    */
-  public static long globalMaxValue(IndexSearcher searcher, String field) throws IOException {
+  public static long globalMaxValue(IndexReader reader, String field) throws IOException {
     long maxValue = Long.MIN_VALUE;
-    for (LeafReaderContext ctx : searcher.getLeafContexts()) {
+    for (LeafReaderContext ctx : reader.leaves()) {
       if (ctx.reader().getFieldInfos().fieldInfo(field) == null) {
         continue; // no field values in this segment, so we can ignore it
       }
@@ -175,12 +174,12 @@ public abstract class DocValuesSkipper {
   /**
    * Returns the total skipper document count for a field across all segments
    *
-   * @param searcher a searcher over the index
+   * @param reader the index reader to be stated
    * @param field the field to retrieve values for
    */
-  public static int globalDocCount(IndexSearcher searcher, String field) throws IOException {
+  public static int globalDocCount(IndexReader reader, String field) throws IOException {
     int docCount = 0;
-    for (LeafReaderContext ctx : searcher.getLeafContexts()) {
+    for (LeafReaderContext ctx : reader.leaves()) {
       DocValuesSkipper skipper = ctx.reader().getDocValuesSkipper(field);
       if (skipper != null) {
         docCount += skipper.docCount();


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
Resolves https://github.com/apache/lucene/pull/15083#discussion_r2635111352