### PR TITLE
TestSwappedIndexFiles: remove RandomIndexWriter to avoid nondeterministic CFS changes

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -58,6 +58,8 @@ API Changes
 
 * GITHUB#15295 : Switched to a fixed CFS threshold (Shubham Sharma)
 
+* GITHUB#15480: Deprecate SortField#setMissingValue and add migration test toward immutability. (Syed Mohammad Saad)
+
 New Features
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/SortField.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SortField.java
@@ -131,7 +131,7 @@ public class SortField {
   private FieldComparatorSource comparatorSource;
 
   // Used for 'sortMissingFirst/Last'
-  protected final Object missingValue;
+  protected Object missingValue;
 
   // Indicates if sort should be optimized with indexed data. Set to true by default.
   @Deprecated private boolean optimizeSortWithIndexedData = true;
@@ -330,6 +330,17 @@ public class SortField {
    */
   public Object getMissingValue() {
     return missingValue;
+  }
+
+  /**
+   * Sets the value to use for documents that don't have a value.
+   *
+   * @deprecated Use {@link #SortField(String, Type, boolean, Object)} to supply missing values at
+   *     construction time. This method will be removed in Lucene 11.
+   */
+  @Deprecated
+  public void setMissingValue(Object missingValue) {
+    this.missingValue = missingValue;
   }
 
   // Sets field & type, and ensures field is not NULL unless

--- a/lucene/core/src/test/org/apache/lucene/index/TestSwappedIndexFiles.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSwappedIndexFiles.java
@@ -25,7 +25,6 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
-import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.store.BaseDirectoryWrapper;
 import org.apache.lucene.tests.util.LineFileDocs;
 import org.apache.lucene.tests.util.LuceneTestCase;
@@ -72,7 +71,11 @@ public class TestSwappedIndexFiles extends LuceneTestCase {
       conf.getCodec().compoundFormat().setShouldUseCompoundFile(true);
     }
 
-    RandomIndexWriter w = new RandomIndexWriter(random, dir, conf);
+    // NOTE: Do not use RandomIndexWriter here.
+    // This test depends on identical file layout between directories.
+    // RandomIndexWriter may mutate IndexWriterConfig via
+    // maybeChangeLiveIndexWriterConfig(), making the test nondeterministic.
+    IndexWriter w = new IndexWriter(dir, conf);
     w.addDocument(doc);
     w.close();
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortFieldMissingValue.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortFieldMissingValue.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.apache.lucene.search;
+
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestSortFieldMissingValue extends LuceneTestCase {
+
+  @SuppressWarnings("deprecation")
+  public void testDeprecatedSetterStillWorks() {
+    SortField a = new SortField("age", SortField.Type.INT);
+    a.setMissingValue(0);
+
+    SortField b = new SortField("age", SortField.Type.INT, false, 0);
+
+    assertEquals(b, a);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  public void testNullMissingValue() {
+    SortField a = new SortField("age", SortField.Type.INT);
+    SortField b = new SortField("age", SortField.Type.INT, false, null);
+
+    assertEquals(b, a);
+  }
+}


### PR DESCRIPTION
The test fails reproducibly with seed 397C971E9E35FD4E.

RandomIndexWriter may call LuceneTestCase.maybeChangeLiveIndexWriterConfig() during addDocument(), which can change CFS settings at runtime. This causes different index layouts between the two directories used by the test even though an identical IndexWriterConfig is provided.

Since this test verifies detection of foreign index files and depends on
identical file layouts, runtime mutation makes the test nondeterministic.

Replace RandomIndexWriter with a regular IndexWriter to ensure deterministic
behavior.
