### PR TITLE
Fix missing jacocoAggregatedReport task registration

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/CodeCoveragePlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/CodeCoveragePlugin.java
@@ -106,7 +106,8 @@ public class CodeCoveragePlugin extends LuceneGradlePlugin {
 
   private static TaskProvider<JacocoReport> configureJacocoReport(
       TaskContainer tasks, String jacocoTaskName, String logLine) {
-    TaskProvider<JacocoReport> jacocoAggregatedReport = tasks.register(jacocoTaskName,JacocoReport.class);
+    TaskProvider<JacocoReport> jacocoAggregatedReport =
+        tasks.register(jacocoTaskName, JacocoReport.class);
 
     jacocoAggregatedReport.configure(
         task -> {

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/CodeCoveragePlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/CodeCoveragePlugin.java
@@ -106,7 +106,7 @@ public class CodeCoveragePlugin extends LuceneGradlePlugin {
 
   private static TaskProvider<JacocoReport> configureJacocoReport(
       TaskContainer tasks, String jacocoTaskName, String logLine) {
-    var jacocoAggregatedReport = tasks.withType(JacocoReport.class).named(jacocoTaskName);
+    TaskProvider<JacocoReport> jacocoAggregatedReport = tasks.register(jacocoTaskName,JacocoReport.class);
 
     jacocoAggregatedReport.configure(
         task -> {


### PR DESCRIPTION
### Description

This change fixes a build failure when running with test coverage enabled.

`CodeCoveragePlugin.RootExtPlugin` attempts to look up the
`jacocoAggregatedReport` task during plugin application, but the task is never
registered in the root project. This causes the build to fail during
configuration time.

The fix explicitly registers the `JacocoReport` task before configuring it,
ensuring the task always exists when coverage is enabled.