### PR TITLE
Use Google's maven central mirror on github runners

### DIFF
--- a/build-tools/build-infra-shadow/build.gradle
+++ b/build-tools/build-infra-shadow/build.gradle
@@ -22,14 +22,7 @@ plugins {
   id "java-gradle-plugin"
 }
 
-repositories {
-  mavenCentral()
-  maven {
-    url "https://maven-central.storage-download.googleapis.com/maven2/"
-  }
-  gradlePluginPortal()
-}
-
+apply from: rootProject.file("build-tools/build-infra/declare-repositories.gradle")
 apply from: rootProject.file("build-tools/build-infra/ecj-source.gradle")
 apply from: rootProject.file("build-tools/build-infra/declare-dependencies.gradle")
 

--- a/build-tools/build-infra/build.gradle
+++ b/build-tools/build-infra/build.gradle
@@ -20,14 +20,7 @@ plugins {
   alias(deps.plugins.forbiddenapis) apply false
 }
 
-repositories {
-  mavenCentral()
-  maven {
-    url "https://maven-central.storage-download.googleapis.com/maven2/"
-  }
-  gradlePluginPortal()
-}
-
+apply from: file("declare-repositories.gradle")
 apply from: file("ecj-source.gradle")
 
 group = "org.apache"

--- a/build-tools/build-infra/declare-repositories.gradle
+++ b/build-tools/build-infra/declare-repositories.gradle
@@ -23,7 +23,7 @@ repositories {
   // running on github runners (https://github.com/apache/lucene/issues/15541)
   boolean useGoogleMavenProxy = System.getenv("GITHUB_ACTIONS") != null
   if (useGoogleMavenProxy) {
-    google {
+    maven {
       url "https://maven-central.storage-download.googleapis.com/maven2/"
     }
   } else {

--- a/build-tools/build-infra/declare-repositories.gradle
+++ b/build-tools/build-infra/declare-repositories.gradle
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// These are repository declarations. This file is extracted
+// because it's reused in build-infra-shadow and from build settings.
+
+repositories {
+  mavenCentral()
+  maven {
+    url "https://maven-central.storage-download.googleapis.com/maven2/"
+  }
+  gradlePluginPortal()
+}
+

--- a/build-tools/build-infra/declare-repositories.gradle
+++ b/build-tools/build-infra/declare-repositories.gradle
@@ -23,7 +23,9 @@ repositories {
   // running on github runners (https://github.com/apache/lucene/issues/15541)
   boolean useGoogleMavenProxy = System.getenv("GITHUB_ACTIONS") != null
   if (useGoogleMavenProxy) {
-    google()
+    google {
+      url "https://maven-central.storage-download.googleapis.com/maven2/"
+    }
   } else {
     mavenCentral()
   }

--- a/build-tools/build-infra/declare-repositories.gradle
+++ b/build-tools/build-infra/declare-repositories.gradle
@@ -19,10 +19,14 @@
 // because it's reused in build-infra-shadow and from build settings.
 
 repositories {
-  mavenCentral()
-  maven {
-    url "https://maven-central.storage-download.googleapis.com/maven2/"
+  // use google's maven central mirror first, if requested or if we're
+  // running on github runners (https://github.com/apache/lucene/issues/15541)
+  boolean useGoogleMavenProxy = System.getenv("GITHUB_ACTIONS") != null
+  if (useGoogleMavenProxy) {
+    google()
+  } else {
+    mavenCentral()
   }
+
   gradlePluginPortal()
 }
-

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/misc/LuceneRootConfigurationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/misc/LuceneRootConfigurationPlugin.java
@@ -123,7 +123,10 @@ public class LuceneRootConfigurationPlugin extends LuceneGradlePlugin {
     // use google's maven central mirror first on github runners.
     // https://github.com/apache/lucene/issues/15541
     if (project.getProviders().environmentVariable("GITHUB_ACTIONS").isPresent()) {
-      project.getRepositories().google();
+      project
+          .getRepositories()
+          .google(
+              repo -> repo.setUrl("https://maven-central.storage-download.googleapis.com/maven2/"));
     } else {
       project.getRepositories().mavenCentral();
     }

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/misc/LuceneRootConfigurationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/misc/LuceneRootConfigurationPlugin.java
@@ -120,7 +120,13 @@ public class LuceneRootConfigurationPlugin extends LuceneGradlePlugin {
       project.setVersion(project.getRootProject().getVersion());
     }
 
-    project.getRepositories().mavenCentral();
+    // use google's maven central mirror first on github runners.
+    // https://github.com/apache/lucene/issues/15541
+    if (project.getProviders().environmentVariable("GITHUB_ACTIONS").isPresent()) {
+      project.getRepositories().google();
+    } else {
+      project.getRepositories().mavenCentral();
+    }
 
     // Common archive artifact naming.
     var baseExt = project.getExtensions().getByType(BasePluginExtension.class);

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/misc/LuceneRootConfigurationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/misc/LuceneRootConfigurationPlugin.java
@@ -125,7 +125,7 @@ public class LuceneRootConfigurationPlugin extends LuceneGradlePlugin {
     if (project.getProviders().environmentVariable("GITHUB_ACTIONS").isPresent()) {
       project
           .getRepositories()
-          .google(
+          .maven(
               repo -> repo.setUrl("https://maven-central.storage-download.googleapis.com/maven2/"));
     } else {
       project.getRepositories().mavenCentral();

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,13 +16,7 @@
  */
 
 pluginManagement {
-    repositories {
-        mavenCentral()
-        maven {
-            url "https://maven-central.storage-download.googleapis.com/maven2/"
-        }
-        gradlePluginPortal()
-    }
+    apply from: file("build-tools/build-infra/declare-repositories.gradle"), to: delegate
 
     // the classpath of the included composite project is resolved independently.
     // so custom ecj versions are not found unless we repeat the same code


### PR DESCRIPTION
Those intermittent resolution errors on github runners are hard to work around. Let's see if we can use
google's mirrors instead (on github only) since we're running jenkins jobs separately (using maven central).