### PR TITLE
Disallow invalid offset 0 for LZ4 decompression

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -239,6 +239,8 @@ Improvements
 
 * GITHUB#15479: Add NumericDocValueRangeQuery base class to add accessor methods for field, lower and upper values (Alan Woodward)
 
+* GITHUB#15570: Disallow invalid offset 0 for LZ4 decompression (Marcono1234)
+
 Optimizations
 ---------------------
 * GITHUB#15140: Optimize TopScoreDocCollector with TernaryLongHeap for improved performance over Binary-LongHeap. (Ramakrishna Chilaka)

--- a/lucene/core/src/java/org/apache/lucene/util/compress/LZ4.java
+++ b/lucene/core/src/java/org/apache/lucene/util/compress/LZ4.java
@@ -111,7 +111,9 @@ public final class LZ4 {
 
       // matchs
       final int matchDec = compressed.readShort() & 0xFFFF;
-      assert matchDec > 0;
+      if (matchDec == 0) {
+        throw new IOException("offset 0 is invalid");
+      }
 
       int matchLen = token & 0x0F;
       if (matchLen == 0x0F) {

--- a/lucene/core/src/test/org/apache/lucene/util/compress/LZ4TestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/compress/LZ4TestCase.java
@@ -384,34 +384,4 @@ public abstract class LZ4TestCase extends LuceneTestCase {
     // own
     assertTrue(out.size() < len);
   }
-
-  public void testDecompressOffset0() {
-    byte[] input =
-        new byte[] {
-          // token
-          0xE,
-          // offset 0
-          0,
-          0,
-          // last literal
-          // token
-          7 << 4,
-          // literal
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0
-        };
-
-    byte[] output = new byte[18];
-
-    var e =
-        assertThrows(
-            IOException.class,
-            () -> LZ4.decompress(new ByteArrayDataInput(input), output.length, output, 0));
-    assertEquals("offset 0 is invalid", e.getMessage());
-  }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/compress/TestDecompressLZ4.java
+++ b/lucene/core/src/test/org/apache/lucene/util/compress/TestDecompressLZ4.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util.compress;
+
+import java.io.IOException;
+import org.apache.lucene.store.ByteArrayDataInput;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestDecompressLZ4 extends LuceneTestCase {
+  public void testDecompressOffset0() {
+    byte[] input =
+        new byte[] {
+          // token
+          0xE,
+          // offset 0 (invalid)
+          0,
+          0,
+          // last literal
+          // token
+          7 << 4,
+          // literal
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0
+        };
+
+    byte[] output = new byte[18];
+
+    var e =
+        assertThrows(
+            IOException.class,
+            () -> LZ4.decompress(new ByteArrayDataInput(input), output.length, output, 0));
+    assertEquals("offset 0 is invalid", e.getMessage());
+  }
+}


### PR DESCRIPTION
### Description

For LZ4 offset 0 is invalid, see https://github.com/lz4/lz4/blob/dev/doc/lz4_Block_format.md#compressed-block-format:
> Note that 0 is an invalid `offset` value. The presence of a 0 `offset` value denotes an invalid (corrupted) block.

Permitting offset 0 leads to the content of the given output buffer appearing in the output, which is a problem when reusing buffers. See also CVE-2025-66566.
Can also be seen with the input of the added test here, and using e.g. `Arrays.fill(output, ...)` to prefill the output array with different content between runs; you will notice that after decompression it contains part of the original prefilled content.


Side note: The native C implementation of LZ4 actually permits offset 0, but in that case emits 0 in the output, see https://github.com/lz4/lz4/issues/1631 and the comments there. Though to my understanding offset 0 only occurs for malformed input, so there might be no point in intentionally trying to support it?