### PR TITLE
Optimize DocIdSetIteratorAcceptDocs#cost

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -315,6 +315,8 @@ Optimizations
 
 * GITHUB#15582: Avoid copying bitset that's subsequently cleared (Viliam Durina)
 
+* GITHUB#15592: Optimize DocIdSetIteratorAcceptDocs#cost. (Shubham Chaudhary)
+
 Bug Fixes
 ---------------------
 * GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException

--- a/lucene/core/src/java/org/apache/lucene/search/AcceptDocs.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AcceptDocs.java
@@ -189,8 +189,14 @@ public abstract class AcceptDocs {
 
     @Override
     public int cost() throws IOException {
-      createBitSetAcceptDocsIfNecessary();
-      return cardinality;
+      if (acceptBitSet != null) {
+        return cardinality;
+      }
+      DocIdSetIterator iterator = iterator();
+      if (liveDocs == null && iterator instanceof BitSetIterator bitSetIterator) {
+        return bitSetIterator.getBitSet().approximateCardinality();
+      }
+      return Math.toIntExact(iterator.cost());
     }
 
     @Override
@@ -198,8 +204,8 @@ public abstract class AcceptDocs {
       if (acceptBitSet != null) {
         return new BitSetIterator(acceptBitSet, cardinality);
       }
-      DocIdSetIterator iterator = Objects.requireNonNull(iteratorSupplier.get());
-      return AcceptDocs.getFilteredDocIdSetIterator(iterator, liveDocs);
+      return AcceptDocs.getFilteredDocIdSetIterator(
+          Objects.requireNonNull(iteratorSupplier.get()), liveDocs);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/AcceptDocs.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AcceptDocs.java
@@ -157,7 +157,7 @@ public abstract class AcceptDocs {
 
   /**
    * Impl backed by a {@link DocIdSetIterator}, which lazily creates a {@link BitSet} if {@link
-   * #cost()} or {@link #bits()} are called.
+   * #bits()} is called. Otherwise, returns the cost of underlying iterator.
    */
   private static class DocIdSetIteratorAcceptDocs extends AcceptDocs {
 
@@ -192,11 +192,7 @@ public abstract class AcceptDocs {
       if (acceptBitSet != null) {
         return cardinality;
       }
-      DocIdSetIterator iterator = iterator();
-      if (liveDocs == null && iterator instanceof BitSetIterator bitSetIterator) {
-        return bitSetIterator.getBitSet().approximateCardinality();
-      }
-      return Math.toIntExact(iterator.cost());
+      return Math.toIntExact(iterator().cost());
     }
 
     @Override

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -60,7 +60,6 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.store.BaseDirectoryWrapper;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
-import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
@@ -1159,8 +1158,8 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
           BitSetIterator bitSetIterator =
               new BitSetIterator(docs, docs.approximateCardinality()) {
                 @Override
-                public BitSet getBitSet() {
-                  throw new UnsupportedOperationException("reusing BitSet is not supported");
+                public long cost() {
+                  throw new UnsupportedOperationException("reusing BitSetIterator cost");
                 }
               };
           final var scorer = new ConstantScoreScorer(score(), scoreMode, bitSetIterator);

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -687,6 +687,19 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
         for (int i = 0; i < dimension; i++) {
           vector[i] = i % 2 == 0 ? 42 : 7;
         }
+        // This is to consistently ensure we take the exactSearch path and make the #cost not random
+        // when we don't cache in PointRangeQuery
+        searcher.setQueryCachingPolicy(
+            new QueryCachingPolicy() {
+
+              @Override
+              public void onUse(Query query) {}
+
+              @Override
+              public boolean shouldCache(Query query) throws IOException {
+                return true;
+              }
+            });
         Query filter4 = IntPoint.newRangeQuery("tag", 250, 256);
         expectThrows(
             UnsupportedOperationException.class,


### PR DESCRIPTION
### Description

We want to avoid realizing the bitset and defer it to `#bits` and rely on approximation to speedup filtered search where filter is very restrictive. See https://github.com/apache/lucene/issues/15561

Closes https://github.com/apache/lucene/issues/15561

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
