### PR TITLE
Minor refactor/fix to l2normalize

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
@@ -17,7 +17,7 @@
 
 package org.apache.lucene.internal.vectorization;
 
-import static org.apache.lucene.util.VectorUtil.EPSILON;
+import static org.apache.lucene.util.VectorUtil.isUnitVector;
 
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.Constants;
@@ -432,19 +432,20 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
 
   @Override
   public float[] l2normalize(float[] v, boolean throwOnZero) {
-    double l1norm = this.dotProduct(v, v);
-    if (l1norm == 0) {
+    double squaredNorm = this.dotProduct(v, v);
+    if (squaredNorm == 0) {
       if (throwOnZero) {
         throw new IllegalArgumentException("Cannot normalize a zero-length vector");
       } else {
         return v;
       }
     }
-    if (Math.abs(l1norm - 1.0d) <= EPSILON) {
+    if (isUnitVector(squaredNorm)) {
       return v;
     }
+
     int dim = v.length;
-    double l2norm = Math.sqrt(l1norm);
+    double l2norm = Math.sqrt(squaredNorm);
     for (int i = 0; i < dim; i++) {
       v[i] /= (float) l2norm;
     }

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -171,8 +171,12 @@ public final class VectorUtil {
   }
 
   public static boolean isUnitVector(float[] v) {
-    double l1norm = IMPL.dotProduct(v, v);
-    return Math.abs(l1norm - 1.0d) <= EPSILON;
+    double squaredNorm = IMPL.dotProduct(v, v);
+    return isUnitVector(squaredNorm);
+  }
+
+  public static boolean isUnitVector(double squaredNorm) {
+    return Math.abs(squaredNorm - 1.0d) <= EPSILON;
   }
 
   /**

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -26,7 +26,7 @@ import static jdk.incubator.vector.VectorOperators.S2I;
 import static jdk.incubator.vector.VectorOperators.ZERO_EXTEND_B2I;
 import static jdk.incubator.vector.VectorOperators.ZERO_EXTEND_B2S;
 import static jdk.incubator.vector.VectorOperators.ZERO_EXTEND_S2I;
-import static org.apache.lucene.util.VectorUtil.EPSILON;
+import static org.apache.lucene.util.VectorUtil.isUnitVector;
 
 import java.lang.foreign.MemorySegment;
 import jdk.incubator.vector.ByteVector;
@@ -1402,19 +1402,19 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
   @Override
   public float[] l2normalize(float[] v, boolean throwOnZero) {
-    double l1norm = this.dotProduct(v, v);
-    if (l1norm == 0) {
+    double squaredNorm = this.dotProduct(v, v);
+    if (squaredNorm == 0) {
       if (throwOnZero) {
         throw new IllegalArgumentException("Cannot normalize a zero-length vector");
       } else {
         return v;
       }
     }
-    if (Math.abs(l1norm - 1.0d) <= EPSILON) {
+    if (isUnitVector(squaredNorm)) {
       return v;
     }
 
-    float invNorm = 1.0f / (float) Math.sqrt(l1norm);
+    float invNorm = 1.0f / (float) Math.sqrt(squaredNorm);
     int i = 0;
 
     // if the array size is large (> 2x platform vector size), it's worth the overhead to vectorize


### PR DESCRIPTION
### Description

- Minor change fixes the wrongly named variable(confusing) as `l1norm` whereas it doesn't store the L1 norm value(but rather squared norm) and move the common check to static function in VectorUtil
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
