### PR TITLE
Optimize int4 vector computations by avoiding conversions

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -206,6 +206,8 @@ Optimizations
 
 * GITHUB#15729: Lucene90DocValuesProducer is not prefetching any data for DocValueSkippers anymore (Alexander Reelsen)
 
+* GITHUB#15742: Optimize int4 dotProduct and squareDistance computations by replacing vector conversions with reinterpret casting + bit manipulation. (Trevor McCulloch, Kaival Parikh)
+
 Bug Fixes
 ---------------------
 * GITHUB#15668: Fix UnsupportedOperationException in WeightedSpanTermExtractor by

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -612,10 +612,10 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         ByteVector va8 = unpacked.load(Int4Constants.BYTE_SPECIES, i + j + packed.length());
 
         ShortVector prod16 = vb8.and((byte) 0x0F).mul(va8).reinterpretAsShorts();
-        acc0 = acc0.add(prod16.lanewise(LSHR, 8)).add(prod16.and((short) 0xFF));
+        acc0 = acc0.add(prod16.lanewise(LSHR, 8).add(prod16.and((short) 0xFF)));
 
         ShortVector prod16a = vb8.lanewise(LSHR, 4).mul(vc8).reinterpretAsShorts();
-        acc1 = acc1.add(prod16a.lanewise(LSHR, 8)).add(prod16a.and((short) 0xFF));
+        acc1 = acc1.add(prod16a.lanewise(LSHR, 8).add(prod16a.and((short) 0xFF)));
       }
 
       IntVector intAcc0 = acc0.reinterpretAsInts();
@@ -673,12 +673,12 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
         // upper
         ShortVector prod16 = vb8.and((byte) 0x0F).mul(va8.and((byte) 0x0F)).reinterpretAsShorts();
-        acc0 = acc0.add(prod16.lanewise(LSHR, 8)).add(prod16.and((short) 0xFF));
+        acc0 = acc0.add(prod16.lanewise(LSHR, 8).add(prod16.and((short) 0xFF)));
 
         // lower
         ShortVector prod16a =
             vb8.lanewise(LSHR, 4).mul(va8.lanewise(LSHR, 4)).reinterpretAsShorts();
-        acc1 = acc1.add(prod16a.lanewise(LSHR, 8)).add(prod16a.and((short) 0xFF));
+        acc1 = acc1.add(prod16a.lanewise(LSHR, 8).add(prod16a.and((short) 0xFF)));
       }
 
       IntVector intAcc0 = acc0.reinterpretAsInts();
@@ -970,10 +970,11 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         // unpacked
         var va8 = a.load(Int4Constants.BYTE_SPECIES, i + j);
 
-        ByteVector diff8 = vb8.sub(va8);
-        ShortVector prod16 = diff8.mul(diff8).reinterpretAsShorts();
-        acc0 = acc0.add(prod16.and((short) 0xFF));
-        acc1 = acc1.add(prod16.lanewise(LSHR, 8));
+        ShortVector diff8 = vb8.sub(va8).abs().reinterpretAsShorts();
+        ShortVector diff16 = diff8.and((short) 0xFF);
+        acc0 = acc0.add(diff16.mul(diff16));
+        ShortVector diff16a = diff8.lanewise(LSHR, 8);
+        acc1 = acc1.add(diff16a.mul(diff16a));
       }
 
       IntVector intAcc0 = acc0.reinterpretAsInts();
@@ -1040,11 +1041,11 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
         ByteVector diff8 = vb8.and((byte) 0x0F).sub(va8);
         ShortVector prod16 = diff8.mul(diff8).reinterpretAsShorts();
-        acc0 = acc0.add(prod16.and((short) 0xFF)).add(prod16.lanewise(LSHR, 8));
+        acc0 = acc0.add(prod16.and((short) 0xFF).add(prod16.lanewise(LSHR, 8)));
 
         ByteVector diff8a = vb8.lanewise(LSHR, 4).sub(vc8);
         ShortVector prod16a = diff8a.mul(diff8a).reinterpretAsShorts();
