### PR TITLE
Reduce memory usage of `NeighborArray`

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -98,6 +98,8 @@ Optimizations
 
 * GITHUB#15085, GITHUB#15092: Hunspell suggestions: Ensure candidate roots are not worse before updating. (Ilia Permiashkin)
 
+* GITHUB#15597: Reduce memory usage of NeighborArray (Viliam Durina)
+
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -42,7 +42,6 @@ public class NeighborArray {
   private final MaxSizedFloatArrayList scores;
   private final MaxSizedIntArrayList nodes;
   private int sortedNodeSize;
-  private long ramBytesUsed = BASE_RAM_BYTES_USED;
   private final LongConsumer onHeapMemoryUsageListener;
 
   public NeighborArray(int maxSize, boolean descOrder) {
@@ -53,11 +52,11 @@ public class NeighborArray {
     this.maxSize = maxSize;
     nodes = new MaxSizedIntArrayList(maxSize, maxSize / 8);
     scores = new MaxSizedFloatArrayList(maxSize, maxSize / 8);
-    this.ramBytesUsed += nodes.ramBytesUsed() + scores.ramBytesUsed();
     this.scoresDescOrder = descOrder;
     this.onHeapMemoryUsageListener = onHeapMemoryUsageListener;
     if (onHeapMemoryUsageListener != null) {
-      onHeapMemoryUsageListener.accept(ramBytesUsed);
+      onHeapMemoryUsageListener.accept(
+          BASE_RAM_BYTES_USED + nodes.ramBytesUsed() + scores.ramBytesUsed());
     }
   }
 
@@ -145,7 +144,7 @@ public class NeighborArray {
     int[] uncheckedIndexes = new int[size - sortedNodeSize];
     int count = 0;
     while (sortedNodeSize != size) {
-      // TODO: Instead of do an array copy on every insertion, I think we can do better here:
+      // TODO: Instead of doing an array copy on every insertion, I think we can do better here:
       //       Remember the insertion point of each unsorted node and insert them altogether
       //       We can save several array copy by doing that
       uncheckedIndexes[count] = insertSortedInternal(scorer); // sortedNodeSize is increased inside


### PR DESCRIPTION
Saves 4 bytes pre instance. We have one instance for every node and every level, so for a 1 million-node graph, we might save 5-6MB of heap memory.

In fact, `BASE_RAM_BYTES_USED` went from 48 to 40 bytes thanks to 8-byte object size alignment, so the saving is double.

A lot more can be done to reduce memory here, e.g. by:
- removing `onHeapMemoryUsageListener` and passing an instance to `addInOrder` and `addOutOfOrder` (easy, saves 4 bytes)
- removing `size` and using the `nodes.size()` instead (easy, saves 4 bytes)
- use `int[]` and `float[]` directly instead of `MaxSizedIntArrayList` and `MaxSizedFloatArrayList` (bit harder, saves 40 bytes)
- separating the in-order and out-of-order cases into subclasses: saves 5 bytes for the in-order case and 1 byte for the out-of-order case.

LMK if you're interested in these changes, esp. the 3rd one.