### PR TITLE
Improve performance of panama int4{DotProduct,SquareDistance}SinglePacked

### DIFF
--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -610,11 +610,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
             prod8a.convertShape(ZERO_EXTEND_B2S, Int4Constants.SHORT_SPECIES, 0);
         acc1 = acc1.add(prod16a);
       }
-      Vector<Integer> intAcc0 = acc0.convert(S2I, 0);
-      Vector<Integer> intAcc1 = acc0.convert(S2I, 1);
-      Vector<Integer> intAcc2 = acc1.convert(S2I, 0);
-      Vector<Integer> intAcc3 = acc1.convert(S2I, 1);
-      sum += intAcc0.add(intAcc1).add(intAcc2).add(intAcc3).reinterpretAsInts().reduceLanes(ADD);
+      ShortVector accShort = acc0.add(acc1);
+      Vector<Integer> intAcc0 = accShort.convert(ZERO_EXTEND_S2I, 0);
+      Vector<Integer> intAcc1 = accShort.convert(ZERO_EXTEND_S2I, 1);
+      sum += intAcc0.add(intAcc1).reinterpretAsInts().reduceLanes(ADD);
     }
     return sum;
   }
@@ -1020,11 +1019,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         Vector<Short> diff16a = diff8a.convertShape(B2S, Int4Constants.SHORT_SPECIES, 0);
         acc1 = acc1.add(diff16a.mul(diff16a));
       }
-      Vector<Integer> intAcc0 = acc0.convert(S2I, 0);
-      Vector<Integer> intAcc1 = acc0.convert(S2I, 1);
-      Vector<Integer> intAcc2 = acc1.convert(S2I, 0);
-      Vector<Integer> intAcc3 = acc1.convert(S2I, 1);
-      sum += intAcc0.add(intAcc1).add(intAcc2).add(intAcc3).reinterpretAsInts().reduceLanes(ADD);
+      ShortVector accShort = acc0.add(acc1);
+      Vector<Integer> intAcc0 = accShort.convert(ZERO_EXTEND_S2I, 0);
+      Vector<Integer> intAcc1 = accShort.convert(ZERO_EXTEND_S2I, 1);
+      sum += intAcc0.add(intAcc1).reinterpretAsInts().reduceLanes(ADD);
     }
     return sum;
   }


### PR DESCRIPTION
The conversion operations to int were observed to be very slow in the async profiler. These operations widen vectors
that are already at the maximum native length, so it's preferable to do fewer of them by summing the two short
accumulators before widening. Summing before widening could potentially overflow, but it is sufficient to switch
the integer widening to zero extend since these dot products are implicitly unsigned.

This may fix #15697 

M4 Before
```
Benchmark                                                       (size)   Mode  Cnt  Score   Error   Units
VectorUtilBenchmark.binaryHalfByteDotProductSinglePackedScalar    1024  thrpt   15  4.111 ± 0.028  ops/us
VectorUtilBenchmark.binaryHalfByteDotProductSinglePackedVector    1024  thrpt   15  3.413 ± 0.022  ops/us
VectorUtilBenchmark.binaryHalfByteSquareSinglePackedScalar        1024  thrpt   15  4.597 ± 0.055  ops/us
VectorUtilBenchmark.binaryHalfByteSquareSinglePackedVector        1024  thrpt   15  3.418 ± 0.017  ops/us
```

M4 After
```
Benchmark                                                       (size)   Mode  Cnt   Score   Error   Units
VectorUtilBenchmark.binaryHalfByteDotProductSinglePackedScalar    1024  thrpt   15   4.016 ± 0.032  ops/us
VectorUtilBenchmark.binaryHalfByteDotProductSinglePackedVector    1024  thrpt   15  26.741 ± 0.180  ops/us
VectorUtilBenchmark.binaryHalfByteSquareSinglePackedScalar        1024  thrpt   15   4.592 ± 0.041  ops/us
VectorUtilBenchmark.binaryHalfByteSquareSinglePackedVector        1024  thrpt   15  26.597 ± 0.071  ops/us
```

AMD Ryzen AI 395 (AVX 512) Before
```
Benchmark                                                       (size)   Mode  Cnt   Score   Error   Units
VectorUtilBenchmark.binaryHalfByteDotProductSinglePackedScalar    1024  thrpt   15   2.471 ± 0.059  ops/us
VectorUtilBenchmark.binaryHalfByteDotProductSinglePackedVector    1024  thrpt   15  11.226 ± 0.333  ops/us
VectorUtilBenchmark.binaryHalfByteSquareSinglePackedScalar        1024  thrpt   15   2.281 ± 0.028  ops/us
VectorUtilBenchmark.binaryHalfByteSquareSinglePackedVector        1024  thrpt   15  12.019 ± 0.379  ops/us
```

AMD Ryzen AI 395 After
```
Benchmark                                                       (size)   Mode  Cnt   Score   Error   Units
VectorUtilBenchmark.binaryHalfByteDotProductSinglePackedScalar    1024  thrpt   15   2.477 ± 0.053  ops/us
VectorUtilBenchmark.binaryHalfByteDotProductSinglePackedVector    1024  thrpt   15  27.912 ± 0.162  ops/us
VectorUtilBenchmark.binaryHalfByteSquareSinglePackedScalar        1024  thrpt   15   2.266 ± 0.028  ops/us
VectorUtilBenchmark.binaryHalfByteSquareSinglePackedVector        1024  thrpt   15  40.499 ± 0.578  ops/us
```