-        acc1 = acc1.add(prod16a.and((short) 0xFF)).add(prod16a.lanewise(LSHR, 8));
+        acc1 = acc1.add(prod16a.and((short) 0xFF).add(prod16a.lanewise(LSHR, 8)));
       }
 
       IntVector intAcc0 = acc0.reinterpretAsInts();
@@ -1106,12 +1107,12 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         // upper
         ByteVector diff8 = vb8.and((byte) 0x0F).sub(va8.and((byte) 0x0F));
         ShortVector prod16 = diff8.mul(diff8).reinterpretAsShorts();
-        acc0 = acc0.add(prod16.and((short) 0xFF)).add(prod16.lanewise(LSHR, 8));
+        acc0 = acc0.add(prod16.and((short) 0xFF).add(prod16.lanewise(LSHR, 8)));
 
         // lower
         ByteVector diff8a = vb8.lanewise(LSHR, 4).sub(va8.lanewise(LSHR, 4));
         ShortVector prod16a = diff8a.mul(diff8a).reinterpretAsShorts();
-        acc1 = acc1.add(prod16a.and((short) 0xFF)).add(prod16a.lanewise(LSHR, 8));
+        acc1 = acc1.add(prod16a.and((short) 0xFF).add(prod16a.lanewise(LSHR, 8)));
       }
 
       IntVector intAcc0 = acc0.reinterpretAsInts();

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -490,17 +490,17 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
     static {
       if (VECTOR_BITSIZE >= 512) {
-        BYTE_SPECIES = ByteVector.SPECIES_256;
+        BYTE_SPECIES = ByteVector.SPECIES_512;
         SHORT_SPECIES = ShortVector.SPECIES_512;
-        CHUNK = 4096;
+        CHUNK = 8192;
       } else if (VECTOR_BITSIZE == 256) {
-        BYTE_SPECIES = ByteVector.SPECIES_128;
+        BYTE_SPECIES = ByteVector.SPECIES_256;
         SHORT_SPECIES = ShortVector.SPECIES_256;
-        CHUNK = 2048;
+        CHUNK = 4096;
       } else {
-        BYTE_SPECIES = ByteVector.SPECIES_64;
+        BYTE_SPECIES = ByteVector.SPECIES_128;
         SHORT_SPECIES = ShortVector.SPECIES_128;
-        CHUNK = 1024;
+        CHUNK = 2048;
       }
     }
   }
@@ -541,17 +541,16 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
       for (int j = 0; j < innerLimit; j += Int4Constants.BYTE_SPECIES.length()) {
         // unpacked
         ByteVector vb8 = b.load(Int4Constants.BYTE_SPECIES, i + j);
-        Vector<Short> vb16 = vb8.convertShape(B2S, Int4Constants.SHORT_SPECIES, 0);
 
         // unpacked
         ByteVector va8 = a.load(Int4Constants.BYTE_SPECIES, i + j);
-        Vector<Short> va16 = va8.convertShape(B2S, Int4Constants.SHORT_SPECIES, 0);
 
-        acc = acc.add(vb16.mul(va16));
+        ByteVector prod8 = va8.mul(vb8);
+        ShortVector prod16 = prod8.reinterpretAsShorts();
+        acc = acc.add(prod16.and((short) 0xFF)).add(prod16.lanewise(LSHR, 8));
       }
-      Vector<Integer> intAcc0 = acc.convert(S2I, 0);
-      Vector<Integer> intAcc1 = acc.convert(S2I, 1);
-      sum += intAcc0.add(intAcc1).reinterpretAsInts().reduceLanes(ADD);
+      IntVector intAcc = acc.reinterpretAsInts();
+      sum += intAcc.and(0xFFFF).add(intAcc.lanewise(LSHR, 16)).reduceLanes(ADD);
     }
     return sum;
   }
@@ -599,22 +598,28 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
         // upper
         ByteVector va8 = unpacked.load(Int4Constants.BYTE_SPECIES, i + j + packed.length());
