### PR TITLE
Fix Potential NullPointException in BytesRefHash initialization

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -200,6 +200,7 @@ Bug Fixes
 * GITHUB#15668: Fix UnsupportedOperationException in WeightedSpanTermExtractor by
   implementing getFieldInfos in DelegatingLeafReader. (Simranjeet Singh)
 
+* GITHUB#15702: Fix Potential NullPointException in BytesRefHash initialization#15702 (tyronecai)
 
 Other
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
@@ -138,7 +138,7 @@ public final class BytesRefHash implements Accountable {
     bytesStart = bytesStartArray.init();
     final Counter bytesUsed = bytesStartArray.bytesUsed();
     this.bytesUsed = bytesUsed == null ? Counter.newCounter() : bytesUsed;
-    bytesUsed.addAndGet(hashSize * (long) Integer.BYTES);
+    this.bytesUsed.addAndGet(hashSize * (long) Integer.BYTES);
   }
 
   /**


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

because of variable shadowing, an npe may produce here. detected by Intellj ide.

```
final Counter bytesUsed = bytesStartArray.bytesUsed();
this.bytesUsed = bytesUsed == null ? Counter.newCounter() : bytesUsed;
bytesUsed.addAndGet(hashSize * (long) Integer.BYTES);
~~~~~~
```

ref: https://github.com/apache/lucene/issues/15701

