### PR TITLE
Allow a DataAccessHint to be passed during the construction of a Lucene99FlatVectorsReader

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -195,6 +195,9 @@ API Changes
   and throughput. This provides visibility into Lucene's merge backpressure mechanisms that can
   stall indexing when merge debt accumulates. (Zihan Xu)
 
+* GITHUB#15569: Allow a DataAccessHint to be passed during the construction of Lucene99FlatVectorsReader
+  (Chris Hegarty)
+
 New Features
 ---------------------
 * GITHUB#15328: VectorSimilarityFunction.getValues() now implements doubleVal allowing its

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
@@ -22,6 +22,8 @@ import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.readVe
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
@@ -43,6 +45,7 @@ import org.apache.lucene.store.DataAccessHint;
 import org.apache.lucene.store.FileDataHint;
 import org.apache.lucene.store.FileTypeHint;
 import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IOContext.FileOpenHint;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
@@ -68,13 +71,24 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
     this(state, scorer, DataAccessHint.RANDOM);
   }
 
+  /**
+   * Creates a Lucene99FlatVectorsReader.
+   *
+   * @param state the segment read state
+   * @param scorer the flat vectors scorer
+   * @param accessHint a data access hint, or null
+   */
   public Lucene99FlatVectorsReader(
       SegmentReadState state, FlatVectorsScorer scorer, DataAccessHint accessHint)
       throws IOException {
     super(scorer);
     int versionMeta = readMetadata(state);
     this.fieldInfos = state.fieldInfos;
-    dataContext = state.context.withHints(FileTypeHint.DATA, FileDataHint.KNN_VECTORS, accessHint);
+    FileOpenHint[] hints =
+        Stream.of(FileTypeHint.DATA, FileDataHint.KNN_VECTORS, accessHint)
+            .filter(Objects::nonNull)
+            .toArray(FileOpenHint[]::new);
+    dataContext = state.context.withHints(hints);
     try {
       vectorData =
           openDataInput(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
@@ -65,13 +65,16 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
 
   public Lucene99FlatVectorsReader(SegmentReadState state, FlatVectorsScorer scorer)
       throws IOException {
+    this(state, scorer, DataAccessHint.RANDOM);
+  }
+
+  public Lucene99FlatVectorsReader(
+      SegmentReadState state, FlatVectorsScorer scorer, DataAccessHint accessHint)
+      throws IOException {
     super(scorer);
     int versionMeta = readMetadata(state);
     this.fieldInfos = state.fieldInfos;
-    // Flat formats are used to randomly access vectors from their node ID that is stored
-    // in the HNSW graph.
-    dataContext =
-        state.context.withHints(FileTypeHint.DATA, FileDataHint.KNN_VECTORS, DataAccessHint.RANDOM);
+    dataContext = state.context.withHints(FileTypeHint.DATA, FileDataHint.KNN_VECTORS, accessHint);
     try {
       vectorData =
           openDataInput(


### PR DESCRIPTION
This is a small change to allow the DataAccessHint to be passed during the construction of a Lucene99FlatVectorsReader. The reader if often used in conjunction with a graph, where random access is appropriate. However, the reader can be used without a graph, when implementing a so-called "flat" index, where SEQUENTIAL would likely be more appropriate.