### PR TITLE
Fix Lucene84RWCodec to cache CompoundFormat instance

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene84/Lucene84RWCodec.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene84/Lucene84RWCodec.java
@@ -35,6 +35,7 @@ import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
 public class Lucene84RWCodec extends Lucene84Codec {
 
   private final PostingsFormat defaultPF = new Lucene84RWPostingsFormat();
+  private final CompoundFormat compoundFormat = new Lucene50RWCompoundFormat();
   private final PostingsFormat postingsFormat =
       new PerFieldPostingsFormat() {
         @Override
@@ -70,7 +71,7 @@ public class Lucene84RWCodec extends Lucene84Codec {
 
   @Override
   public final CompoundFormat compoundFormat() {
-    return new Lucene50RWCompoundFormat();
+    return compoundFormat;
   }
 
   @Override

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene86/Lucene86RWCodec.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene86/Lucene86RWCodec.java
@@ -36,6 +36,7 @@ public class Lucene86RWCodec extends Lucene86Codec {
 
   private final StoredFieldsFormat storedFieldsFormat;
   private final PostingsFormat defaultPF = new Lucene84RWPostingsFormat();
+  private final CompoundFormat compoundFormat = new Lucene50RWCompoundFormat();
   private final PostingsFormat postingsFormat =
       new PerFieldPostingsFormat() {
         @Override
@@ -76,7 +77,7 @@ public class Lucene86RWCodec extends Lucene86Codec {
 
   @Override
   public final CompoundFormat compoundFormat() {
-    return new Lucene50RWCompoundFormat();
+    return compoundFormat;
   }
 
   @Override

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene87/Lucene87RWCodec.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene87/Lucene87RWCodec.java
@@ -35,6 +35,7 @@ import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
 public class Lucene87RWCodec extends Lucene87Codec {
 
   private final PostingsFormat defaultPF = new Lucene84RWPostingsFormat();
+  private final CompoundFormat compoundFormat = new Lucene50RWCompoundFormat();
   private final PostingsFormat postingsFormat =
       new PerFieldPostingsFormat() {
         @Override
@@ -60,7 +61,7 @@ public class Lucene87RWCodec extends Lucene87Codec {
 
   @Override
   public final CompoundFormat compoundFormat() {
-    return new Lucene50RWCompoundFormat();
+    return compoundFormat;
   }
 
   @Override


### PR DESCRIPTION
The compoundFormat() method was creating a new Lucene50RWCompoundFormat 
instance on every call. This caused configuration changes made via 
setShouldUseCompoundFile() to be lost, as subsequent calls would return 
a different instance with default settings.

This fix caches the CompoundFormat instance as a field, following the 
pattern used by the parent class Lucene84Codec.

Closes #15615