### PR TITLE
Replace pre-sized array or empty array with lambda expression to call Collection#toArray.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -91,6 +91,8 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#15681: Use empty array style to call Collection#toArray. (Zhou Hui)
+
 * GITHUB#13782: Replace handwritten loops compare with Arrays.compareUnsigned in TermsEnum and TermsEnumFrame classes. (Zhou Hui)
 
 * GITHUB#14011: Reduce allocation rate in HNSW concurrent merge. (Viliam Durina)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -91,7 +91,7 @@ Improvements
 
 Optimizations
 ---------------------
-* GITHUB#15681: Replace pre-sized array with lambda style to call Collection#toArray. (Zhou Hui)
+* GITHUB#15681: Replace pre-sized array or empty array with lambda expression to call Collection#toArray. (Zhou Hui)
 
 * GITHUB#13782: Replace handwritten loops compare with Arrays.compareUnsigned in TermsEnum and TermsEnumFrame classes. (Zhou Hui)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -91,7 +91,7 @@ Improvements
 
 Optimizations
 ---------------------
-* GITHUB#15681: Use empty array style to call Collection#toArray. (Zhou Hui)
+* GITHUB#15681: Replace pre-sized array with lambda style to call Collection#toArray. (Zhou Hui)
 
 * GITHUB#13782: Replace handwritten loops compare with Arrays.compareUnsigned in TermsEnum and TermsEnumFrame classes. (Zhou Hui)
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/custom/CustomAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/custom/CustomAnalyzer.java
@@ -586,9 +586,9 @@ public final class CustomAnalyzer extends Analyzer {
         throw new IllegalStateException("You have to set at least a tokenizer.");
       }
       return new CustomAnalyzer(
-          charFilters.toArray(new CharFilterFactory[0]),
+          charFilters.toArray(CharFilterFactory[]::new),
           tokenizer.get(),
-          tokenFilters.toArray(new TokenFilterFactory[0]),
+          tokenFilters.toArray(TokenFilterFactory[]::new),
           posIncGap.get(),
           offsetGap.get());
     }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/custom/CustomAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/custom/CustomAnalyzer.java
@@ -586,9 +586,9 @@ public final class CustomAnalyzer extends Analyzer {
         throw new IllegalStateException("You have to set at least a tokenizer.");
       }
       return new CustomAnalyzer(
-          charFilters.toArray(new CharFilterFactory[charFilters.size()]),
+          charFilters.toArray(new CharFilterFactory[0]),
           tokenizer.get(),
-          tokenFilters.toArray(new TokenFilterFactory[tokenFilters.size()]),
+          tokenFilters.toArray(new TokenFilterFactory[0]),
           posIncGap.get(),
           offsetGap.get());
     }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/query/QueryAutoStopWordAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/query/QueryAutoStopWordAnalyzer.java
