### PR TITLE
Add Case Insensitive makeChar and makeString to Automata

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -322,6 +322,8 @@ Improvements
 
 * GITHUB#15570: Disallow invalid offset 0 for LZ4 decompression (Marcono1234)
 
+* GITHUB#15753: Add Case Insensitive makeChar and makeString to Automata. (John Wagster)
+
 Optimizations
 ---------------------
 * GITHUB#15140: Optimize TopScoreDocCollector with TernaryLongHeap for improved performance over Binary-LongHeap. (Ramakrishna Chilaka)
@@ -855,8 +857,6 @@ Improvements
 * GITHUB#14213: Allowing indexing stored-only StoredField directly from DataInput. (Tim Brooks)
 
 * GITHUB#14364: Completion FSTs to be loaded off-heap at all times. (Luca Cavanna)
-
-* GITHUB#15753: Add Case Insensitive makeChar and makeString to Automata. (John Wagster)
 
 Optimizations
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -207,7 +207,7 @@ New Features
 
 Improvements
 ---------------------
-(No changes)
+* GITHUB#15753: Add Case Insensitive makeChar and makeString to Automata. (John Wagster)
 
 Optimizations
 ---------------------
@@ -332,8 +332,6 @@ Improvements
 * GITHUB#15479: Add NumericDocValueRangeQuery base class to add accessor methods for field, lower and upper values (Alan Woodward)
 
 * GITHUB#15570: Disallow invalid offset 0 for LZ4 decompression (Marcono1234)
-
-* GITHUB#15753: Add Case Insensitive makeChar and makeString to Automata. (John Wagster)
 
 Optimizations
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -850,12 +850,13 @@ Improvements
 * GITHUB#14239: Hunspell's option to tolerate affix rule count mismatches was
   improved to tolerate more instances of this problem.  (Robert Muir)
 
-
 * GITHUB#14238: Improve test coverage of Dynamic Range Faceting. (John Houser)
 
 * GITHUB#14213: Allowing indexing stored-only StoredField directly from DataInput. (Tim Brooks)
 
 * GITHUB#14364: Completion FSTs to be loaded off-heap at all times. (Luca Cavanna)
+
+* GITHUB#15753: Add Case Insensitive makeChar and makeString to Automata. (John Wagster)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
@@ -118,8 +118,10 @@ public final class Automata {
     return makeCharRange(c, c);
   }
 
