### PR TITLE
Add explicit action folders to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directories: 
+      - "/"
+      - ".github/actions/eclint"
+      - ".github/actions/prepare-for-build"
     open-pull-requests-limit: 25
     schedule:
       interval: monthly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directories: 
+    directories:
       - "/"
       - ".github/actions/eclint"
       - ".github/actions/prepare-for-build"


### PR DESCRIPTION
By default, dependabot doesn't scan the repository's own `.github/actions/*`. This adds them explicitly so that they're scanned for updates.