@@ -173,7 +173,7 @@ public final class QueryAutoStopWordAnalyzer extends AnalyzerWrapper {
    */
   public String[] getStopWords(String fieldName) {
     Set<String> stopWords = stopWordsPerField.get(fieldName);
-    return stopWords != null ? stopWords.toArray(new String[stopWords.size()]) : new String[0];
+    return stopWords != null ? stopWords.toArray(new String[0]) : new String[0];
   }
 
   /**

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/query/QueryAutoStopWordAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/query/QueryAutoStopWordAnalyzer.java
@@ -173,7 +173,7 @@ public final class QueryAutoStopWordAnalyzer extends AnalyzerWrapper {
    */
   public String[] getStopWords(String fieldName) {
     Set<String> stopWords = stopWordsPerField.get(fieldName);
-    return stopWords != null ? stopWords.toArray(new String[0]) : new String[0];
+    return stopWords != null ? stopWords.toArray(String[]::new) : new String[0];
   }
 
   /**

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SolrSynonymParser.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SolrSynonymParser.java
@@ -166,7 +166,7 @@ public class SolrSynonymParser extends SynonymMap.Parser {
       list.add(sb.toString());
     }
 
-    return list.toArray(new String[0]);
+    return list.toArray(String[]::new);
   }
 
   private String unescape(String s) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SolrSynonymParser.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SolrSynonymParser.java
@@ -166,7 +166,7 @@ public class SolrSynonymParser extends SynonymMap.Parser {
       list.add(sb.toString());
     }
 
-    return list.toArray(new String[list.size()]);
+    return list.toArray(new String[0]);
   }
 
   private String unescape(String s) {

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/SearchTravRetHighlightTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/SearchTravRetHighlightTask.java
@@ -278,7 +278,7 @@ public class SearchTravRetHighlightTask extends SearchTravTask {
     UnifiedHighlighter highlighter;
     IndexSearcher lastSearcher;
     UnifiedHighlighter.OffsetSource offsetSource; // null means auto select
-    String[] fields = hlFields.toArray(new String[hlFields.size()]);
+    String[] fields = hlFields.toArray(new String[0]);
     int[] maxPassages;
 
     UnifiedHLImpl(final UnifiedHighlighter.OffsetSource offsetSource) {

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/SearchTravRetHighlightTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/SearchTravRetHighlightTask.java
@@ -278,7 +278,7 @@ public class SearchTravRetHighlightTask extends SearchTravTask {
     UnifiedHighlighter highlighter;
     IndexSearcher lastSearcher;
     UnifiedHighlighter.OffsetSource offsetSource; // null means auto select
-    String[] fields = hlFields.toArray(new String[0]);
+    String[] fields = hlFields.toArray(String[]::new);
     int[] maxPassages;
 
     UnifiedHLImpl(final UnifiedHighlighter.OffsetSource offsetSource) {

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/utils/Config.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/utils/Config.java
@@ -327,7 +327,7 @@ public class Config {
       String t = st.nextToken();
       a.add(t);
     }
-    return a.toArray(new String[0]);
+    return a.toArray(String[]::new);
   }
 
   // extract properties to array, e.g. for "10:100:5" return int[]{10,100,5}.

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/utils/Config.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/utils/Config.java
@@ -327,7 +327,7 @@ public class Config {
       String t = st.nextToken();
       a.add(t);
     }
-    return a.toArray(new String[a.size()]);
+    return a.toArray(new String[0]);
   }
 
   // extract properties to array, e.g. for "10:100:5" return int[]{10,100,5}.

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextCompoundFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextCompoundFormat.java
@@ -161,7 +161,7 @@ public class SimpleTextCompoundFormat extends CompoundFormat {
     String dataFile = IndexFileNames.segmentFileName(si.name, "", DATA_EXTENSION);
 
     int numFiles = si.files().size();
-    String[] names = si.files().toArray(new String[numFiles]);
+    String[] names = si.files().toArray(new String[0]);
     Arrays.sort(names);
     long[] startOffsets = new long[numFiles];
     long[] endOffsets = new long[numFiles];

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextCompoundFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextCompoundFormat.java
@@ -161,7 +161,7 @@ public class SimpleTextCompoundFormat extends CompoundFormat {
     String dataFile = IndexFileNames.segmentFileName(si.name, "", DATA_EXTENSION);
 
     int numFiles = si.files().size();
-    String[] names = si.files().toArray(new String[0]);
+    String[] names = si.files().toArray(String[]::new);
     Arrays.sort(names);
     long[] startOffsets = new long[numFiles];
     long[] endOffsets = new long[numFiles];

--- a/lucene/core/src/java/org/apache/lucene/codecs/DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/DocValuesConsumer.java
@@ -678,7 +678,7 @@ public abstract class DocValuesConsumer implements Closeable {
     }
 
     final int numReaders = toMerge.size();
-    final SortedDocValues[] dvs = toMerge.toArray(new SortedDocValues[0]);
+    final SortedDocValues[] dvs = toMerge.toArray(SortedDocValues[]::new);
 
     TermsEnum[] liveTerms = new TermsEnum[dvs.length];
     long[] weights = new long[liveTerms.length];

--- a/lucene/core/src/java/org/apache/lucene/codecs/DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/DocValuesConsumer.java
@@ -678,7 +678,7 @@ public abstract class DocValuesConsumer implements Closeable {
     }
 
     final int numReaders = toMerge.size();
-    final SortedDocValues[] dvs = toMerge.toArray(new SortedDocValues[numReaders]);
+    final SortedDocValues[] dvs = toMerge.toArray(new SortedDocValues[0]);
 
     TermsEnum[] liveTerms = new TermsEnum[dvs.length];
     long[] weights = new long[liveTerms.length];

--- a/lucene/core/src/java/org/apache/lucene/codecs/FieldsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/FieldsConsumer.java
@@ -90,8 +90,7 @@ public abstract class FieldsConsumer implements Closeable {
     Fields mergedFields =
         new MappedMultiFields(
             mergeState,
-            new MultiFields(
-                fields.toArray(Fields.EMPTY_ARRAY), slices.toArray(ReaderSlice.EMPTY_ARRAY)));
+            new MultiFields(fields.toArray(Fields[]::new), slices.toArray(ReaderSlice[]::new)));
     write(mergedFields, norms);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
@@ -171,7 +171,7 @@ final class Lucene90CompoundReader extends CompoundDirectory {
   @Override
   public String[] listAll() {
     ensureOpen();
-    String[] res = entries.keySet().toArray(new String[0]);
+    String[] res = entries.keySet().toArray(String[]::new);
 
     // Add the segment name
     for (int i = 0; i < res.length; i++) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90CompoundReader.java
@@ -171,7 +171,7 @@ final class Lucene90CompoundReader extends CompoundDirectory {
   @Override
   public String[] listAll() {
     ensureOpen();
-    String[] res = entries.keySet().toArray(new String[entries.size()]);
+    String[] res = entries.keySet().toArray(new String[0]);
 
     // Add the segment name
     for (int i = 0; i < res.length; i++) {

--- a/lucene/core/src/java/org/apache/lucene/document/Document.java
+++ b/lucene/core/src/java/org/apache/lucene/document/Document.java
@@ -121,7 +121,7 @@ public final class Document implements Iterable<IndexableField> {
       }
     }
 
-    return result.toArray(new BytesRef[result.size()]);
+    return result.toArray(new BytesRef[0]);
   }
 
   /**
@@ -172,7 +172,7 @@ public final class Document implements Iterable<IndexableField> {
       }
     }
 
-    return result.toArray(new IndexableField[result.size()]);
+    return result.toArray(new IndexableField[0]);
   }
 
   /**
@@ -210,7 +210,7 @@ public final class Document implements Iterable<IndexableField> {
       return NO_STRINGS;
     }
 
-    return result.toArray(new String[result.size()]);
+    return result.toArray(new String[0]);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/document/Document.java
+++ b/lucene/core/src/java/org/apache/lucene/document/Document.java
@@ -121,7 +121,7 @@ public final class Document implements Iterable<IndexableField> {
       }
     }
 
-    return result.toArray(new BytesRef[0]);
+    return result.toArray(BytesRef[]::new);
   }
 
   /**
@@ -172,7 +172,7 @@ public final class Document implements Iterable<IndexableField> {
       }
     }
 
-    return result.toArray(new IndexableField[0]);
+    return result.toArray(IndexableField[]::new);
   }
 
   /**
@@ -210,7 +210,7 @@ public final class Document implements Iterable<IndexableField> {
       return NO_STRINGS;
     }
 
-    return result.toArray(new String[0]);
+    return result.toArray(String[]::new);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/geo/SimpleGeoJSONPolygonParser.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/SimpleGeoJSONPolygonParser.java
@@ -92,7 +92,7 @@ class SimpleGeoJSONPolygonParser {
         polygons.add(parsePolygon((List<Object>) o));
       }
 
-      return polygons.toArray(new Polygon[polygons.size()]);
+      return polygons.toArray(new Polygon[0]);
     }
   }
 
@@ -242,7 +242,7 @@ class SimpleGeoJSONPolygonParser {
       double[][] holePoints = parsePoints((List<Object>) o);
       holes.add(new Polygon(holePoints[0], holePoints[1]));
     }
-    return new Polygon(polyPoints[0], polyPoints[1], holes.toArray(new Polygon[holes.size()]));
+    return new Polygon(polyPoints[0], polyPoints[1], holes.toArray(new Polygon[0]));
   }
 
   /** Parses [[lat, lon], [lat, lon] ...] into 2d double array */

--- a/lucene/core/src/java/org/apache/lucene/geo/SimpleGeoJSONPolygonParser.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/SimpleGeoJSONPolygonParser.java
@@ -92,7 +92,7 @@ class SimpleGeoJSONPolygonParser {
         polygons.add(parsePolygon((List<Object>) o));
       }
 
-      return polygons.toArray(new Polygon[0]);
+      return polygons.toArray(Polygon[]::new);
     }
   }
 
@@ -242,7 +242,7 @@ class SimpleGeoJSONPolygonParser {
       double[][] holePoints = parsePoints((List<Object>) o);
       holes.add(new Polygon(holePoints[0], holePoints[1]));
     }
-    return new Polygon(polyPoints[0], polyPoints[1], holes.toArray(new Polygon[0]));
+    return new Polygon(polyPoints[0], polyPoints[1], holes.toArray(Polygon[]::new));
   }
 
   /** Parses [[lat, lon], [lat, lon] ...] into 2d double array */

