### PR TITLE
Replace the deprecated usage of search(Query, Collector) in core

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanScorer.java
@@ -433,9 +433,8 @@ public class TestBooleanScorer extends LuceneTestCase {
     int totalHitsThreshold = 7;
     TopScoreDocCollectorManager topScoreDocCollectorManager =
         new TopScoreDocCollectorManager(3, null, totalHitsThreshold);
-    TopScoreDocCollector collector = topScoreDocCollectorManager.newCollector();
-    searcher.search(builder.build(), collector);
-    assertEquals(totalHitsThreshold + 1, collector.totalHits);
+    TopDocs topDocs = searcher.search(builder.build(), topScoreDocCollectorManager);
+    assertEquals(totalHitsThreshold + 1, topDocs.totalHits.value());
 
     reader.close();
     w.close();


### PR DESCRIPTION
### Description

This [PR](https://github.com/apache/lucene/pull/14757) reintroduced the deprecated usage of search(Query, Collector) in the test code, replace it with search(Query, CollectorManager) instead.
