### PR TITLE
Add validation to prevent zero vectors in KNN fields

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -214,6 +214,8 @@ API Changes
 
 * GITHUB#15502: Add `count()` method to `FilterWeight`  (Prudhvi Godithi)
 
+* GITHUB#15621: Add validation to prevent zero vectors in KNN fields (Vigya Sharma)
+
 New Features
 ---------------------
 * GITHUB#15328: VectorSimilarityFunction.getValues() now implements doubleVal allowing its

--- a/lucene/codecs/src/test/org/apache/lucene/codecs/bitvectors/TestHnswBitVectorsFormat.java
+++ b/lucene/codecs/src/test/org/apache/lucene/codecs/bitvectors/TestHnswBitVectorsFormat.java
@@ -55,7 +55,9 @@ public class TestHnswBitVectorsFormat extends BaseIndexFileFormatTestCase {
     try (Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new KnnFloatVectorField("f", new float[] {1f, 0f, 0f, 1f}, VectorSimilarityFunction.DOT_PRODUCT));
+      doc.add(
+          new KnnFloatVectorField(
+              "f", new float[] {1f, 0f, 0f, 1f}, VectorSimilarityFunction.DOT_PRODUCT));
       IllegalArgumentException e =
           expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc));
       e.getMessage().contains("HnswBitVectorsFormat only supports BYTE encoding");

--- a/lucene/codecs/src/test/org/apache/lucene/codecs/bitvectors/TestHnswBitVectorsFormat.java
+++ b/lucene/codecs/src/test/org/apache/lucene/codecs/bitvectors/TestHnswBitVectorsFormat.java
@@ -55,7 +55,7 @@ public class TestHnswBitVectorsFormat extends BaseIndexFileFormatTestCase {
     try (Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+      doc.add(new KnnFloatVectorField("f", new float[] {1f, 0f, 0f, 1f}, VectorSimilarityFunction.DOT_PRODUCT));
       IllegalArgumentException e =
           expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc));
       e.getMessage().contains("HnswBitVectorsFormat only supports BYTE encoding");
