### PR TITLE
Use expectThrows for expected exceptions

### DIFF
--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestStopFilterFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestStopFilterFactory.java
@@ -96,7 +96,6 @@ public class TestStopFilterFactory extends BaseTokenStreamFactoryTestCase {
                   // implicit default words file
                   "format",
                   "bogus");
-              fail();
             });
     msg = expected.getMessage();
     assertTrue(msg, msg.contains("can not be specified"));

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocValuesIndexing.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocValuesIndexing.java
@@ -102,7 +102,6 @@ public class TestDocValuesIndexing extends LuceneTestCase {
         IllegalArgumentException.class,
         () -> {
           w.addDocument(doc);
-          fail("didn't hit expected exception");
         });
 
     DirectoryReader r = w.getReader();

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
@@ -661,14 +661,12 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
       writer.addDocument(doc);
       doc.add(newField("crash", "this should crash after 4 terms", DocCopyIterator.custom5));
       doc.add(newField("other", "this will not get indexed", DocCopyIterator.custom5));
-      try {
-        writer.addDocument(doc);
-        fail("did not hit expected exception");
-      } catch (IOException ioe) {
-        if (VERBOSE) {
-          System.out.println("TEST: hit expected exception");
-          ioe.printStackTrace(System.out);
-        }
+      IndexWriter finalWriter = writer;
+      Document finalDoc = doc;
+      IOException ioe = expectThrows(IOException.class, () -> finalWriter.addDocument(finalDoc));
+      if (VERBOSE) {
+        System.out.println("TEST: hit expected exception");
+        ioe.printStackTrace(System.out);
       }
 
       if (0 == i) {
@@ -958,11 +956,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
     for (int i = 0; i < 23; i++) {
       addDoc(writer);
       if ((i - 1) % 2 == 0) {
-        try {
-          writer.commit();
-        } catch (IOException _) {
-          // expected
-        }
+        expectThrows(IOException.class, () -> writer.commit());
       }
     }
     ((ConcurrentMergeScheduler) writer.getConfig().getMergeScheduler()).sync();
@@ -1721,7 +1715,6 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
           Field theField = new StoredField("foo", v);
           doc.add(theField);
           iw.addDocument(doc);
-          fail("didn't get expected exception");
         });
 
     assertNull(iw.getTragicException());
@@ -1750,7 +1743,6 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
           BytesRef v = null;
           theField.setBytesValue(v);
           iw.addDocument(doc);
-          fail("didn't get expected exception");
         });
 
     assertNull(iw.getTragicException());
@@ -1779,7 +1771,6 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
           Field theField = new StoredField("foo", v);
           doc.add(theField);
           iw.addDocument(doc);
-          fail("didn't get expected exception");
         });
 
     assertNull(iw.getTragicException());
@@ -2232,16 +2223,14 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
               return true;
             }
           }) {
-        writer.rollback();
-        fail();
+        RuntimeException e = expectThrows(RuntimeException.class, () -> writer.rollback());
+        assertEquals("boom", e.getMessage());
+        assertEquals(
+            "has suppressed exceptions: " + Arrays.toString(e.getSuppressed()),
+            0,
+            e.getSuppressed().length);
+        assertNull(e.getCause());
       }
-    } catch (RuntimeException e) {
-      assertEquals("boom", e.getMessage());
-      assertEquals(
-          "has suppressed exceptions: " + Arrays.toString(e.getSuppressed()),
-          0,
-          e.getSuppressed().length);
-      assertNull(e.getCause());
     }
   }
 
@@ -2293,12 +2282,14 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
         doc.add(new IntPoint("point2d", random().nextInt(), random().nextInt()));
         writer.addDocument(new Document());
       }
