### PR TITLE
Build: Ensure reproduction line can be copy & pasted into terminal

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/RunListenerPrintReproduceInfo.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/RunListenerPrintReproduceInfo.java
@@ -175,7 +175,7 @@ public final class RunListenerPrintReproduceInfo extends RunListener {
     }
 
     final StringBuilder b = new StringBuilder();
-    b.append("NOTE: reproduce with: gradlew test ");
+    b.append("NOTE: reproduce with: ./gradlew test ");
 
     // Figure out the test case name and method, if any.
     String testClass = RandomizedContext.current().getTargetClass().getSimpleName();


### PR DESCRIPTION
Just a super small thing, but I noticed I always need to add `./` in front of the `gradlew` call in the reproduction line of failing tests when copy-pasting.

Feel free to close without discussion if I missed any reason why this is, which I likely missed.