### PR TITLE
Monitor: Make TestCachePurging more failsafe

### DIFF
--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestCachePurging.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestCachePurging.java
@@ -137,8 +137,6 @@ public class TestCachePurging extends MonitorTestBase {
         new MonitorConfiguration().setPurgeFrequency(50, TimeUnit.MILLISECONDS);
     try (Monitor monitor = new Monitor(ANALYZER, Presearcher.NO_FILTERING, config)) {
 
-      assertEquals(-1, monitor.getQueryCacheStats().lastPurged());
-
       for (int i = 0; i < 100; i++) {
         monitor.register(newMonitorQuery(i));
       }

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestMonitor.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestMonitor.java
@@ -253,4 +253,26 @@ public class TestMonitor extends MonitorTestBase {
       assertEquals(0, matches.getMatchCount());
     }
   }
+
+  public void testQueryCacheStats() throws IOException {
+    try (Monitor monitor = newMonitor()) {
+      assertEquals(-1, monitor.getQueryCacheStats().lastPurged());
+      assertEquals(0, monitor.getQueryCacheStats().queries());
+      assertEquals(0, monitor.getQueryCacheStats().cachedQueries());
+
+      MonitorQuery[] queries =
+          new MonitorQuery[] {
+            new MonitorQuery("1", parse("test1")),
+            new MonitorQuery("2", parse("test2")),
+            new MonitorQuery("3", parse("test3"))
+          };
+      monitor.register(queries);
+      assertEquals(3, monitor.getQueryCacheStats().queries());
+      assertEquals(3, monitor.getQueryCacheStats().cachedQueries());
+
+      assertEquals(-1, monitor.getQueryCacheStats().lastPurged());
+      monitor.purgeCache();
+      assertTrue(monitor.getQueryCacheStats().lastPurged() > 0);
+    }
+  }
 }


### PR DESCRIPTION
Add a new test for testing stats instead of hoping the assertion works in the cache purging tests.

Closes #15587