### PR TITLE
Unpack nibbles in dimension order

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -195,6 +195,8 @@ Optimizations
 ---------------------
 * GITHUB#15637: Lazily allocate ByteArrayDataInputs in SegmentTermsEnumFrame#15637 (Misha Dmitriev)
 
+* GITHUB#15698: For 4-bit quantized vectors, unpack nibbles in dimension order for faster vector computations. (Kaival Parikh)
+
 Bug Fixes
 ---------------------
 * GITHUB#15668: Fix UnsupportedOperationException in WeightedSpanTermExtractor by

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene99/OffHeapQuantizedByteVectorValues.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene99/OffHeapQuantizedByteVectorValues.java
@@ -17,6 +17,8 @@
 
 package org.apache.lucene.backward_codecs.lucene99;
 
+import static org.apache.lucene.codecs.lucene104.OffHeapScalarQuantizedVectorValues.packNibbles;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
@@ -61,9 +63,10 @@ public abstract class OffHeapQuantizedByteVectorValues extends QuantizedByteVect
       throw new IllegalArgumentException(
           "numBytes: " + numBytes + " does not match compressed length: " + compressed.length);
     }
-    for (int i = 0; i < numBytes; ++i) {
-      compressed[numBytes + i] = (byte) (compressed[i] & 0x0F);
-      compressed[i] = (byte) ((compressed[i] & 0xFF) >> 4);
+    // in-place unpackNibbles
+    for (int i = numBytes - 1; i >= 0; i--) {
+      compressed[i * 2 + 1] = (byte) (compressed[i] & 0x0F);
+      compressed[i * 2] = (byte) ((compressed[i] & 0xFF) >> 4);
     }
   }
 
@@ -80,10 +83,7 @@ public abstract class OffHeapQuantizedByteVectorValues extends QuantizedByteVect
       throw new IllegalArgumentException(
           "compressed length: " + compressed.length + " does not match raw length: " + raw.length);
     }
