### PR TITLE
Remove sorted path from FrozenBufferedUpdates.TermDocsIterator

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriter.java
@@ -57,7 +57,7 @@ final class FreqProxTermsWriter extends TermsHash {
 
       BufferedUpdates.DeletedTerms segDeletes = state.segUpdates.deleteTerms;
       FrozenBufferedUpdates.TermDocsIterator iterator =
-          new FrozenBufferedUpdates.TermDocsIterator(fields, true);
+          new FrozenBufferedUpdates.TermDocsIterator(fields);
 
       segDeletes.forEachOrdered(
           (term, docId) -> {

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -49,8 +49,7 @@ final class FrozenBufferedUpdates {
    * we run this before applying the deletes/updates. */
 
   /* Query we often undercount (say 24 bytes), plus int. */
-  static final int BYTES_PER_DEL_QUERY =
-      RamUsageEstimator.NUM_BYTES_OBJECT_REF + Integer.BYTES + 24;
+  static final int BYTES_PER_DEL_QUERY = RamUsageEstimator.NUM_BYTES_OBJECT_REF + Integer.BYTES + 24;
 
   // Terms, in sorted order:
   final PrefixCodedTerms deleteTerms;
@@ -106,10 +105,8 @@ final class FrozenBufferedUpdates {
     this.fieldUpdates = Map.copyOf(updates.fieldUpdates);
     this.fieldUpdatesCount = updates.numFieldUpdates.get();
 
-    bytesUsed =
-        (int)
-            ((deleteTerms.ramBytesUsed() + deleteQueries.length * (long) BYTES_PER_DEL_QUERY)
-                + updates.fieldUpdatesBytesUsed.get());
+    bytesUsed = (int) ((deleteTerms.ramBytesUsed() + deleteQueries.length * (long) BYTES_PER_DEL_QUERY)
+        + updates.fieldUpdatesBytesUsed.get());
 
     if (infoStream != null && infoStream.isEnabled("BD")) {
       infoStream.message(
@@ -201,8 +198,7 @@ final class FrozenBufferedUpdates {
       }
       final boolean isSegmentPrivateDeletes = privateSegment != null;
       if (fieldUpdates.isEmpty() == false) {
-        updateCount +=
-            applyDocValuesUpdates(segState, fieldUpdates, delGen, isSegmentPrivateDeletes);
+        updateCount += applyDocValuesUpdates(segState, fieldUpdates, delGen, isSegmentPrivateDeletes);
       }
     }
 
@@ -250,8 +246,7 @@ final class FrozenBufferedUpdates {
       boolean isNumeric = value.isNumeric();
       FieldUpdatesBuffer.BufferedUpdateIterator iterator = value.iterator();
       FieldUpdatesBuffer.BufferedUpdate bufferedUpdate;
-      TermDocsIterator termDocsIterator =
-          new TermDocsIterator(segState.reader, iterator.isSortedTerms());
+      TermDocsIterator termDocsIterator = new TermDocsIterator(segState.reader, false);
       while ((bufferedUpdate = iterator.next()) != null) {
         // TODO: we traverse the terms in update order (not term order) so that we
         // apply the updates in the correct order, i.e. if two terms update the
@@ -263,8 +258,8 @@ final class FrozenBufferedUpdates {
         // which will get same docIDUpto, yet will still need to respect the order
         // those updates arrived.
         // TODO: we could at least *collate* by field?
-        final DocIdSetIterator docIdSetIterator =
-            termDocsIterator.nextTerm(bufferedUpdate.termField, bufferedUpdate.termValue);
+        final DocIdSetIterator docIdSetIterator = termDocsIterator.nextTerm(bufferedUpdate.termField,
+            bufferedUpdate.termValue);
         if (docIdSetIterator != null) {
           final int limit;
           if (delGen == segState.delGen) {
@@ -285,21 +280,18 @@ final class FrozenBufferedUpdates {
           if (dvUpdates == null) {
             if (isNumeric) {
               if (value.hasSingleValue()) {
-                dvUpdates =
-                    new NumericDocValuesFieldUpdates.SingleValueNumericDocValuesFieldUpdates(
-                        delGen, updateField, segState.reader.maxDoc(), value.getNumericValue(0));
+                dvUpdates = new NumericDocValuesFieldUpdates.SingleValueNumericDocValuesFieldUpdates(
+                    delGen, updateField, segState.reader.maxDoc(), value.getNumericValue(0));
               } else {
-                dvUpdates =
-                    new NumericDocValuesFieldUpdates(
-                        delGen,
-                        updateField,
-                        value.getMinNumeric(),
-                        value.getMaxNumeric(),
-                        segState.reader.maxDoc());
+                dvUpdates = new NumericDocValuesFieldUpdates(
+                    delGen,
+                    updateField,
+                    value.getMinNumeric(),
+                    value.getMaxNumeric(),
+                    segState.reader.maxDoc());
               }
             } else {
-              dvUpdates =
-                  new BinaryDocValuesFieldUpdates(delGen, updateField, segState.reader.maxDoc());
+              dvUpdates = new BinaryDocValuesFieldUpdates(delGen, updateField, segState.reader.maxDoc());
             }
             resolvedUpdates.add(dvUpdates);
           }
@@ -464,7 +456,7 @@ final class FrozenBufferedUpdates {
 
       FieldTermIterator iter = deleteTerms.iterator();
       BytesRef delTerm;
-      TermDocsIterator termDocsIterator = new TermDocsIterator(segState.reader, true);
+      TermDocsIterator termDocsIterator = new TermDocsIterator(segState.reader, false);
       while ((delTerm = iter.next()) != null) {
         final DocIdSetIterator iterator = termDocsIterator.nextTerm(iter.field(), delTerm);
         if (iterator != null) {

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -49,7 +49,8 @@ final class FrozenBufferedUpdates {
    * we run this before applying the deletes/updates. */
 
   /* Query we often undercount (say 24 bytes), plus int. */
-  static final int BYTES_PER_DEL_QUERY = RamUsageEstimator.NUM_BYTES_OBJECT_REF + Integer.BYTES + 24;
+  static final int BYTES_PER_DEL_QUERY =
+      RamUsageEstimator.NUM_BYTES_OBJECT_REF + Integer.BYTES + 24;
 
   // Terms, in sorted order:
   final PrefixCodedTerms deleteTerms;
@@ -105,8 +106,10 @@ final class FrozenBufferedUpdates {
     this.fieldUpdates = Map.copyOf(updates.fieldUpdates);
     this.fieldUpdatesCount = updates.numFieldUpdates.get();
 
-    bytesUsed = (int) ((deleteTerms.ramBytesUsed() + deleteQueries.length * (long) BYTES_PER_DEL_QUERY)
-        + updates.fieldUpdatesBytesUsed.get());
+    bytesUsed =
+        (int)
+            ((deleteTerms.ramBytesUsed() + deleteQueries.length * (long) BYTES_PER_DEL_QUERY)
+                + updates.fieldUpdatesBytesUsed.get());
 
     if (infoStream != null && infoStream.isEnabled("BD")) {
       infoStream.message(
@@ -198,7 +201,8 @@ final class FrozenBufferedUpdates {
       }
       final boolean isSegmentPrivateDeletes = privateSegment != null;
       if (fieldUpdates.isEmpty() == false) {
-        updateCount += applyDocValuesUpdates(segState, fieldUpdates, delGen, isSegmentPrivateDeletes);
+        updateCount +=
+            applyDocValuesUpdates(segState, fieldUpdates, delGen, isSegmentPrivateDeletes);
       }
     }
 
@@ -258,8 +262,8 @@ final class FrozenBufferedUpdates {
         // which will get same docIDUpto, yet will still need to respect the order
         // those updates arrived.
         // TODO: we could at least *collate* by field?
-        final DocIdSetIterator docIdSetIterator = termDocsIterator.nextTerm(bufferedUpdate.termField,
-            bufferedUpdate.termValue);
+        final DocIdSetIterator docIdSetIterator =
+            termDocsIterator.nextTerm(bufferedUpdate.termField, bufferedUpdate.termValue);
         if (docIdSetIterator != null) {
           final int limit;
           if (delGen == segState.delGen) {
@@ -280,18 +284,21 @@ final class FrozenBufferedUpdates {
           if (dvUpdates == null) {
             if (isNumeric) {
               if (value.hasSingleValue()) {
-                dvUpdates = new NumericDocValuesFieldUpdates.SingleValueNumericDocValuesFieldUpdates(
-                    delGen, updateField, segState.reader.maxDoc(), value.getNumericValue(0));
+                dvUpdates =
+                    new NumericDocValuesFieldUpdates.SingleValueNumericDocValuesFieldUpdates(
+                        delGen, updateField, segState.reader.maxDoc(), value.getNumericValue(0));
               } else {
-                dvUpdates = new NumericDocValuesFieldUpdates(
-                    delGen,
-                    updateField,
-                    value.getMinNumeric(),
-                    value.getMaxNumeric(),
-                    segState.reader.maxDoc());
+                dvUpdates =
+                    new NumericDocValuesFieldUpdates(
+                        delGen,
+                        updateField,
+                        value.getMinNumeric(),
+                        value.getMaxNumeric(),
+                        segState.reader.maxDoc());
               }
             } else {
-              dvUpdates = new BinaryDocValuesFieldUpdates(delGen, updateField, segState.reader.maxDoc());
+              dvUpdates =
+                  new BinaryDocValuesFieldUpdates(delGen, updateField, segState.reader.maxDoc());
             }
             resolvedUpdates.add(dvUpdates);
           }

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -544,8 +544,6 @@ final class FrozenBufferedUpdates {
     private String field;
     private TermsEnum termsEnum;
     private PostingsEnum postingsEnum;
-    private BytesRef readerTerm;
-    private BytesRef lastTerm; // only set with asserts
 
     TermDocsIterator(Fields fields) {
       this(fields::terms);

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -250,7 +250,7 @@ final class FrozenBufferedUpdates {
       boolean isNumeric = value.isNumeric();
       FieldUpdatesBuffer.BufferedUpdateIterator iterator = value.iterator();
       FieldUpdatesBuffer.BufferedUpdate bufferedUpdate;
-      TermDocsIterator termDocsIterator = new TermDocsIterator(segState.reader, false);
+      TermDocsIterator termDocsIterator = new TermDocsIterator(segState.reader);
       while ((bufferedUpdate = iterator.next()) != null) {
         // TODO: we traverse the terms in update order (not term order) so that we
         // apply the updates in the correct order, i.e. if two terms update the
@@ -463,7 +463,7 @@ final class FrozenBufferedUpdates {
 
       FieldTermIterator iter = deleteTerms.iterator();
       BytesRef delTerm;
-      TermDocsIterator termDocsIterator = new TermDocsIterator(segState.reader, false);
+      TermDocsIterator termDocsIterator = new TermDocsIterator(segState.reader);
       while ((delTerm = iter.next()) != null) {
         final DocIdSetIterator iterator = termDocsIterator.nextTerm(iter.field(), delTerm);
         if (iterator != null) {
@@ -544,20 +544,18 @@ final class FrozenBufferedUpdates {
     private String field;
     private TermsEnum termsEnum;
     private PostingsEnum postingsEnum;
-    private final boolean sortedTerms;
     private BytesRef readerTerm;
     private BytesRef lastTerm; // only set with asserts
 
-    TermDocsIterator(Fields fields, boolean sortedTerms) {
-      this(fields::terms, sortedTerms);
+    TermDocsIterator(Fields fields) {
+      this(fields::terms);
     }
 
-    TermDocsIterator(LeafReader reader, boolean sortedTerms) {
-      this(reader::terms, sortedTerms);
+    TermDocsIterator(LeafReader reader) {
+      this(reader::terms);
     }
 
-    private TermDocsIterator(IOFunction<String, Terms> provider, boolean sortedTerms) {
-      this.sortedTerms = sortedTerms;
+    private TermDocsIterator(IOFunction<String, Terms> provider) {
       this.provider = provider;
     }
 
@@ -568,11 +566,6 @@ final class FrozenBufferedUpdates {
         Terms terms = provider.apply(field);
         if (terms != null) {
           termsEnum = terms.iterator();
-          if (sortedTerms) {
-            // need to reset otherwise we fail the assertSorted below since we sort per field
-            assert (lastTerm = null) == null;
-            readerTerm = termsEnum.next();
-          }
         } else {
           termsEnum = null;
         }
@@ -581,46 +574,10 @@ final class FrozenBufferedUpdates {
 
     DocIdSetIterator nextTerm(String field, BytesRef term) throws IOException {
       setField(field);
-      if (termsEnum != null) {
-        if (sortedTerms) {
-          assert assertSorted(term);
-          // in the sorted case we can take advantage of the "seeking forward" property
-          // this allows us depending on the term dict impl to reuse data-structures internally
-          // which speed up iteration over terms and docs significantly.
-          int cmp = term.compareTo(readerTerm);
-          if (cmp < 0) {
-            return null; // requested term does not exist in this segment
-          } else if (cmp == 0) {
-            return getDocs();
-          } else {
-            TermsEnum.SeekStatus status = termsEnum.seekCeil(term);
-            switch (status) {
-              case FOUND:
-                return getDocs();
-              case NOT_FOUND:
-                readerTerm = termsEnum.term();
-                return null;
-              case END:
-                // no more terms in this segment
-                termsEnum = null;
-                return null;
-              default:
-                throw new AssertionError("unknown status");
-            }
-          }
-        } else if (termsEnum.seekExact(term)) {
-          return getDocs();
-        }
+      if (termsEnum != null && termsEnum.seekExact(term)) {
+        return getDocs();
       }
       return null;
-    }
-
-    private boolean assertSorted(BytesRef term) {
-      assert sortedTerms;
-      assert lastTerm == null || term.compareTo(lastTerm) >= 0
-          : "boom: " + term.utf8ToString() + " last: " + lastTerm.utf8ToString();
-      lastTerm = BytesRef.deepCopyOf(term);
-      return true;
     }
 
     private DocIdSetIterator getDocs() throws IOException {

--- a/lucene/core/src/test/org/apache/lucene/index/TestFrozenBufferedUpdates.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFrozenBufferedUpdates.java
@@ -79,7 +79,7 @@ public class TestFrozenBufferedUpdates extends LuceneTestCase {
           BytesRefIterator values =
               sorted ? array.iterator(Comparator.naturalOrder()) : array.iterator();
           assertEquals(1, reader.leaves().size());
-          TermDocsIterator iterator = new TermDocsIterator(reader.leaves().get(0).reader(), sorted);
+          TermDocsIterator iterator = new TermDocsIterator(reader.leaves().get(0).reader());
           FixedBitSet bitSet = new FixedBitSet(reader.maxDoc());
           BytesRef ref;
           while ((ref = values.next()) != null) {


### PR DESCRIPTION
When sorted, FBU.TermDocsIterator will seekCeil() on the underlying TermsEnum in an attempt to re-use state
in the underlying enum. Using seekCeil() acts as a defeat device for approximate membership query filter data
structures like bloom filters since you still have to examine the lexicon to find the term immediately after the
seekCeil argument.

Since this optimization was added it seems that the default postings codec does a better job re-using state in these
cases, avoiding unnecessary block seeks and other work. This optimization doesn't seem to do much any more
so remove it.