### PR TITLE
Correctly handle sort pruning on segments where the sort field does not exist

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -373,7 +373,7 @@ Optimizations
 
 * GITHUB#15498: ExitableDirectoryReader keeps singleton SortedSetDocValues or SortedNumericDocValues as singletons. (Houston Putman)
 
-* GITHUB#15511, GITHUB#15696, GITHUB#15709: Dynamic pruning for SORTED(_SET) fields with doc
+* GITHUB#15511, GITHUB#15696, GITHUB#15709, GITHUB#15741: Dynamic pruning for SORTED(_SET) fields with doc
   values skipper (Pan Guixin, Alan Woodward)
 
 * GITHUB#15560: Avoid unnecessary getGraph() call. (Shubham Chaudhary)

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
@@ -279,7 +279,8 @@ public class TermOrdValComparator extends FieldComparator<BytesRef> {
 
       if (enableSkipping) {
         if (terms != null) {
-          competitiveState = new PostingsBasedCompetitiveState(context, field, dense, values.termsEnum());
+          competitiveState =
+              new PostingsBasedCompetitiveState(context, field, dense, values.termsEnum());
         } else if (skipper != null) {
           competitiveState = new SkipperBasedCompetitiveState(context, skipper);
         } else {

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
@@ -276,14 +276,19 @@ public class TermOrdValComparator extends FieldComparator<BytesRef> {
           enableSkipping = false;
         }
       }
-      if (enableSkipping && terms != null) {
-        competitiveState =
-            new PostingsBasedCompetitiveState(context, field, dense, values.termsEnum());
-      } else if (enableSkipping && skipper != null) {
-        competitiveState = new SkipperBasedCompetitiveState(context, skipper);
+
+      if (enableSkipping) {
+        if (terms != null) {
+          competitiveState = new PostingsBasedCompetitiveState(context, field, dense, values.termsEnum());
+        } else if (skipper != null) {
+          competitiveState = new SkipperBasedCompetitiveState(context, skipper);
+        } else {
+          competitiveState = new EmptyCompetitiveState(context);
+        }
       } else {
         competitiveState = null;
       }
+
       updateCompetitiveIterator();
     }
 
@@ -509,6 +514,18 @@ public class TermOrdValComparator extends FieldComparator<BytesRef> {
     }
 
     abstract void update(int minOrd, int maxOrd) throws IOException;
+  }
+
+  private static class EmptyCompetitiveState extends CompetitiveState {
+
+    EmptyCompetitiveState(LeafReaderContext context) {
+      super(context);
+    }
+
+    @Override
+    void update(int minOrd, int maxOrd) throws IOException {
+      iterator.update(DocIdSetIterator.empty());
+    }
   }
 
   private class PostingsBasedCompetitiveState extends CompetitiveState {

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -1071,6 +1071,72 @@ public class TestSortOptimization extends LuceneTestCase {
     dir.close();
   }
 
+  public void testStringSortOptimizationFieldMissingInSegmentBasedPostings() throws IOException {
+    testStringSortOptimizationFieldMissingInSegment(
+        (field, value) -> new KeywordField(field, value, Field.Store.NO));
+  }
+
+  public void testStringSortOptimizationFieldMissingInSegmentBasedDVSkipper() throws IOException {
+    testStringSortOptimizationFieldMissingInSegment(SortedDocValuesField::indexedField);
+  }
+
+  /**
+   * Test that when a segment doesn't contain the sort field at all (fieldInfo == null), the
+   * optimization still works. All docs in such a segment have missing values, and when missing
+   * values are non-competitive the entire segment should be skippable.
+   */
+  private void testStringSortOptimizationFieldMissingInSegment(
+      BiFunction<String, BytesRef, IndexableField> fieldsBuilder) throws IOException {
+    final Directory dir = newDirectory();
+    final IndexWriter writer =
+        new IndexWriter(dir, new IndexWriterConfig().setMergePolicy(newLogMergePolicy()));
+
+    // First segment: a small number of docs with the keyword field, enough to fill the top-N queue.
+    final int docsWithField = 20;
+    for (int i = 0; i < docsWithField; i++) {
+      final Document doc = new Document();
+      doc.add(fieldsBuilder.apply("my_field", new BytesRef(String.format("%05d", i))));
+      writer.addDocument(doc);
+    }
+    writer.flush();
+
+    // Second segment: many docs WITHOUT the keyword field. The field doesn't exist in this
+    // segment's FieldInfos at all, so every doc has a missing value for the sort field.
+    final int docsWithoutField = atLeast(10000);
+    for (int i = 0; i < docsWithoutField; i++) {
+      writer.addDocument(new Document());
+    }
+
+    final DirectoryReader reader = DirectoryReader.open(writer);
+    writer.close();
+
+    final int numDocs = docsWithField + docsWithoutField;
+    final int numHits = 5;
+
+    { // ascending sort with missing-last: once the queue fills from the first segment,
+      // all docs in the second segment have non-competitive missing values and should be skipped
+      SortField sortField =
+          KeywordField.newSortField(
+              "my_field", false, SortedSetSelector.Type.MIN, SortField.STRING_LAST);
+      Sort sort = new Sort(sortField);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
+      assertNonCompetitiveHitsAreSkipped(topDocs.totalHits.value(), numDocs);
+    }
+
+    { // descending sort with missing-first: once the queue fills from the first segment,
+      // all docs in the second segment have non-competitive missing values and should be skipped
+      SortField sortField =
+          KeywordField.newSortField(
+              "my_field", true, SortedSetSelector.Type.MIN, SortField.STRING_FIRST);
+      Sort sort = new Sort(sortField);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
+      assertNonCompetitiveHitsAreSkipped(topDocs.totalHits.value(), numDocs);
+    }
+
+    reader.close();
+    dir.close();
+  }
+
   private void doTestStringSortOptimization(DirectoryReader reader) throws IOException {
     final int numDocs = reader.numDocs();
     final int numHits = 5;

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -49,6 +49,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
@@ -1088,8 +1089,9 @@ public class TestSortOptimization extends LuceneTestCase {
   private void testStringSortOptimizationFieldMissingInSegment(
       BiFunction<String, BytesRef, IndexableField> fieldsBuilder) throws IOException {
     final Directory dir = newDirectory();
+    // Use NoMergePolicy to ensure we have deterministic segment geometry
     final IndexWriter writer =
-        new IndexWriter(dir, new IndexWriterConfig().setMergePolicy(newLogMergePolicy()));
+        new IndexWriter(dir, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE));
 
     // First segment: a small number of docs with the keyword field, enough to fill the top-N queue.
     final int docsWithField = 20;

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -1095,7 +1095,7 @@ public class TestSortOptimization extends LuceneTestCase {
     final int docsWithField = 20;
     for (int i = 0; i < docsWithField; i++) {
       final Document doc = new Document();
-      doc.add(fieldsBuilder.apply("my_field", new BytesRef(String.format("%05d", i))));
+      doc.add(fieldsBuilder.apply("my_field", new BytesRef(Integer.toString(i))));
       writer.addDocument(doc);
     }
     writer.flush();
@@ -1123,6 +1123,20 @@ public class TestSortOptimization extends LuceneTestCase {
       assertNonCompetitiveHitsAreSkipped(topDocs.totalHits.value(), numDocs);
     }
 
+    { // descending sort with missing-last
+      SortField sortField =
+          KeywordField.newSortField(
+              "my_field", true, SortedSetSelector.Type.MIN, SortField.STRING_LAST);
+      Sort sort = new Sort(sortField);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
+
+      sortField.setOptimizeSortWithIndexedData(false);
+      sort = new Sort(sortField);
+      TopDocs unpruned = assertSearchHits(reader, sort, numHits, null);
+
+      CheckHits.checkEqual(MatchAllDocsQuery.INSTANCE, topDocs.scoreDocs, unpruned.scoreDocs);
+    }
+
     { // descending sort with missing-first: once the queue fills from the first segment,
       // all docs in the second segment have non-competitive missing values and should be skipped
       SortField sortField =
@@ -1131,6 +1145,20 @@ public class TestSortOptimization extends LuceneTestCase {
       Sort sort = new Sort(sortField);
       TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
       assertNonCompetitiveHitsAreSkipped(topDocs.totalHits.value(), numDocs);
+    }
+
+    { // ascending sort with missing-first
+      SortField sortField =
+          KeywordField.newSortField(
+              "my_field", false, SortedSetSelector.Type.MIN, SortField.STRING_FIRST);
+      Sort sort = new Sort(sortField);
+      TopDocs topDocs = assertSearchHits(reader, sort, numHits, null);
+
+      sortField.setOptimizeSortWithIndexedData(false);
+      sort = new Sort(sortField);
+      TopDocs unpruned = assertSearchHits(reader, sort, numHits, null);
+
+      CheckHits.checkEqual(MatchAllDocsQuery.INSTANCE, topDocs.scoreDocs, unpruned.scoreDocs);
     }
 
     reader.close();


### PR DESCRIPTION
We inadvertently removed a branch where a segment without a sort field would create a postings-based competitive state that generated an empty iterator, meaning that searches against such segments would waste time checking every document rather than early terminating.  This re-adds that logic, introducing a simpler skip-all-docs implementation and adding explicit tests.