-  /** Returns a new (deterministic) automaton that accepts potentially multiple codepoints of the
-   *  given value. */
+  /**
+   * Returns a new (deterministic) automaton that accepts potentially multiple codepoints of the
+   * given value.
+   */
   public static Automaton makeChar(int c, boolean caseInsensitive) {
     if (caseInsensitive) {
       return makeCharSet(toCaseInsensitiveChar(c));
@@ -570,13 +572,13 @@ public final class Automata {
 
   /** Returns a new (deterministic) automaton that accepts the single given string. */
   public static Automaton makeString(String s, boolean caseInsensitive) {
-    if(caseInsensitive) {
+    if (caseInsensitive) {
       Automaton a = new Automaton();
       int lastState = a.createState();
       for (int i = 0, cp = 0; i < s.length(); i += Character.charCount(cp)) {
         int state = a.createState();
         cp = s.codePointAt(i);
-        for(int alt : toCaseInsensitiveChar(cp)) {
+        for (int alt : toCaseInsensitiveChar(cp)) {
           a.addTransition(lastState, state, alt);
         }
         lastState = state;
@@ -694,7 +696,8 @@ public final class Automata {
   /**
    * This function handles uses the Unicode spec for generating case-insensitive alternates.
    *
-   * <p>See the {@link RegExp#CASE_INSENSITIVE} flag for details on case folding within the Unicode spec.
+   * <p>See the {@link RegExp#CASE_INSENSITIVE} flag for details on case folding within the Unicode
+   * spec.
    *
    * @param codepoint the Character code point to encode as an Automaton
    * @return the original codepoint and the set of alternates

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
@@ -120,14 +120,10 @@ public final class Automata {
 
   /**
    * Returns a new (deterministic) automaton that accepts potentially multiple codepoints of the
-   * given value.
+   * given value that are case-insensitive equivalents.
    */
-  public static Automaton makeChar(int c, boolean caseInsensitive) {
-    if (caseInsensitive) {
-      return makeCharSet(toCaseInsensitiveChar(c));
-    } else {
-      return makeChar(c);
-    }
+  public static Automaton makeCaseInsensitiveChar(int c) {
+    return makeCharSet(toCaseInsensitiveChar(c));
   }
 
   /** Appends the specified character to the specified state, returning a new state. */
@@ -570,30 +566,29 @@ public final class Automata {
     return a;
   }
 
-  /** Returns a new (deterministic) automaton that accepts the single given string. */
-  public static Automaton makeString(String s, boolean caseInsensitive) {
-    if (caseInsensitive) {
-      Automaton a = new Automaton();
-      int lastState = a.createState();
-      for (int i = 0, cp = 0; i < s.length(); i += Character.charCount(cp)) {
-        int state = a.createState();
-        cp = s.codePointAt(i);
-        for (int alt : toCaseInsensitiveChar(cp)) {
-          a.addTransition(lastState, state, alt);
-        }
-        lastState = state;
+  /**
+   * Returns a new (deterministic) automaton that accepts the single given string and the
+   * case-insensitive equivalents.
+   */
+  public static Automaton makeCaseInsensitiveString(String s) {
+    Automaton a = new Automaton();
+    int lastState = a.createState();
+    for (int i = 0, cp = 0; i < s.length(); i += Character.charCount(cp)) {
+      int state = a.createState();
+      cp = s.codePointAt(i);
+      for (int alt : toCaseInsensitiveChar(cp)) {
+        a.addTransition(lastState, state, alt);
       }
-
-      a.setAccept(lastState, true);
-      a.finishState();
-
-      assert a.isDeterministic();
-      assert Operations.hasDeadStates(a) == false;
-
-      return a;
-    } else {
-      return makeString(s);
+      lastState = state;
     }
+
+    a.setAccept(lastState, true);
+    a.finishState();
+
+    assert a.isDeterministic();
+    assert Operations.hasDeadStates(a) == false;
+
+    return a;
   }
 
   /** Returns a new (deterministic) automaton that accepts the single given binary term. */

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
+import org.apache.lucene.internal.hppc.IntArrayList;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
 import org.apache.lucene.util.StringHelper;
@@ -115,6 +116,16 @@ public final class Automata {
   /** Returns a new (deterministic) automaton that accepts a single codepoint of the given value. */
   public static Automaton makeChar(int c) {
     return makeCharRange(c, c);
+  }
+
+  /** Returns a new (deterministic) automaton that accepts potentially multiple codepoints of the
+   *  given value. */
+  public static Automaton makeChar(int c, boolean caseInsensitive) {
+    if (caseInsensitive) {
+      return makeCharSet(toCaseInsensitiveChar(c));
+    } else {
+      return makeChar(c);
+    }
   }
 
   /** Appends the specified character to the specified state, returning a new state. */
@@ -557,6 +568,32 @@ public final class Automata {
     return a;
   }
 
+  /** Returns a new (deterministic) automaton that accepts the single given string. */
+  public static Automaton makeString(String s, boolean caseInsensitive) {
+    if(caseInsensitive) {
+      Automaton a = new Automaton();
+      int lastState = a.createState();
+      for (int i = 0, cp = 0; i < s.length(); i += Character.charCount(cp)) {
+        int state = a.createState();
+        cp = s.codePointAt(i);
+        for(int alt : toCaseInsensitiveChar(cp)) {
+          a.addTransition(lastState, state, alt);
+        }
+        lastState = state;
+      }
+
+      a.setAccept(lastState, true);
+      a.finishState();
+
+      assert a.isDeterministic();
+      assert Operations.hasDeadStates(a) == false;
+
+      return a;
+    } else {
+      return makeString(s);
+    }
+  }
+
   /** Returns a new (deterministic) automaton that accepts the single given binary term. */
   public static Automaton makeBinary(BytesRef term) {
     Automaton a = new Automaton();
@@ -652,5 +689,24 @@ public final class Automata {
    */
   public static Automaton makeBinaryStringUnion(BytesRefIterator utf8Strings) throws IOException {
     return StringsToAutomaton.build(utf8Strings, true);
+  }
+
+  /**
+   * This function handles uses the Unicode spec for generating case-insensitive alternates.
+   *
+   * <p>See the {@link RegExp#CASE_INSENSITIVE} flag for details on case folding within the Unicode spec.
+   *
+   * @param codepoint the Character code point to encode as an Automaton
+   * @return the original codepoint and the set of alternates
+   */
+  private static int[] toCaseInsensitiveChar(int codepoint) {
+    IntArrayList list = new IntArrayList();
+    CaseFolding.expand(
+        codepoint,
+        (int variant) -> {
+          list.add(variant);
+        });
+    list.sort();
+    return list.toArray();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
@@ -119,8 +119,8 @@ public final class Automata {
   }
 
   /**
-   * Returns a new (deterministic) automaton that accepts potentially multiple codepoints of the
-   * given value that are case-insensitive equivalents.
+   * Returns a new (deterministic and minimal) automaton that accepts potentially multiple
+   * codepoints of the given value that are case-insensitive equivalents.
    */
   public static Automaton makeCaseInsensitiveChar(int c) {
     return makeCharSet(toCaseInsensitiveChar(c));
@@ -567,8 +567,8 @@ public final class Automata {
   }
 
   /**
-   * Returns a new (deterministic) automaton that accepts the single given string and the
-   * case-insensitive equivalents.
+   * Returns a new (deterministic and minimal) automaton that accepts the single given string and
+   * the case-insensitive equivalents.
    */
   public static Automaton makeCaseInsensitiveString(String s) {
     Automaton a = new Automaton();

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -706,7 +706,7 @@ public class RegExp {
         break;
       case REGEXP_CHAR:
         if (check(ASCII_CASE_INSENSITIVE | CASE_INSENSITIVE)) {
-          a = Automata.makeChar(c, true);
+          a = Automata.makeCaseInsensitiveChar(c);
         } else {
           a = Automata.makeChar(c);
         }
@@ -725,7 +725,7 @@ public class RegExp {
         break;
       case REGEXP_STRING:
         if (check(ASCII_CASE_INSENSITIVE | CASE_INSENSITIVE)) {
-          a = Automata.makeString(s, true);
+          a = Automata.makeCaseInsensitiveString(s);
         } else {
           a = Automata.makeString(s);
         }

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -32,7 +32,6 @@ package org.apache.lucene.util.automaton;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -707,7 +707,7 @@ public class RegExp {
         break;
       case REGEXP_CHAR:
         if (check(ASCII_CASE_INSENSITIVE | CASE_INSENSITIVE)) {
-          a = Automata.makeCharSet(toCaseInsensitiveChar(c));
+          a = Automata.makeChar(c, true);
         } else {
           a = Automata.makeChar(c);
         }
@@ -726,7 +726,7 @@ public class RegExp {
         break;
       case REGEXP_STRING:
         if (check(ASCII_CASE_INSENSITIVE | CASE_INSENSITIVE)) {
-          a = toCaseInsensitiveString();
+          a = Automata.makeString(s, true);
         } else {
           a = Automata.makeString(s);
         }
@@ -814,17 +814,6 @@ public class RegExp {
       rangeStarts.add(transition.min);
       rangeEnds.add(transition.max);
     }
-  }
-
-  private Automaton toCaseInsensitiveString() {
-    List<Automaton> list = new ArrayList<>();
-
-    Iterator<Integer> iter = s.codePoints().iterator();
-    while (iter.hasNext()) {
-      int[] points = toCaseInsensitiveChar(iter.next());
-      list.add(Automata.makeCharSet(points));
-    }
-    return Operations.concatenate(list);
   }
 
   private void findLeaves(

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
@@ -1730,55 +1730,45 @@ public class TestAutomaton extends LuceneTestCase {
   }
 
   public void testMakeCharCaseInsensitive() {
-    Automaton a = Automata.makeChar('a', true);
+    Automaton a = Automata.makeCaseInsensitiveChar('a');
     assertTrue(Operations.run(a, "a"));
     assertTrue(Operations.run(a, "A"));
     assertFalse(Operations.run(a, "b"));
 
-    a = Automata.makeChar('A', true);
+    a = Automata.makeCaseInsensitiveChar('A');
     assertTrue(Operations.run(a, "a"));
     assertTrue(Operations.run(a, "A"));
     assertFalse(Operations.run(a, "b"));
 
-    a = Automata.makeChar('a', false);
-    Automaton b = Automata.makeChar('a');
-    assertTrue(AutomatonTestUtil.sameLanguage(a, b));
-    assertTrue(Operations.run(a, "a"));
-    assertFalse(Operations.run(a, "A"));
-
-    a = Automata.makeChar('Σ', true);
+    a = Automata.makeCaseInsensitiveChar('Σ');
     assertTrue(Operations.run(a, "Σ"));
     assertTrue(Operations.run(a, "σ"));
     assertTrue(Operations.run(a, "ς"));
 
     // German sharp S: 'ß' (U+00DF) and 'ẞ' (U+1E9E)
-    a = Automata.makeChar(223, true);
+    a = Automata.makeCaseInsensitiveChar(223);
     assertTrue(Operations.run(a, Character.toString(223)));
     assertTrue(Operations.run(a, Character.toString(7838)));
 
-    assertTrue(a.isDeterministic());
-    assertFalse(Operations.hasDeadStates(a));
+    AutomatonTestUtil.assertMinimalDFA(a);
+    AutomatonTestUtil.assertNoDetachedStates(a);
+    assertTrue(AutomatonTestUtil.isFinite(a));
   }
 
   public void testMakeStringCaseInsensitiveSimple() {
-    Automaton a = Automata.makeString("abc", true);
+    Automaton a = Automata.makeCaseInsensitiveString("abc");
     assertTrue(Operations.run(a, "abc"));
     assertTrue(Operations.run(a, "AbC"));
     assertFalse(Operations.run(a, "ab"));
     assertFalse(Operations.run(a, "xyz"));
 
-    a = Automata.makeString("abc", false);
-    Automaton b = Automata.makeString("abc");
-    assertTrue(AutomatonTestUtil.sameLanguage(a, b));
-    assertTrue(Operations.run(a, "abc"));
-    assertFalse(Operations.run(a, "Abc"));
-
-    a = Automata.makeString("Σίγμα", true);
+    a = Automata.makeCaseInsensitiveString("Σίγμα");
     assertTrue(Operations.run(a, "Σίγμα"));
     assertTrue(Operations.run(a, "σίγμα"));
     assertTrue(Operations.run(a, "ςίγμα"));
 
-    assertTrue(a.isDeterministic());
-    assertFalse(Operations.hasDeadStates(a));
+    AutomatonTestUtil.assertMinimalDFA(a);
+    AutomatonTestUtil.assertNoDetachedStates(a);
+    assertTrue(AutomatonTestUtil.isFinite(a));
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
@@ -1728,4 +1728,57 @@ public class TestAutomaton extends LuceneTestCase {
     AutomatonTestUtil.assertMinimalDFA(actual);
     assertTrue(AutomatonTestUtil.sameLanguage(expected, actual));
   }
+
+  public void testMakeCharCaseInsensitive() {
+    Automaton a = Automata.makeChar('a', true);
+    assertTrue(Operations.run(a, "a"));
+    assertTrue(Operations.run(a, "A"));
+    assertFalse(Operations.run(a, "b"));
+
+    a = Automata.makeChar('A', true);
+    assertTrue(Operations.run(a, "a"));
+    assertTrue(Operations.run(a, "A"));
+    assertFalse(Operations.run(a, "b"));
+
+    a = Automata.makeChar('a', false);
+    Automaton b = Automata.makeChar('a');
+    assertTrue(AutomatonTestUtil.sameLanguage(a, b));
+    assertTrue(Operations.run(a, "a"));
+    assertFalse(Operations.run(a, "A"));
+
+    a = Automata.makeChar('Σ', true);
+    assertTrue(Operations.run(a, "Σ"));
+    assertTrue(Operations.run(a, "σ"));
+    assertTrue(Operations.run(a, "ς"));
+
+    // German sharp S: 'ß' (U+00DF) and 'ẞ' (U+1E9E)
+    a = Automata.makeChar(223, true);
+    assertTrue(Operations.run(a, Character.toString(223)));
+    assertTrue(Operations.run(a, Character.toString(7838)));
+
+    assertTrue(a.isDeterministic());
+    assertFalse(Operations.hasDeadStates(a));
+  }
+
+  public void testMakeStringCaseInsensitiveSimple() {
+    Automaton a = Automata.makeString("abc", true);
+    assertTrue(Operations.run(a, "abc"));
+    assertTrue(Operations.run(a, "AbC"));
+    assertFalse(Operations.run(a, "ab"));
+    assertFalse(Operations.run(a, "xyz"));
+
+    a = Automata.makeString("abc", false);
+    Automaton b = Automata.makeString("abc");
+    assertTrue(AutomatonTestUtil.sameLanguage(a, b));
+    assertTrue(Operations.run(a, "abc"));
+    assertFalse(Operations.run(a, "Abc"));
+
+    a = Automata.makeString("Σίγμα", true);
+    assertTrue(Operations.run(a, "Σίγμα"));
+    assertTrue(Operations.run(a, "σίγμα"));
+    assertTrue(Operations.run(a, "ςίγμα"));
+
+    assertTrue(a.isDeterministic());
+    assertFalse(Operations.hasDeadStates(a));
+  }
 }


### PR DESCRIPTION
Expands Automata to allow case insensitive `makeChar` and `makeString` this is useful for consistency across RegExp, WildcardQuery, TermQuery, and PrefixQuery for case folding where it may make sense to, for instance, subsequently allow case insensitive wild card matching.

I thought about adding a case insensitive variants for other functions in this class but didn't think it made sense yet; feedback on this is welcome.  My thinking is extending additional functions such as `makeCharSet` and `makeCharClass` in Automata with a case insensitive flag would be beneficial in optimization so could be added subsequently.