--- a/lucene/core/src/java/org/apache/lucene/geo/SimpleWKTShapeParser.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/SimpleWKTShapeParser.java
@@ -196,7 +196,7 @@ public class SimpleWKTShapeParser {
     while (nextCloserOrComma(stream).equals(COMMA)) {
       lines.add(parseLine(stream));
     }
-    return lines.toArray(new Line[0]);
+    return lines.toArray(Line[]::new);
   }
 
   /** parses the hole of a polygon */
@@ -227,7 +227,7 @@ public class SimpleWKTShapeParser {
       return new Polygon(
           lats.stream().mapToDouble(i -> i).toArray(),
           lons.stream().mapToDouble(i -> i).toArray(),
-          holes.toArray(new Polygon[0]));
+          holes.toArray(Polygon[]::new));
     }
     return new Polygon(
         lats.stream().mapToDouble(i -> i).toArray(), lons.stream().mapToDouble(i -> i).toArray());
@@ -245,7 +245,7 @@ public class SimpleWKTShapeParser {
     while (nextCloserOrComma(stream).equals(COMMA)) {
       polygons.add(parsePolygon(stream));
     }
-    return polygons.toArray(new Polygon[0]);
+    return polygons.toArray(Polygon[]::new);
   }
 
   /** parses an ENVELOPE */
@@ -275,7 +275,7 @@ public class SimpleWKTShapeParser {
     while (nextCloserOrComma(stream).equals(COMMA)) {
       geometries.add(parseGeometry(stream, null));
     }
-    return geometries.toArray(new Object[0]);
+    return geometries.toArray(Object[]::new);
   }
 
   /** next word in the stream */

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -827,7 +827,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
 
     FieldInfos finish() {
       finished = true;
-      return new FieldInfos(byName.values().toArray(new FieldInfo[byName.size()]));
+      return new FieldInfos(byName.values().toArray(new FieldInfo[0]));
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -827,7 +827,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
 
     FieldInfos finish() {
       finished = true;
-      return new FieldInfos(byName.values().toArray(new FieldInfo[0]));
+      return new FieldInfos(byName.values().toArray(FieldInfo[]::new));
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/Fields.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Fields.java
@@ -44,7 +44,4 @@ public abstract class Fields implements Iterable<String> {
    * 0, {@link #iterator} will return as many field names.
    */
   public abstract int size();
-
-  /** Zero-length {@code Fields} array. */
-  public static final Fields[] EMPTY_ARRAY = new Fields[0];
 }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -6458,7 +6458,7 @@ public class IndexWriter
       throw t;
     }
 
-    return segStates.toArray(new BufferedUpdatesStream.SegmentState[0]);
+    return segStates.toArray(BufferedUpdatesStream.SegmentState[]::new);
   }
 
   /** Tests should override this to enable test points. Default is <code>false</code>. */

--- a/lucene/core/src/java/org/apache/lucene/index/MultiFields.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiFields.java
@@ -76,9 +76,7 @@ public final class MultiFields extends Fields {
       }
     }
     if (subs2.size() != 0) {
-      result =
-          new MultiTerms(
-              subs2.toArray(Terms.EMPTY_ARRAY), slices2.toArray(ReaderSlice.EMPTY_ARRAY));
+      result = new MultiTerms(subs2.toArray(Terms[]::new), slices2.toArray(ReaderSlice[]::new));
       terms.put(field, result);
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/MultiTerms.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiTerms.java
@@ -89,7 +89,7 @@ public final class MultiTerms extends Terms {
       return null;
     } else {
       return new MultiTerms(
-          termsPerLeaf.toArray(EMPTY_ARRAY), slicePerLeaf.toArray(ReaderSlice.EMPTY_ARRAY));
+          termsPerLeaf.toArray(Terms[]::new), slicePerLeaf.toArray(ReaderSlice[]::new));
     }
   }
 
@@ -145,7 +145,7 @@ public final class MultiTerms extends Terms {
     }
 
     if (termsEnums.size() > 0) {
-      return new MultiTermsEnum(subSlices).reset(termsEnums.toArray(TermsEnumIndex.EMPTY_ARRAY));
+      return new MultiTermsEnum(subSlices).reset(termsEnums.toArray(TermsEnumIndex[]::new));
     } else {
       return TermsEnum.EMPTY;
     }
@@ -189,7 +189,7 @@ public final class MultiTerms extends Terms {
     }
 
     if (termsEnums.size() > 0) {
-      return new MultiTermsEnum(subSlices).reset(termsEnums.toArray(TermsEnumIndex.EMPTY_ARRAY));
+      return new MultiTermsEnum(subSlices).reset(termsEnums.toArray(TermsEnumIndex[]::new));
     } else {
       return TermsEnum.EMPTY;
     }

--- a/lucene/core/src/java/org/apache/lucene/index/ReaderSlice.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReaderSlice.java
@@ -24,8 +24,4 @@ package org.apache.lucene.index;
  * @param readerIndex Sub-reader index for this slice.
  * @lucene.internal
  */
-public record ReaderSlice(int start, int length, int readerIndex) {
-
-  /** Zero-length {@code ReaderSlice} array. */
-  public static final ReaderSlice[] EMPTY_ARRAY = new ReaderSlice[0];
-}
+public record ReaderSlice(int start, int length, int readerIndex) {}

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -681,7 +681,7 @@ final class ReadersAndUpdates {
             byName.put(fi.name, fi);
           }
         }
-        fieldInfos = new FieldInfos(byName.values().toArray(new FieldInfo[0]));
+        fieldInfos = new FieldInfos(byName.values().toArray(FieldInfo[]::new));
         final DocValuesFormat docValuesFormat = codec.docValuesFormat();
 
         handleDVUpdates(

--- a/lucene/core/src/java/org/apache/lucene/index/SoftDeletesDirectoryReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SoftDeletesDirectoryReaderWrapper.java
@@ -108,7 +108,7 @@ public final class SoftDeletesDirectoryReaderWrapper extends FilterDirectoryRead
           wrapped.add(wrap);
         }
       }
