### PR TITLE
ci: pin unpinned actions ref

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -79,7 +79,7 @@ jobs:
           fi
 
       - name: Checkout PR code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: ${{ env.head_repo_full }}
           ref: ${{ env.head_ref }}


### PR DESCRIPTION
Fixes error found in the new zizmor release. Previously some of these actions were exempt from the pinning. Just pin for consistency, dependabot takes care anyway

See explanation in release notes:
* https://docs.zizmor.sh/release-notes/#changes

