### PR TITLE
Avoid copying bitset that's subsequently cleared

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -98,6 +98,8 @@ Optimizations
 
 * GITHUB#15085, GITHUB#15092: Hunspell suggestions: Ensure candidate roots are not worse before updating. (Ilia Permiashkin)
 
+* GITHUB#15582: Avoid copying bitset that's subsequently cleared
+
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -553,8 +553,7 @@ final class ReadersAndUpdates {
         scratch = new FixedBitSet(bitSet.length());
       } else {
         // It's OK even if bitset.length() == 0 according the contract.
-        scratch = FixedBitSet.ensureCapacity(scratch, bitSet.length() - 1);
-        scratch.clear();
+        scratch = FixedBitSet.ensureCapacityAndClear(scratch, bitSet.length() - 1);
       }
 
       onDiskDocValues.intoBitSet(upTo, scratch, offset);

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -56,13 +56,13 @@ public final class FixedBitSet extends BitSet {
   /// bitset is allocated.
   ///
   /// @see #ensureCapacity(FixedBitSet, int)
-  public static FixedBitSet ensureCapacityAndClear(FixedBitSet bits, int numBits) {
-    return ensureCapacityInternal(bits, numBits, false);
+  public static FixedBitSet ensureCapacityAndClear(FixedBitSet bits, int desiredBit) {
+    return ensureCapacityInternal(bits, desiredBit, false);
   }
 
   private static FixedBitSet ensureCapacityInternal(
-      FixedBitSet bits, int numBits, boolean preserveData) {
-    if (numBits < bits.numBits) {
+      FixedBitSet bits, int desiredBit, boolean preserveData) {
+    if (desiredBit < bits.numBits) {
       if (!preserveData) {
         bits.clear();
       }
@@ -70,7 +70,7 @@ public final class FixedBitSet extends BitSet {
     } else {
       // Depends on the ghost bits being clear!
       // (Otherwise, they may become visible in the new instance)
-      int numWords = bits2words(numBits);
+      int numWords = bits2words(desiredBit);
       long[] arr = bits.getBits();
       if (numWords >= arr.length) {
         if (preserveData) {

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -42,34 +42,20 @@ public final class FixedBitSet extends BitSet {
   private final int numBits; // The number of bits in use
   private final int numWords; // The exact number of longs needed to hold numBits (<= bits.length)
 
-  /**
-   * If the given {@link FixedBitSet} is large enough to hold {@code numBits+1}, returns the given
-   * bits, otherwise returns a new {@link FixedBitSet} which can hold {@code numBits+1} bits. That
-   * means the bitset returned by this method can be safely called with {@code bits.set(numBits)}.
-   * Existing contents lf {@code bits} are preserved.
-   *
-   * <p><b>NOTE:</b> the returned bitset reuses the underlying {@code long[]} of the given {@code
-   * bits} if possible. Also, calling {@link #length()} on the returned bits may return a value
-   * greater than {@code numBits+1}.
-   *
-   * @see #ensureCapacityAndClear(FixedBitSet, int)
-   */
-  public static FixedBitSet ensureCapacity(FixedBitSet bits, int numBits) {
-    return ensureCapacityInternal(bits, numBits, true);
+  /// Ensure the given `bits` can store a value at `desiredBit` index. If the current [#length()] is
+  /// sufficient, `bits` is simply returned. Otherwise, a new, larger bitset is allocated, with
+  /// contents of `bits` copied.
+  ///
+  /// @see #ensureCapacityAndClear(FixedBitSet, int)
+  public static FixedBitSet ensureCapacity(FixedBitSet bits, int desiredBit) {
+    return ensureCapacityInternal(bits, desiredBit, true);
   }
 
-  /**
-   * If the given {@link FixedBitSet} is large enough to hold {@code numBits+1}, clears the given
-   * {@code bits} and return it. Otherwise, allocate a new {@link FixedBitSet} which can hold {@code
-   * numBits+1} bits. That means the bitset returned by this method can be safely called with {@code
-   * bits.set(numBits)}.
-   *
-   * <p><b>NOTE:</b> Calling {@link #length()} on the returned bits may return a value greater than
-   * {@code numBits+1}.
-   *
-   * @return Cleared {@code bits}, if large enough, or a new instance otherwise.
-   * @see #ensureCapacity(FixedBitSet, int)
-   */
+  /// Clear the given `bits` and ensure it can store a value at `desiredBit` index. If the current
+  /// [#length()] is sufficient, `bits` is simply cleared and returned. Otherwise, a new, larger
+  /// bitset is allocated.
+  ///
+  /// @see #ensureCapacity(FixedBitSet, int)
   public static FixedBitSet ensureCapacityAndClear(FixedBitSet bits, int numBits) {
     return ensureCapacityInternal(bits, numBits, false);
   }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -369,9 +369,10 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
   private void prepareScratchState(int capacity, int bulkScoreSize) {
     candidates.clear();
     if (visited.length() < capacity) {
-      visited = FixedBitSet.ensureCapacity((FixedBitSet) visited, capacity);
+      visited = FixedBitSet.ensureCapacityAndClear((FixedBitSet) visited, capacity);
+    } else {
+      visited.clear();
     }
-    visited.clear();
     if (bulkNodes == null || bulkNodes.length < bulkScoreSize) {
       bulkNodes = new int[bulkScoreSize];
       bulkScores = new float[bulkScoreSize];


### PR DESCRIPTION
In two instances, `FixedBitSet.ensureCapacity()` was called right before the bitset was cleared. This unnecessarily copied the internal array.

This PR adds `FixedBitSet.ensureCapacityAndClear()` that avoids the copying. This should give a small performance improvement.

Also rename `numBits` to `desiredBit` -  the argument didn't specify the number of bits we want to store, but the desired index we wanted to store at. This allowed for a much simpler javadoc that's not self-contradictory.