-    for (int i = 0; i < compressed.length; ++i) {
-      int v = (raw[i] << 4) | raw[compressed.length + i];
-      compressed[i] = (byte) v;
-    }
+    packNibbles(raw, compressed);
   }
 
   OffHeapQuantizedByteVectorValues(

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.benchmark.jmh;
 
+import static org.apache.lucene.codecs.lucene104.OffHeapScalarQuantizedVectorValues.packNibbles;
+
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.lucene.util.VectorUtil;
@@ -44,13 +46,6 @@ import org.openjdk.jmh.annotations.Warmup;
     value = 3,
     jvmArgsAppend = {"-Xmx2g", "-Xms2g", "-XX:+AlwaysPreTouch"})
 public class VectorUtilBenchmark {
-  static void compressBytes(byte[] raw, byte[] compressed) {
-    for (int i = 0; i < compressed.length; ++i) {
-      int v = (raw[i] << 4) | raw[compressed.length + i];
-      compressed[i] = (byte) v;
-    }
-  }
-
   private byte[] bytesA;
   private byte[] bytesB;
   private byte[] halfBytesA;
@@ -91,10 +86,10 @@ public class VectorUtilBenchmark {
     // pack the half byte arrays
     if (size % 2 == 0) {
       halfBytesAPacked = new byte[(size + 1) >> 1];
-      compressBytes(halfBytesA, halfBytesAPacked);
+      packNibbles(halfBytesA, halfBytesAPacked);
 
       halfBytesBPacked = new byte[(size + 1) >> 1];
-      compressBytes(halfBytesB, halfBytesBPacked);
+      packNibbles(halfBytesB, halfBytesBPacked);
     }
 
     // random float arrays for float methods

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/OffHeapScalarQuantizedVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/OffHeapScalarQuantizedVectorValues.java
@@ -186,7 +186,7 @@ public abstract class OffHeapScalarQuantizedVectorValues extends QuantizedByteVe
   }
 
   public static void unpackNibbles(byte[] packed, byte[] unpacked) {
-    assert unpacked.length == packed.length * 2;
+    assert (unpacked.length + 1) >> 1 == packed.length;
     for (int i = 0; i < packed.length; i++) {
       unpacked[i * 2] = (byte) ((packed[i] >> 4) & 0x0F);
       unpacked[i * 2 + 1] = (byte) (packed[i] & 0x0F);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/OffHeapScalarQuantizedVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/OffHeapScalarQuantizedVectorValues.java
@@ -177,19 +177,19 @@ public abstract class OffHeapScalarQuantizedVectorValues extends QuantizedByteVe
     return vectorValue.length;
   }
 
-  static void packNibbles(byte[] unpacked, byte[] packed) {
+  public static void packNibbles(byte[] unpacked, byte[] packed) {
     assert unpacked.length == packed.length * 2;
     for (int i = 0; i < packed.length; i++) {
-      int x = unpacked[i] << 4 | unpacked[packed.length + i];
+      int x = unpacked[i * 2] << 4 | unpacked[i * 2 + 1];
       packed[i] = (byte) x;
     }
   }
 
-  static void unpackNibbles(byte[] packed, byte[] unpacked) {
+  public static void unpackNibbles(byte[] packed, byte[] unpacked) {
     assert unpacked.length == packed.length * 2;
     for (int i = 0; i < packed.length; i++) {
-      unpacked[i] = (byte) ((packed[i] >> 4) & 0x0F);
-      unpacked[packed.length + i] = (byte) (packed[i] & 0x0F);
+      unpacked[i * 2] = (byte) ((packed[i] >> 4) & 0x0F);
+      unpacked[i * 2 + 1] = (byte) (packed[i] & 0x0F);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
@@ -173,8 +173,8 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
     int total = 0;
     for (int i = 0; i < packed.length; i++) {
       byte packedByte = packed[i];
-      byte unpacked1 = unpacked[i];
-      byte unpacked2 = unpacked[i + packed.length];
+      byte unpacked1 = unpacked[i * 2];
+      byte unpacked2 = unpacked[i * 2 + 1];
       total += (packedByte & 0x0F) * unpacked2;
       total += ((packedByte & 0xFF) >> 4) * unpacked1;
     }
@@ -231,8 +231,8 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
     int total = 0;
     for (int i = 0; i < packed.length; i++) {
       byte packedByte = packed[i];
-      byte unpacked1 = unpacked[i];
-      byte unpacked2 = unpacked[i + packed.length];
+      byte unpacked1 = unpacked[i * 2];
+      byte unpacked2 = unpacked[i * 2 + 1];
 
       int diff1 = (packedByte & 0x0F) - unpacked2;
       int diff2 = ((packedByte & 0xFF) >> 4) - unpacked1;

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -39,6 +39,7 @@ import jdk.incubator.vector.Vector;
 import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorShape;
+import jdk.incubator.vector.VectorShuffle;
 import jdk.incubator.vector.VectorSpecies;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.SuppressForbidden;
@@ -487,6 +488,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     static final VectorSpecies<Byte> BYTE_SPECIES;
     static final VectorSpecies<Short> SHORT_SPECIES;
     static final int CHUNK;
+    static final VectorShuffle<Byte> LOWER_SHUFFLE;
+    static final VectorShuffle<Byte> UPPER_SHUFFLE;
 
     static {
       if (VECTOR_BITSIZE >= 512) {
@@ -502,6 +505,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         SHORT_SPECIES = ShortVector.SPECIES_128;
         CHUNK = 1024;
       }
+      LOWER_SHUFFLE = VectorShuffle.makeZip(BYTE_SPECIES, 0);
+      UPPER_SHUFFLE = VectorShuffle.makeZip(BYTE_SPECIES, 1);
     }
   }
 
@@ -577,8 +582,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     // scalar tail
     for (; i < packed.length(); i++) {
       byte packedByte = packed.tail(i);
-      byte unpacked1 = unpacked.tail(i);
-      byte unpacked2 = unpacked.tail(i + packed.length());
+      byte unpacked1 = unpacked.tail(i * 2);
+      byte unpacked2 = unpacked.tail(i * 2 + 1);
       res += (packedByte & 0x0F) * unpacked2;
       res += ((packedByte & 0xFF) >> 4) * unpacked1;
     }
@@ -594,21 +599,29 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       ShortVector acc1 = ShortVector.zero(Int4Constants.SHORT_SPECIES);
       int innerLimit = Math.min(limit - i, Int4Constants.CHUNK);
       for (int j = 0; j < innerLimit; j += Int4Constants.BYTE_SPECIES.length()) {
-        // packed
-        ByteVector vb8 = packed.load(Int4Constants.BYTE_SPECIES, i + j);
+        int packedOffset = i + j;
 
-        // upper
-        ByteVector va8 = unpacked.load(Int4Constants.BYTE_SPECIES, i + j + packed.length());
-        ByteVector prod8 = vb8.and((byte) 0x0F).mul(va8);
-        Vector<Short> prod16 = prod8.convertShape(ZERO_EXTEND_B2S, Int4Constants.SHORT_SPECIES, 0);
-        acc0 = acc0.add(prod16);
+        // packed
+        ByteVector vb8 = packed.load(Int4Constants.BYTE_SPECIES, packedOffset);
+        ByteVector vb8Even = vb8.and((byte) 0x0F); // get all even dimensions
+        ByteVector vb8Odd = vb8.lanewise(LSHR, 4); // get all odd dimensions
+
+        int unpackedOffset = packedOffset * 2;
 
         // lower
-        ByteVector vc8 = unpacked.load(Int4Constants.BYTE_SPECIES, i + j);
-        ByteVector prod8a = vb8.lanewise(LSHR, 4).mul(vc8);
+        ByteVector vc8 = unpacked.load(Int4Constants.BYTE_SPECIES, unpackedOffset);
+        ByteVector prod8a = vb8Odd.rearrange(Int4Constants.LOWER_SHUFFLE, vb8Even).mul(vc8);
         Vector<Short> prod16a =
             prod8a.convertShape(ZERO_EXTEND_B2S, Int4Constants.SHORT_SPECIES, 0);
         acc1 = acc1.add(prod16a);
+
+        // upper
+        ByteVector va8 =
+            unpacked.load(
+                Int4Constants.BYTE_SPECIES, unpackedOffset + Int4Constants.BYTE_SPECIES.length());
+        ByteVector prod8 = vb8Odd.rearrange(Int4Constants.UPPER_SHUFFLE, vb8Even).mul(va8);
+        Vector<Short> prod16 = prod8.convertShape(ZERO_EXTEND_B2S, Int4Constants.SHORT_SPECIES, 0);
+        acc0 = acc0.add(prod16);
       }
       Vector<Integer> intAcc0 = acc0.convert(S2I, 0);
       Vector<Integer> intAcc1 = acc0.convert(S2I, 1);
@@ -985,8 +998,8 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     // scalar tail
     for (; i < packed.length(); i++) {
       byte packedByte = packed.tail(i);
-      byte unpacked1 = unpacked.tail(i);
-      byte unpacked2 = unpacked.tail(i + packed.length());
+      byte unpacked1 = unpacked.tail(i * 2);
+      byte unpacked2 = unpacked.tail(i * 2 + 1);
 
       int diff1 = (packedByte & 0x0F) - unpacked2;
       int diff2 = ((packedByte & 0xFF) >> 4) - unpacked1;
@@ -1005,20 +1018,28 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       ShortVector acc1 = ShortVector.zero(Int4Constants.SHORT_SPECIES);
       int innerLimit = Math.min(limit - i, Int4Constants.CHUNK);
       for (int j = 0; j < innerLimit; j += Int4Constants.BYTE_SPECIES.length()) {
-        // packed
-        ByteVector vb8 = packed.load(Int4Constants.BYTE_SPECIES, i + j);
+        int packedOffset = i + j;
 
-        // upper
-        ByteVector va8 = unpacked.load(Int4Constants.BYTE_SPECIES, i + j + packed.length());
-        ByteVector diff8 = vb8.and((byte) 0x0F).sub(va8);
-        Vector<Short> diff16 = diff8.convertShape(B2S, Int4Constants.SHORT_SPECIES, 0);
-        acc0 = acc0.add(diff16.mul(diff16));
+        // packed
+        ByteVector vb8 = packed.load(Int4Constants.BYTE_SPECIES, packedOffset);
+        ByteVector vb8Even = vb8.and((byte) 0x0F); // get all even dimensions
+        ByteVector vb8Odd = vb8.lanewise(LSHR, 4); // get all odd dimensions
+
+        int unpackedOffset = packedOffset * 2;
 
         // lower
-        ByteVector vc8 = unpacked.load(Int4Constants.BYTE_SPECIES, i + j);
-        ByteVector diff8a = vb8.lanewise(LSHR, 4).sub(vc8);
+        ByteVector vc8 = unpacked.load(Int4Constants.BYTE_SPECIES, unpackedOffset);
+        ByteVector diff8a = vb8Odd.rearrange(Int4Constants.LOWER_SHUFFLE, vb8Even).sub(vc8);
         Vector<Short> diff16a = diff8a.convertShape(B2S, Int4Constants.SHORT_SPECIES, 0);
         acc1 = acc1.add(diff16a.mul(diff16a));
+
+        // upper
+        ByteVector va8 =
+            unpacked.load(
+                Int4Constants.BYTE_SPECIES, unpackedOffset + Int4Constants.BYTE_SPECIES.length());
+        ByteVector diff8 = vb8Odd.rearrange(Int4Constants.UPPER_SHUFFLE, vb8Even).sub(va8);
+        Vector<Short> diff16 = diff8.convertShape(B2S, Int4Constants.SHORT_SPECIES, 0);
+        acc0 = acc0.add(diff16.mul(diff16));
       }
       Vector<Integer> intAcc0 = acc0.convert(S2I, 0);
       Vector<Integer> intAcc1 = acc0.convert(S2I, 1);

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -484,6 +484,7 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     return acc.reduceLanes(ADD);
   }
 
+  @SuppressForbidden(reason = "Uses VectorShuffle only where fast and carefully contained")
   private static class Int4Constants {
     static final VectorSpecies<Byte> BYTE_SPECIES;
     static final VectorSpecies<Short> SHORT_SPECIES;

--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.internal.vectorization;
 
+import static org.apache.lucene.codecs.lucene104.OffHeapScalarQuantizedVectorValues.packNibbles;
+
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -258,11 +260,8 @@ public class TestVectorUtilSupport extends BaseVectorizationTestCase {
   }
 
   static byte[] pack(byte[] unpacked) {
-    int len = (unpacked.length + 1) / 2;
-    var packed = new byte[len];
-    for (int i = 0; i < len; i++) {
-      packed[i] = (byte) (unpacked[i] << 4 | unpacked[packed.length + i]);
-    }
+    byte[] packed = new byte[(unpacked.length + 1) >> 1];
+    packNibbles(unpacked, packed);
     return packed;
   }
 


### PR DESCRIPTION
### Description

Addresses #15697 

Individual dimensions of 4-bit quantized vectors are stored as packed nibbles (i.e. two dimensions in a single byte).
Example: `[1 2][3 4][5 6][7 8]`

These need to be "unpacked" to perform vector comparisons. Currently, we [take the second nibble from each byte and place them at the end](https://github.com/apache/lucene/blob/448c7d8e2414eaae43b68cc398fcb3e2191b4132/lucene/core/src/java/org/apache/lucene/codecs/lucene104/OffHeapScalarQuantizedVectorValues.java#L188-L194).
Example: `[1][3][5][7][2][4][6][8]`

Sometimes, we need to compare a "packed" vector with an "unpacked" one. We [read one byte from the "packed" vector and corresponding dimensions from the "unpacked" one](https://github.com/apache/lucene/blob/448c7d8e2414eaae43b68cc398fcb3e2191b4132/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java#L171-L182).

Because of the layout of the "unpacked" vector, it can lead to CPU cache line misses (two consecutive dimensions are apart by `dimension count / 2` bytes).

Proposing to unpack nibbles in dimension order.
Example: `[1][2][3][4][5][6][7][8]`