-      return wrapped.toArray(new LeafReader[0]);
+      return wrapped.toArray(LeafReader[]::new);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
@@ -149,7 +149,7 @@ public final class StandardDirectoryReader extends DirectoryReader {
 
       return new StandardDirectoryReader(
           dir,
-          readers.toArray(new SegmentReader[0]),
+          readers.toArray(SegmentReader[]::new),
           writer,
           segmentInfos,
           writer.getConfig().getLeafSorter(),

--- a/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
@@ -147,16 +147,14 @@ public final class StandardDirectoryReader extends DirectoryReader {
 
       writer.incRefDeleter(segmentInfos);
 
-      StandardDirectoryReader result =
-          new StandardDirectoryReader(
-              dir,
-              readers.toArray(new SegmentReader[readers.size()]),
-              writer,
-              segmentInfos,
-              writer.getConfig().getLeafSorter(),
-              applyAllDeletes,
-              writeAllDeletes);
-      return result;
+      return new StandardDirectoryReader(
+          dir,
+          readers.toArray(new SegmentReader[0]),
+          writer,
+          segmentInfos,
+          writer.getConfig().getLeafSorter(),
+          applyAllDeletes,
+          writeAllDeletes);
     } catch (Throwable t) {
       try {
         IOUtils.applyToAll(readers, SegmentReader::decRef);

--- a/lucene/core/src/java/org/apache/lucene/index/Terms.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Terms.java
@@ -135,9 +135,6 @@ public abstract class Terms {
   /** Returns true if documents in this field store payloads. */
   public abstract boolean hasPayloads();
 
-  /** Zero-length array of {@link Terms}. */
-  public static final Terms[] EMPTY_ARRAY = new Terms[0];
-
   /**
    * Returns the smallest term (in lexicographic order) in the field. Note that, just like other
    * term measures, this measure does not take deleted documents into account. This returns null

--- a/lucene/core/src/java/org/apache/lucene/index/TermsEnumIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermsEnumIndex.java
@@ -31,8 +31,6 @@ import org.apache.lucene.util.BytesRefBuilder;
  */
 class TermsEnumIndex {
 
-  static final TermsEnumIndex[] EMPTY_ARRAY = new TermsEnumIndex[0];
-
   /**
    * Copy the first 8 bytes of the given term as a comparable unsigned long. In case the term has
    * less than 8 bytes, missing bytes will be replaced with zeroes. Note that two terms that produce

--- a/lucene/core/src/java/org/apache/lucene/search/BlockMaxConjunctionScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BlockMaxConjunctionScorer.java
@@ -36,7 +36,7 @@ final class BlockMaxConjunctionScorer extends Scorer {
 
   /** Create a new {@link BlockMaxConjunctionScorer} from scoring clauses. */
   BlockMaxConjunctionScorer(Collection<Scorer> scorersList) throws IOException {
-    this.scorers = scorersList.toArray(new Scorer[scorersList.size()]);
+    this.scorers = scorersList.toArray(new Scorer[0]);
     // Sort scorer by cost
     Arrays.sort(this.scorers, Comparator.comparingLong(s -> s.iterator().cost()));
     this.scorables =
@@ -56,7 +56,7 @@ final class BlockMaxConjunctionScorer extends Scorer {
       approximations[i] = ScorerUtil.likelyImpactsEnum(approximations[i]);
       scorer.advanceShallow(0);
     }
-    this.twoPhases = twoPhaseList.toArray(new TwoPhaseIterator[twoPhaseList.size()]);
+    this.twoPhases = twoPhaseList.toArray(new TwoPhaseIterator[0]);
     Arrays.sort(this.twoPhases, Comparator.comparingDouble(TwoPhaseIterator::matchCost));
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/BlockMaxConjunctionScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BlockMaxConjunctionScorer.java
@@ -36,7 +36,7 @@ final class BlockMaxConjunctionScorer extends Scorer {
 
   /** Create a new {@link BlockMaxConjunctionScorer} from scoring clauses. */
   BlockMaxConjunctionScorer(Collection<Scorer> scorersList) throws IOException {
-    this.scorers = scorersList.toArray(new Scorer[0]);
+    this.scorers = scorersList.toArray(Scorer[]::new);
     // Sort scorer by cost
     Arrays.sort(this.scorers, Comparator.comparingLong(s -> s.iterator().cost()));
     this.scorables =
@@ -56,7 +56,7 @@ final class BlockMaxConjunctionScorer extends Scorer {
       approximations[i] = ScorerUtil.likelyImpactsEnum(approximations[i]);
       scorer.advanceShallow(0);
     }
-    this.twoPhases = twoPhaseList.toArray(new TwoPhaseIterator[0]);
+    this.twoPhases = twoPhaseList.toArray(TwoPhaseIterator[]::new);
     Arrays.sort(this.twoPhases, Comparator.comparingDouble(TwoPhaseIterator::matchCost));
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/ExactPhraseMatcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ExactPhraseMatcher.java
@@ -79,7 +79,7 @@ public final class ExactPhraseMatcher extends PhraseMatcher {
     for (PhraseQuery.PostingsAndFreq posting : postings) {
       postingsAndPositions.add(new PostingsAndPosition(posting.postings, posting.position));
     }
-    this.postings = postingsAndPositions.toArray(new PostingsAndPosition[0]);
+    this.postings = postingsAndPositions.toArray(PostingsAndPosition[]::new);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -1004,7 +1004,7 @@ public class IndexSearcher {
     private final int maxDocs;
 
     public LeafSlice(List<LeafReaderContextPartition> partitions) {
-      this(partitions.toArray(new LeafReaderContextPartition[0]));
+      this(partitions.toArray(LeafReaderContextPartition[]::new));
     }
 
     private static LeafSlice entireSegments(List<LeafReaderContext> contexts) {

--- a/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
@@ -176,7 +176,7 @@ public class MultiCollector implements Collector {
     private final boolean skipNonCompetitiveScores;
 
     private MultiLeafCollector(List<LeafCollector> collectors, boolean skipNonCompetitive) {
-      this.collectors = collectors.toArray(new LeafCollector[collectors.size()]);
+      this.collectors = collectors.toArray(LeafCollector[]::new);
       this.skipNonCompetitiveScores = skipNonCompetitive;
       this.minScores = this.skipNonCompetitiveScores ? new float[this.collectors.length] : null;
     }

--- a/lucene/core/src/java/org/apache/lucene/search/MultiPhraseQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiPhraseQuery.java
@@ -235,7 +235,7 @@ public class MultiPhraseQuery extends Query {
           return similarity.scorer(
               boost,
               searcher.collectionStatistics(field),
-              allTermStats.toArray(new TermStatistics[allTermStats.size()]));
+              allTermStats.toArray(TermStatistics[]::new));
         }
       }
 
@@ -436,7 +436,7 @@ public class MultiPhraseQuery extends Query {
         cost += sub.cost();
       }
       this.cost = cost;
-      this.subs = subs.toArray(new PostingsEnum[subs.size()]);
+      this.subs = subs.toArray(PostingsEnum[]::new);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/MultiPhraseQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiPhraseQuery.java
@@ -141,7 +141,7 @@ public class MultiPhraseQuery extends Query {
 
     /** Builds a {@link MultiPhraseQuery}. */
     public MultiPhraseQuery build() {
-      Term[][] termArraysArray = termArrays.toArray(new Term[0][]);
+      Term[][] termArraysArray = termArrays.toArray(Term[][]::new);
       return new MultiPhraseQuery(field, termArraysArray, positions.toArray(), slop);
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/search/MultiPhraseQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiPhraseQuery.java
@@ -141,7 +141,7 @@ public class MultiPhraseQuery extends Query {
 
     /** Builds a {@link MultiPhraseQuery}. */
     public MultiPhraseQuery build() {
-      Term[][] termArraysArray = termArrays.toArray(new Term[termArrays.size()][]);
+      Term[][] termArraysArray = termArrays.toArray(new Term[0][]);
       return new MultiPhraseQuery(field, termArraysArray, positions.toArray(), slop);
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
@@ -156,7 +156,7 @@ public class PhraseQuery extends Query {
 
     /** Build a phrase query based on the terms that have been added. */
     public PhraseQuery build() {
-      Term[] terms = this.terms.toArray(new Term[0]);
+      Term[] terms = this.terms.toArray(Term[]::new);
       return new PhraseQuery(slop, terms, positions.toArray());
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/search/SynonymQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SynonymQuery.java
@@ -103,7 +103,7 @@ public final class SynonymQuery extends Query {
     /** Builds the {@link SynonymQuery}. */
     public SynonymQuery build() {
       terms.sort(Comparator.comparing(a -> a.term));
-      return new SynonymQuery(terms.toArray(new TermAndBoost[0]), field);
+      return new SynonymQuery(terms.toArray(TermAndBoost[]::new), field);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/store/FSDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/FSDirectory.java
@@ -181,7 +181,7 @@ public abstract class FSDirectory extends BaseDirectory {
       }
     }
 
-    String[] array = entries.toArray(new String[0]);
+    String[] array = entries.toArray(String[]::new);
     // Directory.listAll javadocs state that we sort the results here, so we don't let filesystem
     // specifics leak out of this abstraction:
     Arrays.sort(array);

--- a/lucene/core/src/java/org/apache/lucene/store/FileSwitchDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/FileSwitchDirectory.java
@@ -135,7 +135,7 @@ public class FileSwitchDirectory extends Directory {
     if (exc != null && files.isEmpty()) {
       throw exc;
     }
-    String[] result = files.toArray(new String[files.size()]);
+    String[] result = files.toArray(new String[0]);
     Arrays.sort(result);
     return result;
   }

--- a/lucene/core/src/java/org/apache/lucene/store/FileSwitchDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/FileSwitchDirectory.java
@@ -135,7 +135,7 @@ public class FileSwitchDirectory extends Directory {
     if (exc != null && files.isEmpty()) {
       throw exc;
     }
-    String[] result = files.toArray(new String[0]);
+    String[] result = files.toArray(String[]::new);
     Arrays.sort(result);
     return result;
   }

--- a/lucene/core/src/java/org/apache/lucene/store/NRTCachingDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/NRTCachingDirectory.java
@@ -116,7 +116,7 @@ public class NRTCachingDirectory extends FilterDirectory implements Accountable 
     final Set<String> files = new TreeSet<>();
     Collections.addAll(files, cacheDirectory.listAll());
     Collections.addAll(files, in.listAll());
-    return files.toArray(new String[0]);
+    return files.toArray(String[]::new);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/AttributeSource.java
+++ b/lucene/core/src/java/org/apache/lucene/util/AttributeSource.java
@@ -163,7 +163,7 @@ public class AttributeSource {
             clazz = clazz.getSuperclass();
           } while (clazz != null);
           @SuppressWarnings({"unchecked", "rawtypes"})
-          final Class<? extends Attribute>[] a = intfSet.toArray(new Class[intfSet.size()]);
+          final Class<? extends Attribute>[] a = intfSet.toArray(new Class[0]);
           return a;
         }
       };

--- a/lucene/core/src/java/org/apache/lucene/util/AttributeSource.java
+++ b/lucene/core/src/java/org/apache/lucene/util/AttributeSource.java
@@ -163,7 +163,7 @@ public class AttributeSource {
             clazz = clazz.getSuperclass();
           } while (clazz != null);
           @SuppressWarnings({"unchecked", "rawtypes"})
-          final Class<? extends Attribute>[] a = intfSet.toArray(new Class[0]);
+          final Class<? extends Attribute>[] a = intfSet.toArray(Class[]::new);
           return a;
         }
       };

--- a/lucene/core/src/java/org/apache/lucene/util/QueryBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/QueryBuilder.java
@@ -478,9 +478,9 @@ public class QueryBuilder {
 
       if (positionIncrement > 0 && multiTerms.size() > 0) {
         if (enablePositionIncrements) {
-          mpqb.add(multiTerms.toArray(new Term[0]), position);
+          mpqb.add(multiTerms.toArray(Term[]::new), position);
         } else {
-          mpqb.add(multiTerms.toArray(new Term[0]));
+          mpqb.add(multiTerms.toArray(Term[]::new));
         }
         multiTerms.clear();
       }
@@ -489,9 +489,9 @@ public class QueryBuilder {
     }
 
     if (enablePositionIncrements) {
-      mpqb.add(multiTerms.toArray(new Term[0]), position);
+      mpqb.add(multiTerms.toArray(Term[]::new), position);
     } else {
-      mpqb.add(multiTerms.toArray(new Term[0]));
+      mpqb.add(multiTerms.toArray(Term[]::new));
     }
     return mpqb.build();
   }

--- a/lucene/core/src/test/org/apache/lucene/index/TestMaxTermFrequency.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMaxTermFrequency.java
@@ -90,7 +90,7 @@ public class TestMaxTermFrequency extends LuceneTestCase {
     }
     expected.add(max);
     Collections.shuffle(terms, random());
-    return Arrays.toString(terms.toArray(new String[0]));
+    return Arrays.toString(terms.toArray(String[]::new));
   }
 
   /** Simple similarity that encodes maxTermFrequency directly as a byte */

--- a/lucene/core/src/test/org/apache/lucene/index/TestMaxTermFrequency.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMaxTermFrequency.java
@@ -90,7 +90,7 @@ public class TestMaxTermFrequency extends LuceneTestCase {
     }
     expected.add(max);
     Collections.shuffle(terms, random());
-    return Arrays.toString(terms.toArray(new String[terms.size()]));
+    return Arrays.toString(terms.toArray(new String[0]));
   }
 
   /** Simple similarity that encodes maxTermFrequency directly as a byte */

--- a/lucene/core/src/test/org/apache/lucene/index/TestTieredMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTieredMergePolicy.java
@@ -696,9 +696,7 @@ public class TestTieredMergePolicy extends BaseMergePolicyTestCase {
     }
     reader.close();
 
-    Term[] termsToDel = new Term[toDelete.size()];
-    toDelete.toArray(termsToDel);
-    w.deleteDocuments(termsToDel);
+    w.deleteDocuments(toDelete.toArray(Term[]::new));
     w.commit();
     return toDelete.size();
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestPointQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPointQueries.java
@@ -2116,7 +2116,7 @@ public class TestPointQueries extends LuceneTestCase {
     }
 
     PointInSetQuery query =
-        (PointInSetQuery) BinaryPoint.newSetQuery("field", values.toArray(new byte[][] {}));
+        (PointInSetQuery) BinaryPoint.newSetQuery("field", values.toArray(byte[][]::new));
     Collection<byte[]> packedPoints = query.getPackedPoints();
     assertEquals(numValues, packedPoints.size());
     Iterator<byte[]> iterator = packedPoints.iterator();

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestCompiledAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestCompiledAutomaton.java
@@ -101,7 +101,7 @@ public class TestCompiledAutomaton extends LuceneTestCase {
     while (terms.size() != numTerms) {
       terms.add(randomString());
     }
-    testTerms(numTerms * 100, terms.toArray(new String[terms.size()]));
+    testTerms(numTerms * 100, terms.toArray(new String[0]));
   }
 
   private String randomString() {

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestCompiledAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestCompiledAutomaton.java
@@ -101,7 +101,7 @@ public class TestCompiledAutomaton extends LuceneTestCase {
     while (terms.size() != numTerms) {
       terms.add(randomString());
     }
-    testTerms(numTerms * 100, terms.toArray(new String[0]));
+    testTerms(numTerms * 100, terms.toArray(String[]::new));
   }
 
   private String randomString() {

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestDistinctValuesCollector.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestDistinctValuesCollector.java
@@ -479,10 +479,7 @@ public class TestDistinctValuesCollector extends AbstractGroupingTestCase {
 
     w.close();
     return new IndexContext(
-        dir,
-        reader,
-        searchTermToGroupCounts,
-        contentStrings.toArray(new String[contentStrings.size()]));
+        dir, reader, searchTermToGroupCounts, contentStrings.toArray(new String[0]));
   }
 
   private record IndexContext(

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestDistinctValuesCollector.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestDistinctValuesCollector.java
@@ -479,7 +479,7 @@ public class TestDistinctValuesCollector extends AbstractGroupingTestCase {
 
     w.close();
     return new IndexContext(
-        dir, reader, searchTermToGroupCounts, contentStrings.toArray(new String[0]));
+        dir, reader, searchTermToGroupCounts, contentStrings.toArray(String[]::new));
   }
 
   private record IndexContext(

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
@@ -456,7 +456,7 @@ public class TestGrouping extends LuceneTestCase {
           mvalTopGroups.withinGroupSort,
           mvalTopGroups.totalHitCount,
           mvalTopGroups.totalGroupedHitCount,
-          groups.toArray(new GroupDocs[0]),
+          groups.toArray(GroupDocs[]::new),
           Float.NaN);
     }
     fail();
@@ -500,7 +500,7 @@ public class TestGrouping extends LuceneTestCase {
     }
     // Break ties:
     sortFields.add(new SortField("id", SortField.Type.INT));
-    return new Sort(sortFields.toArray(new SortField[0]));
+    return new Sort(sortFields.toArray(SortField[]::new));
   }
 
   private Comparator<GroupDoc> getComparator(Sort sort) {

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
@@ -456,7 +456,7 @@ public class TestGrouping extends LuceneTestCase {
           mvalTopGroups.withinGroupSort,
           mvalTopGroups.totalHitCount,
           mvalTopGroups.totalGroupedHitCount,
-          groups.toArray(new GroupDocs[groups.size()]),
+          groups.toArray(new GroupDocs[0]),
           Float.NaN);
     }
     fail();
@@ -500,7 +500,7 @@ public class TestGrouping extends LuceneTestCase {
     }
     // Break ties:
     sortFields.add(new SortField("id", SortField.Type.INT));
-    return new Sort(sortFields.toArray(new SortField[sortFields.size()]));
+    return new Sort(sortFields.toArray(new SortField[0]));
   }
 
   private Comparator<GroupDoc> getComparator(Sort sort) {

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
@@ -1213,7 +1213,7 @@ public class UnifiedHighlighter {
         filteredTerms.add(term.bytes());
       }
     }
-    return filteredTerms.toArray(new BytesRef[0]);
+    return filteredTerms.toArray(BytesRef[]::new);
   }
 
   protected PhraseHelper getPhraseHelper(

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
@@ -1213,7 +1213,7 @@ public class UnifiedHighlighter {
         filteredTerms.add(term.bytes());
       }
     }
-    return filteredTerms.toArray(new BytesRef[filteredTerms.size()]);
+    return filteredTerms.toArray(new BytesRef[0]);
   }
 
   protected PhraseHelper getPhraseHelper(

--- a/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/BaseFragmentsBuilder.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/BaseFragmentsBuilder.java
@@ -168,7 +168,7 @@ public abstract class BaseFragmentsBuilder implements FragmentsBuilder {
       fragments.add(
           makeFragment(buffer, nextValueIndex, values, fragInfo, preTags, postTags, encoder));
     }
-    return fragments.toArray(new String[fragments.size()]);
+    return fragments.toArray(new String[0]);
   }
 
   protected Field[] getFields(IndexReader reader, int docId, final String fieldName)

--- a/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/BaseFragmentsBuilder.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/BaseFragmentsBuilder.java
@@ -168,7 +168,7 @@ public abstract class BaseFragmentsBuilder implements FragmentsBuilder {
       fragments.add(
           makeFragment(buffer, nextValueIndex, values, fragInfo, preTags, postTags, encoder));
     }
-    return fragments.toArray(new String[0]);
+    return fragments.toArray(String[]::new);
   }
 
   protected Field[] getFields(IndexReader reader, int docId, final String fieldName)

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermVec.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermVec.java
@@ -144,7 +144,7 @@ public class TestUnifiedHighlighterTermVec extends UnifiedHighlighterTestBase {
     TopDocs topDocs = searcher.search(query, 10, Sort.INDEXORDER);
     assertEquals(numDocs, topDocs.totalHits.value());
     Map<String, String[]> fieldToSnippets =
-        highlighter.highlightFields(fields.toArray(new String[0]), query, topDocs);
+        highlighter.highlightFields(fields.toArray(String[]::new), query, topDocs);
     String[] expectedSnippetsByDoc = new String[numDocs];
     Arrays.fill(expectedSnippetsByDoc, "some <b>test</b> text");
     for (String field : fields) {

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermVec.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermVec.java
@@ -144,7 +144,7 @@ public class TestUnifiedHighlighterTermVec extends UnifiedHighlighterTestBase {
     TopDocs topDocs = searcher.search(query, 10, Sort.INDEXORDER);
     assertEquals(numDocs, topDocs.totalHits.value());
     Map<String, String[]> fieldToSnippets =
-        highlighter.highlightFields(fields.toArray(new String[numTvFields]), query, topDocs);
+        highlighter.highlightFields(fields.toArray(new String[0]), query, topDocs);
     String[] expectedSnippetsByDoc = new String[numDocs];
     Arrays.fill(expectedSnippetsByDoc, "some <b>test</b> text");
     for (String field : fields) {

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
@@ -1354,10 +1354,10 @@ public class TestJoinUtil extends LuceneTestCase {
 
         Set<ScoreMode> scoreModes = EnumSet.allOf(ScoreMode.class);
         ScoreMode scoreMode1 =
-            scoreModes.toArray(new ScoreMode[0])[random().nextInt(scoreModes.size())];
+            scoreModes.toArray(ScoreMode[]::new)[random().nextInt(scoreModes.size())];
         scoreModes.remove(scoreMode1);
         ScoreMode scoreMode2 =
-            scoreModes.toArray(new ScoreMode[0])[random().nextInt(scoreModes.size())];
+            scoreModes.toArray(ScoreMode[]::new)[random().nextInt(scoreModes.size())];
 
         final Query x;
         try (IndexReader r = w.getReader()) {

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/search/MLTConfig.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/search/MLTConfig.java
@@ -74,7 +74,7 @@ public final class MLTConfig {
   }
 
   public String[] getFieldNames() {
-    return fields.toArray(new String[fields.size()]);
+    return fields.toArray(new String[0]);
   }
 
   public int getMaxDocFreq() {

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/search/MLTConfig.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/search/MLTConfig.java
@@ -74,7 +74,7 @@ public final class MLTConfig {
   }
 
   public String[] getFieldNames() {
-    return fields.toArray(new String[0]);
+    return fields.toArray(String[]::new);
   }
 
   public int getMaxDocFreq() {

--- a/lucene/queries/src/java/org/apache/lucene/queries/mlt/MoreLikeThis.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/mlt/MoreLikeThis.java
@@ -556,7 +556,7 @@ public final class MoreLikeThis {
     if (fieldNames == null) {
       // gather list of valid fields from lucene
       Collection<String> fields = FieldInfos.getIndexedFields(ir);
-      fieldNames = fields.toArray(new String[fields.size()]);
+      fieldNames = fields.toArray(new String[0]);
     }
 
     return createQuery(retrieveTerms(docNum));
@@ -570,7 +570,7 @@ public final class MoreLikeThis {
     if (fieldNames == null) {
       // gather list of valid fields from lucene
       Collection<String> fields = FieldInfos.getIndexedFields(ir);
-      fieldNames = fields.toArray(new String[fields.size()]);
+      fieldNames = fields.toArray(new String[0]);
     }
     return createQuery(retrieveTerms(filteredDocument));
   }

--- a/lucene/queries/src/java/org/apache/lucene/queries/mlt/MoreLikeThis.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/mlt/MoreLikeThis.java
@@ -556,7 +556,7 @@ public final class MoreLikeThis {
     if (fieldNames == null) {
       // gather list of valid fields from lucene
       Collection<String> fields = FieldInfos.getIndexedFields(ir);
-      fieldNames = fields.toArray(new String[0]);
+      fieldNames = fields.toArray(String[]::new);
     }
 
     return createQuery(retrieveTerms(docNum));
@@ -570,7 +570,7 @@ public final class MoreLikeThis {
     if (fieldNames == null) {
       // gather list of valid fields from lucene
       Collection<String> fields = FieldInfos.getIndexedFields(ir);
-      fieldNames = fields.toArray(new String[0]);
+      fieldNames = fields.toArray(String[]::new);
     }
     return createQuery(retrieveTerms(filteredDocument));
   }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/complexPhrase/ComplexPhraseQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/complexPhrase/ComplexPhraseQueryParser.java
@@ -345,7 +345,7 @@ public class ComplexPhraseQueryParser extends QueryParser {
         i += 1;
       }
 
-      SpanQuery[] includeClauses = positiveClauses.toArray(new SpanQuery[positiveClauses.size()]);
+      SpanQuery[] includeClauses = positiveClauses.toArray(new SpanQuery[0]);
 
       SpanQuery include = null;
       if (includeClauses.length == 1) {
@@ -410,11 +410,11 @@ public class ComplexPhraseQueryParser extends QueryParser {
       if (ors.size() == 0) {
         return;
       }
-      SpanOrQuery soq = new SpanOrQuery(ors.toArray(new SpanQuery[ors.size()]));
+      SpanOrQuery soq = new SpanOrQuery(ors.toArray(new SpanQuery[0]));
       if (nots.size() == 0) {
         spanClauses.add(soq);
       } else {
-        SpanOrQuery snqs = new SpanOrQuery(nots.toArray(new SpanQuery[nots.size()]));
+        SpanOrQuery snqs = new SpanOrQuery(nots.toArray(new SpanQuery[0]));
         SpanNotQuery snq = new SpanNotQuery(soq, snqs);
         spanClauses.add(snq);
       }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/complexPhrase/ComplexPhraseQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/complexPhrase/ComplexPhraseQueryParser.java
@@ -345,7 +345,7 @@ public class ComplexPhraseQueryParser extends QueryParser {
         i += 1;
       }
 
-      SpanQuery[] includeClauses = positiveClauses.toArray(new SpanQuery[0]);
+      SpanQuery[] includeClauses = positiveClauses.toArray(SpanQuery[]::new);
 
       SpanQuery include = null;
       if (includeClauses.length == 1) {
@@ -410,11 +410,11 @@ public class ComplexPhraseQueryParser extends QueryParser {
       if (ors.size() == 0) {
         return;
       }
-      SpanOrQuery soq = new SpanOrQuery(ors.toArray(new SpanQuery[0]));
+      SpanOrQuery soq = new SpanOrQuery(ors.toArray(SpanQuery[]::new));
       if (nots.size() == 0) {
         spanClauses.add(soq);
       } else {
-        SpanOrQuery snqs = new SpanOrQuery(nots.toArray(new SpanQuery[0]));
+        SpanOrQuery snqs = new SpanOrQuery(nots.toArray(SpanQuery[]::new));
         SpanNotQuery snq = new SpanNotQuery(soq, snqs);
         spanClauses.add(snq);
       }

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/codecs/idversion/TestIDVersionPostingsFormat.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/codecs/idversion/TestIDVersionPostingsFormat.java
@@ -694,7 +694,7 @@ public class TestIDVersionPostingsFormat extends LuceneTestCase {
     while (idsSeen.size() < numIDs) {
       idsSeen.add(idsSource.next());
     }
-    final String[] ids = idsSeen.toArray(new String[0]);
+    final String[] ids = idsSeen.toArray(String[]::new);
 
     final Object[] locks = new Object[ids.length];
     for (int i = 0; i < locks.length; i++) {

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/codecs/idversion/TestIDVersionPostingsFormat.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/codecs/idversion/TestIDVersionPostingsFormat.java
@@ -694,7 +694,7 @@ public class TestIDVersionPostingsFormat extends LuceneTestCase {
     while (idsSeen.size() < numIDs) {
       idsSeen.add(idsSource.next());
     }
-    final String[] ids = idsSeen.toArray(new String[numIDs]);
+    final String[] ids = idsSeen.toArray(new String[0]);
 
     final Object[] locks = new Object[ids.length];
     for (int i = 0; i < locks.length; i++) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/BaseTokenStreamTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/BaseTokenStreamTestCase.java
@@ -1414,10 +1414,10 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
       // offset + pos + posLength + type
       assertTokenStreamContents(
           ts,
-          tokens.toArray(new String[0]),
+          tokens.toArray(String[]::new),
           toIntArray(startOffsets),
           toIntArray(endOffsets),
-          types.toArray(new String[0]),
+          types.toArray(String[]::new),
           toIntArray(positions),
           toIntArray(positionLengths),
           text.length(),
@@ -1426,10 +1426,10 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
       // offset + pos + type
       assertTokenStreamContents(
           ts,
-          tokens.toArray(new String[0]),
+          tokens.toArray(String[]::new),
           toIntArray(startOffsets),
           toIntArray(endOffsets),
-          types.toArray(new String[0]),
+          types.toArray(String[]::new),
           toIntArray(positions),
           null,
           text.length(),
@@ -1438,7 +1438,7 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
       // offset + pos + posLength
       assertTokenStreamContents(
           ts,
-          tokens.toArray(new String[0]),
+          tokens.toArray(String[]::new),
           toIntArray(startOffsets),
           toIntArray(endOffsets),
           null,
@@ -1450,7 +1450,7 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
       // offset + pos
       assertTokenStreamContents(
           ts,
-          tokens.toArray(new String[0]),
+          tokens.toArray(String[]::new),
           toIntArray(startOffsets),
           toIntArray(endOffsets),
           null,
@@ -1462,7 +1462,7 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
       // offset
       assertTokenStreamContents(
           ts,
-          tokens.toArray(new String[0]),
+          tokens.toArray(String[]::new),
           toIntArray(startOffsets),
           toIntArray(endOffsets),
           null,
@@ -1472,7 +1472,7 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
           graphOffsetsAreCorrect);
     } else {
       // terms only
-      assertTokenStreamContents(ts, tokens.toArray(new String[0]));
+      assertTokenStreamContents(ts, tokens.toArray(String[]::new));
     }
 
     a.normalize("dummy", text);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/BaseTokenStreamTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/BaseTokenStreamTestCase.java
@@ -1414,10 +1414,10 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
       // offset + pos + posLength + type
       assertTokenStreamContents(
           ts,
-          tokens.toArray(new String[tokens.size()]),
+          tokens.toArray(new String[0]),
           toIntArray(startOffsets),
           toIntArray(endOffsets),
-          types.toArray(new String[types.size()]),
+          types.toArray(new String[0]),
           toIntArray(positions),
           toIntArray(positionLengths),
           text.length(),
@@ -1426,10 +1426,10 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
       // offset + pos + type
       assertTokenStreamContents(
           ts,
-          tokens.toArray(new String[tokens.size()]),
+          tokens.toArray(new String[0]),
           toIntArray(startOffsets),
           toIntArray(endOffsets),
-          types.toArray(new String[types.size()]),
+          types.toArray(new String[0]),
           toIntArray(positions),
           null,
           text.length(),
@@ -1438,7 +1438,7 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
       // offset + pos + posLength
       assertTokenStreamContents(
           ts,
-          tokens.toArray(new String[tokens.size()]),
+          tokens.toArray(new String[0]),
           toIntArray(startOffsets),
           toIntArray(endOffsets),
           null,
@@ -1450,7 +1450,7 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
       // offset + pos
       assertTokenStreamContents(
           ts,
-          tokens.toArray(new String[tokens.size()]),
+          tokens.toArray(new String[0]),
           toIntArray(startOffsets),
           toIntArray(endOffsets),
           null,
@@ -1462,7 +1462,7 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
       // offset
       assertTokenStreamContents(
           ts,
-          tokens.toArray(new String[tokens.size()]),
+          tokens.toArray(new String[0]),
           toIntArray(startOffsets),
           toIntArray(endOffsets),
           null,
@@ -1472,7 +1472,7 @@ public abstract class BaseTokenStreamTestCase extends LuceneTestCase {
           graphOffsetsAreCorrect);
     } else {
       // terms only
-      assertTokenStreamContents(ts, tokens.toArray(new String[tokens.size()]));
+      assertTokenStreamContents(ts, tokens.toArray(new String[0]));
     }
 
     a.normalize("dummy", text);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseTermVectorsFormatTestCase.java
@@ -392,7 +392,7 @@ public abstract class BaseTermVectorsFormatTestCase extends BaseIndexFileFormatT
         fieldNames.add(TestUtil.randomSimpleString(random()));
         fieldNames.remove("id");
       }
-      this.fieldNames = fieldNames.toArray(new String[0]);
+      this.fieldNames = fieldNames.toArray(String[]::new);
       terms = new String[disctinctTerms];
       termBytes = new BytesRef[disctinctTerms];
       for (int i = 0; i < disctinctTerms; ++i) {
@@ -447,7 +447,7 @@ public abstract class BaseTermVectorsFormatTestCase extends BaseIndexFileFormatT
     for (String term : tk.freqs.keySet()) {
       uniqueTerms.add(new BytesRef(term));
     }
-    final BytesRef[] sortedTerms = uniqueTerms.toArray(new BytesRef[0]);
+    final BytesRef[] sortedTerms = uniqueTerms.toArray(BytesRef[]::new);
     Arrays.sort(sortedTerms);
     final TermsEnum termsEnum = terms.iterator();
     for (int i = 0; i < sortedTerms.length; ++i) {


### PR DESCRIPTION
Quota from [jetbrains](https://www.jetbrains.com/help/inspectopedia/ToArrayCallWithZeroLengthArrayArgument.html):

```
In older Java versions, using a pre-sized array was recommended, as the reflection call necessary to create 
an array of proper size was quite slow.

However, since late updates of OpenJDK 6, this call was intrinsified, making the performance 
of the empty array version the same, and sometimes even better, compared to the pre-sized 
version. Also, passing a pre-sized array is dangerous for a concurrent or synchronized collection 
as a data race is possible between the size and toArray calls. This may result in extra nulls at the 
end of the array if the collection was concurrently shrunk during the operation.
```

Or we can use another call style: `Collection#toArray(T[]::new)`.
