### PR TITLE
Allow AlreadyClosedException to be a possible outcome of injecting fake exceptions in TestIndexFileDeleter

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexFileDeleter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexFileDeleter.java
@@ -481,13 +481,12 @@ public class TestIndexFileDeleter extends LuceneTestCase {
         }
       } catch (Throwable t) {
         if (t.toString().contains("fake fail")
-            || (t.getCause() != null && t.getCause().toString().contains("fake fail"))) {
-          // ok.
-        } else if (t instanceof AlreadyClosedException) {
-          // This is also ok. This can happen if the injected exception (RuntimeException("fake
-          // fail")) happened
-          // inside the concurrent merges and this closed the index writer's reader pool.
-          throw t;
+            || (t.getCause() != null && t.getCause().toString().contains("fake fail"))
+            || t instanceof AlreadyClosedException) {
+          // All these conditions are fine.
+          // AlreadyClosedException can happen if the injected exception (RuntimeException("fake
+          // fail")) happened inside the concurrent merges and this closed the index writer's
+          // reader pool.
         } else {
           throw t;
         }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexFileDeleter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexFileDeleter.java
@@ -30,6 +30,7 @@ import org.apache.lucene.codecs.simpletext.SimpleTextCodec;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexWriterConfig.OpenMode;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
@@ -40,11 +41,6 @@ import org.apache.lucene.tests.store.MockDirectoryWrapper;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.InfoStream;
-
-/*
-  Verify we can read the pre-2.1 file format, do searches
-  against it, and add documents to it.
-*/
 
 public class TestIndexFileDeleter extends LuceneTestCase {
 
@@ -440,7 +436,6 @@ public class TestIndexFileDeleter extends LuceneTestCase {
         });
 
     IndexWriterConfig iwc = newIndexWriterConfig(new MockAnalyzer(random()));
-    // iwc.setMergeScheduler(new SerialMergeScheduler());
     MergeScheduler ms = iwc.getMergeScheduler();
     if (ms instanceof ConcurrentMergeScheduler) {
       final ConcurrentMergeScheduler suppressFakeFail =
@@ -487,7 +482,12 @@ public class TestIndexFileDeleter extends LuceneTestCase {
       } catch (Throwable t) {
         if (t.toString().contains("fake fail")
             || (t.getCause() != null && t.getCause().toString().contains("fake fail"))) {
-          // ok
+          // ok.
+        } else if (t instanceof AlreadyClosedException) {
+          // This is also ok. This can happen if the injected exception (RuntimeException("fake
+          // fail")) happened
+          // inside the concurrent merges and this closed the index writer's reader pool.
+          throw t;
         } else {
           throw t;
         }


### PR DESCRIPTION
We get occasional exceptions in tests like this one:
https://jenkins.thetaphi.de/job/Lucene-nightly-main-Linux/1070/console

```
org.apache.lucene.index.TestIndexFileDeleter > test suite's output saved to /home/jenkins/workspace/Lucene-nightly-main-Linux/lucene/core/build/test-results/test/outputs/OUTPUT-org.apache.lucene.index.TestIndexFileDeleter.txt, copied below:
   >     org.apache.lucene.store.AlreadyClosedException: ReaderPool is already closed
   >         at __randomizedtesting.SeedInfo.seed([807AD80E9847078:E19ADAB29F4D9785]:0)
   >         at app//org.apache.lucene.index.ReaderPool.get(ReaderPool.java:397)
   >         at app//org.apache.lucene.index.IndexWriter.writeReaderPool(IndexWriter.java:4000)
   >         at app//org.apache.lucene.index.IndexWriter.getReader(IndexWriter.java:607)
   >         at app//org.apache.lucene.index.IndexWriter$4.getReader(IndexWriter.java:6588)
   >         at app//org.apache.lucene.tests.index.RandomIndexWriter.getReader(RandomIndexWriter.java:502)
   >         at app//org.apache.lucene.tests.index.RandomIndexWriter.getReader(RandomIndexWriter.java:428)
   >         at app//org.apache.lucene.index.TestIndexFileDeleter.testExcInDecRef(TestIndexFileDeleter.java:481)
```

I (as well as claude...) think it is possible that the injected runtime exception may happen inside the concurrent merge scheduler's merge thread, causing the IW and the reader pool to be shut down. Then the test thread gets AlreadyClosedException on w.getReader(). 

I think allowing AlreadyClosedException is fine here.