### PR TITLE
Revert "Don't run changelog verifier on draft PRs (#14685)"

### DIFF
--- a/.github/workflows/verify-changelog-and-set-milestone.yml
+++ b/.github/workflows/verify-changelog-and-set-milestone.yml
@@ -10,7 +10,6 @@ jobs:
     name: Verify Change Log Entry and Set Milestone
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     permissions:
       pull-requests: write # edits PR milestones, adds comments
 


### PR DESCRIPTION
This reverts commit 564f483bee0df504bd295804b6ad5911d8629e05.

### Description

IMO, we don't need to skip the job anymore as it does not add comment on the PR. So, we don't need to worry about adding multiple comments on the PR, even when it is in draft state.