-      try {
-        writer.commit();
-        fail();
-      } catch (RuntimeException e) {
-        assertEquals("boom", e.getMessage());
-      }
+      RuntimeException expected =
+          expectThrows(
+              RuntimeException.class,
+              () -> {
+                writer.commit();
+              });
+      assertEquals("boom", expected.getMessage());
+
       try {
         maybeFailDelete.set(true);
         writer.rollback();

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMergePolicy.java
@@ -725,10 +725,9 @@ public class TestIndexWriterMergePolicy extends LuceneTestCase {
         writer.addDocument(d2);
         writer.flush();
         mergeAndFail.set(true);
-        try (DirectoryReader reader = DirectoryReader.open(writer)) {
-          assertNotNull(reader); // make compiler happy and use the reader
-          fail();
-        } catch (RuntimeException e) {
+        try {
+          RuntimeException e =
+              expectThrows(RuntimeException.class, () -> DirectoryReader.open(writer));
           assertEquals("boom", e.getMessage());
         } finally {
           mergeAndFail.set(false);

--- a/lucene/core/src/test/org/apache/lucene/util/TestAttributeSource.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestAttributeSource.java
@@ -165,7 +165,6 @@ public class TestAttributeSource extends LuceneTestCase {
         () -> {
           AttributeSource src = new AttributeSource();
           src.addAttribute(Token.class);
-          fail("Should throw IllegalArgumentException");
         });
 
     expectThrows(

--- a/lucene/core/src/test/org/apache/lucene/util/TestBytesRefHash.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestBytesRefHash.java
@@ -332,26 +332,22 @@ public class TestBytesRefHash extends LuceneTestCase {
     }
   }
 
-  @Test(expected = MaxBytesLengthExceededException.class)
+  @Test
   public void testLargeValue() {
     int[] sizes =
-        new int[] {
-          random().nextInt(5),
-          ByteBlockPool.BYTE_BLOCK_SIZE - 33 + random().nextInt(31),
-          ByteBlockPool.BYTE_BLOCK_SIZE - 1 + random().nextInt(37)
-        };
+        new int[] {random().nextInt(5), ByteBlockPool.BYTE_BLOCK_SIZE - 33 + random().nextInt(31)};
     BytesRef ref = new BytesRef();
     for (int i = 0; i < sizes.length; i++) {
       ref.bytes = new byte[sizes[i]];
       ref.offset = 0;
       ref.length = sizes[i];
-      try {
-        assertEquals(i, hash.add(ref));
-      } catch (MaxBytesLengthExceededException e) {
-        if (i < sizes.length - 1) fail("unexpected exception at size: " + sizes[i]);
-        throw e;
-      }
+      assertEquals(i, hash.add(ref));
     }
+
+    ref.bytes = new byte[ByteBlockPool.BYTE_BLOCK_SIZE - 1 + random().nextInt(37)];
+    ref.offset = 0;
+    ref.length = ref.bytes.length;
+    expectThrows(MaxBytesLengthExceededException.class, () -> hash.add(ref));
   }
 
   /** Test method for {@link org.apache.lucene.util.BytesRefHash#addByPoolOffset(int)} . */

--- a/lucene/core/src/test/org/apache/lucene/util/TestSetOnce.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestSetOnce.java
@@ -55,19 +55,19 @@ public class TestSetOnce extends LuceneTestCase {
     assertNull(set.get());
   }
 
-  @Test(expected = AlreadySetException.class)
+  @Test
   public void testSettingCtor() throws Exception {
     SetOnce<Integer> set = new SetOnce<>(5);
     assertEquals(5, set.get().intValue());
-    set.set(7);
+    expectThrows(AlreadySetException.class, () -> set.set(7));
   }
 
-  @Test(expected = AlreadySetException.class)
+  @Test
   public void testSetOnce() throws Exception {
     SetOnce<Integer> set = new SetOnce<>();
     set.set(5);
     assertEquals(5, set.get().intValue());
-    set.set(7);
+    expectThrows(AlreadySetException.class, () -> set.set(7));
   }
 
   @Test

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestLimitedFiniteStringsIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestLimitedFiniteStringsIterator.java
@@ -53,7 +53,6 @@ public class TestLimitedFiniteStringsIterator extends LuceneTestCase {
         IllegalArgumentException.class,
         () -> {
           new LimitedFiniteStringsIterator(a, -7);
-          fail("did not hit exception");
         });
   }
 

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterReanalysis.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterReanalysis.java
@@ -55,7 +55,7 @@ public class TestUnifiedHighlighterReanalysis extends UnifiedHighlighterTestBase
     assertEquals("Hello", highlighter.highlightWithoutSearcher("nonexistent", query, "Hello", 1));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testIndexSearcherNullness() throws IOException {
     String text =
         "This is a test. Just a test highlighting without a searcher. Feel free to ignore.";
@@ -66,7 +66,9 @@ public class TestUnifiedHighlighterReanalysis extends UnifiedHighlighterTestBase
         IndexReader indexReader = indexWriter.getReader()) {
       IndexSearcher searcher = newSearcher(indexReader);
       UnifiedHighlighter highlighter = UnifiedHighlighter.builder(searcher, indexAnalyzer).build();
-      highlighter.highlightWithoutSearcher("body", query, text, 1); // should throw
+      expectThrows(
+          IllegalStateException.class,
+          () -> highlighter.highlightWithoutSearcher("body", query, text, 1));
     }
   }
 }

--- a/lucene/luke/src/test/org/apache/lucene/luke/models/analysis/TestAnalysisImpl.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/analysis/TestAnalysisImpl.java
@@ -132,7 +132,7 @@ public class TestAnalysisImpl extends LuceneTestCase {
     assertNotNull(tokens);
   }
 
-  @Test(expected = LukeException.class)
+  @Test
   public void testAnalyzeStepByStep_preset() {
     AnalysisImpl analysis = new AnalysisImpl();
     String analyzerType = "org.apache.lucene.analysis.standard.StandardAnalyzer";
@@ -140,7 +140,7 @@ public class TestAnalysisImpl extends LuceneTestCase {
     assertEquals(analyzerType, analyzer.getClass().getName());
 
     String text = "This test must fail.";
-    analysis.analyzeStepByStep(text);
+    expectThrows(LukeException.class, () -> analysis.analyzeStepByStep(text));
   }
 
   @Test

--- a/lucene/luke/src/test/org/apache/lucene/luke/models/documents/TestDocumentsImpl.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/documents/TestDocumentsImpl.java
@@ -243,10 +243,10 @@ public class TestDocumentsImpl extends DocumentsTestBase {
     assertEquals(0, documents.getTermPositions().size());
   }
 
-  @Test(expected = AlreadyClosedException.class)
+  @Test
   public void testClose() throws Exception {
     new DocumentsImpl(reader);
     reader.close();
-    IndexUtils.getFieldNames(reader);
+    expectThrows(AlreadyClosedException.class, () -> IndexUtils.getFieldNames(reader));
   }
 }

--- a/lucene/luke/src/test/org/apache/lucene/luke/models/overview/TestOverviewImpl.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/overview/TestOverviewImpl.java
@@ -121,16 +121,16 @@ public class TestOverviewImpl extends OverviewTestBase {
     assertEquals("f2", result.get(0).getField());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetTopTerms_illegal_numterms() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
-    overview.getTopTerms("f2", -1);
+    expectThrows(IllegalArgumentException.class, () -> overview.getTopTerms("f2", -1));
   }
 
-  @Test(expected = AlreadyClosedException.class)
+  @Test
   public void testClose() throws Exception {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     reader.close();
-    overview.getNumFields();
+    expectThrows(AlreadyClosedException.class, () -> overview.getNumFields());
   }
 }