-        ByteVector prod8 = vb8.and((byte) 0x0F).mul(va8);
-        Vector<Short> prod16 = prod8.convertShape(ZERO_EXTEND_B2S, Int4Constants.SHORT_SPECIES, 0);
-        acc0 = acc0.add(prod16);
 
         // lower
         ByteVector vc8 = unpacked.load(Int4Constants.BYTE_SPECIES, i + j);
+
+        ByteVector prod8 = vb8.and((byte) 0x0F).mul(va8);
+        ShortVector prod16 = prod8.reinterpretAsShorts();
+        acc0 = acc0.add(prod16.and((short) 0xFF)).add(prod16.lanewise(LSHR, 8));
+
         ByteVector prod8a = vb8.lanewise(LSHR, 4).mul(vc8);
-        Vector<Short> prod16a =
-            prod8a.convertShape(ZERO_EXTEND_B2S, Int4Constants.SHORT_SPECIES, 0);
-        acc1 = acc1.add(prod16a);
+        ShortVector prod16a = prod8a.reinterpretAsShorts();
+        acc1 = acc1.add(prod16a.and((short) 0xFF)).add(prod16a.lanewise(LSHR, 8));
       }
-      Vector<Integer> intAcc0 = acc0.convert(S2I, 0);
-      Vector<Integer> intAcc1 = acc0.convert(S2I, 1);
-      Vector<Integer> intAcc2 = acc1.convert(S2I, 0);
-      Vector<Integer> intAcc3 = acc1.convert(S2I, 1);
-      sum += intAcc0.add(intAcc1).add(intAcc2).add(intAcc3).reinterpretAsInts().reduceLanes(ADD);
+
+      IntVector intAcc0 = acc0.reinterpretAsInts();
+      IntVector intAcc1 = acc1.reinterpretAsInts();
+      sum +=
+          intAcc0
+              .and(0xFFFF)
+              .add(intAcc0.lanewise(LSHR, 16))
+              .add(intAcc1.and(0xFFFF))
+              .add(intAcc1.lanewise(LSHR, 16))
+              .reduceLanes(ADD);
     }
     return sum;
   }
@@ -661,20 +666,24 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
         // upper
         ByteVector prod8 = vb8.and((byte) 0x0F).mul(va8.and((byte) 0x0F));
-        Vector<Short> prod16 = prod8.convertShape(ZERO_EXTEND_B2S, Int4Constants.SHORT_SPECIES, 0);
-        acc0 = acc0.add(prod16);
+        ShortVector prod16 = prod8.reinterpretAsShorts();
+        acc0 = acc0.add(prod16.and((short) 0xFF)).add(prod16.lanewise(LSHR, 8));
 
         // lower
         ByteVector prod8a = vb8.lanewise(LSHR, 4).mul(va8.lanewise(LSHR, 4));
-        Vector<Short> prod16a =
-            prod8a.convertShape(ZERO_EXTEND_B2S, Int4Constants.SHORT_SPECIES, 0);
-        acc1 = acc1.add(prod16a);
+        ShortVector prod16a = prod8a.reinterpretAsShorts();
+        acc1 = acc1.add(prod16a.and((short) 0xFF)).add(prod16a.lanewise(LSHR, 8));
       }
-      Vector<Integer> intAcc0 = acc0.convert(S2I, 0);
-      Vector<Integer> intAcc1 = acc0.convert(S2I, 1);
-      Vector<Integer> intAcc2 = acc1.convert(S2I, 0);
-      Vector<Integer> intAcc3 = acc1.convert(S2I, 1);
-      sum += intAcc0.add(intAcc1).add(intAcc2).add(intAcc3).reinterpretAsInts().reduceLanes(ADD);
+
+      IntVector intAcc0 = acc0.reinterpretAsInts();
+      IntVector intAcc1 = acc1.reinterpretAsInts();
+      sum +=
+          intAcc0
+              .and(0xFFFF)
+              .add(intAcc0.lanewise(LSHR, 16))
+              .add(intAcc1.and(0xFFFF))
+              .add(intAcc1.lanewise(LSHR, 16))
+              .reduceLanes(ADD);
     }
     return sum;
   }
