### PR TITLE
Update documentation in Lucene104PostingsWriter

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -426,8 +426,6 @@ Other
 
 * GITHUB#15619: Update documentation in Lucene104PostingsFormat. with 259 documents, the first 256 document ids should be  encoded as one packed block (Lyon-NEU)
 
-* GITHUB#15670: Update documentation in Lucene104PostingsWriter. since BLOCK_SIZE now is 256, level1 truely doc cnt equals 8192. (Lyon-NEU)
-
 Build
 ---------------------
 * Upgrade forbiddenapis to version 3.10.  (Uwe Schindler)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -426,6 +426,8 @@ Other
 
 * GITHUB#15619: Update documentation in Lucene104PostingsFormat. with 259 documents, the first 256 document ids should be  encoded as one packed block (Lyon-NEU)
 
+* GITHUB#15670: Update documentation in Lucene104PostingsWriter. since BLOCK_SIZE now is 256, level1 truely doc cnt equals 8192. (Lyon-NEU)
+
 Build
 ---------------------
 * Upgrade forbiddenapis to version 3.10.  (Uwe Schindler)

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104PostingsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104PostingsWriter.java
@@ -483,7 +483,7 @@ public class Lucene104PostingsWriter extends PushPostingsWriterBase {
       level0FreqNormAccumulator.clear();
     }
 
-    if ((docCount & LEVEL1_MASK) == 0) { // true every 32 blocks (4,096 docs)
+    if ((docCount & LEVEL1_MASK) == 0) { // true every 32 blocks (8,192 docs)
       writeLevel1SkipData();
       level1LastDocID = docID;
       level1CompetitiveFreqNormAccumulator.clear();


### PR DESCRIPTION
BLOCK_SIZE now is 256, lso, evel1 truely doc cnt equals 8192　(#15670)

### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
