### PR TITLE
Fix CachedExecutor thread pool leak on IndexWriter init failure

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -128,6 +128,9 @@ Bug Fixes
 * GITHUB#12561: UAX29URLEmailTokenizer matched emails with commas and invalid
   periods in the local part. (Eran Yarkon)
 
+* GITHUB#14971: Fix CachedExecutor thread pool leak in ConcurrentMergeScheduler
+  when IndexWriter initialization fails. (Su Beom)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14187: The query cache is now disabled by default. (Adrien Grand)

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1200,7 +1200,7 @@ public class IndexWriter
       if (infoStream.isEnabled("IW")) {
         infoStream.message("IW", "init: hit exception on init; releasing write lock: " + t);
       }
-      IOUtils.closeWhileSuppressingExceptions(t, writeLock);
+      IOUtils.closeWhileSuppressingExceptions(t, config.getMergeScheduler(), writeLock);
       writeLock = null;
       throw t;
     }


### PR DESCRIPTION
### Description

Fixes #14971.

`ConcurrentMergeScheduler` creates a `CachedExecutor` (wrapping a `ThreadPoolExecutor`) in `mergeScheduler.initialize()`, which is called during `IndexWriter` construction. 

When the constructor fails after this point, the catch block only closed the `writeLock` without closing the `mergeScheduler`, leaving the `ThreadPoolExecutor` alive and causing a thread pool leak detectable by LuceneTestCase's thread leak checker. 

The fix adds `config.getMergeScheduler()` to the existing `IOUtils.closeWhileSuppressingExceptions` call in the catch block.

`config.getMergeScheduler()` is used  instead of the `mergeScheduler` field directly because it is declared `final` and may not yet be assigned when the catch block is reached.

This PR includes a regression test that verifies the `MergeScheduler` is properly closed when `IndexWriter` initialization fails.

Closes #14971