### PR TITLE
Reduce lock scope in StringHelper#randomId()

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -319,6 +319,8 @@ Optimizations
 
 * GITHUB#15592: Optimize DocIdSetIteratorAcceptDocs#cost. (Shubham Chaudhary)
 
+* GITHUB#15631: Reduce lock scope in StringHelper#randomId(). (Zhang Chao)
+
 Bug Fixes
 ---------------------
 * GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException

--- a/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
@@ -458,11 +458,12 @@ public abstract class StringHelper {
     //     what impact that has on the period, whereas the simple ++ (mod 2^128)
     //     we use here is guaranteed to have the full period.
 
-    byte[] bits;
+    final BigInteger scratch;
     synchronized (idLock) {
-      bits = nextId.toByteArray();
+      scratch = nextId;
       nextId = nextId.add(BigInteger.ONE).and(mask128);
     }
+    byte[] bits = scratch.toByteArray();
 
     // toByteArray() always returns a sign bit, so it may require an extra byte (always zero)
     if (bits.length > ID_LENGTH) {


### PR DESCRIPTION
This change moves `BigInteger#toByteArray()` outside the `synchronized` block, since it allocates and copies data. this method does not seem to be on a hot path, so the performance impact may be minimal.