### PR TITLE
Make intellij think vector module is imported for mrjar/java25 module

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/mrjar/LuceneJavaCoreMrjarPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/mrjar/LuceneJavaCoreMrjarPlugin.java
@@ -107,14 +107,24 @@ public class LuceneJavaCoreMrjarPlugin extends LuceneGradlePlugin {
                 compilerArgs.remove("-Xlint:options");
                 compilerArgs.add("-Xlint:-options");
 
-                compilerArgs.addAll(
-                    List.of(
-                        "--add-exports",
-                        "java.base/java.lang.foreign=ALL-UNNAMED",
-                        // for compilation, we patch the incubator packages into java.base, this has
-                        // no effect on resulting class files:
-                        "--add-exports",
-                        "java.base/jdk.incubator.vector=ALL-UNNAMED"));
+                if (getLuceneBuildGlobals(project).getIntellijIdea().get().isIdeaSync()) {
+                  // Let's make it simpler for intellij so that it doesn't complain
+                  // about inaccessible incubator module. We enable this only for
+                  // "syncing" IDE settings, not for actual compilation done from within
+                  // the IDE.
+                  compilerArgs.addAll(List.of("--add-modules", "jdk.incubator.vector"));
+                  compilerArgs.remove("-Xlint:incubating");
+                  compilerArgs.remove("-Xlint:-incubating");
+                } else {
+                  compilerArgs.addAll(
+                      List.of(
+                          "--add-exports",
+                          "java.base/java.lang.foreign=ALL-UNNAMED",
+                          // for compilation, we patch the incubator packages into java.base, this
+                          // has no effect on resulting class files:
+                          "--add-exports",
+                          "java.base/jdk.incubator.vector=ALL-UNNAMED"));
+                }
 
                 var argsProvider = project.getObjects().newInstance(CompilerArgsProvider.class);
                 argsProvider.getApiJarFile().set(apijar);

--- a/lucene/luke/build.gradle
+++ b/lucene/luke/build.gradle
@@ -61,6 +61,7 @@ tasks.named("compileJava").configure {
 }
 
 // Process UTF8 property files to unicode escapes.
+
 tasks.withType(ProcessResources).configureEach { task ->
   task.filesMatching("**/messages*.properties", {
     filteringCharset = 'UTF-8'


### PR DESCRIPTION
Intellij by default complains that the vector module is inaccessible to java25 folder (mr-jar module under the core). This patch tweaks compiler settings during the "sync" phase so that IntelliJ thinks we add the vector module and tweaks compiler options accordingly -

<img width="2774" height="1748" alt="image" src="https://github.com/user-attachments/assets/6e7d13ca-32d7-45bf-b6ea-a1e54dc9ccc3" />

These settings don't seem to be used if gradle is used for actual compilation (which is the default). And it improves dev experience because now vector API classes are visible and don't show red flags:

<img width="2176" height="1560" alt="image" src="https://github.com/user-attachments/assets/85160203-2811-4df2-936b-78f3d03d7b19" />


