### PR TITLE
Revert "Optimize DocIdSetIteratorAcceptDocs#cost (#15592)"

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -363,8 +363,6 @@ Optimizations
 
 * GITHUB#15582: Avoid copying bitset that's subsequently cleared (Viliam Durina)
 
-* GITHUB#15592: Optimize DocIdSetIteratorAcceptDocs#cost. (Shubham Chaudhary)
-
 * GITHUB#15618: SegmentTermsEnumFrame: avoid unnecessary array allocations that waste memory (Misha Dmitriev)
 
 * GITHUB#15585: Added shared prefetch counter to maintain count across clones and slices of MemorySegmentIndexInput. (Shubham Sharma)

--- a/lucene/core/src/java/org/apache/lucene/search/AcceptDocs.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AcceptDocs.java
@@ -157,7 +157,7 @@ public abstract class AcceptDocs {
 
   /**
    * Impl backed by a {@link DocIdSetIterator}, which lazily creates a {@link BitSet} if {@link
-   * #bits()} is called. Otherwise, returns the cost of underlying iterator.
+   * #cost()} or {@link #bits()} are called.
    */
   private static class DocIdSetIteratorAcceptDocs extends AcceptDocs {
 
@@ -189,10 +189,8 @@ public abstract class AcceptDocs {
 
     @Override
     public int cost() throws IOException {
-      if (acceptBitSet != null) {
-        return cardinality;
-      }
-      return Math.toIntExact(iterator().cost());
+      createBitSetAcceptDocsIfNecessary();
+      return cardinality;
     }
 
     @Override
@@ -200,8 +198,8 @@ public abstract class AcceptDocs {
       if (acceptBitSet != null) {
         return new BitSetIterator(acceptBitSet, cardinality);
       }
-      return AcceptDocs.getFilteredDocIdSetIterator(
-          Objects.requireNonNull(iteratorSupplier.get()), liveDocs);
+      DocIdSetIterator iterator = Objects.requireNonNull(iteratorSupplier.get());
+      return AcceptDocs.getFilteredDocIdSetIterator(iterator, liveDocs);
     }
   }
 


### PR DESCRIPTION
@shubhamvishu sorry for the revert :(. I ran into some weird test failures and it turns out (unsurprisingly) mutating the behavior of cost depending on if some other method was called is a pretty rough API.

For now, I am going to revert, and I will likely have to rebuild another RC for 10.4. 

I think if we are going to do this, we need a `cost` and an `approximateCost` API. Where `approximateCost` can change, but `cost` is when we want the real cost :(