@@ -955,12 +964,11 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
         var va8 = a.load(Int4Constants.BYTE_SPECIES, i + j);
 
         ByteVector diff8 = vb8.sub(va8);
-        Vector<Short> diff16 = diff8.convertShape(B2S, Int4Constants.SHORT_SPECIES, 0);
-        acc = acc.add(diff16.mul(diff16));
+        ShortVector prod16 = diff8.mul(diff8).reinterpretAsShorts();
+        acc = acc.add(prod16.and((short) 0xFF)).add(prod16.lanewise(LSHR, 8));
       }
-      Vector<Integer> intAcc0 = acc.convert(S2I, 0);
-      Vector<Integer> intAcc1 = acc.convert(S2I, 1);
-      sum += intAcc0.add(intAcc1).reinterpretAsInts().reduceLanes(ADD);
+      IntVector intAcc = acc.reinterpretAsInts();
+      sum += intAcc.and(0xFFFF).add(intAcc.lanewise(LSHR, 16)).reduceLanes(ADD);
     }
     return sum;
   }
@@ -1010,21 +1018,28 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
         // upper
         ByteVector va8 = unpacked.load(Int4Constants.BYTE_SPECIES, i + j + packed.length());
-        ByteVector diff8 = vb8.and((byte) 0x0F).sub(va8);
-        Vector<Short> diff16 = diff8.convertShape(B2S, Int4Constants.SHORT_SPECIES, 0);
-        acc0 = acc0.add(diff16.mul(diff16));
 
         // lower
         ByteVector vc8 = unpacked.load(Int4Constants.BYTE_SPECIES, i + j);
+
+        ByteVector diff8 = vb8.and((byte) 0x0F).sub(va8);
+        ShortVector prod16 = diff8.mul(diff8).reinterpretAsShorts();
+        acc0 = acc0.add(prod16.and((short) 0xFF)).add(prod16.lanewise(LSHR, 8));
+
         ByteVector diff8a = vb8.lanewise(LSHR, 4).sub(vc8);
-        Vector<Short> diff16a = diff8a.convertShape(B2S, Int4Constants.SHORT_SPECIES, 0);
-        acc1 = acc1.add(diff16a.mul(diff16a));
+        ShortVector prod16a = diff8a.mul(diff8a).reinterpretAsShorts();
+        acc1 = acc1.add(prod16a.and((short) 0xFF)).add(prod16a.lanewise(LSHR, 8));
       }
-      Vector<Integer> intAcc0 = acc0.convert(S2I, 0);
-      Vector<Integer> intAcc1 = acc0.convert(S2I, 1);
-      Vector<Integer> intAcc2 = acc1.convert(S2I, 0);
-      Vector<Integer> intAcc3 = acc1.convert(S2I, 1);
-      sum += intAcc0.add(intAcc1).add(intAcc2).add(intAcc3).reinterpretAsInts().reduceLanes(ADD);
+
+      IntVector intAcc0 = acc0.reinterpretAsInts();
+      IntVector intAcc1 = acc1.reinterpretAsInts();
+      sum +=
+          intAcc0
+              .and(0xFFFF)
+              .add(intAcc0.lanewise(LSHR, 16))
+              .add(intAcc1.and(0xFFFF))
+              .add(intAcc1.lanewise(LSHR, 16))
+              .reduceLanes(ADD);
     }
     return sum;
   }
@@ -1074,19 +1089,24 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
         // upper
         ByteVector diff8 = vb8.and((byte) 0x0F).sub(va8.and((byte) 0x0F));
-        Vector<Short> diff16 = diff8.convertShape(B2S, Int4Constants.SHORT_SPECIES, 0);
-        acc0 = acc0.add(diff16.mul(diff16));
+        ShortVector prod16 = diff8.mul(diff8).reinterpretAsShorts();
+        acc0 = acc0.add(prod16.and((short) 0xFF)).add(prod16.lanewise(LSHR, 8));
 
         // lower
         ByteVector diff8a = vb8.lanewise(LSHR, 4).sub(va8.lanewise(LSHR, 4));
