### PR TITLE
Grammar and javadoc fixes

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsFormat.java
@@ -113,7 +113,7 @@ public final class Lucene99HnswVectorsFormat extends KnnVectorsFormat {
    */
   public static final int DEFAULT_BEAM_WIDTH = HnswGraphBuilder.DEFAULT_BEAM_WIDTH;
 
-  /** Default to use single thread merge */
+  /** Default to use single-thread merge */
   public static final int DEFAULT_NUM_MERGE_WORKER = 1;
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -198,7 +198,7 @@ public class IndexWriter
     implements Closeable, TwoPhaseCommit, Accountable, MergePolicy.MergeContext {
 
   /**
-   * Hard limit on maximum number of documents that may be added to the index. If you try to add
+   * Hard limit on the maximum number of documents that may be added to the index. If you try to add
    * more than this you'll hit {@code IllegalArgumentException}.
    */
   // We defensively subtract 128 to be well below the lowest
@@ -260,7 +260,7 @@ public class IndexWriter
   public static final int MAX_STORED_STRING_LENGTH =
       ArrayUtil.MAX_ARRAY_LENGTH / UnicodeUtil.MAX_UTF8_BYTES_PER_CHAR;
 
-  // when unrecoverable disaster strikes, we populate this with the reason that we had to close
+  // when unrecoverable disaster strikes, we populate this with the reason why we had to close the
   // IndexWriter
   private final AtomicReference<Throwable> tragedy = new AtomicReference<>(null);
 
@@ -412,11 +412,11 @@ public class IndexWriter
   private final AtomicLong mergeFinishedGen = new AtomicLong();
 
   // The instance that was passed to the constructor. It is saved only in order
-  // to allow users to query an IndexWriter settings.
+  // to allow users to query IndexWriter settings.
   private final LiveIndexWriterConfig config;
 
   /**
-   * System.nanoTime() when commit started; used to write an infoStream message about how long
+   * System.nanoTime() when commit started; used to write an infoStream message about how long the
    * commit took.
    */
   private long startCommitTime;
@@ -567,7 +567,7 @@ public class IndexWriter
        *  - flush all currently in-memory DWPTs to disk
        *  - apply all deletes & updates to new and to the existing DWPTs
        *  - prevent flushes and applying deletes of concurrently indexing DWPTs to be applied
-       *  - open a SDR on the updated SIS
+       *  - open an SDR on the updated SIS
        *
        * in order to prevent concurrent flushes we call DocumentsWriter#flushAllThreads that swaps out the deleteQueue
        *  (this enforces a happens before relationship between this and the subsequent full flush) and informs the
@@ -577,7 +577,7 @@ public class IndexWriter
        * and apply deletes & updates to the written segments without worrying about concurrently indexing DWPTs. The important
        * aspect is that it all happens between DocumentsWriter#flushAllThread() and DocumentsWriter#finishFullFlush(boolean)
        * since once the flush is marked as done deletes start to be applied to the segments on disk without guarantees that
-       * the corresponding added documents (in the update case) are flushed and visible when opening a SDR.
+       * the corresponding added documents (in the update case) are flushed and visible when opening an SDR.
        */
       synchronized (fullFlushLock) {
         try {
@@ -838,9 +838,8 @@ public class IndexWriter
               if (bytesUsedBefore == 0) {
                 continue; // nothing to do here - lets not acquire the lock
               }
-              // Only acquire IW lock on each write, since this is a time consuming operation.  This
-              // way
-              // other threads get a chance to run in between our writes.
+              // Only acquire IW lock on each write, since this is a time-consuming operation.  This
+              // way other threads get a chance to run in between our writes.
               synchronized (this) {
                 // It's possible that the segment of a reader returned by readerPool#getReadersByRam
                 // is dropped before being processed here. If it happens, we need to skip that
@@ -1480,7 +1479,7 @@ public class IndexWriter
    *
    * <p>Note that it's possible to create an invalid Unicode string in java if a UTF16 surrogate
    * pair is malformed. In this case, the invalid characters are silently replaced with the Unicode
-   * replacement character U+FFFD.
+   * replacement character {@code U+FFFD}.
    *
    * @return The <a href="#sequence_number">sequence number</a> for this operation
    * @throws CorruptIndexException if the index is corrupt
@@ -1499,7 +1498,7 @@ public class IndexWriter
    * segment will be preserved, even when child documents within a block are deleted. Most search
    * features (like result grouping and block joining) require you to mark documents; when these
    * documents are deleted these search features will not work as expected. Obviously adding
-   * documents to an existing block will require you the reindex the entire block.
+   * documents to an existing block will require you to reindex the entire block.
    *
    * <p>However it's possible that in the future Lucene may merge more aggressively re-order
    * documents (for example, perhaps to obtain better index compression), in which case you may need
@@ -1647,9 +1646,9 @@ public class IndexWriter
    * matching the term. This can be used to un-delete a soft-deleted document since this method will
    * apply the field update even if the document is marked as deleted.
    *
-   * <p><b>NOTE</b>: this method can only updates documents visible to the currently open NRT
-   * reader. If you need to update documents indexed after opening the NRT reader you must use
-   * {@link #updateDocValues(Term, Field...)}.
+   * <p><b>NOTE</b>: this method can only update documents visible to the currently open NRT reader.
+   * If you need to update documents indexed after opening the NRT reader you must use {@link
+   * #updateDocValues(Term, Field...)}.
    */
   public synchronized long tryUpdateDocValue(IndexReader readerIn, int docID, Field... fields)
       throws IOException {
@@ -1976,7 +1975,7 @@ public class IndexWriter
         throw new IllegalArgumentException(
             "can only update NUMERIC or BINARY fields! field=" + f.name());
       }
-      // if this field doesn't exists we try to add it.
+      // if this field doesn't exist we try to add it.
       // if it exists and the DV type doesn't match or it is not DV only field,
       // we will get an error.
       globalFieldNumberMap.verifyOrCreateDvOnlyField(f.name(), dvType, false);
@@ -2355,7 +2354,7 @@ public class IndexWriter
     final CachingMergeContext cachingMergeContext = new CachingMergeContext(this);
     if (maxNumSegments != UNBOUNDED_MAX_MERGE_SEGMENTS) {
       assert trigger == MergeTrigger.EXPLICIT || trigger == MergeTrigger.MERGE_FINISHED
-          : "Expected EXPLICT or MERGE_FINISHED as trigger even with maxNumSegments set but was: "
+          : "Expected EXPLICIT or MERGE_FINISHED as trigger even with maxNumSegments set but was: "
               + trigger.name();
 
       spec =
@@ -2537,8 +2536,7 @@ public class IndexWriter
         segmentInfos.rollbackSegmentInfos(rollbackSegments);
         int rollbackMaxDoc = segmentInfos.totalMaxDoc();
         // now we need to adjust this back to the rolled back SI but don't set it to the absolute
-        // value
-        // otherwise we might hide internal bugsf
+        // value, otherwise we might hide internal bugs
         adjustPendingNumDocs(-(totalMaxDoc - rollbackMaxDoc));
         if (infoStream.isEnabled("IW")) {
           infoStream.message("IW", "rollback: infos=" + segString(segmentInfos));
@@ -2558,7 +2556,7 @@ public class IndexWriter
         lastCommitChangeCount = changeCount.get();
         // Don't bother saving any changes in our segmentInfos
         readerPool.close();
-        // Must set closed while inside same sync block where we call deleter.refresh, else
+        // Must set closed while inside the same sync block where we call deleter.refresh, else
         // concurrent threads may try to sneak a flush in,
         // after we leave this sync block and before we enter the sync block in the finally clause
         // below that sets closed:
@@ -2615,12 +2613,13 @@ public class IndexWriter
    * This change will not be visible until a {@link #commit()} has been called. This method can be
    * rolled back using {@link #rollback()}.
    *
-   * <p>NOTE: this method is much faster than using deleteDocuments( MatchAllDocsQuery.INSTANCE ).
-   * Yet, this method also has different semantics compared to {@link #deleteDocuments(Query...)}
-   * since internal data-structures are cleared as well as all segment information is forcefully
-   * dropped anti-viral semantics like omitting norms are reset or doc value types are cleared.
-   * Essentially a call to {@link #deleteAll()} is equivalent to creating a new {@link IndexWriter}
-   * with {@link OpenMode#CREATE} which a delete query only marks documents as deleted.
+   * <p>NOTE: this method is much faster than using {@code
+   * deleteDocuments(MatchAllDocsQuery.INSTANCE)}. Yet, this method also has different semantics
+   * compared to {@link #deleteDocuments(Query...)} since internal data structures are cleared as
+   * well as all segment information is forcefully dropped, anti-viral semantics like omitting norms
+   * are reset, or doc value types are cleared. Essentially a call to {@link #deleteAll()} is
+   * equivalent to creating a new {@link IndexWriter} with {@link OpenMode#CREATE}, while a delete
+   * query only marks documents as deleted.
    *
    * <p>NOTE: this method will forcefully abort all merges in progress. If other threads are running
    * {@link #forceMerge}, {@link #addIndexes(CodecReader[])} or {@link #forceMergeDeletes} methods,
@@ -2632,16 +2631,14 @@ public class IndexWriter
   public long deleteAll() throws IOException {
     ensureOpen();
     // Remove any buffered docs
-    /* hold the full flush lock to prevent concurrency commits / NRT reopens to
+    /* hold the full flush lock to prevent concurrent commits / NRT reopens to
      * get in our way and do unnecessary work. -- if we don't lock this here we might
-     * get in trouble if */
-    /*
-     * We first abort and trash everything we have in-memory
-     * and keep the thread-states locked, the lockAndAbortAll operation
-     * also guarantees "point in time semantics" ie. the checkpoint that we need in terms
+     * get in trouble if we first abort and trash everything we have in memory
+     * and keep the thread states locked, the lockAndAbortAll operation
+     * also guarantees "point in time semantics", i.e. the checkpoint that we need in terms
      * of logical happens-before relationship in the DW. So we do
-     * abort all in memory structures
-     * We also drop global field numbering before during abort to make
+     * abort all in-memory structures.
+     * We also drop global field numbering during abort to make
      * sure it's just like a fresh index.
      */
     try {
@@ -2895,13 +2892,11 @@ public class IndexWriter
       final boolean isFullyHardDeleted = newSegment.getDelCount() == newSegment.info.maxDoc();
       // we either have a fully hard-deleted segment or one or more docs are soft-deleted. In both
       // cases we need
-      // to go and check if they are fully deleted. This has the nice side-effect that we now have
-      // accurate numbers
-      // for the soft delete right after we flushed to disk.
+      // to go and check if they are fully deleted. This has a nice side effect that we now have
+      // accurate numbers for the soft delete right after we flushed to disk.
       if (hasInitialSoftDeleted || isFullyHardDeleted) {
-        // this operation is only really executed if needed an if soft-deletes are not configured it
-        // only be executed
-        // if we deleted all docs in this newly flushed segment.
+        // this operation is only really executed if needed. If soft-deletes are not configured it
+        // will only be executed if we deleted all docs in this newly flushed segment.
         ReadersAndUpdates rld = getPooledInstance(newSegment, true);
         try {
           if (isFullyDeleted(rld)) {
@@ -3493,7 +3488,7 @@ public class IndexWriter
     if (useCompoundFile) {
       Collection<String> filesToDelete = merge.getMergeInfo().files();
       TrackingDirectoryWrapper trackingCFSDir = new TrackingDirectoryWrapper(mergeDirectory);
-      // createCompoundFile tries to cleanup, but it might not always be able to...
+      // createCompoundFile tries to clean up, but it might not always be able to...
       createCompoundFile(
           infoStream, trackingCFSDir, merge.getMergeInfo().info, context, this::deleteNewFiles);
 
@@ -3677,7 +3672,7 @@ public class IndexWriter
               seqNo = -seqNo;
             }
             if (anyChanges == false) {
-              // prevent double increment since docWriter#doFlush increments the flushcount
+              // prevent double increment since docWriter#doFlush increments the flushCount
               // if we flushed anything.
               flushCount.incrementAndGet();
             }
@@ -3899,7 +3894,7 @@ public class IndexWriter
                         if (stopCollectingMergeResults.getAsBoolean() == false
                             && isAborted() == false
                             && info.info.maxDoc()
-                                > 0 /* never do this if the segment if dropped / empty */) {
+                                > 0 /* never do this if the segment is dropped / empty */) {
                           mergeFinished.accept(info);
                           // clone the target info to make sure we have the original info without
                           // the updated del and update gens
@@ -4061,12 +4056,13 @@ public class IndexWriter
    * wait for any running background merges to finish. This may be a costly operation, so you should
    * test the cost in your application and do it only when really necessary.
    *
-   * <p>Note that this operation calls Directory.sync on the index files. That call should not
-   * return until the file contents and metadata are on stable storage. For FSDirectory, this calls
-   * the OS's fsync. But, beware: some hardware devices may in fact cache writes even during fsync,
-   * and return before the bits are actually on stable storage, to give the appearance of faster
-   * performance. If you have such a device, and it does not have a battery backup (for example)
-   * then on power loss it may still lose data. Lucene cannot guarantee consistency on such devices.
+   * <p>Note that this operation calls {@link Directory#sync} on the index files. That call should
+   * not return until the file contents and metadata are on stable storage. For FSDirectory, this
+   * calls the OS's fsync. But, beware: some hardware devices may in fact cache writes even during
+   * fsync, and return before the bits are actually on stable storage, to give the appearance of
+   * faster performance. If you have such a device, and it does not have a battery backup (for
+   * example) then on power loss it may still lose data. Lucene cannot guarantee consistency on such
+   * devices.
    *
    * <p>If nothing was committed, because there were no pending changes, this returns -1. Otherwise,
    * it returns the sequence number such that all indexing operations prior to this sequence will be
@@ -5035,8 +5031,7 @@ public class IndexWriter
     // on merges to finish.
     notifyAll();
 
-    // It's possible we are called twice, eg if there was an
-    // exception inside mergeInit
+    // It's possible we are called twice, e.g. if there was an exception inside mergeInit
     if (merge.registerDone) {
       final List<SegmentCommitInfo> sourceSegments = merge.segments;
       for (SegmentCommitInfo info : sourceSegments) {

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -579,8 +579,8 @@ public abstract class MergePolicy {
   }
 
   /**
-   * Default ratio for compound file system usage. Set to <code>1.0</code>, always use compound file
-   * system.
+   * Default ratio for compound file system usage. Set to <code>1.0</code> to always use compound
+   * file system.
    */
   protected static final double DEFAULT_NO_CFS_RATIO = 1.0;
 

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -320,7 +320,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
     Throwable priorE = null;
     int format = -1;
     try {
-      // NOTE: as long as we want to throw indexformattooold (vs corruptindexexception), we need
+      // NOTE: as we want to throw IndexFormatTooOld (vs CorruptIndexException), we need
       // to read the magic ourselves.
       int magic = CodecUtil.readBEInt(input);
       if (magic != CodecUtil.CODEC_MAGIC) {
@@ -728,7 +728,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
     return generation;
   }
 
-  /** Returns last succesfully read or written generation. */
+  /** Returns the last successfully read or written generation. */
   public long getLastGeneration() {
     return lastGeneration;
   }

--- a/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/ArrayUtil.java
@@ -602,7 +602,7 @@ public final class ArrayUtil {
   }
 
   /**
-   * Reorganize {@code arr[from:to[} so that the element at offset k is at the same position as if
+   * Reorganize {@code arr[from:to]} so that the element at offset k is at the same position as if
    * {@code arr[from:to]} was sorted, and all elements on its left are less than or equal to it, and
    * all elements on its right are greater than or equal to it.
    *

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -19,13 +19,12 @@ package org.apache.lucene.util;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
-import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
 
 /**
  * BitSet of fixed length (numBits), backed by accessible ({@link #getBits}) long[], accessed with
- * an int index, implementing {@link Bits} and {@link DocIdSet}. If you need to manage more than
- * 2.1B bits, use {@link LongBitSet}.
+ * an int index, implementing {@link BitSet}. If you need to manage more than 2.1B bits, use {@link
+ * LongBitSet}.
  *
  * @lucene.internal
  */

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/OnHeapHnswGraph.java
@@ -44,9 +44,9 @@ public final class OnHeapHnswGraph extends HnswGraph implements Accountable {
   // level
   // e.g. graph[1][2] is all the neighbours of node 1 at level 2
   private NeighborArray[][] graph;
-  // essentially another 2d map which the first dimension is level and second dimension is node id,
-  // this is only
-  // generated on demand when there's someone calling getNodeOnLevel on a non-zero level
+  // essentially another 2d map in which the first dimension is level and second dimension is node
+  // id, this is only generated on demand when there's someone calling getNodeOnLevel on a
+  // non-zero level
   private IntArrayList[] levelToNodes;
   private int
       lastFreezeSize; // remember the size we are at last time to freeze the graph and generate

--- a/lucene/core/src/test/org/apache/lucene/index/TestAllFilesCheckIndexHeader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAllFilesCheckIndexHeader.java
@@ -86,7 +86,7 @@ public class TestAllFilesCheckIndexHeader extends LuceneTestCase {
 
   private void checkOneFile(Directory dir, String victim) throws IOException {
     // use ramdir explicitly, as we do evil things like trying to generate broken files, deletes
-    // mustk work.
+    // must work.
     try (BaseDirectoryWrapper dirCopy =
         new MockDirectoryWrapper(random(), new ByteBuffersDirectory())) {
       dirCopy.setCheckIndexOnClose(false);

--- a/lucene/core/src/test/org/apache/lucene/index/TestAllFilesCheckIndexHeader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAllFilesCheckIndexHeader.java
@@ -85,8 +85,8 @@ public class TestAllFilesCheckIndexHeader extends LuceneTestCase {
   }
 
   private void checkOneFile(Directory dir, String victim) throws IOException {
-    // use ramdir explicit, as we do evil things like try to generate broken files, deletes must
-    // work.
+    // use ramdir explicitly, as we do evil things like trying to generate broken files, deletes
+    // mustk work.
     try (BaseDirectoryWrapper dirCopy =
         new MockDirectoryWrapper(random(), new ByteBuffersDirectory())) {
       dirCopy.setCheckIndexOnClose(false);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomIndexWriter.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/RandomIndexWriter.java
@@ -51,7 +51,7 @@ import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.InfoStream;
 
 /**
- * Silly class that randomizes the indexing experience. EG it may swap in a different merge
+ * Silly class that randomizes the indexing experience. E.g. it may swap in a different merge
  * policy/scheduler; may commit periodically; may or may not forceMerge in the end, may flush by doc
  * count instead of RAM, etc.
  */


### PR DESCRIPTION
A collection of grammar issues and typo fixes collected over time studying Lucene sources. No code changed, all changes are documentation. I think no Changelog entry needed.

The only non-grammar change is in `FixedBitSet`, where it said it implements `DocIdSet` - it doesn't.