### PR TITLE
SegmentTermsEnumFrame: avoid unnecessary array allocations that waste memory

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -317,6 +317,8 @@ Optimizations
 
 * GITHUB#15582: Avoid copying bitset that's subsequently cleared (Viliam Durina)
 
+* GITHUB#15618: SegmentTermsEnumFrame: avoid unnecessary array allocations that waste memory (Misha Dmitriev)
+
 Bug Fixes
 ---------------------
 * GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/SegmentTermsEnumFrame.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/SegmentTermsEnumFrame.java
@@ -45,13 +45,13 @@ final class SegmentTermsEnumFrame {
   long fpEnd;
   long totalSuffixBytes; // for stats
 
-  byte[] suffixBytes = new byte[128];
+  byte[] suffixBytes;
   final ByteArrayDataInput suffixesReader = new ByteArrayDataInput();
 
   byte[] suffixLengthBytes;
   final ByteArrayDataInput suffixLengthsReader;
 
-  byte[] statBytes = new byte[64];
+  byte[] statBytes;
   int statsSingletonRunLength = 0;
   final ByteArrayDataInput statsReader = new ByteArrayDataInput();
 
@@ -95,7 +95,7 @@ final class SegmentTermsEnumFrame {
   final BlockTermState state;
 
   // metadata buffer
-  byte[] bytes = new byte[32];
+  byte[] bytes;
   final ByteArrayDataInput bytesReader = new ByteArrayDataInput();
 
   private final SegmentTermsEnum ste;
@@ -105,7 +105,6 @@ final class SegmentTermsEnumFrame {
     this.ord = ord;
     this.state = ste.fr.parent.postingsReader.newTermState();
     this.state.totalTermFreq = -1;
-    suffixLengthBytes = new byte[32];
     suffixLengthsReader = new ByteArrayDataInput();
   }
 
@@ -192,7 +191,7 @@ final class SegmentTermsEnumFrame {
     final long codeL = ste.in.readVLong();
     isLeafBlock = (codeL & 0x04) != 0;
     final int numSuffixBytes = (int) (codeL >>> 3);
-    if (suffixBytes.length < numSuffixBytes) {
+    if (suffixBytes == null || suffixBytes.length < numSuffixBytes) {
       suffixBytes = new byte[ArrayUtil.oversize(numSuffixBytes, 1)];
     }
     try {
@@ -206,7 +205,7 @@ final class SegmentTermsEnumFrame {
     int numSuffixLengthBytes = ste.in.readVInt();
     allEqual = (numSuffixLengthBytes & 0x01) != 0;
     numSuffixLengthBytes >>>= 1;
-    if (suffixLengthBytes.length < numSuffixLengthBytes) {
+    if (suffixLengthBytes == null || suffixLengthBytes.length < numSuffixLengthBytes) {
       suffixLengthBytes = new byte[ArrayUtil.oversize(numSuffixLengthBytes, 1)];
     }
     if (allEqual) {
@@ -227,7 +226,7 @@ final class SegmentTermsEnumFrame {
 
     // stats
     int numBytes = ste.in.readVInt();
-    if (statBytes.length < numBytes) {
+    if (statBytes == null || statBytes.length < numBytes) {
       statBytes = new byte[ArrayUtil.oversize(numBytes, 1)];
     }
     ste.in.readBytes(statBytes, 0, numBytes);
@@ -243,7 +242,7 @@ final class SegmentTermsEnumFrame {
     // that's rare so won't help much
     // metadata
     numBytes = ste.in.readVInt();
-    if (bytes.length < numBytes) {
+    if (bytes == null || bytes.length < numBytes) {
       bytes = new byte[ArrayUtil.oversize(numBytes, 1)];
     }
     ste.in.readBytes(bytes, 0, numBytes);


### PR DESCRIPTION
### Description

At LinkedIn, we use lucene in some important search apps. We recently started to look at possible GC and memory footprint optimizations in several of them. We first analyzed a memory allocation profile and found that around 1/3 of memory allocation, in bytes per second, is due to byte[] arrays managed by class SegmentTermsEnumFrame ('suffixBytes', 'statBytes' etc). Next, we analyzed a heap dump and found that of these arrays, around 80% are empty. That is, they contain only zeroes, which likely signals that they are never used. Of the remaining arrays, a significant percentage has a lot of trailing zeroes, which likely means that the default size is too big and these arrays are underutilized. All in all, we estimated that if the arrays in question were allocated lazily, the total memory allocation should drop by ~25%. That's a huge saving, potentially allowing us to run the same apps with much higher QPS.

We made an experimental local change to lucene 9.8.0 that we currently use, and confirmed that memory allocation rate drops as expected, after which QPS can be raised significantly without affecting application's latency. 

Please note that this PR is in the 'main' branch. If somebody else backports it to the 9.8.0 and other old branches, they will need to implement a similar fix for the 'floorData' field that exists only in these branches.