--- a/lucene/luke/src/test/org/apache/lucene/luke/models/search/TestSearchImpl.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/search/TestSearchImpl.java
@@ -254,10 +254,10 @@ public class TestSearchImpl extends LuceneTestCase {
         search.guessSortTypes("f7").toArray());
   }
 
-  @Test(expected = LukeException.class)
+  @Test
   public void testGuessSortTypesNoSuchField() {
     SearchImpl search = new SearchImpl(reader);
-    search.guessSortTypes("unknown");
+    expectThrows(LukeException.class, () -> search.guessSortTypes("unknown"));
   }
 
   @Test
@@ -295,11 +295,10 @@ public class TestSearchImpl extends LuceneTestCase {
     assertFalse(search.getSortType("f7", "STRING", false).isPresent());
   }
 
-  @Test(expected = LukeException.class)
+  @Test
   public void testGetSortTypeNoSuchField() {
     SearchImpl search = new SearchImpl(reader);
-
-    search.getSortType("unknown", "STRING", false);
+    expectThrows(LukeException.class, () -> search.getSortType("unknown", "STRING", false));
   }
 
   @Test
@@ -341,10 +340,10 @@ public class TestSearchImpl extends LuceneTestCase {
     assertEquals(10, res.getOffset());
   }
 
-  @Test(expected = LukeException.class)
+  @Test
   public void testNextPageSearchNotStarted() {
     SearchImpl search = new SearchImpl(reader);
-    search.nextPage();
+    expectThrows(LukeException.class, () -> search.nextPage());
   }
 
   @Test
@@ -371,10 +370,10 @@ public class TestSearchImpl extends LuceneTestCase {
     assertEquals(0, res.getOffset());
   }
 
-  @Test(expected = LukeException.class)
+  @Test
   public void testPrevPageSearchNotStarted() {
     SearchImpl search = new SearchImpl(reader);
-    search.prevPage();
+    expectThrows(LukeException.class, () -> search.prevPage());
   }
 
   @Test

--- a/lucene/queries/src/test/org/apache/lucene/queries/spans/TestSpanWithinQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/spans/TestSpanWithinQuery.java
@@ -118,12 +118,16 @@ public class TestSpanWithinQuery extends LuceneTestCase {
     check(query, expectedDocs);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDifferentFieldsThrowsIllegalArgumentException() {
     SpanQuery big = new SpanTermQuery(new Term("field1", "one"));
     SpanQuery little = new SpanTermQuery(new Term("field2", "two"));
 
-    new SpanWithinQuery(big, little);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new SpanWithinQuery(big, little);
+        });
   }
 
   public void testToString() {

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/vector/TestPointVectorStrategy.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/vector/TestPointVectorStrategy.java
@@ -51,12 +51,12 @@ public class TestPointVectorStrategy extends StrategyTestCase {
     assertNotNull(query);
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testInvalidQueryShape() {
     this.strategy = PointVectorStrategy.newInstance(ctx, getClass().getSimpleName());
     Point point = ctx.makePoint(0, 0);
     SpatialArgs args = new SpatialArgs(SpatialOperation.Intersects, point);
-    this.strategy.makeQuery(args);
+    expectThrows(UnsupportedOperationException.class, () -> this.strategy.makeQuery(args));
   }
 
   @Test


### PR DESCRIPTION
This PR updates tests to use `expectThrows` instead of the `expected` attribute of the `@Test` annotation or manual` try-catch-fail` blocks. It also removes unnecessary `fail()` calls.