### PR TITLE
Doc values skipper: Disable prefetching

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -140,6 +140,8 @@ Changes in Runtime Behavior
 ---------------------
 * GITHUB#14187: The query cache is now disabled by default. (Adrien Grand)
 
+* GITHUB#15729: Lucene90DocValuesProducer is not prefetching any data for DocValueSkippers anymore (Alexander Reelsen)
+
 Build
 ---------------------
 * GITHUB#15327: New low-level build options to detect abuse of LuceneTestCase.random():

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -1865,11 +1865,6 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     final DocValuesSkipperEntry entry = skippers.get(field.number);
 
     final IndexInput input = data.slice("doc value skipper", entry.offset, entry.length);
-    // Prefetch the first page of data. Following pages are expected to get prefetched through
-    // read-ahead.
-    if (input.length() > 0) {
-      input.prefetch(0, 1);
-    }
     // TODO: should we write to disk the actual max level for this segment?
     return new DocValuesSkipper() {
       final int[] minDocID = new int[SKIP_INDEX_MAX_LEVEL];


### PR DESCRIPTION
This change requires some explanation. While trying to understand how doc value skippers work, I noticed on skipper generation `input.prefetch()` is always called - essentially translating to an madvise willneed, indicating that this will be needed in the future. While for most other usage in the doc values producer this seems correct, in the case of the doc value skipper there there is the possibility to exit early without doing any disk accesses for min/max value and doccount, so the prefetch is wasted.

My understanding of the madvise usage is that it mostly makes sense if we are sure to read ahead, which is not the case for doc value skippers.

In addtion I also don't think it makes sense to move prefetching within the `advance()` call, as I suppose those are called when the data is actually needed, so prefetching would not help.