### PR TITLE
GITHUB#15225: Improve JavaDocs for org.apache.lucene.util package

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -91,6 +91,8 @@ Improvements
 
 * GITHUB#15453: Avoid unnecessary sorting and instantiations in readMapOfStrings. (Benjamin Lerer)
 
+* GITHUB#15225: Improve package documentation for org.apache.lucene.util. (Syed Mohammad Saad)
+
 Optimizations
 ---------------------
 * GITHUB#15681: Replace pre-sized array or empty array with lambda expression to call Collection#toArray. (Zhou Hui)

--- a/lucene/core/src/java/org/apache/lucene/util/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/util/package-info.java
@@ -15,5 +15,23 @@
  * limitations under the License.
  */
 
-/** Some utility classes. */
+/**
+ * Core utility classes used throughout Lucene.
+ *
+ * <p>This package provides low-level helper utilities that support many parts of the Lucene
+ * indexing and search infrastructure. These classes are generally not intended for direct use by
+ * most applications, but may be useful for advanced integrations or extensions.
+ *
+ * <p>The utilities include:
+ *
+ * <ul>
+ *   <li>Data structures optimized for performance and memory usage
+ *   <li>Bit set and numeric helpers
+ *   <li>String and byte sequence abstractions such as {@link org.apache.lucene.util.BytesRef}
+ *   <li>Reusable iterators and collection helpers
+ *   <li>Math and hashing utilities used internally by indexing and search components
+ * </ul>
+ *
+ * <p>APIs in this package are primarily internal and may change between releases.
+ */
 package org.apache.lucene.util;


### PR DESCRIPTION
Related to #15225

This PR improves the package-level documentation for org.apache.lucene.util.

The previous documentation only contained a minimal description. This change adds an overview of the purpose of the package, typical contents, and guidance about its intended internal usage to make it clearer for users and contributors.
