### PR TITLE
Deferring lambda in TermStates.java according to prefetch

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -58,6 +58,8 @@ API Changes
 
 * GITHUB#15295 : Switched to a fixed CFS threshold (Shubham Sharma)
 
+* GITHUB#15627 : Deferred lambda in TermStates.java according to prefetch (Shubham Sharma)
+
 New Features
 ---------------------
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/blocktree/SegmentTermsEnumFrame.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/blocktree/SegmentTermsEnumFrame.java
@@ -133,10 +133,10 @@ final class SegmentTermsEnumFrame {
     loadBlock();
   }
 
-  void prefetchBlock() throws IOException {
+  boolean prefetchBlock() throws IOException {
     if (nextEnt != -1) {
       // Already loaded
-      return;
+      return false;
     }
 
     // Clone the IndexInput lazily, so that consumers
@@ -145,7 +145,7 @@ final class SegmentTermsEnumFrame {
     ste.initIndexInput();
 
     // TODO: Could we know the number of bytes to prefetch?
-    ste.in.prefetch(fp, 1);
+    return ste.in.prefetch(fp, 1);
   }
 
   /* Does initial decode of next block of terms; this

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/SegmentTermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/SegmentTermsEnum.java
@@ -471,10 +471,10 @@ final class SegmentTermsEnum extends BaseTermsEnum {
       return null;
     }
 
-    return getIoBooleanSupplier(target, prefetch);
+    return getIOBooleanSupplier(target, prefetch);
   }
 
-  private IOBooleanSupplier getIoBooleanSupplier(BytesRef target, boolean prefetch)
+  private IOBooleanSupplier getIOBooleanSupplier(BytesRef target, boolean prefetch)
       throws IOException {
     boolean doDefer;
     if (prefetch) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/SegmentTermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/SegmentTermsEnum.java
@@ -434,33 +434,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
           return null;
         }
 
-        boolean doDefer = maybePrefetch(prefetch);
-
-        return new IOBooleanSupplier() {
-          @Override
-          public boolean get() throws IOException {
-            currentFrame.loadBlock();
-
-            final SeekStatus result = currentFrame.scanToTerm(target, true);
-            if (result == SeekStatus.FOUND) {
-              // if (DEBUG) {
-              //   System.out.println("  return FOUND term=" + term.utf8ToString() + " " + term);
-              // }
-              return true;
-            } else {
-              // if (DEBUG) {
-              //   System.out.println("  got " + result + "; return NOT_FOUND term=" +
-              // ToStringUtils.bytesRefToString(term));
-              // }
-              return false;
-            }
-          }
-
-          @Override
-          public boolean doDefer() {
-            return doDefer;
-          }
-        };
+        return getIoBooleanSupplier(target, prefetch);
       } else {
         // Follow this node
         node = nextNode;
@@ -497,7 +471,12 @@ final class SegmentTermsEnum extends BaseTermsEnum {
       return null;
     }
 
-    boolean doDefer = maybePrefetch(prefetch);
+    return getIoBooleanSupplier(target, prefetch);
+  }
+
+  private IOBooleanSupplier getIoBooleanSupplier(BytesRef target, boolean prefetch)
+      throws IOException {
+    final boolean doDefer = maybePrefetch(prefetch);
 
     return new IOBooleanSupplier() {
       @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/SegmentTermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/SegmentTermsEnum.java
@@ -250,7 +250,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
     return true;
   }
 
-  private IOBooleanSupplier prepareSeekExact(BytesRef target, boolean prefetch) throws IOException {
+  private IOBooleanSupplier prepareSeekExactly(BytesRef target) throws IOException {
     if (fr.size() > 0 && (target.compareTo(fr.getMin()) < 0 || target.compareTo(fr.getMax()) > 0)) {
       return null;
     }
@@ -434,7 +434,7 @@ final class SegmentTermsEnum extends BaseTermsEnum {
           return null;
         }
 
-        return getIoBooleanSupplier(target, prefetch);
+        return getIoBooleanSupplier(target);
       } else {
         // Follow this node
         node = nextNode;
@@ -471,12 +471,11 @@ final class SegmentTermsEnum extends BaseTermsEnum {
       return null;
     }
 
-    return getIoBooleanSupplier(target, prefetch);
+    return getIoBooleanSupplier(target);
   }
 
-  private IOBooleanSupplier getIoBooleanSupplier(BytesRef target, boolean prefetch)
-      throws IOException {
-    final boolean doDefer = maybePrefetch(prefetch);
+  private IOBooleanSupplier getIoBooleanSupplier(BytesRef target) throws IOException {
+    final boolean doDefer = currentFrame.prefetchBlock();
 
     return new IOBooleanSupplier() {
       @Override
@@ -506,35 +505,14 @@ final class SegmentTermsEnum extends BaseTermsEnum {
     };
   }
 
-  private boolean maybePrefetch(boolean prefetch) throws IOException {
-    boolean doDefer;
-    if (prefetch) {
-      doDefer = currentFrame.prefetchBlock();
-      if (doDefer) {
-        hotCounter = 0;
-      } else {
-        hotCounter++;
-      }
-    } else {
-      doDefer = false;
-    }
-    return doDefer;
-  }
-
   @Override
   public IOBooleanSupplier prepareSeekExact(BytesRef target) throws IOException {
-    return prepareSeekExact(target, likelyCold());
-  }
-
-  private short hotCounter = 0;
-
-  private boolean likelyCold() {
-    return hotCounter < 1000; // TODO: constant/param/heurisitcs?
+    return prepareSeekExactly(target);
   }
 
   @Override
   public boolean seekExact(BytesRef target) throws IOException {
-    IOBooleanSupplier termExistsSupplier = prepareSeekExact(target, false);
+    IOBooleanSupplier termExistsSupplier = prepareSeekExactly(target);
     return termExistsSupplier != null && termExistsSupplier.get();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/SegmentTermsEnumFrame.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/SegmentTermsEnumFrame.java
@@ -135,10 +135,10 @@ final class SegmentTermsEnumFrame {
     loadBlock();
   }
 
-  void prefetchBlock() throws IOException {
+  boolean prefetchBlock() throws IOException {
     if (nextEnt != -1) {
       // Already loaded
-      return;
+      return false;
     }
 
     // Clone the IndexInput lazily, so that consumers
@@ -147,7 +147,7 @@ final class SegmentTermsEnumFrame {
     ste.initIndexInput();
 
     // TODO: Could we know the number of bytes to prefetch?
-    ste.in.prefetch(fp, 1);
+    return ste.in.prefetch(fp, 1);
   }
 
   /* Does initial decode of next block of terms; this

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90NormsProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90NormsProducer.java
@@ -345,8 +345,9 @@ final class Lucene90NormsProducer extends NormsProducer implements Cloneable {
       }
 
       @Override
-      public void prefetch(long offset, long length) throws IOException {
+      public boolean prefetch(long offset, long length) throws IOException {
         // Not delegating to the wrapped instance on purpose. This is only used for merging.
+        return false;
       }
     };
   }

--- a/lucene/core/src/java/org/apache/lucene/index/TermStates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermStates.java
@@ -208,7 +208,8 @@ public final class TermStates {
       if (termExistsSupplier.doDefer()) {
         return stateSupplier;
       } else {
-        TermState termState = stateSupplier.get();
+        stateSupplier.get();
+        TermState termState = this.states[ctx.ord];
         return termState == EMPTY_TERMSTATE ? null : () -> termState;
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/index/TermStates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermStates.java
@@ -202,16 +202,18 @@ public final class TermStates {
                 this.states[ctx.ord] = EMPTY_TERMSTATE;
               }
             }
-            return this.states[ctx.ord] == EMPTY_TERMSTATE ? null : this.states[ctx.ord];
+            TermState termState = this.states[ctx.ord];
+            return termState == EMPTY_TERMSTATE ? null : termState;
           };
       if (termExistsSupplier.doDefer()) {
         return stateSupplier;
       } else {
-        stateSupplier.get();
-        return this.states[ctx.ord] == EMPTY_TERMSTATE ? null : () -> this.states[ctx.ord];
+        TermState termState = stateSupplier.get();
+        return termState == EMPTY_TERMSTATE ? null : () -> termState;
       }
     }
-    return this.states[ctx.ord] == EMPTY_TERMSTATE ? null : () -> this.states[ctx.ord];
+    TermState termState = this.states[ctx.ord];
+    return termState == EMPTY_TERMSTATE ? null : () -> termState;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/TermStates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermStates.java
@@ -193,46 +193,25 @@ public final class TermStates {
         this.states[ctx.ord] = EMPTY_TERMSTATE;
         return null;
       }
-      if (termExistsSupplier.doDefer()) {
-        return () -> {
-          if (this.states[ctx.ord] == null) {
-            TermState state = null;
-            if (termExistsSupplier.get()) {
-              state = termsEnum.termState();
-              this.states[ctx.ord] = state;
-            } else {
-              this.states[ctx.ord] = EMPTY_TERMSTATE;
+      IOSupplier<TermState> stateSupplier =
+          () -> {
+            if (this.states[ctx.ord] == null) {
+              if (termExistsSupplier.get()) {
+                this.states[ctx.ord] = termsEnum.termState();
+              } else {
+                this.states[ctx.ord] = EMPTY_TERMSTATE;
+              }
             }
-          }
-          TermState state = this.states[ctx.ord];
-          if (state == EMPTY_TERMSTATE) {
-            return null;
-          }
-          return state;
-        };
+            return this.states[ctx.ord] == EMPTY_TERMSTATE ? null : this.states[ctx.ord];
+          };
+      if (termExistsSupplier.doDefer()) {
+        return stateSupplier;
       } else {
-        // TODO: dedup? also, do we need this second == null check for both defer/not defer?
-        if (this.states[ctx.ord] == null) {
-          TermState state = null;
-          if (termExistsSupplier.get()) {
-            state = termsEnum.termState();
-            this.states[ctx.ord] = state;
-          } else {
-            this.states[ctx.ord] = EMPTY_TERMSTATE;
-          }
-        }
-        TermState state = this.states[ctx.ord];
-        if (state == EMPTY_TERMSTATE) {
-          return null;
-        }
-        return () -> state;
+        stateSupplier.get();
+        return this.states[ctx.ord] == EMPTY_TERMSTATE ? null : () -> this.states[ctx.ord];
       }
     }
-    TermState state = this.states[ctx.ord];
-    if (state == EMPTY_TERMSTATE) {
-      return null;
-    }
-    return () -> state;
+    return this.states[ctx.ord] == EMPTY_TERMSTATE ? null : () -> this.states[ctx.ord];
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
@@ -202,8 +202,8 @@ public abstract class IndexInput extends DataInput implements Closeable {
         }
 
         @Override
-        public void prefetch(long offset, long length) throws IOException {
-          slice.prefetch(offset, length);
+        public boolean prefetch(long offset, long length) throws IOException {
+          return slice.prefetch(offset, length);
         }
 
         @Override
@@ -223,8 +223,12 @@ public abstract class IndexInput extends DataInput implements Closeable {
    *
    * @param offset start offset
    * @param length the number of bytes to prefetch
+   * @return true if prefetch actually prefetched something, hence user can benefit from deferring
+   *     reading the prefetched memory block.
    */
-  public void prefetch(long offset, long length) throws IOException {}
+  public boolean prefetch(long offset, long length) throws IOException {
+    return false;
+  }
 
   /**
    * Optional method: Updates the {@code IOContext} to specify a new read access pattern. IndexInput

--- a/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -32,7 +32,6 @@ import java.util.function.Function;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.Constants;
-import org.apache.lucene.util.IOConsumer;
 
 /**
  * Base IndexInput implementation that uses an array of MemorySegments to represent a file.
@@ -328,9 +327,9 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
   }
 
   @Override
-  public void prefetch(long offset, long length) throws IOException {
+  public boolean prefetch(long offset, long length) throws IOException {
     if (NATIVE_ACCESS.isEmpty()) {
-      return;
+      return false;
     }
 
     ensureOpen();
@@ -340,20 +339,54 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
       // power of two. There is a good chance that a good chunk of this index input is cached in
       // physical memory. Let's skip the overhead of the madvise system call, we'll be trying again
       // on the next power of two of the counter.
-      return;
+      return false;
     }
 
     final NativeAccess nativeAccess = NATIVE_ACCESS.get();
-    advise(
+    return advise(
         offset,
         length,
         segment -> {
-          if (segment.isLoaded() == false) {
+          if (isProbablyLoaded(segment)) {
+            return false;
+          } else {
             // We have a cache miss on at least one page, let's reset the counter.
             sharedPrefetchCounter.set(0);
             nativeAccess.madviseWillNeed(segment);
+            return true;
           }
         });
+  }
+
+  public boolean isProbablyLoaded(MemorySegment segment) {
+    if (NATIVE_ACCESS.isEmpty()) {
+      return true;
+    }
+
+    final NativeAccess nativeAccess = NATIVE_ACCESS.get();
+    final long pageSize = nativeAccess.getPageSize();
+    final long segmentSize = segment.byteSize();
+
+    // Sample at most 3 pages: start, middle, end
+    final int maxSamples = Math.min(3, (int) ((segmentSize + pageSize - 1) / pageSize));
+
+    for (int i = 0; i < maxSamples; i++) {
+      long offset = (i * segmentSize) / maxSamples;
+      offset = (offset / pageSize) * pageSize; // Align to page boundary
+
+      if (offset + pageSize > segmentSize) {
+        offset = segmentSize - pageSize;
+      }
+
+      if (offset >= 0) {
+        MemorySegment pageSlice = segment.asSlice(offset, Math.min(pageSize, segmentSize - offset));
+        if (!pageSlice.isLoaded()) {
+          return false;
+        }
+      }
+    }
+
+    return true;
   }
 
   @Override
@@ -369,14 +402,25 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
 
     long offset = 0;
     for (MemorySegment seg : segments) {
-      advise(offset, seg.byteSize(), segment -> nativeAccess.madvise(segment, readAdvice));
+      advise(
+          offset,
+          seg.byteSize(),
+          segment -> {
+            nativeAccess.madvise(segment, readAdvice);
+            return true;
+          });
       offset += seg.byteSize();
     }
   }
 
-  void advise(long offset, long length, IOConsumer<MemorySegment> advice) throws IOException {
+  @FunctionalInterface
+  interface ReadAdviceConsumer {
+    boolean accept(MemorySegment input) throws IOException;
+  }
+
+  boolean advise(long offset, long length, ReadAdviceConsumer advice) throws IOException {
     if (NATIVE_ACCESS.isEmpty()) {
-      return;
+      return false;
     }
 
     ensureOpen();
@@ -404,12 +448,12 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
         length -= nativeAccess.getPageSize();
         if (length <= 0) {
           // This segment has no data beyond the first page.
-          return;
+          return false;
         }
       }
 
       final MemorySegment advisedSlice = segment.asSlice(offset, length);
-      advice.accept(advisedSlice);
+      return advice.accept(advisedSlice);
     } catch (IndexOutOfBoundsException _) {
       throw new EOFException("Read past EOF: " + this);
     } catch (NullPointerException | IllegalStateException e) {
@@ -615,6 +659,7 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
             slice.length,
             segment -> {
               nativeAccess.madvise(segment, advice);
+              return true;
             });
       }
     }
@@ -804,9 +849,9 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
     }
 
     @Override
-    public void prefetch(long offset, long length) throws IOException {
+    public boolean prefetch(long offset, long length) throws IOException {
       Objects.checkFromIndexSize(offset, length, this.length);
-      super.prefetch(offset, length);
+      return super.prefetch(offset, length);
     }
   }
 
@@ -904,9 +949,9 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
     }
 
     @Override
-    public void prefetch(long offset, long length) throws IOException {
+    public boolean prefetch(long offset, long length) throws IOException {
       Objects.checkFromIndexSize(offset, length, this.length);
-      super.prefetch(this.offset + offset, length);
+      return super.prefetch(this.offset + offset, length);
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/store/RandomAccessInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RandomAccessInput.java
@@ -77,7 +77,9 @@ public interface RandomAccessInput {
    *
    * @see IndexInput#prefetch
    */
-  default void prefetch(long offset, long length) throws IOException {}
+  default boolean prefetch(long offset, long length) throws IOException {
+    return false;
+  }
 
   /**
    * Returns a hint whether all the contents of this input are resident in physical memory.

--- a/lucene/core/src/java/org/apache/lucene/util/IOBooleanSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IOBooleanSupplier.java
@@ -34,4 +34,8 @@ public interface IOBooleanSupplier {
    * @throws IOException if supplying the result throws an {@link IOException}
    */
   boolean get() throws IOException;
+
+  default boolean doDefer() {
+    return false;
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/IOBooleanSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IOBooleanSupplier.java
@@ -35,6 +35,11 @@ public interface IOBooleanSupplier {
    */
   boolean get() throws IOException;
 
+  /**
+   * Returns whether the TermState get should be deferred.
+   *
+   * @return {@code true} if the TermState get should be deferred, {@code false} otherwise
+   */
   default boolean doDefer() {
     return false;
   }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90StoredFieldsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90StoredFieldsFormat.java
@@ -66,9 +66,10 @@ public class TestLucene90StoredFieldsFormat extends BaseStoredFieldsFormatTestCa
     }
 
     @Override
-    public void prefetch(long offset, long length) throws IOException {
+    public boolean prefetch(long offset, long length) throws IOException {
       in.prefetch(offset, length);
       counter.incrementAndGet();
+      return true;
     }
 
     @Override

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90TermVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90TermVectorsFormat.java
@@ -68,9 +68,10 @@ public class TestLucene90TermVectorsFormat extends BaseTermVectorsFormatTestCase
     }
 
     @Override
-    public void prefetch(long offset, long length) throws IOException {
+    public boolean prefetch(long offset, long length) throws IOException {
       in.prefetch(offset, length);
       counter.incrementAndGet();
+      return true;
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockIndexInputWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockIndexInputWrapper.java
@@ -171,10 +171,10 @@ public class MockIndexInputWrapper extends FilterIndexInput {
   }
 
   @Override
-  public void prefetch(long offset, long length) throws IOException {
+  public boolean prefetch(long offset, long length) throws IOException {
     ensureOpen();
     ensureAccessible();
-    in.prefetch(offset, length);
+    return in.prefetch(offset, length);
   }
 
   @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/SerialIOCountingDirectory.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/SerialIOCountingDirectory.java
@@ -126,7 +126,7 @@ public class SerialIOCountingDirectory extends FilterDirectory {
     }
 
     @Override
-    public void prefetch(long offset, long length) throws IOException {
+    public boolean prefetch(long offset, long length) throws IOException {
       final long firstPage = (sliceOffset + offset) >> PAGE_SHIFT;
       final long lastPage = (sliceOffset + offset + length - 1) >> PAGE_SHIFT;
 
@@ -152,6 +152,8 @@ public class SerialIOCountingDirectory extends FilterDirectory {
       for (long page = firstPage; page <= lastPage; ++page) {
         pendingPages.add(page);
       }
+
+      return true; // TODO: looks like the right thing to do for this class?
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/store/SerialIOCountingDirectory.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/store/SerialIOCountingDirectory.java
@@ -153,7 +153,7 @@ public class SerialIOCountingDirectory extends FilterDirectory {
         pendingPages.add(page);
       }
 
-      return true; // TODO: looks like the right thing to do for this class?
+      return true;
     }
 
     @Override


### PR DESCRIPTION
### Problem
Currently, for term lookup `TermStates.get` defers for every case (to the lambda in TermStates.java). This works great for cold indexes but might not be the best for hot indexes.

### Solution
We can depend upon prefetch for deferring. If prefetch is being done then index is still cold hence we should defer termstate lookup through lambda, if not we should short-circuit and look up termstate directly instead of deferring.

### Testing

We added this new task to demonstrate that this changes are beneficial for cases when one term is missing(`jasdgiasgdiuygduasgd`) and the other term is present in high frequency(`ring`) and enabled sort order (Thanks  @epotyom !): 

`AndMissingHigh: titledvsort//+jasdgiasgdiuygduasgd +ring`


The task shows good improvements in QPS (+31.8%), rest of the tasks are stable:

```
                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                           range     3610.60      (6.5%)     3536.68      (5.7%)   -2.0% ( -13% -   10%) 0.286
                       MedPhrase      247.57      (3.9%)      244.81      (4.5%)   -1.1% (  -9% -    7%) 0.399
                      AndHighLow     1632.42      (3.0%)     1617.01      (4.2%)   -0.9% (  -7% -    6%) 0.416
            BrowseDateTaxoFacets        3.20      (5.0%)        3.18      (4.9%)   -0.8% ( -10% -    9%) 0.597
                       OrHighMed      675.71      (1.6%)      670.72      (2.4%)   -0.7% (  -4% -    3%) 0.258
       BrowseDayOfYearTaxoFacets        3.22      (4.9%)        3.20      (4.8%)   -0.7% (  -9% -    9%) 0.631
                          IntSet      774.21      (5.8%)      768.52      (5.3%)   -0.7% ( -11% -   10%) 0.675
               HighTermMonthSort     1457.35      (2.6%)     1447.58      (3.4%)   -0.7% (  -6% -    5%) 0.479
                      OrHighHigh      317.76      (3.8%)      316.28      (5.0%)   -0.5% (  -8% -    8%) 0.738
                    OrNotHighLow     1553.80      (3.7%)     1546.93      (3.3%)   -0.4% (  -7% -    6%) 0.690
                     AndHighHigh      266.04      (2.5%)      265.04      (2.4%)   -0.4% (  -5% -    4%) 0.624
           HighTermDayOfYearSort      334.42      (4.9%)      333.19      (5.0%)   -0.4% (  -9% -   10%) 0.814
            MedTermDayTaxoFacets       35.70      (1.2%)       35.58      (1.3%)   -0.3% (  -2% -    2%) 0.396
                       LowPhrase       78.41      (1.5%)       78.26      (1.0%)   -0.2% (  -2% -    2%) 0.641
                         LowTerm     1770.19      (2.3%)     1767.79      (3.6%)   -0.1% (  -5% -    5%) 0.888
     BrowseRandomLabelTaxoFacets        2.41      (2.0%)        2.40      (1.5%)   -0.1% (  -3% -    3%) 0.912
         AndHighMedDayTaxoFacets       88.80      (0.8%)       88.75      (1.0%)   -0.0% (  -1% -    1%) 0.859
                     LowSpanNear       40.39      (2.1%)       40.40      (1.3%)    0.0% (  -3% -    3%) 0.943
                          IntNRQ      347.74      (1.4%)      347.98      (1.8%)    0.1% (  -3% -    3%) 0.893
            HighTermTitleBDVSort       53.80      (1.2%)       53.86      (1.1%)    0.1% (  -2% -    2%) 0.752
                    OrNotHighMed      560.70      (3.8%)      561.73      (2.4%)    0.2% (  -5% -    6%) 0.856
                      AndHighMed      705.30      (1.9%)      707.15      (1.8%)    0.3% (  -3% -    4%) 0.652
                    HighSpanNear       29.65      (3.2%)       29.74      (2.8%)    0.3% (  -5% -    6%) 0.752
                       OrHighLow      888.06      (2.3%)      890.92      (2.2%)    0.3% (  -4% -    4%) 0.652
                     MedSpanNear       70.96      (2.2%)       71.19      (1.9%)    0.3% (  -3% -    4%) 0.613
                         MedTerm     1171.64      (3.3%)     1175.76      (3.4%)    0.4% (  -6% -    7%) 0.741
                    OrHighNotLow      997.56      (4.8%)     1001.22      (3.9%)    0.4% (  -7% -    9%) 0.790
                      HighPhrase       52.03      (2.2%)       52.22      (1.4%)    0.4% (  -3% -    4%) 0.521
                         Respell       38.32      (2.3%)       38.48      (1.9%)    0.4% (  -3% -    4%) 0.534
                      TermDTSort      303.26      (2.0%)      304.59      (1.7%)    0.4% (  -3% -    4%) 0.458
        AndHighHighDayTaxoFacets       21.18      (1.7%)       21.29      (1.7%)    0.5% (  -2% -    3%) 0.357
          OrHighMedDayTaxoFacets        6.75      (1.7%)        6.78      (1.6%)    0.5% (  -2% -    3%) 0.319
                         Prefix3      998.21      (3.3%)     1004.68      (2.5%)    0.6% (  -5% -    6%) 0.489
            BrowseDateSSDVFacets        0.90      (8.5%)        0.90      (8.5%)    0.7% ( -15% -   19%) 0.802
                        PKLookup      198.47      (3.1%)      200.00      (2.2%)    0.8% (  -4% -    6%) 0.366
               HighTermTitleSort      172.27      (3.2%)      173.61      (2.2%)    0.8% (  -4% -    6%) 0.368
                    OrHighNotMed      648.55      (4.5%)      653.66      (3.0%)    0.8% (  -6% -    8%) 0.519
           BrowseMonthTaxoFacets        2.77      (0.2%)        2.79      (1.8%)    0.8% (  -1% -    2%) 0.045
                HighSloppyPhrase        6.77      (6.6%)        6.83      (7.0%)    0.8% ( -11% -   15%) 0.701
                        HighTerm     1169.75      (4.0%)     1179.75      (4.0%)    0.9% (  -6% -    9%) 0.498
             MedIntervalsOrdered       49.21      (4.0%)       49.65      (3.7%)    0.9% (  -6% -    8%) 0.472
                 LowSloppyPhrase       33.78      (3.6%)       34.09      (3.4%)    0.9% (  -5% -    8%) 0.399
                          Fuzzy2       69.59      (2.4%)       70.25      (2.1%)    1.0% (  -3% -    5%) 0.183
     BrowseRandomLabelSSDVFacets        3.23     (12.7%)        3.26     (10.2%)    1.1% ( -19% -   27%) 0.762
                          Fuzzy1       78.62      (3.0%)       79.53      (2.6%)    1.1% (  -4% -    6%) 0.188
                 MedSloppyPhrase      109.90      (7.2%)      111.54      (6.4%)    1.5% ( -11% -   16%) 0.488
                   OrHighNotHigh      244.30      (7.5%)      248.19      (6.2%)    1.6% ( -11% -   16%) 0.465
            HighIntervalsOrdered       56.91      (8.0%)       57.95      (6.5%)    1.8% ( -11% -   17%) 0.424
             LowIntervalsOrdered      452.78      (7.7%)      463.41      (6.3%)    2.3% ( -10% -   17%) 0.293
       BrowseDayOfYearSSDVFacets        4.30      (7.3%)        4.42      (8.4%)    2.8% ( -12% -   19%) 0.260
                   OrNotHighHigh      511.85      (8.7%)      526.59     (10.0%)    2.9% ( -14% -   23%) 0.331
                        Wildcard       68.34      (5.7%)       71.24      (3.3%)    4.2% (  -4% -   14%) 0.004
           BrowseMonthSSDVFacets        4.45     (13.2%)        4.74     (18.7%)    6.6% ( -22% -   44%) 0.200
                  AndMissingHigh     2158.52      (5.3%)     2844.18      (6.1%)   31.8% (  19% -   45%) 0.000

``` 

I have also tried simulating a cold index by using https://github.com/mikemccand/luceneutil/blob/main/src/python/ramhog.c . 

```
shubhamsekdev % free -h                                            
              total        used        free      shared  buff/cache   available
Mem:           247G        232G        8.5G        948K        6.0G         11G
Swap:            0B          0B          0B
```

The results look fine : 

```
                          TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                           range     2190.34      (4.3%)     2140.19      (6.3%)   -2.3% ( -12% -    8%) 0.179
     BrowseRandomLabelSSDVFacets        3.26     (10.9%)        3.21      (8.7%)   -1.6% ( -19% -   20%) 0.609
                      AndHighMed      829.92      (1.5%)      819.00      (2.3%)   -1.3% (  -5% -    2%) 0.032
                        HighTerm      833.25      (4.3%)      822.93      (5.6%)   -1.2% ( -10% -    9%) 0.435
                    OrHighNotMed      656.71      (5.5%)      649.27      (5.2%)   -1.1% ( -11% -   10%) 0.502
                    OrHighNotLow     1044.04      (4.1%)     1032.56      (4.8%)   -1.1% (  -9% -    8%) 0.436
                          Fuzzy1       90.66      (1.5%)       89.83      (2.1%)   -0.9% (  -4% -    2%) 0.115
                       OrHighLow     1223.62      (2.3%)     1212.71      (1.9%)   -0.9% (  -4% -    3%) 0.178
                 LowSloppyPhrase       27.00      (2.0%)       26.82      (4.3%)   -0.7% (  -6% -    5%) 0.523
                       OrHighMed      730.32      (1.4%)      726.01      (1.6%)   -0.6% (  -3% -    2%) 0.209
                          Fuzzy2       69.22      (1.3%)       68.86      (1.7%)   -0.5% (  -3% -    2%) 0.288
                 MedSloppyPhrase       68.68      (1.7%)       68.34      (2.5%)   -0.5% (  -4% -    3%) 0.469
                HighSloppyPhrase       28.17      (2.7%)       28.05      (3.0%)   -0.4% (  -5% -    5%) 0.634
                         MedTerm     1234.74      (4.5%)     1229.69      (4.6%)   -0.4% (  -9% -    9%) 0.777
                     LowSpanNear       45.21      (2.3%)       45.05      (2.4%)   -0.4% (  -4% -    4%) 0.629
           BrowseMonthTaxoFacets        2.79      (2.1%)        2.78      (0.9%)   -0.3% (  -3% -    2%) 0.614
        AndHighHighDayTaxoFacets       26.91      (1.5%)       26.86      (1.5%)   -0.2% (  -3% -    2%) 0.695
                      HighPhrase      293.10      (1.9%)      292.56      (1.7%)   -0.2% (  -3% -    3%) 0.747
                     MedSpanNear       39.04      (1.4%)       38.97      (1.7%)   -0.2% (  -3% -    2%) 0.720
                      AndHighLow     1517.90      (2.9%)     1515.76      (2.6%)   -0.1% (  -5% -    5%) 0.871
            BrowseDateSSDVFacets        0.90      (8.5%)        0.90      (8.6%)   -0.1% ( -15% -   18%) 0.959
                        Wildcard      372.32      (4.3%)      371.81      (3.1%)   -0.1% (  -7% -    7%) 0.907
                    HighSpanNear       42.36      (1.7%)       42.31      (1.8%)   -0.1% (  -3% -    3%) 0.822
                         LowTerm     1730.51      (3.6%)     1728.87      (2.8%)   -0.1% (  -6% -    6%) 0.926
            HighTermTitleBDVSort       36.39      (1.5%)       36.38      (1.9%)   -0.0% (  -3% -    3%) 0.965
                    OrNotHighLow     1343.68      (3.7%)     1344.38      (3.1%)    0.1% (  -6% -    7%) 0.961
                       MedPhrase      394.21      (1.1%)      394.43      (0.8%)    0.1% (  -1% -    1%) 0.853
               HighTermTitleSort      167.15      (2.4%)      167.27      (2.4%)    0.1% (  -4% -    4%) 0.926
                       LowPhrase      179.37      (1.2%)      179.50      (1.3%)    0.1% (  -2% -    2%) 0.849
                         Respell       39.85      (1.4%)       39.88      (1.3%)    0.1% (  -2% -    2%) 0.862
                      OrHighHigh      164.00      (4.9%)      164.14      (3.3%)    0.1% (  -7% -    8%) 0.950
           HighTermDayOfYearSort      338.43      (2.1%)      338.83      (2.6%)    0.1% (  -4% -    4%) 0.876
            MedTermDayTaxoFacets       39.30      (1.0%)       39.36      (1.5%)    0.2% (  -2% -    2%) 0.701
                          IntSet      847.58      (5.1%)      849.31      (4.9%)    0.2% (  -9% -   10%) 0.898
            BrowseDateTaxoFacets        3.18      (5.0%)        3.19      (8.6%)    0.3% ( -12% -   14%) 0.909
         AndHighMedDayTaxoFacets       90.92      (0.8%)       91.18      (1.0%)    0.3% (  -1% -    2%) 0.298
       BrowseDayOfYearTaxoFacets        3.21      (4.9%)        3.22      (8.1%)    0.3% ( -12% -   13%) 0.889
                         Prefix3      528.21      (3.6%)      530.75      (3.5%)    0.5% (  -6% -    7%) 0.666
          OrHighMedDayTaxoFacets        7.68      (2.3%)        7.72      (1.3%)    0.5% (  -2% -    4%) 0.399
                          IntNRQ      452.72      (1.6%)      454.94      (1.5%)    0.5% (  -2% -    3%) 0.330
                   OrHighNotHigh      521.22      (4.6%)      524.07      (4.6%)    0.5% (  -8% -   10%) 0.707
                     AndHighHigh      215.59      (6.6%)      217.01      (5.0%)    0.7% ( -10% -   13%) 0.723
                      TermDTSort      279.76      (5.7%)      282.28      (5.7%)    0.9% (  -9% -   12%) 0.615
     BrowseRandomLabelTaxoFacets        2.40      (1.5%)        2.42      (6.5%)    1.1% (  -6% -    9%) 0.477
           BrowseMonthSSDVFacets        4.55     (12.1%)        4.60     (12.9%)    1.1% ( -21% -   29%) 0.781
                   OrNotHighHigh      386.83      (5.0%)      391.18      (4.7%)    1.1% (  -8% -   11%) 0.466
       BrowseDayOfYearSSDVFacets        4.45      (7.5%)        4.51      (7.8%)    1.2% ( -13% -   17%) 0.619
               HighTermMonthSort     1430.45      (2.6%)     1449.30      (2.5%)    1.3% (  -3% -    6%) 0.107
             LowIntervalsOrdered      374.77      (6.1%)      380.25      (6.3%)    1.5% ( -10% -   14%) 0.453
            HighIntervalsOrdered       24.88      (4.7%)       25.25      (4.7%)    1.5% (  -7% -   11%) 0.320
             MedIntervalsOrdered      117.02      (4.8%)      118.89      (4.7%)    1.6% (  -7% -   11%) 0.290
                        PKLookup      197.14      (2.2%)      200.83      (2.4%)    1.9% (  -2% -    6%) 0.011
                    OrNotHighMed      710.06     (13.5%)      729.26      (8.8%)    2.7% ( -17% -   28%) 0.452
                  AndMissingHigh     2187.90      (4.1%)     2911.33      (6.4%)   33.1% (  21% -   45%) 0.000
```