### PR TITLE
Document scoring and ranking behavior changes across major Lucene versions

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -195,7 +195,7 @@ Bug Fixes
 
 Other
 ---------------------
-(No changes)
+* GITHUB#15586: Document that scoring and ranking may change across major Lucene versions, and that applications requiring stable ranking should explicitly configure Similarity. (Parveen Saini)
 
 ======================= Lucene 10.4.0 =======================
 

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -126,6 +126,17 @@ As part of GITHUB#13820, GITHUB#13825, GITHUB#13830, this issue corrects DataInp
 to be public and not-final, allowing subclasses to override it. This change also removes the protected
 DataInput.readGroupVInt method: subclasses should delegate or reimplement it entirely.
 
+### Scoring and ranking across major versions
+
+Lucene does not guarantee identical scoring or document ranking behavior across
+major version upgrades. Changes may occur due to improvements or modifications
+in Similarity implementations, query execution, or related internals.
+
+Applications that require stable ranking behavior across upgrades should
+explicitly configure the Similarity used for indexing and searching rather than
+relying on defaults. Reviewing `CHANGES.txt` for intervening major versions is
+recommended when upgrading.
+
 ### OpenNLP dependency upgrade
 
 [Apache OpenNLP](https://opennlp.apache.org) 2.x opens the door to accessing various models via the ONNX runtime. To migrate you will need to update any deprecated OpenNLP methods that you may be using.


### PR DESCRIPTION

### **Description**

This PR adds a concise documentation note clarifying that scoring and ranking behavior can legitimately change across major Lucene versions, even when no index format break occurs.

**Motivation**

While upgrading a production Solr deployment across multiple Lucene major versions, we encountered ranking differences that were not attributable to index corruption or misconfiguration. Investigation showed these differences stemmed from intentional changes accumulated over major releases (similarity defaults, normalization details, tokenization/scoring refinements, etc.).

Although these changes are expected and documented in individual release notes, it is not always obvious to users performing large version jumps that *preserving historical ranking behavior may require explicitly pinning or supplying a custom `Similarity`*.

**What this PR adds**

* A short, centralized note highlighting:

  * Scoring is not guaranteed to be stable across major versions
  * Large version jumps can surface accumulated scoring differences
  * Custom `Similarity` implementations are the appropriate mitigation if strict backward ranking compatibility is required
* No behavior or API changes

**Why documentation (not code)**

The underlying behavior is intentional and consistent with Lucene’s evolution model. This PR aims to reduce confusion during major upgrades by making the tradeoff explicit and discoverable.

**Scope**

* Documentation-only change
* No impact on runtime behavior
* Intended to complement existing `CHANGES.txt` and migration guidance