### PR TITLE
Remove deprecated RegExp complement syntax

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,6 +7,10 @@ http://s.apache.org/luceneversions
 
 API Changes
 ---------------------
+* GITHUB#XXXXX: Remove deprecated RegExp complement syntax support. The DEPRECATED_COMPLEMENT flag,
+  REGEXP_DEPRECATED_COMPLEMENT enum value, and makeDeprecatedComplement method have been removed.
+  Users should use complement bracket expressions ([^...]) instead. (Saurabh Singh)
+
 * GITHUB#15517: Remove newHashMap, newHashSet from CollectionUtil, and use HashMap.newHashMap, HashSet.newHashSet
   directly. (Zhou Hui)
 

--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -250,18 +250,14 @@ These classes no longer take a `determinizeWorkLimit` and no longer determinize
 behind the scenes. It is the responsibility of the caller to call
 `Operations.determinize()` for DFA execution.
 
-### RegExp optional complement syntax has been deprecated
+### RegExp optional complement syntax has been removed (LUCENE-11)
 
-Support for the optional complement syntax (`~`) has been deprecated.
-The `COMPLEMENT` syntax flag has been removed and replaced by the
-`DEPRECATED_COMPLEMENT` flag. Users wanting to enable the deprecated
-complement support can do so by explicitly passing a syntax flags that
-has `DEPRECATED_COMPLEMENT` when creating a `RegExp`. For example:
-`new RegExp("~(foo)", RegExp.DEPRECATED_COMPLEMENT)`.
+Support for the optional complement syntax (`~`) that was deprecated in Lucene 10
+has been removed. The `DEPRECATED_COMPLEMENT` flag and `REGEXP_DEPRECATED_COMPLEMENT`
+enum value are no longer available.
 
-Alternatively, and quite commonly, a more simple _complement bracket expression_,
-`[^...]`, may be a suitable replacement, For example, `[^fo]` matches any
-character that is not an `f` or `o`.
+Users should migrate to using _complement bracket expressions_ (`[^...]`) instead.
+For example, `[^fo]` matches any character that is not an `f` or `o`.
 
 ### DocValuesFieldExistsQuery, NormsFieldExistsQuery and KnnVectorFieldExistsQuery removed in favor of FieldExistsQuery (LUCENE-10436)
 

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -389,14 +389,7 @@ public class RegExp {
     /** An Automaton expression */
     REGEXP_AUTOMATON,
     /** An Interval expression */
-    REGEXP_INTERVAL,
-    /**
-     * The complement of an expression.
-     *
-     * @deprecated Will be removed in Lucene 11
-     */
-    @Deprecated
-    REGEXP_DEPRECATED_COMPLEMENT
+    REGEXP_INTERVAL
   }
 
   // -----  Syntax flags ( <= 0xff )  ------
