### PR TITLE
Fix/fvh boost issue

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -2,7 +2,10 @@ Lucene Change Log
 
 For more information on past and future Lucene versions, please see:
 http://s.apache.org/luceneversions
-
+Bug Fixes
+---------------------
+* Fix FVH boost issue where boost values were not preserved
+when merging overlapping phrases (issue #15442, PR #15604)
 ======================= Lucene 10.3.3 =======================
 
 Bug Fixes

--- a/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/FieldPhraseList.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/FieldPhraseList.java
@@ -177,6 +177,7 @@ public class FieldPhraseList {
         // The result is that all informations in TermInfo are lost and not available for further
         // operations.
         existWpi.getTermsInfos().addAll(wpi.getTermsInfos());
+        existWpi.boost += wpi.getBoost(); // Accumulate boost
         return;
       }
     }

--- a/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestFieldPhraseList.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestFieldPhraseList.java
@@ -268,6 +268,23 @@ public class TestFieldPhraseList extends AbstractTestCase {
     assertConsistentLessThan(d, c);
   }
 
+  public void testMergeOverlappingWeightedPhraseInfoAccumulateBoost() {
+    LinkedList<TermInfo> infos1 = new LinkedList<>();
+    infos1.add(new TermInfo("中国", 0, 2, 0, 0));
+    infos1.add(new TermInfo("经济", 3, 5, 1, 1));
+    WeightedPhraseInfo wpi1 = new WeightedPhraseInfo(infos1, 2.0f);
+
+    LinkedList<TermInfo> infos2 = new LinkedList<>();
+    infos2.add(new TermInfo("经济", 3, 5, 1, 1));
+    infos2.add(new TermInfo("发展", 6, 8, 2, 2));
+    WeightedPhraseInfo wpi2 = new WeightedPhraseInfo(infos2, 3.0f);
+
+    // trigger merge
+    WeightedPhraseInfo merged = new WeightedPhraseInfo(java.util.List.of(wpi1, wpi2));
+
+    assertEquals(5.0f, merged.getBoost(), 0.0001f);
+  }
+
   private WeightedPhraseInfo newInfo(int startOffset, int endOffset, float boost) {
     LinkedList<TermInfo> infos = new LinkedList<>();
     infos.add(new TermInfo(TestUtil.randomUnicodeString(random()), startOffset, endOffset, 0, 0));


### PR DESCRIPTION
Summary
This PR fixes a small issue in FastVectorHighlighter where boost values were not fully preserved when overlapping phrases were merged (#15442).
The change is limited to the boost accumulation logic, and a unit test is added to cover the case.

Motivation
While investigating FastVectorHighlighter behavior with overlapping phrase queries, I noticed that part of the boost information could be lost during phrase merging.
This can lead to highlight scoring that does not fully reflect the original query boosts.
This mainly affects legacy Elasticsearch and Solr setups that still rely on FVH.

Implementation
Preserve boost values when merging overlapping WeightedPhraseInfo instances
Add a small null-safety guard around TokenGroup boost handling
Add a focused test reproducing the issue

Risks
The change is small and limited to FVH internals, and should be safe to backport to 10.3.