@@ -68,8 +68,7 @@ public class TestHnswBitVectorsFormat extends BaseIndexFileFormatTestCase {
           new byte[] {(byte) 0b10101110, (byte) 0b01010111},
           new byte[] {(byte) 0b11111000, (byte) 0b00001111},
           new byte[] {(byte) 0b11001100, (byte) 0b00110011},
-          new byte[] {(byte) 0b11111111, (byte) 0b00000000},
-          new byte[] {(byte) 0b00000000, (byte) 0b00000000}
+          new byte[] {(byte) 0b11111111, (byte) 0b00000000}
         };
     try (Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {

--- a/lucene/core/src/java/org/apache/lucene/document/KnnByteVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnByteVectorField.java
@@ -98,6 +98,9 @@ public class KnnByteVectorField extends Field {
   public KnnByteVectorField(
       String name, byte[] vector, VectorSimilarityFunction similarityFunction) {
     super(name, createType(vector, similarityFunction));
+    if (VectorUtil.isZeroVector(vector) == true) {
+      throw new IllegalArgumentException("zero vector not allowed for vector field value");
+    }
     fieldsData = vector; // null-check done above
   }
 

--- a/lucene/core/src/java/org/apache/lucene/document/KnnByteVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnByteVectorField.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.KnnByteVectorQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.VectorUtil;
 
 /**
  * A field that contains a single byte numeric vector (or none) for each document. Vectors are dense
@@ -137,6 +138,9 @@ public class KnnByteVectorField extends Field {
     if (vector.length != fieldType.vectorDimension()) {
       throw new IllegalArgumentException(
           "The number of vector dimensions does not match the field type");
+    }
+    if (VectorUtil.isZeroVector(vector) == true) {
+      throw new IllegalArgumentException("zero vector not allowed for vector field value");
     }
     fieldsData = vector;
   }

--- a/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
@@ -98,6 +98,9 @@ public class KnnFloatVectorField extends Field {
   public KnnFloatVectorField(
       String name, float[] vector, VectorSimilarityFunction similarityFunction) {
     super(name, createType(vector, similarityFunction));
+    if (VectorUtil.isZeroVector(vector) == true) {
+      throw new IllegalArgumentException("zero vector not allowed for vector field value");
+    }
     fieldsData = VectorUtil.checkFinite(vector); // null check done above
   }
 

--- a/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
@@ -139,6 +139,9 @@ public class KnnFloatVectorField extends Field {
       throw new IllegalArgumentException(
           "The number of vector dimensions does not match the field type");
     }
+    if (VectorUtil.isZeroVector(vector) == true) {
+      throw new IllegalArgumentException("zero vector not allowed for vector field value");
+    }
     fieldsData = VectorUtil.checkFinite(vector);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -438,6 +438,18 @@ public final class VectorUtil {
   }
 
   /**
+   * Returns true if all dimensions of provided vector are zero, false otherwise.
+   */
+  public static boolean isZeroVector(float[] v) {
+    for (float value : v) {
+      if (value != 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
    * Given an array {@code buffer} that is sorted between indexes {@code 0} inclusive and {@code to}
    * exclusive, find the first array index whose value is greater than or equal to {@code target}.
    * This index is guaranteed to be at least {@code from}. If there is no such array index, {@code

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -437,9 +437,7 @@ public final class VectorUtil {
     return v;
   }
 
-  /**
-   * Returns true if all dimensions of provided vector are zero, false otherwise.
-   */
+  /** Returns true if all dimensions of provided vector are zero, false otherwise. */
   public static boolean isZeroVector(float[] v) {
     for (float value : v) {
       if (value != 0) {
@@ -449,9 +447,7 @@ public final class VectorUtil {
     return true;
   }
 
-  /**
-   * Returns true if all dimensions of provided vector are zero, false otherwise.
-   */
+  /** Returns true if all dimensions of provided vector are zero, false otherwise. */
   public static boolean isZeroVector(byte[] v) {
     for (float value : v) {
       if (value != 0) {

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -450,6 +450,18 @@ public final class VectorUtil {
   }
 
   /**
+   * Returns true if all dimensions of provided vector are zero, false otherwise.
+   */
+  public static boolean isZeroVector(byte[] v) {
+    for (float value : v) {
+      if (value != 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
    * Given an array {@code buffer} that is sorted between indexes {@code 0} inclusive and {@code to}
    * exclusive, find the first array index whose value is greater than or equal to {@code target}.
    * This index is guaranteed to be at least {@code from}. If there is no such array index, {@code

--- a/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldKnnVectorsFormat.java
@@ -55,6 +55,7 @@ import org.apache.lucene.tests.codecs.asserting.AssertingCodec;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 import org.apache.lucene.tests.index.RandomCodec;
 import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.TestVectorUtil;
 import org.hamcrest.MatcherAssert;
 
 /** Basic tests of PerFieldDocValuesFormat */
@@ -232,14 +233,14 @@ public class TestPerFieldKnnVectorsFormat extends BaseKnnVectorsFormatTestCase {
           });
       try (IndexWriter writer = new IndexWriter(directory, iwc)) {
         Document doc1 = new Document();
-        doc1.add(new KnnFloatVectorField("field1", new float[33]));
+        doc1.add(new KnnFloatVectorField("field1", TestVectorUtil.randomVector(33)));
         Exception exc =
             expectThrows(IllegalArgumentException.class, () -> writer.addDocument(doc1));
         assertTrue(exc.getMessage().contains("vector's dimensions must be <= [32]"));
 
         Document doc2 = new Document();
-        doc2.add(new KnnFloatVectorField("field1", new float[32]));
-        doc2.add(new KnnFloatVectorField("field2", new float[33]));
+        doc2.add(new KnnFloatVectorField("field1", TestVectorUtil.randomVector(32)));
+        doc2.add(new KnnFloatVectorField("field2", TestVectorUtil.randomVector(33)));
         writer.addDocument(doc2);
       }
 

--- a/lucene/core/src/test/org/apache/lucene/document/TestField.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestField.java
@@ -699,9 +699,9 @@ public class TestField extends LuceneTestCase {
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       Document doc = new Document();
       byte[] empty = new byte[5];
-      IllegalArgumentException zeroError = expectThrows(
-          IllegalArgumentException.class,
-          () -> new KnnByteVectorField("binaryZeroErr", empty));
+      IllegalArgumentException zeroError =
+          expectThrows(
+              IllegalArgumentException.class, () -> new KnnByteVectorField("binaryZeroErr", empty));
       assertTrue(zeroError.getMessage().contains("zero vector not allowed"));
 
       byte[] b = new byte[] {1, 1, 1, 1, 1};
@@ -713,21 +713,28 @@ public class TestField extends LuceneTestCase {
       expectThrows(
           IllegalArgumentException.class,
           () -> new KnnFloatVectorField("bogus", new float[] {1}, (FieldType) field.fieldType()));
-      zeroError = expectThrows(
-          IllegalArgumentException.class,
-          () -> new KnnByteVectorField("float", new byte[] {0, 0, 0, 0, 0}, (FieldType) field.fieldType()));
+      zeroError =
+          expectThrows(
+              IllegalArgumentException.class,
+              () ->
+                  new KnnByteVectorField(
+                      "float", new byte[] {0, 0, 0, 0, 0}, (FieldType) field.fieldType()));
       assertTrue(zeroError.getMessage().contains("zero vector not allowed"));
-      zeroError = expectThrows(
-          IllegalArgumentException.class,
-          () -> new KnnFloatVectorField("zerovec", new float[] {0, 0, 0, 0}));
+      zeroError =
+          expectThrows(
+              IllegalArgumentException.class,
+              () -> new KnnFloatVectorField("zerovec", new float[] {0, 0, 0, 0}));
       assertTrue(zeroError.getMessage().contains("zero vector not allowed"));
 
       float[] vector = new float[] {1, 2};
       Field field2 = new KnnFloatVectorField("float", vector);
       assertNull(field2.binaryValue());
-      zeroError = expectThrows(
-          IllegalArgumentException.class,
-          () -> new KnnFloatVectorField("float", new float[] {0, 0}, (FieldType) field2.fieldType()));
+      zeroError =
+          expectThrows(
+              IllegalArgumentException.class,
+              () ->
+                  new KnnFloatVectorField(
+                      "float", new float[] {0, 0}, (FieldType) field2.fieldType()));
       assertTrue(zeroError.getMessage().contains("zero vector not allowed"));
 
       doc.add(field);

--- a/lucene/core/src/test/org/apache/lucene/index/TestAllFilesDetectMismatchedChecksum.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAllFilesDetectMismatchedChecksum.java
@@ -41,6 +41,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressFileSystems;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.TestVectorUtil;
 
 /** Test that the default codec detects mismatched checksums at open or checkIntegrity time. */
 @SuppressFileSystems("ExtrasFS")
@@ -69,7 +70,7 @@ public class TestAllFilesDetectMismatchedChecksum extends LuceneTestCase {
     doc.add(pointNumber);
     Field dvNumber = new NumericDocValuesField("long", 0L);
     doc.add(dvNumber);
-    KnnFloatVectorField vector = new KnnFloatVectorField("vector", new float[16]);
+    KnnFloatVectorField vector = new KnnFloatVectorField("vector", TestVectorUtil.randomVector(16));
     doc.add(vector);
 
     for (int i = 0; i < 100; i++) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestAllFilesDetectTruncation.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAllFilesDetectTruncation.java
@@ -42,6 +42,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressFileSystems;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.TestVectorUtil;
 
 /** Test that a plain default detects index file truncation early (on opening a reader). */
 @SuppressFileSystems("ExtrasFS")
@@ -82,7 +83,7 @@ public class TestAllFilesDetectTruncation extends LuceneTestCase {
     doc.add(pointNumber);
     Field dvNumber = new NumericDocValuesField("long", 0L);
     doc.add(dvNumber);
-    KnnFloatVectorField vector = new KnnFloatVectorField("vector", new float[16]);
+    KnnFloatVectorField vector = new KnnFloatVectorField("vector", TestVectorUtil.randomVector(16));
     doc.add(vector);
 
     for (int i = 0; i < 100; i++) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
@@ -49,6 +49,7 @@ import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.SameThreadExecutorService;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.SuppressForbidden;
+import org.apache.lucene.util.TestVectorUtil;
 import org.apache.lucene.util.Version;
 
 public class TestConcurrentMergeScheduler extends LuceneTestCase {
@@ -109,7 +110,7 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
     IndexWriter writer = new IndexWriter(directory, iwc);
     Document doc = new Document();
     Field idField = newStringField("id", "", Field.Store.YES);
-    KnnFloatVectorField knnField = new KnnFloatVectorField("knn", new float[] {0.0f, 0.0f});
+    KnnFloatVectorField knnField = new KnnFloatVectorField("knn", TestVectorUtil.randomVector(2));
     doc.add(idField);
     // Add knn float vectors to test parallel merge
     doc.add(knnField);
@@ -244,7 +245,7 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
     Directory directory = newDirectory();
     Document doc = new Document();
     Field idField = newStringField("id", "", Field.Store.YES);
-    KnnFloatVectorField knnField = new KnnFloatVectorField("knn", new float[] {0.0f, 0.0f});
+    KnnFloatVectorField knnField = new KnnFloatVectorField("knn", TestVectorUtil.randomVector(2));
     doc.add(idField);
     doc.add(knnField);
     IndexWriterConfig iwc =

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -270,7 +270,8 @@ public class TestKnnGraph extends LuceneTestCase {
     for (int i = 0; i < values.length; i++) {
       // System.out.printf("%d: (%d, %d)\n", i, index % n, index / n);
       int x = index % n, y = index / n;
-      values[i] = new float[] {x, y};
+      // avoid zero vectors
+      values[i] = new float[] {x + 1e-5f, y + 1e-5f};
       index = (index + stepSize) % (n * n);
       add(iw, i, values[i]);
       if (i == 13) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
@@ -176,7 +176,7 @@ public class TestSortingCodecReader extends LuceneTestCase {
           doc.add(
               new SortedSetDocValuesField("sorted_set_dv", new BytesRef(Integer.toString(docId))));
           if (dense || docId % 2 == 0) {
-            doc.add(new KnnFloatVectorField("vector", new float[] {(float) docId}));
+            doc.add(new KnnFloatVectorField("vector", new float[] {(float) docId + 1e-6f}));
           }
           doc.add(new NumericDocValuesField("foo", random().nextInt(20)));
 

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -397,7 +397,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
   }
 
   public void testScoreMIP() throws IOException {
-    float[][] vectors = {{0, 1}, {1, 2}, {0, 0}};
+    float[][] vectors = {{0, 1}, {1, 2}, {0 + 1e-6f, 0 + 1e-6f}};
     try (Directory d =
             getStableIndexStore("field", VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, vectors);
         IndexReader reader = DirectoryReader.open(d)) {

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -177,10 +177,10 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
    */
   public void testFindAll() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       IndexSearcher searcher = newSearcher(reader);
-      AbstractKnnVectorQuery kvq = getKnnVectorQuery("field", new float[] {0, 0}, 10);
+      AbstractKnnVectorQuery kvq = getKnnVectorQuery("field", new float[] {1, 1}, 10);
       assertMatches(searcher, kvq, 3);
       ScoreDoc[] scoreDocs = searcher.search(kvq, 3).scoreDocs;
       assertIdMatches(reader, "id2", scoreDocs[0]);
@@ -191,10 +191,10 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
 
   public void testFindFewer() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       IndexSearcher searcher = newSearcher(reader);
-      AbstractKnnVectorQuery kvq = getKnnVectorQuery("field", new float[] {0, 0}, 2);
+      AbstractKnnVectorQuery kvq = getKnnVectorQuery("field", new float[] {1, 1}, 2);
       assertMatches(searcher, kvq, 2);
       ScoreDoc[] scoreDocs = searcher.search(kvq, 3).scoreDocs;
       assertEquals(scoreDocs.length, 2);
@@ -204,11 +204,11 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
 
   public void testSearchBoost() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       IndexSearcher searcher = newSearcher(reader);
 
-      Query vectorQuery = getKnnVectorQuery("field", new float[] {0, 0}, 10);
+      Query vectorQuery = getKnnVectorQuery("field", new float[] {1, 1}, 10);
       ScoreDoc[] scoreDocs = searcher.search(vectorQuery, 3).scoreDocs;
 
       Query boostQuery = new BoostQuery(vectorQuery, 3.0f);
@@ -228,11 +228,11 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
   /** Tests that a AbstractKnnVectorQuery applies the filter query */
   public void testSimpleFilter() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       IndexSearcher searcher = newSearcher(reader);
       Query filter = new TermQuery(new Term("id", "id2"));
-      Query kvq = getKnnVectorQuery("field", new float[] {0, 0}, 10, filter);
+      Query kvq = getKnnVectorQuery("field", new float[] {1, 1}, 10, filter);
       TopDocs topDocs = searcher.search(kvq, 3);
       assertEquals(1, topDocs.totalHits.value());
       assertIdMatches(reader, "id2", topDocs.scoreDocs[0]);
@@ -241,12 +241,12 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
 
   public void testFilterWithNoVectorMatches() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       IndexSearcher searcher = newSearcher(reader);
 
       Query filter = new TermQuery(new Term("other", "value"));
-      Query kvq = getKnnVectorQuery("field", new float[] {0, 0}, 10, filter);
+      Query kvq = getKnnVectorQuery("field", new float[] {1, 1}, 10, filter);
       TopDocs topDocs = searcher.search(kvq, 3);
       assertEquals(0, topDocs.totalHits.value());
     }
@@ -254,13 +254,13 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
 
   public void testMatchAllFilter() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       IndexSearcher searcher = newSearcher(reader);
 
       // make sure we don't drop to exact search, even though the filter matches fewer than k docs
       Query kvq =
-          getThrowingKnnVectorQuery("field", new float[] {0, 0}, 10, MatchAllDocsQuery.INSTANCE);
+          getThrowingKnnVectorQuery("field", new float[] {1, 1}, 10, MatchAllDocsQuery.INSTANCE);
       TopDocs topDocs = searcher.search(kvq, 3);
       assertEquals(3, topDocs.totalHits.value());
     }
@@ -269,7 +269,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
   /** testDimensionMismatch */
   public void testDimensionMismatch() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       IndexSearcher searcher = newSearcher(reader);
       AbstractKnnVectorQuery kvq = getKnnVectorQuery("field", new float[] {0}, 1);
@@ -282,7 +282,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
   /** testNonVectorField */
   public void testNonVectorField() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       IndexSearcher searcher = newSearcher(reader);
       assertMatches(searcher, getKnnVectorQuery("xyzzy", new float[] {0}, 10), 0);
@@ -297,7 +297,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
 
   public void testDifferentReader() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       AbstractKnnVectorQuery query = getKnnVectorQuery("field", new float[] {2, 3}, 3);
       Query dasq = query.rewrite(newSearcher(reader));
@@ -311,7 +311,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
   public void testScoreEuclidean() throws IOException {
     float[][] vectors = new float[5][];
     for (int j = 0; j < 5; j++) {
-      vectors[j] = new float[] {j, j};
+      vectors[j] = new float[] {j + 1, j + 1};
     }
     try (Directory d = getStableIndexStore("field", vectors);
         IndexReader reader = DirectoryReader.open(d)) {
@@ -332,17 +332,17 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
       DocIdSetIterator it = scorer.iterator();
       assertEquals(3, it.cost());
       int firstDoc = it.nextDoc();
-      if (firstDoc == 1) {
+      if (firstDoc == 0) {
         assertEquals(1 / 6f, scorer.score(), 0);
-        assertEquals(3, it.advance(3));
+        assertEquals(2, it.advance(2));
         assertEquals(1 / 2f, scorer.score(), 0);
-        assertEquals(NO_MORE_DOCS, it.advance(4));
+        assertEquals(NO_MORE_DOCS, it.advance(3));
       } else {
-        assertEquals(2, firstDoc);
+        assertEquals(1, firstDoc);
         assertEquals(1 / 2f, scorer.score(), 0);
-        assertEquals(4, it.advance(4));
+        assertEquals(3, it.advance(3));
         assertEquals(1 / 6f, scorer.score(), 0);
-        assertEquals(NO_MORE_DOCS, it.advance(5));
+        assertEquals(NO_MORE_DOCS, it.advance(4));
       }
       expectThrows(ArrayIndexOutOfBoundsException.class, scorer::score);
     }
@@ -397,7 +397,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
   }
 
   public void testScoreMIP() throws IOException {
-    float[][] vectors = {{0, 1}, {1, 2}, {0 + 1e-6f, 0 + 1e-6f}};
+    float[][] vectors = {{0, 1}, {1, 2}, {1, 1}};
     try (Directory d =
             getStableIndexStore("field", VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, vectors);
         IndexReader reader = DirectoryReader.open(d)) {
@@ -405,11 +405,11 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
       AbstractKnnVectorQuery kvq = getKnnVectorQuery("field", new float[] {0, -1}, 10);
       assertMatches(searcher, kvq, 3);
       ScoreDoc[] scoreDocs = searcher.search(kvq, 3).scoreDocs;
-      assertIdMatches(reader, "id2", scoreDocs[0]);
-      assertIdMatches(reader, "id0", scoreDocs[1]);
+      assertIdMatches(reader, "id0", scoreDocs[0]);
+      assertIdMatches(reader, "id2", scoreDocs[1]);
       assertIdMatches(reader, "id1", scoreDocs[2]);
 
-      assertEquals(1.0, scoreDocs[0].score, 1e-7);
+      assertEquals(1 / 2f, scoreDocs[0].score, 1e-7);
       assertEquals(1 / 2f, scoreDocs[1].score, 1e-7);
       assertEquals(1 / 3f, scoreDocs[2].score, 1e-7);
     }
@@ -418,7 +418,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
   public void testExplain() throws IOException {
     try (Directory d = newDirectoryForTest()) {
       try (IndexWriter w = new IndexWriter(d, new IndexWriterConfig())) {
-        for (int j = 0; j < 5; j++) {
+        for (int j = 1; j <= 5; j++) {
           Document doc = new Document();
           doc.add(getKnnVectorField("field", new float[] {j, j}));
           w.addDocument(doc);
@@ -446,7 +446,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
   public void testExplainMultipleSegments() throws IOException {
     try (Directory d = newDirectoryForTest()) {
       try (IndexWriter w = new IndexWriter(d, new IndexWriterConfig())) {
-        for (int j = 0; j < 5; j++) {
+        for (int j = 1; j <= 5; j++) {
           Document doc = new Document();
           doc.add(getKnnVectorField("field", new float[] {j, j}));
           w.addDocument(doc);
@@ -480,7 +480,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
      */
     try (Directory d = newDirectoryForTest()) {
       try (IndexWriter w = new IndexWriter(d, configStandardCodec())) {
-        int r = 0;
+        int r = 1;
         for (int i = 0; i < 5; i++) {
           for (int j = 0; j < 5; j++) {
             Document doc = new Document();
@@ -494,10 +494,10 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
       }
       try (IndexReader reader = DirectoryReader.open(d)) {
         IndexSearcher searcher = newSearcher(reader);
-        TopDocs results = searcher.search(getKnnVectorQuery("field", new float[] {0, 0}, 8), 10);
+        TopDocs results = searcher.search(getKnnVectorQuery("field", new float[] {1, 1}, 8), 10);
         assertEquals(8, results.scoreDocs.length);
-        assertIdMatches(reader, "id0", results.scoreDocs[0]);
-        assertIdMatches(reader, "id7", results.scoreDocs[7]);
+        assertIdMatches(reader, "id1", results.scoreDocs[0]);
+        assertIdMatches(reader, "id8", results.scoreDocs[7]);
 
         // test some results in the middle of the sequence - also tests docid tiebreaking
         results = searcher.search(getKnnVectorQuery("field", new float[] {10, 10}, 8), 10);
@@ -916,7 +916,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
   /** Test functionality of {@link TimeLimitingKnnCollectorManager}. */
   public void testTimeLimitingKnnCollectorManager() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       IndexSearcher searcher = newSearcher(reader);
 
@@ -962,7 +962,7 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
   /** Test that the query times out correctly. */
   public void testTimeout() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       IndexSearcher searcher = newSearcher(reader);
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnByteVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnByteVectorQuery.java
@@ -81,7 +81,7 @@ public class TestKnnByteVectorQuery extends BaseKnnVectorQueryTestCase {
 
   public void testToString() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       AbstractKnnVectorQuery query = getKnnVectorQuery("field", new float[] {0, 1}, 10);
       assertEquals("KnnByteVectorQuery:field[0,...][10]", query.toString("ignored"));
@@ -104,7 +104,7 @@ public class TestKnnByteVectorQuery extends BaseKnnVectorQueryTestCase {
 
   public void testVectorEncodingMismatch() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       Query filter = null;
       if (random().nextBoolean()) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestKnnFloatVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestKnnFloatVectorQuery.java
@@ -81,7 +81,7 @@ public class TestKnnFloatVectorQuery extends BaseKnnVectorQueryTestCase {
 
   public void testToString() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       AbstractKnnVectorQuery query = getKnnVectorQuery("field", new float[] {0.0f, 1.0f}, 10);
       assertEquals("KnnFloatVectorQuery:field[0.0,...][10]", query.toString("ignored"));
@@ -97,7 +97,7 @@ public class TestKnnFloatVectorQuery extends BaseKnnVectorQueryTestCase {
 
   public void testVectorEncodingMismatch() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       Query filter = null;
       if (random().nextBoolean()) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestPatienceByteVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPatienceByteVectorQuery.java
@@ -90,7 +90,7 @@ public class TestPatienceByteVectorQuery extends BaseKnnVectorQueryTestCase {
 
   public void testToString() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       AbstractKnnVectorQuery query = getKnnVectorQuery("field", new float[] {0.0f, 1.0f}, 10);
       assertEquals(

--- a/lucene/core/src/test/org/apache/lucene/search/TestPatienceFloatVectorQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPatienceFloatVectorQuery.java
@@ -80,7 +80,7 @@ public class TestPatienceFloatVectorQuery extends BaseKnnVectorQueryTestCase {
 
   public void testToString() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       AbstractKnnVectorQuery query = getKnnVectorQuery("field", new float[] {0.0f, 1.0f}, 10);
       assertEquals(

--- a/lucene/core/src/test/org/apache/lucene/search/TestVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestVectorScorer.java
@@ -39,7 +39,7 @@ public class TestVectorScorer extends LuceneTestCase {
     VectorEncoding encoding = RandomPicks.randomFrom(random(), VectorEncoding.values());
     try (Directory indexStore =
             getIndexStore(
-                "field", encoding, new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+                "field", encoding, new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       assert reader.leaves().size() == 1;
       LeafReaderContext context = reader.leaves().get(0);

--- a/lucene/join/src/test/org/apache/lucene/search/join/ParentBlockJoinKnnVectorQueryTestCase.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/ParentBlockJoinKnnVectorQueryTestCase.java
@@ -176,7 +176,7 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
 
   public void testFilterWithNoVectorMatches() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       IndexSearcher searcher = newSearcher(reader);
       Query filter = new TermQuery(new Term("other", "value"));
@@ -251,7 +251,7 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
     try (Directory d = newDirectory()) {
       try (IndexWriter w =
           new IndexWriter(d, new IndexWriterConfig().setCodec(TestUtil.getDefaultCodec()))) {
-        int r = 0;
+        int r = 1;
         for (int i = 0; i < 5; i++) {
           for (int j = 0; j < 5; j++) {
             List<Document> toAdd = new ArrayList<>();
@@ -271,11 +271,11 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
         TopDocs results =
             searcher.search(
                 getParentJoinKnnQuery(
-                    "field", new float[] {0, 0}, null, 8, parentFilter(searcher.getIndexReader())),
+                    "field", new float[] {1, 1}, null, 8, parentFilter(searcher.getIndexReader())),
                 10);
         assertEquals(8, results.scoreDocs.length);
-        assertIdMatches(reader, "0", results.scoreDocs[0].doc);
-        assertIdMatches(reader, "7", results.scoreDocs[7].doc);
+        assertIdMatches(reader, "1", results.scoreDocs[0].doc);
+        assertIdMatches(reader, "8", results.scoreDocs[7].doc);
 
         // test some results in the middle of the sequence - also tests docid tiebreaking
         results =
@@ -297,7 +297,7 @@ abstract class ParentBlockJoinKnnVectorQueryTestCase extends LuceneTestCase {
   /** Test that the query times out correctly. */
   public void testTimeout() throws IOException {
     try (Directory indexStore =
-            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {1, 1});
         IndexReader reader = DirectoryReader.open(indexStore)) {
       BitSetProducer parentFilter = parentFilter(reader);
       IndexSearcher searcher = newSearcher(reader);

--- a/lucene/misc/src/test/org/apache/lucene/misc/index/TestBPReorderingMergePolicy.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/index/TestBPReorderingMergePolicy.java
@@ -257,7 +257,7 @@ public class TestBPReorderingMergePolicy extends LuceneTestCase {
     doc.add(idField);
     StringField bodyField = new StringField("body", "", Store.YES);
     doc.add(bodyField);
-    KnnFloatVectorField vectorField = new KnnFloatVectorField("vector", new float[] {0});
+    KnnFloatVectorField vectorField = new KnnFloatVectorField("vector", new float[] {1});
     doc.add(vectorField);
 
     for (int i = 0; i < 10; ++i) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -161,7 +161,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
   }
 
   public void testFieldConstructor() {
-    float[] v = new float[1];
+    float[] v = new float[] {1f};
     KnnFloatVectorField field = new KnnFloatVectorField("f", v);
     assertEquals(1, field.fieldType().vectorDimension());
     assertEquals(VectorSimilarityFunction.EUCLIDEAN, field.fieldType().vectorSimilarityFunction());
@@ -169,20 +169,20 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
   }
 
   public void testFieldConstructorExceptions() {
-    expectThrows(IllegalArgumentException.class, () -> new KnnFloatVectorField(null, new float[1]));
+    expectThrows(IllegalArgumentException.class, () -> new KnnFloatVectorField(null, new float[] {1f}));
     expectThrows(IllegalArgumentException.class, () -> new KnnFloatVectorField("f", null));
     expectThrows(
         IllegalArgumentException.class,
-        () -> new KnnFloatVectorField("f", new float[1], (VectorSimilarityFunction) null));
+        () -> new KnnFloatVectorField("f", new float[] {1f}, (VectorSimilarityFunction) null));
     expectThrows(IllegalArgumentException.class, () -> new KnnFloatVectorField("f", new float[0]));
   }
 
   public void testFieldSetValue() {
-    KnnFloatVectorField field = new KnnFloatVectorField("f", new float[1]);
-    float[] v1 = new float[1];
+    KnnFloatVectorField field = new KnnFloatVectorField("f", new float[] {1f});
+    float[] v1 = new float[] {1f};
     field.setVectorValue(v1);
     assertSame(v1, field.vectorValue());
-    expectThrows(IllegalArgumentException.class, () -> field.setVectorValue(new float[2]));
+    expectThrows(IllegalArgumentException.class, () -> field.setVectorValue(new float[] {0f, 1f}));
     expectThrows(IllegalArgumentException.class, () -> field.setVectorValue(null));
   }
 
@@ -192,11 +192,11 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+      doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
       w.addDocument(doc);
 
       Document doc2 = new Document();
-      doc2.add(new KnnFloatVectorField("f", new float[6], VectorSimilarityFunction.DOT_PRODUCT));
+      doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
       IllegalArgumentException expected =
           expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc2));
       String errMsg =
@@ -209,12 +209,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+      doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
       w.addDocument(doc);
       w.commit();
 
       Document doc2 = new Document();
-      doc2.add(new KnnFloatVectorField("f", new float[6], VectorSimilarityFunction.DOT_PRODUCT));
+      doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
       IllegalArgumentException expected =
           expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc2));
       String errMsg =
@@ -229,11 +229,11 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+      doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
       w.addDocument(doc);
 
       Document doc2 = new Document();
-      doc2.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.EUCLIDEAN));
+      doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
       IllegalArgumentException expected =
           expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc2));
       String errMsg =
@@ -246,12 +246,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+      doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
       w.addDocument(doc);
       w.commit();
 
       Document doc2 = new Document();
-      doc2.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.EUCLIDEAN));
+      doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
       IllegalArgumentException expected =
           expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc2));
       String errMsg =
@@ -265,13 +265,13 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
 
       try (IndexWriter w2 = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc2 = new Document();
-        doc2.add(new KnnFloatVectorField("f", new float[2], VectorSimilarityFunction.DOT_PRODUCT));
+        doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f}, VectorSimilarityFunction.DOT_PRODUCT));
         IllegalArgumentException expected =
             expectThrows(IllegalArgumentException.class, () -> w2.addDocument(doc2));
         assertEquals(
@@ -307,7 +307,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           writer.addDocument(doc);
         }
         writer.commit();
-        for (int i = 0; i < 10; i++) {
+        for (int i = 1; i <= 10; i++) {
           var doc = new Document();
           doc.add(new KnnFloatVectorField("otherVector", new float[] {i, i, i, i}));
           writer.addDocument(doc);
@@ -338,14 +338,14 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
       iwc.setMergeScheduler(mergeScheduler);
       iwc.setMergePolicy(new ForceMergePolicy(iwc.getMergePolicy()));
       try (var writer = new IndexWriter(dir, iwc)) {
-        for (int i = 0; i < 10; i++) {
+        for (int i = 1; i <= 10; i++) {
           var doc = new Document();
           doc.add(
               new KnnByteVectorField("field", new byte[] {(byte) i, (byte) i, (byte) i, (byte) i}));
           writer.addDocument(doc);
         }
         writer.commit();
-        for (int i = 0; i < 10; i++) {
+        for (int i = 1; i <= 10; i++) {
           var doc = new Document();
           doc.add(
               new KnnByteVectorField(
@@ -448,13 +448,13 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
 
       try (IndexWriter w2 = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc2 = new Document();
-        doc2.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.EUCLIDEAN));
+        doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
         IllegalArgumentException expected =
             expectThrows(IllegalArgumentException.class, () -> w2.addDocument(doc2));
         assertEquals(
@@ -468,7 +468,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
   public void testAddIndexesDirectory0() throws Exception {
     String fieldName = "field";
     Document doc = new Document();
-    doc.add(new KnnFloatVectorField(fieldName, new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+    doc.add(new KnnFloatVectorField(fieldName, new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
     try (Directory dir = newDirectory();
         Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
@@ -499,7 +499,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         w.addDocument(doc);
       }
       doc.add(
-          new KnnFloatVectorField(fieldName, new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+          new KnnFloatVectorField(fieldName, new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
       try (IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig())) {
         w2.addDocument(doc);
         w2.addIndexes(dir);
@@ -518,7 +518,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
 
   public void testAddIndexesDirectory01() throws Exception {
     String fieldName = "field";
-    float[] vector = new float[2];
+    float[] vector = new float[] {0f, 1f};
     Document doc = new Document();
     doc.add(new KnnFloatVectorField(fieldName, vector, VectorSimilarityFunction.DOT_PRODUCT));
     try (Directory dir = newDirectory();
@@ -553,12 +553,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[6], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
         w2.addDocument(doc);
         IllegalArgumentException expected =
             expectThrows(
@@ -576,12 +576,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.EUCLIDEAN));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
         w2.addDocument(doc);
         IllegalArgumentException expected =
             expectThrows(IllegalArgumentException.class, () -> w2.addIndexes(dir));
@@ -598,12 +598,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[6], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
         w2.addDocument(doc);
         try (DirectoryReader r = DirectoryReader.open(dir)) {
           IllegalArgumentException expected =
@@ -624,12 +624,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.EUCLIDEAN));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
         w2.addDocument(doc);
         try (DirectoryReader r = DirectoryReader.open(dir)) {
           IllegalArgumentException expected =
@@ -650,12 +650,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[6], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
         w2.addDocument(doc);
         try (DirectoryReader r = DirectoryReader.open(dir)) {
           IllegalArgumentException expected =
@@ -674,12 +674,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.EUCLIDEAN));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
         w2.addDocument(doc);
         try (DirectoryReader r = DirectoryReader.open(dir)) {
           IllegalArgumentException expected =
@@ -697,8 +697,8 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
-      doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+      doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+      doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
       IllegalArgumentException expected =
           expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc));
       assertEquals(
@@ -714,7 +714,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
       doc.add(
           new KnnFloatVectorField(
               "f",
-              new float[getVectorsMaxDimensions("f") + 1],
+              randomFloatVector(getVectorsMaxDimensions("f") + 1),
               VectorSimilarityFunction.DOT_PRODUCT));
       Exception exc = expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc));
       assertTrue(
@@ -722,14 +722,14 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
               .contains("vector's dimensions must be <= [" + getVectorsMaxDimensions("f") + "]"));
 
       Document doc2 = new Document();
-      doc2.add(new KnnFloatVectorField("f", new float[2], VectorSimilarityFunction.DOT_PRODUCT));
+      doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f}, VectorSimilarityFunction.DOT_PRODUCT));
       w.addDocument(doc2);
 
       Document doc3 = new Document();
       doc3.add(
           new KnnFloatVectorField(
               "f",
-              new float[getVectorsMaxDimensions("f") + 1],
+              randomFloatVector(getVectorsMaxDimensions("f") + 1),
               VectorSimilarityFunction.DOT_PRODUCT));
       exc = expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc3));
       assertTrue(
@@ -744,7 +744,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
       doc4.add(
           new KnnFloatVectorField(
               "f",
-              new float[getVectorsMaxDimensions("f") + 1],
+              randomFloatVector(getVectorsMaxDimensions("f") + 1),
               VectorSimilarityFunction.DOT_PRODUCT));
       exc = expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc4));
       assertTrue(
@@ -767,7 +767,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
       assertEquals("cannot index an empty vector", e.getMessage());
 
       Document doc2 = new Document();
-      doc2.add(new KnnFloatVectorField("f", new float[2], VectorSimilarityFunction.EUCLIDEAN));
+      doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
       w.addDocument(doc2);
     }
   }
@@ -777,14 +777,14 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       IndexWriterConfig iwc = newIndexWriterConfig();
       iwc.setCodec(Codec.forName("SimpleText"));
       try (IndexWriter w = new IndexWriter(dir, iwc)) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
         w.forceMerge(1);
       }
@@ -798,12 +798,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, iwc)) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[4], VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
         w.forceMerge(1);
       }
@@ -812,11 +812,11 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
 
   public void testInvalidKnnVectorFieldUsage() {
     KnnFloatVectorField field =
-        new KnnFloatVectorField("field", new float[2], VectorSimilarityFunction.EUCLIDEAN);
+        new KnnFloatVectorField("field", new float[] {0f, 1f}, VectorSimilarityFunction.EUCLIDEAN);
 
     expectThrows(IllegalArgumentException.class, () -> field.setIntValue(14));
 
-    expectThrows(IllegalArgumentException.class, () -> field.setVectorValue(new float[1]));
+    expectThrows(IllegalArgumentException.class, () -> field.setVectorValue(new float[] {1f}));
 
     assertNull(field.numericValue());
   }
@@ -1154,7 +1154,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     // We copy indexed values (as for BinaryDocValues) so the input float[] can be reused across
     // calls to IndexWriter.addDocument.
     String fieldName = "field";
-    float[] v = {0, 0};
+    float[] v = {0, 1};
     try (Directory dir = newDirectory();
         IndexWriter iw =
             new IndexWriter(
@@ -1789,7 +1789,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           if (random().nextInt(4) == 3) {
             doc.add(
                 new KnnFloatVectorField(
-                    fieldName, new float[4], VectorSimilarityFunction.EUCLIDEAN));
+                    fieldName, new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
           }
           w.addDocument(doc);
         }
@@ -2348,5 +2348,13 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         return exactSearch(context, DocIdSetIterator.all(totalDocs), null);
       }
     };
+  }
+
+  float[] randomFloatVector(int dims) {
+    float[] fa = new float[dims];
+    for (int i = 0; i < dims; ++i) {
+      fa[i] = random().nextFloat();
+    }
+    return fa;
   }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -169,7 +169,8 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
   }
 
   public void testFieldConstructorExceptions() {
-    expectThrows(IllegalArgumentException.class, () -> new KnnFloatVectorField(null, new float[] {1f}));
+    expectThrows(
+        IllegalArgumentException.class, () -> new KnnFloatVectorField(null, new float[] {1f}));
     expectThrows(IllegalArgumentException.class, () -> new KnnFloatVectorField("f", null));
     expectThrows(
         IllegalArgumentException.class,
@@ -192,11 +193,15 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+      doc.add(
+          new KnnFloatVectorField(
+              "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
       w.addDocument(doc);
 
       Document doc2 = new Document();
-      doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
+      doc2.add(
+          new KnnFloatVectorField(
+              "f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
       IllegalArgumentException expected =
           expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc2));
       String errMsg =
@@ -209,12 +214,16 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+      doc.add(
+          new KnnFloatVectorField(
+              "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
       w.addDocument(doc);
       w.commit();
 
       Document doc2 = new Document();
-      doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
+      doc2.add(
+          new KnnFloatVectorField(
+              "f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
       IllegalArgumentException expected =
           expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc2));
       String errMsg =
@@ -229,11 +238,15 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+      doc.add(
+          new KnnFloatVectorField(
+              "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
       w.addDocument(doc);
 
       Document doc2 = new Document();
-      doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
+      doc2.add(
+          new KnnFloatVectorField(
+              "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
       IllegalArgumentException expected =
           expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc2));
       String errMsg =
@@ -246,12 +259,16 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+      doc.add(
+          new KnnFloatVectorField(
+              "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
       w.addDocument(doc);
       w.commit();
 
       Document doc2 = new Document();
-      doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
+      doc2.add(
+          new KnnFloatVectorField(
+              "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
       IllegalArgumentException expected =
           expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc2));
       String errMsg =
@@ -265,13 +282,17 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
 
       try (IndexWriter w2 = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc2 = new Document();
-        doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc2.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f}, VectorSimilarityFunction.DOT_PRODUCT));
         IllegalArgumentException expected =
             expectThrows(IllegalArgumentException.class, () -> w2.addDocument(doc2));
         assertEquals(
@@ -448,13 +469,17 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
 
       try (IndexWriter w2 = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc2 = new Document();
-        doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
+        doc2.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
         IllegalArgumentException expected =
             expectThrows(IllegalArgumentException.class, () -> w2.addDocument(doc2));
         assertEquals(
@@ -468,7 +493,9 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
   public void testAddIndexesDirectory0() throws Exception {
     String fieldName = "field";
     Document doc = new Document();
-    doc.add(new KnnFloatVectorField(fieldName, new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+    doc.add(
+        new KnnFloatVectorField(
+            fieldName, new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
     try (Directory dir = newDirectory();
         Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
@@ -499,7 +526,8 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         w.addDocument(doc);
       }
       doc.add(
-          new KnnFloatVectorField(fieldName, new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+          new KnnFloatVectorField(
+              fieldName, new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
       try (IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig())) {
         w2.addDocument(doc);
         w2.addIndexes(dir);
@@ -553,12 +581,16 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
         w2.addDocument(doc);
         IllegalArgumentException expected =
             expectThrows(
@@ -576,12 +608,16 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
         w2.addDocument(doc);
         IllegalArgumentException expected =
             expectThrows(IllegalArgumentException.class, () -> w2.addIndexes(dir));
@@ -598,12 +634,16 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
         w2.addDocument(doc);
         try (DirectoryReader r = DirectoryReader.open(dir)) {
           IllegalArgumentException expected =
@@ -624,12 +664,16 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
         w2.addDocument(doc);
         try (DirectoryReader r = DirectoryReader.open(dir)) {
           IllegalArgumentException expected =
@@ -650,12 +694,16 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f, 4f, 5f}, VectorSimilarityFunction.DOT_PRODUCT));
         w2.addDocument(doc);
         try (DirectoryReader r = DirectoryReader.open(dir)) {
           IllegalArgumentException expected =
@@ -674,12 +722,16 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
         Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
         w2.addDocument(doc);
         try (DirectoryReader r = DirectoryReader.open(dir)) {
           IllegalArgumentException expected =
@@ -697,8 +749,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
-      doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+      doc.add(
+          new KnnFloatVectorField(
+              "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+      doc.add(
+          new KnnFloatVectorField(
+              "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
       IllegalArgumentException expected =
           expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc));
       assertEquals(
@@ -722,7 +778,8 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
               .contains("vector's dimensions must be <= [" + getVectorsMaxDimensions("f") + "]"));
 
       Document doc2 = new Document();
-      doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f}, VectorSimilarityFunction.DOT_PRODUCT));
+      doc2.add(
+          new KnnFloatVectorField("f", new float[] {0f, 1f}, VectorSimilarityFunction.DOT_PRODUCT));
       w.addDocument(doc2);
 
       Document doc3 = new Document();
@@ -767,7 +824,9 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
       assertEquals("cannot index an empty vector", e.getMessage());
 
       Document doc2 = new Document();
-      doc2.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
+      doc2.add(
+          new KnnFloatVectorField(
+              "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.EUCLIDEAN));
       w.addDocument(doc2);
     }
   }
@@ -777,14 +836,18 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       IndexWriterConfig iwc = newIndexWriterConfig();
       iwc.setCodec(Codec.forName("SimpleText"));
       try (IndexWriter w = new IndexWriter(dir, iwc)) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
         w.forceMerge(1);
       }
@@ -798,12 +861,16 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     try (Directory dir = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, iwc)) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
       }
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
+        doc.add(
+            new KnnFloatVectorField(
+                "f", new float[] {0f, 1f, 2f, 3f}, VectorSimilarityFunction.DOT_PRODUCT));
         w.addDocument(doc);
         w.forceMerge(1);
       }


### PR DESCRIPTION
We don't have checks to disallow zero vectors from getting indexed today. This becomes a problem later when vectors are searched or segments are merged, as noted in #15540. This change prevents zero vectors from getting indexed.

_AI Disclosure:_ The change itself is trivial but it broke quite a few tests. I fixed about half of them manually, then leveraged AI to fix remaining tests. I've reviewed all AI test fixes. Most of them were simply replacing zero/empty vectors with non-empty vector values. Some tests checked for vector similarity scores, and I've fixed them accordingly.

Addresses #15540 

