### PR TITLE
Fix FVH boost issue (#15442)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -332,6 +332,10 @@ Optimizations
 
 Bug Fixes
 ---------------------
+* GITHUB#15442: Preserve boost values when merging overlapping phrases in
+  FastVectorHighlighter so highlight scoring fully reflects query boosts.
+  (Yang Feng)
+
 * GITHUB#14161: PointInSetQuery's constructor now throws IllegalArgumentException
   instead of UnsupportedOperationException when values are out of order. (Shubham Sharma)
 

--- a/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/FieldPhraseList.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/FieldPhraseList.java
@@ -177,6 +177,7 @@ public class FieldPhraseList {
         // The result is that all informations in TermInfo are lost and not available for further
         // operations.
         existWpi.getTermsInfos().addAll(wpi.getTermsInfos());
+        existWpi.boost += wpi.getBoost(); // Accumulate boost
         return;
       }
     }

--- a/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestFieldPhraseList.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestFieldPhraseList.java
@@ -289,4 +289,21 @@ public class TestFieldPhraseList extends AbstractTestCase {
     assertTrue(a.compareTo(b) < 0);
     assertTrue(b.compareTo(a) > 0);
   }
+
+  public void testMergeOverlappingWeightedPhraseInfoAccumulateBoost() {
+    LinkedList<TermInfo> infos1 = new LinkedList<>();
+    infos1.add(new TermInfo("中国", 0, 2, 0, 0));
+    infos1.add(new TermInfo("经济", 3, 5, 1, 1));
+    WeightedPhraseInfo wpi1 = new WeightedPhraseInfo(infos1, 2.0f);
+
+    LinkedList<TermInfo> infos2 = new LinkedList<>();
+    infos2.add(new TermInfo("经济", 3, 5, 1, 1));
+    infos2.add(new TermInfo("发展", 6, 8, 2, 2));
+    WeightedPhraseInfo wpi2 = new WeightedPhraseInfo(infos2, 3.0f);
+
+    // trigger merge
+    WeightedPhraseInfo merged = new WeightedPhraseInfo(java.util.List.of(wpi1, wpi2));
+
+    assertEquals(5.0f, merged.getBoost(), 0.0001f);
+  }
 }

--- a/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestFieldPhraseList.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestFieldPhraseList.java
@@ -301,8 +301,15 @@ public class TestFieldPhraseList extends AbstractTestCase {
     infos2.add(new TermInfo("发展", 6, 8, 2, 2));
     WeightedPhraseInfo wpi2 = new WeightedPhraseInfo(infos2, 3.0f);
 
-    // trigger merge
-    WeightedPhraseInfo merged = new WeightedPhraseInfo(java.util.List.of(wpi1, wpi2));
+    FieldPhraseList fpl = new FieldPhraseList(new FieldPhraseList[0]);
+    fpl.getPhraseList().add(wpi1);
+
+    // This will execute: existWpi.boost += wpi.getBoost();
+    fpl.addIfNoOverlap(wpi2);
+
+    assertEquals(1, fpl.getPhraseList().size());
+
+    WeightedPhraseInfo merged = fpl.getPhraseList().get(0);
 
     assertEquals(5.0f, merged.getBoost(), 0.0001f);
   }


### PR DESCRIPTION
Resubmitted on top of `main` following the feedback on PR #15604.

Fixes GITHUB#15442. Tests pass on current `main`.

This change keeps boost values when merging overlapping phrases in
FastVectorHighlighter so highlight scores correctly reflect query boosts.
It only touches FVH internals and adds a small test for the case.
