### PR TITLE
Fix Highlighter crash by implementing getFieldInfos in DelegatingLeafReader

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -128,6 +128,9 @@ Bug Fixes
 * GITHUB#12561: UAX29URLEmailTokenizer matched emails with commas and invalid
   periods in the local part. (Eran Yarkon)
 
+* GITHUB#15668: Fix UnsupportedOperationException in WeightedSpanTermExtractor by
+  implementing getFieldInfos in DelegatingLeafReader. (Simranjeet Singh)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14187: The query cache is now disabled by default. (Adrien Grand)

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/WeightedSpanTermExtractor.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/WeightedSpanTermExtractor.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.apache.lucene.analysis.CachingTokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.IndexReader;
@@ -444,7 +445,14 @@ public class WeightedSpanTermExtractor {
 
     @Override
     public FieldInfos getFieldInfos() {
-      throw new UnsupportedOperationException(); // TODO merge them
+
+      return new FieldInfos(
+          new FieldInfo[] {super.getFieldInfos().fieldInfo(DelegatingLeafReader.FIELD_NAME)}) {
+        @Override
+        public FieldInfo fieldInfo(String fieldName) {
+          return super.fieldInfo(DelegatingLeafReader.FIELD_NAME);
+        }
+      };
     }
 
     @Override

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/WeightedSpanTermExtractor.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/WeightedSpanTermExtractor.java
@@ -54,7 +54,6 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
-import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -237,8 +236,6 @@ public class WeightedSpanTermExtractor {
         }
       }
     } else if (query instanceof MatchAllDocsQuery) {
-      // nothing
-    } else if (query instanceof FieldExistsQuery) {
       // nothing
     } else if (query instanceof FunctionScoreQuery) {
       extract(((FunctionScoreQuery) query).getWrappedQuery(), boost, terms);

--- a/lucene/highlighter/src/test/org/apache/lucene/search/highlight/TestHighlighter.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/highlight/TestHighlighter.java
@@ -41,6 +41,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
@@ -2231,6 +2232,23 @@ public class TestHighlighter extends BaseTokenStreamTestCase implements Formatte
       String result = h.getBestFragment(stream, text);
       assertEquals("random <B>words</B> and words", result); // only highlight first "word"
     }
+  }
+
+  public void testSortedNumericDocValuesRangeQuery() throws IOException {
+    Query query =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("text", "compensation")), Occur.MUST)
+            .add(
+                SortedNumericDocValuesField.newSlowRangeQuery(
+                    "date_of_review", 20190210L, 20260210L),
+                Occur.FILTER)
+            .build();
+
+    WeightedSpanTermExtractor extractor = new WeightedSpanTermExtractor();
+    Map<String, WeightedSpanTerm> terms =
+        extractor.getWeightedSpanTerms(
+            query, 1, new CannedTokenStream(new Token("compensation", 0, 12)), "text");
+    assertTrue("Term 'compensation' should be extracted", terms.containsKey("compensation"));
   }
 
   @Override


### PR DESCRIPTION
Fixes #15668 

`WeightedSpanTermExtractor` uses an internal `DelegatingLeafReader` to provide a simplified view of a document during the highlighting process. Historically, this reader did not implement `getFieldInfos()`, throwing an `UnsupportedOperationException` instead.

In recent Lucene versions, several query types like `SortedNumericDocValuesRangeQuery` and `FieldExistsQuery` have been optimized to access index metadata via `getFieldInfos()` during their rewrite() phase. When these queries are passed to the `PlainHighlighter`, the rewrite fails, causing the highlighter to crash with an `UnsupportedOperationException`.

While previous fixes ([PR #12088](https://github.com/apache/lucene/pull/12088)) addressed this by explicitly ignoring specific query types in the extractor, this PR implements a structural fix by providing a valid `FieldInfos` implementation in the `DelegatingLeafReader`. This ensures that any current or future query types that rely on index schema metadata during rewrite can be handled gracefully by the highlighter.

**Changes**:

* Implemented `getFieldInfos()` in `WeightedSpanTermExtractor.DelegatingLeafReader`

* Added a regression test in `TestHighlightCustomQuery` that uses a custom query to verify that schema lookups during rewrite no longer trigger an exception. Validated that test fails with `UnsupportedOperationException` if implementation reverted to existing code.

Closes #15668