-        Vector<Short> diff16a = diff8a.convertShape(B2S, Int4Constants.SHORT_SPECIES, 0);
-        acc1 = acc1.add(diff16a.mul(diff16a));
+        ShortVector prod16a = diff8a.mul(diff8a).reinterpretAsShorts();
+        acc1 = acc1.add(prod16a.and((short) 0xFF)).add(prod16a.lanewise(LSHR, 8));
       }
-      Vector<Integer> intAcc0 = acc0.convert(S2I, 0);
-      Vector<Integer> intAcc1 = acc0.convert(S2I, 1);
-      Vector<Integer> intAcc2 = acc1.convert(S2I, 0);
-      Vector<Integer> intAcc3 = acc1.convert(S2I, 1);
-      sum += intAcc0.add(intAcc1).add(intAcc2).add(intAcc3).reinterpretAsInts().reduceLanes(ADD);
+
+      IntVector intAcc0 = acc0.reinterpretAsInts();
+      IntVector intAcc1 = acc1.reinterpretAsInts();
+      sum +=
+          intAcc0
+              .and(0xFFFF)
+              .add(intAcc0.lanewise(LSHR, 16))
+              .add(intAcc1.and(0xFFFF))
+              .add(intAcc1.lanewise(LSHR, 16))
+              .reduceLanes(ADD);
     }
     return sum;
   }


### PR DESCRIPTION
Spinoff from #15736, where @mccullocht identified vector conversions as a potentially slow area (thanks!).
This PR loads and operates on SIMD registers of the preferred bit size to avoid intermediate conversions.

This was sparked from #15697 where we observed a performance drop in JMH benchmarks of some 4-bit vector computations after initial warmup. It's possible that this issue only affects ARM machines.

Ran JMH benchmarks on an AWS Graviton3 host using:

```sh
java --module-path lucene/benchmark-jmh/build/benchmarks --module org.apache.lucene.benchmark.jmh "VectorUtilBenchmark.binaryHalfByte.*Vector" -p size=1024
```

Baseline:

```
Benchmark                                                       (size)   Mode  Cnt   Score   Error   Units
VectorUtilBenchmark.binaryHalfByteDotProductBothPackedVector      1024  thrpt   15  11.846 ± 0.034  ops/us
VectorUtilBenchmark.binaryHalfByteDotProductSinglePackedVector    1024  thrpt   15   2.618 ± 0.009  ops/us
VectorUtilBenchmark.binaryHalfByteDotProductVector                1024  thrpt   15  20.733 ± 0.063  ops/us
VectorUtilBenchmark.binaryHalfByteSquareBothPackedVector          1024  thrpt   15  12.599 ± 0.022  ops/us
VectorUtilBenchmark.binaryHalfByteSquareSinglePackedVector        1024  thrpt   15   2.603 ± 0.008  ops/us
VectorUtilBenchmark.binaryHalfByteSquareVector                    1024  thrpt   15  18.492 ± 0.033  ops/us
```

This PR:

```
Benchmark                                                       (size)   Mode  Cnt   Score   Error   Units
VectorUtilBenchmark.binaryHalfByteDotProductBothPackedVector      1024  thrpt   15  17.356 ± 0.052  ops/us
VectorUtilBenchmark.binaryHalfByteDotProductSinglePackedVector    1024  thrpt   15  19.157 ± 0.055  ops/us
VectorUtilBenchmark.binaryHalfByteDotProductVector                1024  thrpt   15  20.575 ± 0.049  ops/us
VectorUtilBenchmark.binaryHalfByteSquareBothPackedVector          1024  thrpt   15  16.030 ± 0.077  ops/us
VectorUtilBenchmark.binaryHalfByteSquareSinglePackedVector        1024  thrpt   15  16.247 ± 0.120  ops/us
VectorUtilBenchmark.binaryHalfByteSquareVector                    1024  thrpt   15  18.952 ± 0.113  ops/us
```