@@ -487,18 +480,6 @@ public class RegExp {
    */
   public static final int CASE_INSENSITIVE_RANGE = 0x0400;
 
-  // -----  Deprecated flags ( > 0xffff )  ------
-
-  /**
-   * Allows regexp parsing of the complement (<code>~</code>).
-   *
-   * <p>Note that processing the complement can require exponential time, but will be bounded by an
-   * internal limit. Regexes exceeding the limit will fail with TooComplexToDeterminizeException.
-   *
-   * @deprecated This method will be removed in Lucene 11
-   */
-  @Deprecated public static final int DEPRECATED_COMPLEMENT = 0x10000;
-
   // Immutable parsed state
   /** The type of expression */
   public final Kind kind;
@@ -553,7 +534,7 @@ public class RegExp {
    * @exception IllegalArgumentException if an error occurred while parsing the regular expression
    */
   public RegExp(String s, int syntax_flags, int match_flags) throws IllegalArgumentException {
-    if ((syntax_flags & ~DEPRECATED_COMPLEMENT) > ALL) {
+    if (syntax_flags > ALL) {
       throw new IllegalArgumentException("Illegal syntax flag");
     }
 
@@ -698,12 +679,6 @@ public class RegExp {
         // this is just a list of characters (e.g. "a") or ranges (e.g. "b-d")
         a = exp1.toAutomaton(automata, automaton_provider);
         a = Operations.complement(a, Integer.MAX_VALUE);
-        break;
-      case REGEXP_DEPRECATED_COMPLEMENT:
-        // to ease transitions for users only, support arbitrary complement
-        // but bounded by DEFAULT_DETERMINIZE_WORK_LIMIT: must not be configurable.
-        a = exp1.toAutomaton(automata, automaton_provider);
-        a = Operations.complement(a, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
         break;
       case REGEXP_CHAR:
         if (check(ASCII_CASE_INSENSITIVE | CASE_INSENSITIVE)) {
@@ -908,7 +883,6 @@ public class RegExp {
         b.append("){").append(min).append(",").append(max).append("}");
         break;
       case REGEXP_COMPLEMENT:
-      case REGEXP_DEPRECATED_COMPLEMENT:
         b.append("~(");
         exp1.toStringBuilder(b);
         b.append(")");
@@ -985,7 +959,6 @@ public class RegExp {
       case REGEXP_OPTIONAL:
       case REGEXP_REPEAT:
       case REGEXP_COMPLEMENT:
-      case REGEXP_DEPRECATED_COMPLEMENT:
         b.append(indent);
         b.append(kind);
         b.append('\n');
@@ -1106,7 +1079,6 @@ public class RegExp {
       case REGEXP_REPEAT_MIN:
       case REGEXP_REPEAT_MINMAX:
       case REGEXP_COMPLEMENT:
-      case REGEXP_DEPRECATED_COMPLEMENT:
         exp1.getIdentifiers(set);
         break;
       case REGEXP_AUTOMATON:
@@ -1181,16 +1153,6 @@ public class RegExp {
 
   static RegExp makeComplement(int flags, RegExp exp) {
     return newContainerNode(flags, Kind.REGEXP_COMPLEMENT, exp, null);
-  }
-
-  /**
-   * Creates node that will compute complement of arbitrary expression.
-   *
-   * @deprecated Will be removed in Lucene 11
-   */
-  @Deprecated
-  static RegExp makeDeprecatedComplement(int flags, RegExp exp) {
-    return newContainerNode(flags, Kind.REGEXP_DEPRECATED_COMPLEMENT, exp, null);
   }
 
   static RegExp makeChar(int flags, int c) {
@@ -1341,9 +1303,7 @@ public class RegExp {
   }
 
   final RegExp parseComplExp() throws IllegalArgumentException {
-    if (check(DEPRECATED_COMPLEMENT) && match('~'))
-      return makeDeprecatedComplement(flags, parseComplExp());
-    else return parseCharClassExp();
+    return parseCharClassExp();
   }
 
   final RegExp parseCharClassExp() throws IllegalArgumentException {

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
@@ -25,7 +25,6 @@ import static org.hamcrest.Matchers.not;
 import java.util.Locale;
 import java.util.regex.Pattern;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.apache.lucene.tests.util.automaton.AutomatonTestUtil;
 import org.apache.lucene.util.BytesRef;
 
 public class TestRegExp extends LuceneTestCase {
@@ -331,20 +330,5 @@ public class TestRegExp extends LuceneTestCase {
 
   public void testRegExpNoStackOverflow() {
     new RegExp("(a)|".repeat(50000) + "(a)");
-  }
-
-  /**
-   * Tests the deprecate complement flag. Keep the simple test only, no random tests to let it cause
-   * us pain.
-   *
-   * @deprecated Remove in Lucene 11
-   */
-  @Deprecated
-  public void testDeprecatedComplement() {
-    Automaton expected =
-        Operations.complement(
-            Automata.makeString("abcd"), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
-    Automaton actual = new RegExp("~(abcd)", RegExp.DEPRECATED_COMPLEMENT).toAutomaton();
-    assertTrue(AutomatonTestUtil.sameLanguage(expected, actual));
   }
 }


### PR DESCRIPTION
## Description
Removes deprecated RegExp complement syntax support that was marked for removal in Lucene 11.

## Changes
- Removed `DEPRECATED_COMPLEMENT` flag (deprecated in Lucene 10)
- Removed `REGEXP_DEPRECATED_COMPLEMENT` enum value
- Removed `makeDeprecatedComplement()` method
- Removed deprecated test `testDeprecatedComplement()`
- Updated MIGRATE.md with removal notice
- Cleaned up unused imports

## Migration Path
Users should use complement bracket expressions `[^...]` instead of the deprecated `~(...)` syntax.

Example:
- Old: `new RegExp("~(foo)", RegExp.DEPRECATED_COMPLEMENT)`
- New: `new RegExp("[^fo]")`

## Testing
- All 7,784 core tests pass
- Code formatted with `./gradlew tidy`
- No compilation errors
