### PR TITLE
Updating createMultiSegmentIndex to utilize an explicit NoMergePolicy

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -299,6 +299,8 @@ Bug Fixes
 
 * GITHUB#15478: Fix duplicate neighbor issue by checking node existence before making reverse link. (Pulkit Gupta)
 
+* GITHUB#15523: Updating createMultiSegmentIndex to utilize an explicit NoMergePolicy (Bryce Kane)
+
 Other
 ---------------------
 * GITHUB#15237: Fix SmartChinese to only deserialize dictionary data from classpath with a native array

--- a/lucene/core/src/test/org/apache/lucene/index/TestDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDirectoryReader.java
@@ -1423,7 +1423,10 @@ public class TestDirectoryReader extends LuceneTestCase {
   }
 
   private void createMultiSegmentIndex(Directory dir, int numSegments) throws IOException {
-    IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig().setMaxBufferedDocs(2));
+    IndexWriter writer =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig().setMaxBufferedDocs(2).setMergePolicy(NoMergePolicy.INSTANCE));
     for (int i = 0; i < numSegments; i++) {
       Document doc = new Document();
       doc.add(newStringField("id", String.valueOf(i), Field.Store.YES));


### PR DESCRIPTION
### Description
This allows the createMultiSegmentIndex test helper function to properly ensure that merges are not combining segments during unit test execution. 

Fixes #15466 
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
