### PR TITLE
Tests: Replace RandomIndexWriter with IndexWriter

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestSwappedIndexFiles.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSwappedIndexFiles.java
@@ -25,7 +25,6 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
-import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.store.BaseDirectoryWrapper;
 import org.apache.lucene.tests.util.LineFileDocs;
 import org.apache.lucene.tests.util.LuceneTestCase;
@@ -72,7 +71,7 @@ public class TestSwappedIndexFiles extends LuceneTestCase {
       conf.getCodec().compoundFormat().setShouldUseCompoundFile(true);
     }
 
-    RandomIndexWriter w = new RandomIndexWriter(random, dir, conf);
+    IndexWriter w = new IndexWriter(dir, conf);
     w.addDocument(doc);
     w.close();
   }


### PR DESCRIPTION
The test expects both directories to have the same CFS configuration to end up with the same files for copying, however using RandomIndexWriter, this might change.

Closes #15716
