### PR TITLE
Enabled cfs for BaseIndexFileFormatTestCase.java

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
@@ -267,7 +267,6 @@ public abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
     assumeTrue("merge is not stable", mergeIsStable());
     Directory dir = applyCreatedVersionMajor(newDirectory());
 
-    // do not use newMergePolicy that might return a MockMergePolicy that ignores the no-CFS ratio
     // do not use RIW which will change things up!
     MergePolicy mp = newTieredMergePolicy();
     IndexWriterConfig cfg = new IndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(mp);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
@@ -272,9 +272,7 @@ public abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
     MergePolicy mp = newTieredMergePolicy();
     IndexWriterConfig cfg =
         new IndexWriterConfig(new MockAnalyzer(random()))
-            .setUseCompoundFile(false)
             .setMergePolicy(mp);
-    cfg.getCodec().compoundFormat().setShouldUseCompoundFile(false);
     if (VERBOSE) {
       cfg.setInfoStream(System.out);
     }
@@ -294,9 +292,7 @@ public abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
     mp = newTieredMergePolicy();
     cfg =
         new IndexWriterConfig(new MockAnalyzer(random()))
-            .setUseCompoundFile(false)
             .setMergePolicy(mp);
-    cfg.getCodec().compoundFormat().setShouldUseCompoundFile(false);
     w = new IndexWriter(dir2, cfg);
     TestUtil.addIndexesSlowly(w, reader);
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
@@ -270,9 +270,7 @@ public abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
     // do not use newMergePolicy that might return a MockMergePolicy that ignores the no-CFS ratio
     // do not use RIW which will change things up!
     MergePolicy mp = newTieredMergePolicy();
-    IndexWriterConfig cfg =
-        new IndexWriterConfig(new MockAnalyzer(random()))
-            .setMergePolicy(mp);
+    IndexWriterConfig cfg = new IndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(mp);
     if (VERBOSE) {
       cfg.setInfoStream(System.out);
     }
@@ -290,9 +288,7 @@ public abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
 
     Directory dir2 = applyCreatedVersionMajor(newDirectory());
     mp = newTieredMergePolicy();
-    cfg =
-        new IndexWriterConfig(new MockAnalyzer(random()))
-            .setMergePolicy(mp);
+    cfg = new IndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(mp);
     w = new IndexWriter(dir2, cfg);
     TestUtil.addIndexesSlowly(w, reader);
 


### PR DESCRIPTION
### Problem
After merging #15295 some nightly tests started failing. @romseygeek reported the following:

```
TestLucene87StoredFieldsFormatHighCompression > testMergeStability FAILED
--
java.lang.AssertionError: expected:<{fnm=77, fdt=37004, fdx=64, fdm=159}> but was:<{cfs=37366, cfe=150}>
at __randomizedtesting.SeedInfo.seed([DF7E25E7C981E11B:AB3263C8C46BE3AD]:0)
at junit@4.13.2/org.junit.Assert.fail(Assert.java:89)
at junit@4.13.2/org.junit.Assert.failNotEquals(Assert.java:835)
at junit@4.13.2/org.junit.Assert.assertEquals(Assert.java:120)
at junit@4.13.2/org.junit.Assert.assertEquals(Assert.java:146)
at org.apache.lucene.test_framework@11.0.0-SNAPSHOT/org.apache.lucene.tests.index.BaseIndexFileFormatTestCase.testMergeStability(BaseIndexFileFormatTestCase.java:306)
```

### Solution
There are two solutions I can think of:

- We can modify `Lucene87RWCodec` to cache compoundFormat like `Lucene94Codec`:

```
  public final CompoundFormat compoundFormat() {
    return compoundFormat;
  }
```

- We can stop disabling CFS explicitly in this test (leave the default as is). 

I am going with the second one as we don't want to change existing codecs.

### Testing

```
./gradlew test --tests TestLucene87StoredFieldsFormatHighCompression.testMergeStability -Dtests.seed=DF7E25E7C981E11B -Dtests.nightly=true -Dtests.locale=ig-Latn-NG -Dtests.timezone=Asia/Qostanay -Dtests.asserts=true -Dtests.file.encoding=UTF-8
```
Passes:

```
BUILD SUCCESSFUL in 12s
294 actionable tasks: 147 executed, 147 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.2.1/userguide/configuration_cache_enabling.html
```

```
./gradlew test   -Dtests.nightly=true -Dtests.locale=ig-Latn-NG -Dtests.timezone=Asia/Qostanay -Dtests.asserts=true -Dtests.file.encoding=UTF-8
```
Passes:

```
The slowest tests during this run:
  660.88s TestIDVersionPostingsFormat.testGlobalVersions (:lucene:sandbox)
  480.23s TestStressNRTReplication.test (:lucene:replicator)
  347.44s Test2BPostings.test (:lucene:core)
  332.55s TestSortedDvMultiRangeQuery.testDuelWithStandardDisjunction (:lucene:sandbox)
  311.42s TestSimpleTextPostingsFormat.testDocsAndFreqsAndPositionsAndOffsetsAndPayloads (:lucene:codecs)
  238.38s TestBestCompressionLucene80DocValuesFormat.testNumericFieldJumpTables (:lucene:backward-codecs)
  236.20s TestBestSpeedLucene80DocValuesFormat.testNumericFieldJumpTables (:lucene:backward-codecs)
  226.95s TestLucene90DocValuesFormat.testNumericFieldJumpTables (:lucene:core)
  226.79s TestLucene90DocValuesFormatMergeInstance.testNumericFieldJumpTables (:lucene:core)
  162.26s TestDemoParallelLeafReader.testRandomMultipleSchemaGens (:lucene:core)
The slowest suites during this run:
  811.59s TestSimpleTextPostingsFormat (:lucene:codecs)
  661.40s TestIDVersionPostingsFormat (:lucene:sandbox)
  621.32s TestLucene90DocValuesFormat (:lucene:core)
  609.17s TestBestSpeedLucene80DocValuesFormat (:lucene:backward-codecs)
  607.75s TestBestCompressionLucene80DocValuesFormat (:lucene:backward-codecs)
  607.16s TestLucene90DocValuesFormatMergeInstance (:lucene:core)
  480.51s TestStressNRTReplication (:lucene:replicator)
  347.46s Test2BPostings (:lucene:core)
  332.82s TestSortedDvMultiRangeQuery (:lucene:sandbox)
  259.55s TestDemoParallelLeafReader (:lucene:core)

BUILD SUCCESSFUL in 34m 21s
293 actionable tasks: 38 executed, 255 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.2.1/userguide/configuration_cache_enabling.html
```