### PR TITLE
Two bit quantization for dense vectors

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -220,6 +220,11 @@ New Features
    `Lucene104HnswScalarQuantizedVectorsFormat(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE, int, int)`
     (Ben Trent)
 
+ * GITHUB#15564: Further extend `Lucene104ScalarQuantizedVectorsFormat` and `Lucene104HnswScalarQuantizedVectorsFormat` to
+   allow asymmetric quantization with 2 bits and 4 bit queries. This can provide increased recall over single bit
+   with little additional storage cost and latency.
+   (Ben Trent)
+
  * GITHUB#15415: Add fallback support to Lucene104ScalarQuantizedVectorsFormat getFloatVectorValues when there are
    no full-precision vectors present (Pulkit Gupta)
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsFormat.java
@@ -136,7 +136,16 @@ public class Lucene104ScalarQuantizedVectorsFormat extends FlatVectorsFormat {
      * <p>This is the most space efficient encoding, and will produce an index 8x smaller than
      * {@link #UNSIGNED_BYTE}. However, this comes at the cost of accuracy.
      */
-    SINGLE_BIT_QUERY_NIBBLE(3, (byte) 1, 1, (byte) 4, 4);
+    SINGLE_BIT_QUERY_NIBBLE(3, (byte) 1, 1, (byte) 4, 4),
+    /**
+     * Each dimension is quantized to 2 bits (dibit) and packed into bytes. During query time, the
+     * query vector is quantized to 4 bits per dimension.
+     *
+     * <p>This encoding produces an index 4x smaller than {@link #UNSIGNED_BYTE}, offering a balance
+     * between the compression of {@link #SINGLE_BIT_QUERY_NIBBLE} and the accuracy of {@link
+     * #PACKED_NIBBLE}.
+     */
+    DIBIT_QUERY_NIBBLE(4, (byte) 2, 2, (byte) 4, 4);
 
     public static ScalarEncoding fromNumBits(int bits) {
       for (ScalarEncoding encoding : values()) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsWriter.java
@@ -22,6 +22,7 @@ import static org.apache.lucene.index.VectorSimilarityFunction.COSINE;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import static org.apache.lucene.util.RamUsageEstimator.shallowSizeOfInstance;
 import static org.apache.lucene.util.quantization.OptimizedScalarQuantizer.packAsBinary;
+import static org.apache.lucene.util.quantization.OptimizedScalarQuantizer.transposeDibit;
 import static org.apache.lucene.util.quantization.OptimizedScalarQuantizer.transposeHalfByte;
 
 import java.io.Closeable;
@@ -196,7 +197,7 @@ public class Lucene104ScalarQuantizedVectorsWriter extends FlatVectorsWriter {
     byte[] vector =
         switch (encoding) {
           case UNSIGNED_BYTE, SEVEN_BIT -> scratch;
-          case PACKED_NIBBLE, SINGLE_BIT_QUERY_NIBBLE ->
+          case PACKED_NIBBLE, SINGLE_BIT_QUERY_NIBBLE, DIBIT_QUERY_NIBBLE ->
               new byte[encoding.getDocPackedLength(scratch.length)];
         };
     for (int i = 0; i < fieldData.getVectors().size(); i++) {
@@ -206,6 +207,7 @@ public class Lucene104ScalarQuantizedVectorsWriter extends FlatVectorsWriter {
       switch (encoding) {
         case PACKED_NIBBLE -> OffHeapScalarQuantizedVectorValues.packNibbles(scratch, vector);
         case SINGLE_BIT_QUERY_NIBBLE -> OptimizedScalarQuantizer.packAsBinary(scratch, vector);
+        case DIBIT_QUERY_NIBBLE -> OptimizedScalarQuantizer.transposeDibit(scratch, vector);
         case UNSIGNED_BYTE, SEVEN_BIT -> {}
       }
       vectorData.writeBytes(vector, vector.length);
@@ -256,7 +258,7 @@ public class Lucene104ScalarQuantizedVectorsWriter extends FlatVectorsWriter {
     byte[] vector =
         switch (encoding) {
           case UNSIGNED_BYTE, SEVEN_BIT -> scratch;
-          case PACKED_NIBBLE, SINGLE_BIT_QUERY_NIBBLE ->
+          case PACKED_NIBBLE, SINGLE_BIT_QUERY_NIBBLE, DIBIT_QUERY_NIBBLE ->
               new byte[encoding.getDocPackedLength(scratch.length)];
         };
     for (int ordinal : ordMap) {
@@ -266,6 +268,7 @@ public class Lucene104ScalarQuantizedVectorsWriter extends FlatVectorsWriter {
       switch (encoding) {
         case PACKED_NIBBLE -> OffHeapScalarQuantizedVectorValues.packNibbles(scratch, vector);
         case SINGLE_BIT_QUERY_NIBBLE -> OptimizedScalarQuantizer.packAsBinary(scratch, vector);
+        case DIBIT_QUERY_NIBBLE -> OptimizedScalarQuantizer.transposeDibit(scratch, vector);
         case UNSIGNED_BYTE, SEVEN_BIT -> {}
       }
       vectorData.writeBytes(vector, vector.length);
@@ -412,8 +415,13 @@ public class Lucene104ScalarQuantizedVectorsWriter extends FlatVectorsWriter {
               quantizationScratch,
               new byte[] {encoding.getBits(), encoding.getQueryBits()},
               centroid);
-      // pack and store document bit vector
-      packAsBinary(quantizationScratch[0], toIndex);
+      // pack and store document vector based on encoding type
+      switch (encoding) {
+        case SINGLE_BIT_QUERY_NIBBLE -> packAsBinary(quantizationScratch[0], toIndex);
+        case DIBIT_QUERY_NIBBLE -> transposeDibit(quantizationScratch[0], toIndex);
+        default ->
+            throw new IllegalArgumentException("Unsupported asymmetric encoding: " + encoding);
+      }
       binarizedVectorData.writeBytes(toIndex, toIndex.length);
       binarizedVectorData.writeInt(Float.floatToIntBits(r[0].lowerInterval()));
       binarizedVectorData.writeInt(Float.floatToIntBits(r[0].upperInterval()));
@@ -798,7 +806,7 @@ public class Lucene104ScalarQuantizedVectorsWriter extends FlatVectorsWriter {
       this.packed =
           switch (encoding) {
             case UNSIGNED_BYTE, SEVEN_BIT -> this.quantized;
-            case PACKED_NIBBLE, SINGLE_BIT_QUERY_NIBBLE ->
+            case PACKED_NIBBLE, SINGLE_BIT_QUERY_NIBBLE, DIBIT_QUERY_NIBBLE ->
                 new byte[encoding.getDocPackedLength(quantized.length)];
           };
       this.centroid = centroid;
@@ -873,6 +881,7 @@ public class Lucene104ScalarQuantizedVectorsWriter extends FlatVectorsWriter {
       switch (encoding) {
         case PACKED_NIBBLE -> OffHeapScalarQuantizedVectorValues.packNibbles(quantized, packed);
         case SINGLE_BIT_QUERY_NIBBLE -> OptimizedScalarQuantizer.packAsBinary(quantized, packed);
+        case DIBIT_QUERY_NIBBLE -> OptimizedScalarQuantizer.transposeDibit(quantized, packed);
         case UNSIGNED_BYTE, SEVEN_BIT -> {}
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsWriter.java
@@ -419,7 +419,7 @@ public class Lucene104ScalarQuantizedVectorsWriter extends FlatVectorsWriter {
       switch (encoding) {
         case SINGLE_BIT_QUERY_NIBBLE -> packAsBinary(quantizationScratch[0], toIndex);
         case DIBIT_QUERY_NIBBLE -> transposeDibit(quantizationScratch[0], toIndex);
-        default ->
+        case PACKED_NIBBLE, UNSIGNED_BYTE, SEVEN_BIT ->
             throw new IllegalArgumentException("Unsupported asymmetric encoding: " + encoding);
       }
       binarizedVectorData.writeBytes(toIndex, toIndex.length);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/OffHeapScalarQuantizedFloatVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/OffHeapScalarQuantizedFloatVectorValues.java
@@ -123,6 +123,8 @@ abstract class OffHeapScalarQuantizedFloatVectorValues extends FloatVectorValues
           OffHeapScalarQuantizedVectorValues.unpackNibbles(byteValue, unpackedByteVectorValue);
       case SINGLE_BIT_QUERY_NIBBLE ->
           OptimizedScalarQuantizer.unpackBinary(byteValue, unpackedByteVectorValue);
+      case DIBIT_QUERY_NIBBLE ->
+          OptimizedScalarQuantizer.untransposeDibit(byteValue, unpackedByteVectorValue);
       case UNSIGNED_BYTE, SEVEN_BIT -> {
         deQuantize(
             byteValue,

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
@@ -284,6 +284,7 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
   }
 
   public static long int4BitDotProductImpl(byte[] q, byte[] d) {
+    assert q.length == d.length * 4;
     return int4BitDotProductImpl(q, d, 0, d.length);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
@@ -95,6 +95,19 @@ public interface VectorUtilSupport {
   long int4BitDotProduct(byte[] int4Quantized, byte[] binaryQuantized);
 
   /**
+   * Compute the dot product between a quantized int4 vector and a dibit (2-bit) quantized vector.
+   * It is assumed that the int4 quantized bits are packed in the byte array in the same way as the
+   * {@link org.apache.lucene.util.quantization.OptimizedScalarQuantizer#transposeHalfByte(byte[],
+   * byte[])} and that the dibit bits are packed the same way as {@link
+   * org.apache.lucene.util.quantization.OptimizedScalarQuantizer#transposeDibit(byte[], byte[])}.
+   *
+   * @param int4Quantized half byte packed int4 quantized vector (4 stripes)
+   * @param dibitQuantized dibit packed quantized vector (2 stripes)
+   * @return the dot product
+   */
+  long int4DibitDotProduct(byte[] int4Quantized, byte[] dibitQuantized);
+
+  /**
    * Quantizes {@code vector}, putting the result into {@code dest}.
    *
    * @param vector the vector to quantize

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -296,6 +296,25 @@ public final class VectorUtil {
   }
 
   /**
+   * Dot product computed over int4 (values between [0,15]) bytes and a dibit (2-bit) vector.
+   *
+   * <p>The int4 query vector is expected to be transposed (4 stripes, each containing one bit plane
+   * of all dimensions). The dibit document vector is expected to be transposed (2 stripes: lower
+   * bits first, then upper bits).
+   *
+   * @param q the int4 query vector (transposed, 4 stripes)
+   * @param d the dibit document vector (transposed, 2 stripes)
+   * @return the dot product
+   */
+  public static long int4DibitDotProduct(byte[] q, byte[] d) {
+    if (q.length != d.length * 2) {
+      throw new IllegalArgumentException(
+          "vector dimensions incompatible: " + q.length + "!= " + 2 + " x " + d.length);
+    }
+    return IMPL.int4DibitDotProduct(q, d);
+  }
+
+  /**
    * For xorBitCount we stride over the values as either 64-bits (long) or 32-bits (int) at a time.
    * On ARM Long::bitCount is not vectorized, and therefore produces less than optimal code, when
    * compared to Integer::bitCount. While Long::bitCount is optimal on x64. See

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/OptimizedScalarQuantizer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/OptimizedScalarQuantizer.java
@@ -442,8 +442,7 @@ public class OptimizedScalarQuantizer {
 
   /**
    * Transpose a 2-bit (dibit) quantized vector into a byte array for efficient bitwise operations.
-   * The result has 2 stripes: bit0 of all dimensions first, then bit1 of all dimensions. This
-   * layout allows for efficient SIMD operations by performing two passes of single-bit scoring.
+   * The result has 2 stripes: similar to {@link #transposeHalfByte}, but only for 2 bits
    *
    * @param vector the 2-bit quantized vector (values 0-3)
    * @param packed the byte array to store the transposed vector
@@ -490,8 +489,7 @@ public class OptimizedScalarQuantizer {
 
   /**
    * Untranspose a packed 2-bit (dibit) vector back to its original form. This is the reverse of
-   * {@link #transposeDibit}. The packed array has bit0 of all dimensions in the first half, and
-   * bit1 of all dimensions in the second half.
+   * {@link #transposeDibit}.
    *
    * @param packed the packed/transposed byte array
    * @param vector the output vector where each byte will contain a 2-bit value (0-3)

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/OptimizedScalarQuantizer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/OptimizedScalarQuantizer.java
@@ -440,6 +440,88 @@ public class OptimizedScalarQuantizer {
     }
   }
 
+  /**
+   * Transpose a 2-bit (dibit) quantized vector into a byte array for efficient bitwise operations.
+   * The result has 2 stripes: bit0 of all dimensions first, then bit1 of all dimensions. This
+   * layout allows for efficient SIMD operations by performing two passes of single-bit scoring.
+   *
+   * @param vector the 2-bit quantized vector (values 0-3)
+   * @param packed the byte array to store the transposed vector
+   */
+  public static void transposeDibit(byte[] vector, byte[] packed) {
+    int limit = vector.length - 7;
+    int i = 0;
+    int index = 0;
+    for (; i < limit; i += 8, index++) {
+      int lowerByte =
+          (vector[i] & 1) << 7
+              | (vector[i + 1] & 1) << 6
+              | (vector[i + 2] & 1) << 5
+              | (vector[i + 3] & 1) << 4
+              | (vector[i + 4] & 1) << 3
+              | (vector[i + 5] & 1) << 2
+              | (vector[i + 6] & 1) << 1
+              | (vector[i + 7] & 1);
+      int upperByte =
+          ((vector[i] >> 1) & 1) << 7
+              | ((vector[i + 1] >> 1) & 1) << 6
+              | ((vector[i + 2] >> 1) & 1) << 5
+              | ((vector[i + 3] >> 1) & 1) << 4
+              | ((vector[i + 4] >> 1) & 1) << 3
+              | ((vector[i + 5] >> 1) & 1) << 2
+              | ((vector[i + 6] >> 1) & 1) << 1
+              | ((vector[i + 7] >> 1) & 1);
+      packed[index] = (byte) lowerByte;
+      packed[index + packed.length / 2] = (byte) upperByte;
+    }
+    if (i == vector.length) {
+      return;
+    }
+    int lowerByte = 0;
+    int upperByte = 0;
+    for (int j = 7; i < vector.length; j--, i++) {
+      assert vector[i] >= 0 && vector[i] <= 3;
+      lowerByte |= (vector[i] & 1) << j;
+      upperByte |= ((vector[i] >> 1) & 1) << j;
+    }
+    packed[index] = (byte) lowerByte;
+    packed[index + packed.length / 2] = (byte) upperByte;
+  }
+
+  /**
+   * Untranspose a packed 2-bit (dibit) vector back to its original form. This is the reverse of
+   * {@link #transposeDibit}. The packed array has bit0 of all dimensions in the first half, and
+   * bit1 of all dimensions in the second half.
+   *
+   * @param packed the packed/transposed byte array
+   * @param vector the output vector where each byte will contain a 2-bit value (0-3)
+   */
+  public static void untransposeDibit(byte[] packed, byte[] vector) {
+    int stripeSize = packed.length / 2;
+    int limit = vector.length - 7;
+    int i = 0;
+    int index = 0;
+    for (; i < limit; i += 8, index++) {
+      byte lowerByte = packed[index];
+      byte upperByte = packed[index + stripeSize];
+      vector[i] = (byte) (((lowerByte >> 7) & 1) | (((upperByte >> 7) & 1) << 1));
+      vector[i + 1] = (byte) (((lowerByte >> 6) & 1) | (((upperByte >> 6) & 1) << 1));
+      vector[i + 2] = (byte) (((lowerByte >> 5) & 1) | (((upperByte >> 5) & 1) << 1));
+      vector[i + 3] = (byte) (((lowerByte >> 4) & 1) | (((upperByte >> 4) & 1) << 1));
+      vector[i + 4] = (byte) (((lowerByte >> 3) & 1) | (((upperByte >> 3) & 1) << 1));
+      vector[i + 5] = (byte) (((lowerByte >> 2) & 1) | (((upperByte >> 2) & 1) << 1));
+      vector[i + 6] = (byte) (((lowerByte >> 1) & 1) | (((upperByte >> 1) & 1) << 1));
+      vector[i + 7] = (byte) ((lowerByte & 1) | ((upperByte & 1) << 1));
+    }
+    if (i < vector.length) {
+      byte lowerByte = packed[index];
+      byte upperByte = packed[index + stripeSize];
+      for (int j = 7; i < vector.length; j--, i++) {
+        vector[i] = (byte) (((lowerByte >> j) & 1) | (((upperByte >> j) & 1) << 1));
+      }
+    }
+  }
+
   private static double clamp(double x, double a, double b) {
     return Math.min(Math.max(x, a), b);
   }

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -1233,6 +1233,155 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public long int4DibitDotProduct(byte[] q, byte[] d) {
+    assert q.length == d.length * 2;
+    // d has 2 stripes (lower bit, upper bit), each of size d.length/2
+    // q has 4 stripes, each of size q.length/4 = d.length/2
+    int stripeSize = d.length / 2;
+    // Minimum size for vectorization: 16 bytes per stripe
+    if (stripeSize >= 16) {
+      if (VECTOR_BITSIZE >= 256) {
+        return int4DibitDotProduct256(q, d);
+      } else if (VECTOR_BITSIZE == 128) {
+        return int4DibitDotProduct128(q, d);
+      }
+    }
+    return DefaultVectorUtilSupport.int4DibitDotProductImpl(q, d);
+  }
+
+  static long int4DibitDotProduct256(byte[] q, byte[] d) {
+    int stripeSize = d.length / 2;
+    // First pass: lower bit stripe (bit 0), weighted by 2^0 = 1
+    long ret0 = int4BitDotProduct256WithOffset(q, d, 0, stripeSize);
+    // Second pass: upper bit stripe (bit 1), weighted by 2^1 = 2
+    long ret1 = int4BitDotProduct256WithOffset(q, d, stripeSize, stripeSize);
+    return ret0 + (ret1 << 1);
+  }
+
+  static long int4DibitDotProduct128(byte[] q, byte[] d) {
+    int stripeSize = d.length / 2;
+    // First pass: lower bit stripe (bit 0), weighted by 2^0 = 1
+    long ret0 = int4BitDotProduct128WithOffset(q, d, 0, stripeSize);
+    // Second pass: upper bit stripe (bit 1), weighted by 2^1 = 2
+    long ret1 = int4BitDotProduct128WithOffset(q, d, stripeSize, stripeSize);
+    return ret0 + (ret1 << 1);
+  }
+
+  /**
+   * Helper for int4-bit dot product with a specific stripe of the document vector using 256-bit
+   * SIMD.
+   */
+  private static long int4BitDotProduct256WithOffset(
+      byte[] q, byte[] d, int dOffset, int stripeSize) {
+    long subRet0 = 0;
+    long subRet1 = 0;
+    long subRet2 = 0;
+    long subRet3 = 0;
+    int i = 0;
+
+    if (stripeSize >= ByteVector.SPECIES_256.vectorByteSize() * 2) {
+      int limit = ByteVector.SPECIES_256.loopBound(stripeSize);
+      var sum0 = LongVector.zero(LongVector.SPECIES_256);
+      var sum1 = LongVector.zero(LongVector.SPECIES_256);
+      var sum2 = LongVector.zero(LongVector.SPECIES_256);
+      var sum3 = LongVector.zero(LongVector.SPECIES_256);
+      for (; i < limit; i += ByteVector.SPECIES_256.length()) {
+        var vq0 = ByteVector.fromArray(BYTE_SPECIES_256, q, i).reinterpretAsLongs();
+        var vq1 = ByteVector.fromArray(BYTE_SPECIES_256, q, i + stripeSize).reinterpretAsLongs();
+        var vq2 =
+            ByteVector.fromArray(BYTE_SPECIES_256, q, i + stripeSize * 2).reinterpretAsLongs();
+        var vq3 =
+            ByteVector.fromArray(BYTE_SPECIES_256, q, i + stripeSize * 3).reinterpretAsLongs();
+        var vd = ByteVector.fromArray(BYTE_SPECIES_256, d, dOffset + i).reinterpretAsLongs();
+        sum0 = sum0.add(vq0.and(vd).lanewise(VectorOperators.BIT_COUNT));
+        sum1 = sum1.add(vq1.and(vd).lanewise(VectorOperators.BIT_COUNT));
+        sum2 = sum2.add(vq2.and(vd).lanewise(VectorOperators.BIT_COUNT));
+        sum3 = sum3.add(vq3.and(vd).lanewise(VectorOperators.BIT_COUNT));
+      }
+      subRet0 += sum0.reduceLanes(VectorOperators.ADD);
+      subRet1 += sum1.reduceLanes(VectorOperators.ADD);
+      subRet2 += sum2.reduceLanes(VectorOperators.ADD);
+      subRet3 += sum3.reduceLanes(VectorOperators.ADD);
+    }
+
+    if (stripeSize - i >= ByteVector.SPECIES_128.vectorByteSize()) {
+      var sum0 = LongVector.zero(LongVector.SPECIES_128);
+      var sum1 = LongVector.zero(LongVector.SPECIES_128);
+      var sum2 = LongVector.zero(LongVector.SPECIES_128);
+      var sum3 = LongVector.zero(LongVector.SPECIES_128);
+      int limit = ByteVector.SPECIES_128.loopBound(stripeSize);
+      for (; i < limit; i += ByteVector.SPECIES_128.length()) {
+        var vq0 = ByteVector.fromArray(BYTE_SPECIES_128, q, i).reinterpretAsLongs();
+        var vq1 = ByteVector.fromArray(BYTE_SPECIES_128, q, i + stripeSize).reinterpretAsLongs();
+        var vq2 =
+            ByteVector.fromArray(BYTE_SPECIES_128, q, i + stripeSize * 2).reinterpretAsLongs();
+        var vq3 =
+            ByteVector.fromArray(BYTE_SPECIES_128, q, i + stripeSize * 3).reinterpretAsLongs();
+        var vd = ByteVector.fromArray(BYTE_SPECIES_128, d, dOffset + i).reinterpretAsLongs();
+        sum0 = sum0.add(vq0.and(vd).lanewise(VectorOperators.BIT_COUNT));
+        sum1 = sum1.add(vq1.and(vd).lanewise(VectorOperators.BIT_COUNT));
+        sum2 = sum2.add(vq2.and(vd).lanewise(VectorOperators.BIT_COUNT));
+        sum3 = sum3.add(vq3.and(vd).lanewise(VectorOperators.BIT_COUNT));
+      }
+      subRet0 += sum0.reduceLanes(VectorOperators.ADD);
+      subRet1 += sum1.reduceLanes(VectorOperators.ADD);
+      subRet2 += sum2.reduceLanes(VectorOperators.ADD);
+      subRet3 += sum3.reduceLanes(VectorOperators.ADD);
+    }
+    // tail as bytes
+    for (; i < stripeSize; i++) {
+      subRet0 += Integer.bitCount((q[i] & d[dOffset + i]) & 0xFF);
+      subRet1 += Integer.bitCount((q[i + stripeSize] & d[dOffset + i]) & 0xFF);
+      subRet2 += Integer.bitCount((q[i + 2 * stripeSize] & d[dOffset + i]) & 0xFF);
+      subRet3 += Integer.bitCount((q[i + 3 * stripeSize] & d[dOffset + i]) & 0xFF);
+    }
+    return subRet0 + (subRet1 << 1) + (subRet2 << 2) + (subRet3 << 3);
+  }
+
+  /**
+   * Helper for int4-bit dot product with a specific stripe of the document vector using 128-bit
+   * SIMD.
+   */
+  private static long int4BitDotProduct128WithOffset(
+      byte[] q, byte[] d, int dOffset, int stripeSize) {
+    long subRet0 = 0;
+    long subRet1 = 0;
+    long subRet2 = 0;
+    long subRet3 = 0;
+    int i = 0;
+
+    var sum0 = IntVector.zero(IntVector.SPECIES_128);
+    var sum1 = IntVector.zero(IntVector.SPECIES_128);
+    var sum2 = IntVector.zero(IntVector.SPECIES_128);
+    var sum3 = IntVector.zero(IntVector.SPECIES_128);
+    int limit = ByteVector.SPECIES_128.loopBound(stripeSize);
+    for (; i < limit; i += ByteVector.SPECIES_128.length()) {
+      var vd = ByteVector.fromArray(BYTE_SPECIES_128, d, dOffset + i).reinterpretAsInts();
+      var vq0 = ByteVector.fromArray(BYTE_SPECIES_128, q, i).reinterpretAsInts();
+      var vq1 = ByteVector.fromArray(BYTE_SPECIES_128, q, i + stripeSize).reinterpretAsInts();
+      var vq2 = ByteVector.fromArray(BYTE_SPECIES_128, q, i + stripeSize * 2).reinterpretAsInts();
+      var vq3 = ByteVector.fromArray(BYTE_SPECIES_128, q, i + stripeSize * 3).reinterpretAsInts();
+      sum0 = sum0.add(vd.and(vq0).lanewise(VectorOperators.BIT_COUNT));
+      sum1 = sum1.add(vd.and(vq1).lanewise(VectorOperators.BIT_COUNT));
+      sum2 = sum2.add(vd.and(vq2).lanewise(VectorOperators.BIT_COUNT));
+      sum3 = sum3.add(vd.and(vq3).lanewise(VectorOperators.BIT_COUNT));
+    }
+    subRet0 += sum0.reduceLanes(VectorOperators.ADD);
+    subRet1 += sum1.reduceLanes(VectorOperators.ADD);
+    subRet2 += sum2.reduceLanes(VectorOperators.ADD);
+    subRet3 += sum3.reduceLanes(VectorOperators.ADD);
+    // tail as bytes
+    for (; i < stripeSize; i++) {
+      int dValue = d[dOffset + i];
+      subRet0 += Integer.bitCount((dValue & q[i]) & 0xFF);
+      subRet1 += Integer.bitCount((dValue & q[i + stripeSize]) & 0xFF);
+      subRet2 += Integer.bitCount((dValue & q[i + 2 * stripeSize]) & 0xFF);
+      subRet3 += Integer.bitCount((dValue & q[i + 3 * stripeSize]) & 0xFF);
+    }
+    return subRet0 + (subRet1 << 1) + (subRet2 << 2) + (subRet3 << 3);
+  }
+
+  @Override
   public float minMaxScalarQuantize(
       float[] vector, byte[] dest, float scale, float alpha, float minQuantile, float maxQuantile) {
     assert vector.length == dest.length;

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -1133,112 +1133,17 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
   }
 
   static long int4BitDotProduct256(byte[] q, byte[] d) {
-    long subRet0 = 0;
-    long subRet1 = 0;
-    long subRet2 = 0;
-    long subRet3 = 0;
-    int i = 0;
-
-    if (d.length >= ByteVector.SPECIES_256.vectorByteSize() * 2) {
-      int limit = ByteVector.SPECIES_256.loopBound(d.length);
-      var sum0 = LongVector.zero(LongVector.SPECIES_256);
-      var sum1 = LongVector.zero(LongVector.SPECIES_256);
-      var sum2 = LongVector.zero(LongVector.SPECIES_256);
-      var sum3 = LongVector.zero(LongVector.SPECIES_256);
-      for (; i < limit; i += ByteVector.SPECIES_256.length()) {
-        var vq0 = ByteVector.fromArray(BYTE_SPECIES_256, q, i).reinterpretAsLongs();
-        var vq1 = ByteVector.fromArray(BYTE_SPECIES_256, q, i + d.length).reinterpretAsLongs();
-        var vq2 = ByteVector.fromArray(BYTE_SPECIES_256, q, i + d.length * 2).reinterpretAsLongs();
-        var vq3 = ByteVector.fromArray(BYTE_SPECIES_256, q, i + d.length * 3).reinterpretAsLongs();
-        var vd = ByteVector.fromArray(BYTE_SPECIES_256, d, i).reinterpretAsLongs();
-        sum0 = sum0.add(vq0.and(vd).lanewise(VectorOperators.BIT_COUNT));
-        sum1 = sum1.add(vq1.and(vd).lanewise(VectorOperators.BIT_COUNT));
-        sum2 = sum2.add(vq2.and(vd).lanewise(VectorOperators.BIT_COUNT));
-        sum3 = sum3.add(vq3.and(vd).lanewise(VectorOperators.BIT_COUNT));
-      }
-      subRet0 += sum0.reduceLanes(VectorOperators.ADD);
-      subRet1 += sum1.reduceLanes(VectorOperators.ADD);
-      subRet2 += sum2.reduceLanes(VectorOperators.ADD);
-      subRet3 += sum3.reduceLanes(VectorOperators.ADD);
-    }
-
-    if (d.length - i >= ByteVector.SPECIES_128.vectorByteSize()) {
-      var sum0 = LongVector.zero(LongVector.SPECIES_128);
-      var sum1 = LongVector.zero(LongVector.SPECIES_128);
-      var sum2 = LongVector.zero(LongVector.SPECIES_128);
-      var sum3 = LongVector.zero(LongVector.SPECIES_128);
-      int limit = ByteVector.SPECIES_128.loopBound(d.length);
-      for (; i < limit; i += ByteVector.SPECIES_128.length()) {
-        var vq0 = ByteVector.fromArray(BYTE_SPECIES_128, q, i).reinterpretAsLongs();
-        var vq1 = ByteVector.fromArray(BYTE_SPECIES_128, q, i + d.length).reinterpretAsLongs();
-        var vq2 = ByteVector.fromArray(BYTE_SPECIES_128, q, i + d.length * 2).reinterpretAsLongs();
-        var vq3 = ByteVector.fromArray(BYTE_SPECIES_128, q, i + d.length * 3).reinterpretAsLongs();
-        var vd = ByteVector.fromArray(BYTE_SPECIES_128, d, i).reinterpretAsLongs();
-        sum0 = sum0.add(vq0.and(vd).lanewise(VectorOperators.BIT_COUNT));
-        sum1 = sum1.add(vq1.and(vd).lanewise(VectorOperators.BIT_COUNT));
-        sum2 = sum2.add(vq2.and(vd).lanewise(VectorOperators.BIT_COUNT));
-        sum3 = sum3.add(vq3.and(vd).lanewise(VectorOperators.BIT_COUNT));
-      }
-      subRet0 += sum0.reduceLanes(VectorOperators.ADD);
-      subRet1 += sum1.reduceLanes(VectorOperators.ADD);
-      subRet2 += sum2.reduceLanes(VectorOperators.ADD);
-      subRet3 += sum3.reduceLanes(VectorOperators.ADD);
-    }
-    // tail as bytes
-    for (; i < d.length; i++) {
-      subRet0 += Integer.bitCount((q[i] & d[i]) & 0xFF);
-      subRet1 += Integer.bitCount((q[i + d.length] & d[i]) & 0xFF);
-      subRet2 += Integer.bitCount((q[i + 2 * d.length] & d[i]) & 0xFF);
-      subRet3 += Integer.bitCount((q[i + 3 * d.length] & d[i]) & 0xFF);
-    }
-    return subRet0 + (subRet1 << 1) + (subRet2 << 2) + (subRet3 << 3);
+    return int4BitDotProduct256WithOffset(q, d, 0, d.length);
   }
 
   public static long int4BitDotProduct128(byte[] q, byte[] d) {
-    long subRet0 = 0;
-    long subRet1 = 0;
-    long subRet2 = 0;
-    long subRet3 = 0;
-    int i = 0;
-
-    var sum0 = IntVector.zero(IntVector.SPECIES_128);
-    var sum1 = IntVector.zero(IntVector.SPECIES_128);
-    var sum2 = IntVector.zero(IntVector.SPECIES_128);
-    var sum3 = IntVector.zero(IntVector.SPECIES_128);
-    int limit = ByteVector.SPECIES_128.loopBound(d.length);
-    for (; i < limit; i += ByteVector.SPECIES_128.length()) {
-      var vd = ByteVector.fromArray(BYTE_SPECIES_128, d, i).reinterpretAsInts();
-      var vq0 = ByteVector.fromArray(BYTE_SPECIES_128, q, i).reinterpretAsInts();
-      var vq1 = ByteVector.fromArray(BYTE_SPECIES_128, q, i + d.length).reinterpretAsInts();
-      var vq2 = ByteVector.fromArray(BYTE_SPECIES_128, q, i + d.length * 2).reinterpretAsInts();
-      var vq3 = ByteVector.fromArray(BYTE_SPECIES_128, q, i + d.length * 3).reinterpretAsInts();
-      sum0 = sum0.add(vd.and(vq0).lanewise(VectorOperators.BIT_COUNT));
-      sum1 = sum1.add(vd.and(vq1).lanewise(VectorOperators.BIT_COUNT));
-      sum2 = sum2.add(vd.and(vq2).lanewise(VectorOperators.BIT_COUNT));
-      sum3 = sum3.add(vd.and(vq3).lanewise(VectorOperators.BIT_COUNT));
-    }
-    subRet0 += sum0.reduceLanes(VectorOperators.ADD);
-    subRet1 += sum1.reduceLanes(VectorOperators.ADD);
-    subRet2 += sum2.reduceLanes(VectorOperators.ADD);
-    subRet3 += sum3.reduceLanes(VectorOperators.ADD);
-    // tail as bytes
-    for (; i < d.length; i++) {
-      int dValue = d[i];
-      subRet0 += Integer.bitCount((dValue & q[i]) & 0xFF);
-      subRet1 += Integer.bitCount((dValue & q[i + d.length]) & 0xFF);
-      subRet2 += Integer.bitCount((dValue & q[i + 2 * d.length]) & 0xFF);
-      subRet3 += Integer.bitCount((dValue & q[i + 3 * d.length]) & 0xFF);
-    }
-    return subRet0 + (subRet1 << 1) + (subRet2 << 2) + (subRet3 << 3);
+    return int4BitDotProduct128WithOffset(q, d, 0, d.length);
   }
 
   @Override
   public long int4DibitDotProduct(byte[] q, byte[] d) {
     assert q.length == d.length * 2;
-    // d has 2 stripes (lower bit, upper bit), each of size d.length/2
-    // q has 4 stripes, each of size q.length/4 = d.length/2
     int stripeSize = d.length / 2;
-    // Minimum size for vectorization: 16 bytes per stripe
     if (stripeSize >= 16) {
       if (VECTOR_BITSIZE >= 256) {
         return int4DibitDotProduct256(q, d);
@@ -1251,26 +1156,18 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
   static long int4DibitDotProduct256(byte[] q, byte[] d) {
     int stripeSize = d.length / 2;
-    // First pass: lower bit stripe (bit 0), weighted by 2^0 = 1
     long ret0 = int4BitDotProduct256WithOffset(q, d, 0, stripeSize);
-    // Second pass: upper bit stripe (bit 1), weighted by 2^1 = 2
     long ret1 = int4BitDotProduct256WithOffset(q, d, stripeSize, stripeSize);
     return ret0 + (ret1 << 1);
   }
 
   static long int4DibitDotProduct128(byte[] q, byte[] d) {
     int stripeSize = d.length / 2;
-    // First pass: lower bit stripe (bit 0), weighted by 2^0 = 1
     long ret0 = int4BitDotProduct128WithOffset(q, d, 0, stripeSize);
-    // Second pass: upper bit stripe (bit 1), weighted by 2^1 = 2
     long ret1 = int4BitDotProduct128WithOffset(q, d, stripeSize, stripeSize);
     return ret0 + (ret1 << 1);
   }
 
-  /**
-   * Helper for int4-bit dot product with a specific stripe of the document vector using 256-bit
-   * SIMD.
-   */
   private static long int4BitDotProduct256WithOffset(
       byte[] q, byte[] d, int dOffset, int stripeSize) {
     long subRet0 = 0;
@@ -1338,10 +1235,6 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     return subRet0 + (subRet1 << 1) + (subRet2 << 2) + (subRet3 << 3);
   }
 
-  /**
-   * Helper for int4-bit dot product with a specific stripe of the document vector using 128-bit
-   * SIMD.
-   */
   private static long int4BitDotProduct128WithOffset(
       byte[] q, byte[] d, int dOffset, int stripeSize) {
     long subRet0 = 0;

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene104/TestLucene104ScalarQuantizedVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene104/TestLucene104ScalarQuantizedVectorsFormat.java
@@ -70,9 +70,7 @@ public class TestLucene104ScalarQuantizedVectorsFormat extends BaseKnnVectorsFor
   @Override
   public void setUp() throws Exception {
     var encodingValues = ScalarEncoding.values();
-    encoding =
-        ScalarEncoding
-            .DIBIT_QUERY_NIBBLE; // encodingValues[random().nextInt(encodingValues.length)];
+    encoding = encodingValues[random().nextInt(encodingValues.length)];
     format = new Lucene104ScalarQuantizedVectorsFormat(encoding);
     super.setUp();
   }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene104/TestLucene104ScalarQuantizedVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene104/TestLucene104ScalarQuantizedVectorsFormat.java
@@ -70,7 +70,9 @@ public class TestLucene104ScalarQuantizedVectorsFormat extends BaseKnnVectorsFor
   @Override
   public void setUp() throws Exception {
     var encodingValues = ScalarEncoding.values();
-    encoding = encodingValues[random().nextInt(encodingValues.length)];
+    encoding =
+        ScalarEncoding
+            .DIBIT_QUERY_NIBBLE; // encodingValues[random().nextInt(encodingValues.length)];
     format = new Lucene104ScalarQuantizedVectorsFormat(encoding);
     super.setUp();
   }
@@ -201,6 +203,8 @@ public class TestLucene104ScalarQuantizedVectorsFormat extends BaseKnnVectorsFor
                   OffHeapScalarQuantizedVectorValues.packNibbles(scratch, expectedVector);
               case SINGLE_BIT_QUERY_NIBBLE ->
                   OptimizedScalarQuantizer.packAsBinary(scratch, expectedVector);
+              case DIBIT_QUERY_NIBBLE ->
+                  OptimizedScalarQuantizer.transposeDibit(scratch, expectedVector);
             }
             assertArrayEquals(expectedVector, qvectorValues.vectorValue(docIndexIterator.index()));
             var actualCorrections = qvectorValues.getCorrectiveTerms(docIndexIterator.index());


### PR DESCRIPTION
This adds 2-bit quantization as an option for scalar quantizer. For HNSW, this gives a nice recall improvement with little latency increase.

Full disclosure, I used this work as an experiment to try and get reps with opencode. So, yeah, its agentic. I did go through and review, then benchmarked with Lucene util (PR to add 2 bit support there will occur soonish). 

The agent added way too many comments (so annoying), and didn't correctly reuse code (I had to move things around, or this would have been many 100s more loc churn). But, I was pleasantly surprised by how good it did. Goes to show that not only are these things getting pretty good, but also that the format API was well designed.

Lucene Util benchmarks (no rescoring)
```
recall  latency(ms)  netCPU  avgCpuCount  fanout  quantized  visited  index(s)  index_docs/s  force_merge(s)  index_size(MB)  vec_disk(MB)  vec_RAM(MB)
 0.503        0.194   0.181        0.933       0     1 bits     1151    258.04       3875.32          189.18         3136.53      3034.592      104.904
 0.537        0.201   0.195        0.970       5     1 bits     1446    258.04       3875.32          189.18         3136.53      3034.592      104.904
 0.558        0.239   0.233        0.975      10     1 bits     1728    258.04       3875.32          189.18         3136.53      3034.592      104.904
 0.586        0.318   0.312        0.981      25     1 bits     2494    258.04       3875.32          189.18         3136.53      3034.592      104.904
 0.601        0.444   0.438        0.986      50     1 bits     3701    258.04       3875.32          189.18         3136.53      3034.592      104.904
 0.607        0.697   0.689        0.989     100     1 bits     5929    258.04       3875.32          189.18         3136.53      3034.592      104.904
 0.594        0.190   0.183        0.963       0     2 bits     1056    262.08       3815.67          227.70         3221.32      3126.144      196.457
 0.642        0.229   0.223        0.974       5     2 bits     1328    262.08       3815.67          227.70         3221.32      3126.144      196.457
 0.669        0.265   0.259        0.977      10     2 bits     1582    262.08       3815.67          227.70         3221.32      3126.144      196.457
 0.709        0.367   0.361        0.984      25     2 bits     2306    262.08       3815.67          227.70         3221.32      3126.144      196.457
 0.730        0.519   0.512        0.987      50     2 bits     3424    262.08       3815.67          227.70         3221.32      3126.144      196.457
 0.744        0.801   0.794        0.991     100     2 bits     5481    262.08       3815.67          227.70         3221.32      3126.144      196.457
 0.664        0.223   0.216        0.969       0     4 bits     1000    273.00       3663.06          130.39         3402.28      3311.157      381.470
 0.730        0.261   0.255        0.977       5     4 bits     1257    273.00       3663.06          130.39         3402.28      3311.157      381.470
 0.765        0.304   0.296        0.974      10     4 bits     1494    273.00       3663.06          130.39         3402.28      3311.157      381.470
 0.824        0.426   0.418        0.981      25     4 bits     2165    273.00       3663.06          130.39         3402.28      3311.157      381.470
 0.859        0.608   0.602        0.990      50     4 bits     3228    273.00       3663.06          130.39         3402.28      3311.157      381.470
 0.883        0.966   0.958        0.992     100     4 bits     5193    273.00       3663.06          130.39         3402.28      3311.157      381.470
 0.681        0.322   0.309        0.960       0     7 bits      974    254.66       3926.84          223.75         3765.53      3677.368      747.681
 0.753        0.378   0.372        0.984       5     7 bits     1215    254.66       3926.84          223.75         3765.53      3677.368      747.681
 0.798        0.423   0.417        0.986      10     7 bits     1442    254.66       3926.84          223.75         3765.53      3677.368      747.681
 0.873        0.606   0.600        0.990      25     7 bits     2096    254.66       3926.84          223.75         3765.53      3677.368      747.681
 0.921        0.878   0.870        0.991      50     7 bits     3121    254.66       3926.84          223.75         3765.53      3677.368      747.681
 0.953        1.427   1.419        0.994     100     7 bits     5008    254.66       3926.84          223.75         3765.53      3677.368      747.681
 0.694        0.302   0.296        0.980       0     8 bits      993    298.80       3346.74          220.72         3765.59      3677.368      747.681
 0.763        0.383   0.377        0.984       5     8 bits     1237    298.80       3346.74          220.72         3765.59      3677.368      747.681
 0.808        0.442   0.436        0.986      10     8 bits     1466    298.80       3346.74          220.72         3765.59      3677.368      747.681
 0.877        0.601   0.594        0.988      25     8 bits     2108    298.80       3346.74          220.72         3765.59      3677.368      747.681
 0.927        0.891   0.883        0.991      50     8 bits     3123    298.80       3346.74          220.72         3765.59      3677.368      747.681
 0.962        1.410   1.404        0.996     100     8 bits     5019    298.80       3346.74          220.72         3765.59      3677.368      747.681
 0.691        0.212   0.205        0.967       0         no     1011    360.34       2775.15          258.21         3021.60      2929.688     2929.688
 0.767        0.263   0.257        0.977       5         no     1265    360.34       2775.15          258.21         3021.60      2929.688     2929.688
 0.813        0.312   0.306        0.981      10         no     1503    360.34       2775.15          258.21         3021.60      2929.688     2929.688
 0.889        0.451   0.443        0.982      25         no     2175    360.34       2775.15          258.21         3021.60      2929.688     2929.688
 0.938        0.682   0.675        0.990      50         no     3212    360.34       2775.15          258.21         3021.60      2929.688     2929.688
 0.969        1.112   1.105        0.994     100         no     5177    360.34       2775.15          258.21         3021.60      2929.688     2929.688
```