### PR TITLE
Deprecate Operations.minus() and move to test utilities

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,7 +7,11 @@ http://s.apache.org/luceneversions
 
 API Changes
 ---------------------
-* GITHUB#XXXXX: Remove deprecated RegExp complement syntax support. The DEPRECATED_COMPLEMENT flag,
+* GITHUB#XXXXX: Deprecate Operations.minus() method. This slow operation has been moved to
+  AutomatonTestUtil.minus() for testing purposes only. The method will be removed in Lucene 12.
+  (Saurabh Singh)
+
+* GITHUB#15750: Remove deprecated RegExp complement syntax support. The DEPRECATED_COMPLEMENT flag,
   REGEXP_DEPRECATED_COMPLEMENT enum value, and makeDeprecatedComplement method have been removed.
   Users should use complement bracket expressions ([^...]) instead. (Saurabh Singh)
 

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
@@ -378,7 +378,10 @@ public final class Operations {
    * @param determinizeWorkLimit maximum effort to spend determinizing the automaton. Set higher to
    *     allow more complex queries and lower to prevent memory exhaustion. {@link
    *     #DEFAULT_DETERMINIZE_WORK_LIMIT} is a good starting default.
+   * @deprecated This operation can be slow and is not recommended for production use. For testing,
+   *     use {@code AutomatonTestUtil.minus()} instead. This method will be removed in Lucene 12.
    */
+  @Deprecated
   public static Automaton minus(Automaton a1, Automaton a2, int determinizeWorkLimit) {
     if (Operations.isEmpty(a1) || a1 == a2) {
       return Automata.makeEmpty();

--- a/lucene/core/src/test/org/apache/lucene/search/TestAutomatonQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestAutomatonQuery.java
@@ -138,7 +138,7 @@ public class TestAutomatonQuery extends LuceneTestCase {
     assertAutomatonHits(0, Operations.intersection(Automata.makeChar('a'), Automata.makeChar('b')));
     assertAutomatonHits(
         1,
-        Operations.minus(
+        AutomatonTestUtil.minus(
             Automata.makeCharRange('a', 'b'),
             Automata.makeChar('a'),
             DEFAULT_DETERMINIZE_WORK_LIMIT));

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
@@ -548,7 +548,7 @@ public class TestAutomaton extends LuceneTestCase {
     AutomatonTestUtil.assertCleanNFA(a); // this is why we have makeStringUnion()
     assertMatches(a, "foobar", "beebar", "boobar");
 
-    Automaton a4 = Operations.minus(a, a2, DEFAULT_DETERMINIZE_WORK_LIMIT);
+    Automaton a4 = AutomatonTestUtil.minus(a, a2, DEFAULT_DETERMINIZE_WORK_LIMIT);
     AutomatonTestUtil.assertCleanDFA(a4);
 
     assertTrue(Operations.run(a4, "foobar"));
@@ -556,7 +556,7 @@ public class TestAutomaton extends LuceneTestCase {
     assertTrue(Operations.run(a4, "beebar"));
     assertMatches(a4, "foobar", "beebar");
 
-    a4 = Operations.minus(a4, a1, DEFAULT_DETERMINIZE_WORK_LIMIT);
+    a4 = AutomatonTestUtil.minus(a4, a1, DEFAULT_DETERMINIZE_WORK_LIMIT);
     AutomatonTestUtil.assertCleanDFA(a4);
 
     assertFalse(Operations.run(a4, "foobar"));
@@ -564,7 +564,7 @@ public class TestAutomaton extends LuceneTestCase {
     assertTrue(Operations.run(a4, "beebar"));
     assertMatches(a4, "beebar");
 
-    a4 = Operations.minus(a4, a3, DEFAULT_DETERMINIZE_WORK_LIMIT);
+    a4 = AutomatonTestUtil.minus(a4, a3, DEFAULT_DETERMINIZE_WORK_LIMIT);
     AutomatonTestUtil.assertCleanDFA(a4);
 
     assertFalse(Operations.run(a4, "foobar"));
@@ -976,7 +976,7 @@ public class TestAutomaton extends LuceneTestCase {
                 assertTrue(removed);
               }
               Automaton a2 = unionTerms(toRemove);
-              a = Operations.minus(a, a2, Integer.MAX_VALUE);
+              a = AutomatonTestUtil.minus(a, a2, Integer.MAX_VALUE);
             }
           }
           break;
@@ -1016,7 +1016,7 @@ public class TestAutomaton extends LuceneTestCase {
               }
             }
             Automaton a2 = randomNoOp(Operations.union(as));
-            a = Operations.minus(a, a2, DEFAULT_DETERMINIZE_WORK_LIMIT);
+            a = AutomatonTestUtil.minus(a, a2, DEFAULT_DETERMINIZE_WORK_LIMIT);
           }
           break;
 
@@ -1131,7 +1131,9 @@ public class TestAutomaton extends LuceneTestCase {
           if (VERBOSE) {
             System.out.println("  op=remove the empty string");
           }
-          a = Operations.minus(a, Automata.makeEmptyString(), DEFAULT_DETERMINIZE_WORK_LIMIT);
+          a =
+              AutomatonTestUtil.minus(
+                  a, Automata.makeEmptyString(), DEFAULT_DETERMINIZE_WORK_LIMIT);
           terms.remove(newBytesRef());
           break;
 

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestDeterminism.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestDeterminism.java
@@ -71,7 +71,7 @@ public class TestDeterminism extends LuceneTestCase {
     assertTrue(AutomatonTestUtil.sameLanguage(a, equivalent));
 
     // a minus a = empty
-    Automaton empty = Operations.minus(a, a, DEFAULT_DETERMINIZE_WORK_LIMIT);
+    Automaton empty = AutomatonTestUtil.minus(a, a, DEFAULT_DETERMINIZE_WORK_LIMIT);
     assertTrue(Operations.isEmpty(empty));
 
     // as long as don't accept the empty string
@@ -81,7 +81,8 @@ public class TestDeterminism extends LuceneTestCase {
       Automaton optional = Operations.optional(a);
       // System.out.println("optional " + optional);
       equivalent =
-          Operations.minus(optional, Automata.makeEmptyString(), DEFAULT_DETERMINIZE_WORK_LIMIT);
+          AutomatonTestUtil.minus(
+              optional, Automata.makeEmptyString(), DEFAULT_DETERMINIZE_WORK_LIMIT);
       // System.out.println("equiv " + equivalent);
       assertTrue(AutomatonTestUtil.sameLanguage(a, equivalent));
     }

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExpParsing.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExpParsing.java
@@ -273,7 +273,7 @@ public class TestRegExpParsing extends LuceneTestCase {
     AutomatonTestUtil.assertMinimalDFA(actual);
 
     Automaton expected =
-        Operations.minus(
+        AutomatonTestUtil.minus(
             Automata.makeAnyChar(),
             Automata.makeCharRange('0', '9'),
             Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
@@ -310,16 +310,16 @@ public class TestRegExpParsing extends LuceneTestCase {
 
     Automaton expected = Automata.makeAnyChar();
     expected =
-        Operations.minus(
+        AutomatonTestUtil.minus(
             expected, Automata.makeChar(' '), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
     expected =
-        Operations.minus(
+        AutomatonTestUtil.minus(
             expected, Automata.makeChar('\n'), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
     expected =
-        Operations.minus(
+        AutomatonTestUtil.minus(
             expected, Automata.makeChar('\r'), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
     expected =
-        Operations.minus(
+        AutomatonTestUtil.minus(
             expected, Automata.makeChar('\t'), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
     assertSameLanguage(expected, actual);
   }
@@ -355,16 +355,16 @@ public class TestRegExpParsing extends LuceneTestCase {
 
     Automaton expected = Automata.makeAnyChar();
     expected =
-        Operations.minus(
+        AutomatonTestUtil.minus(
             expected, Automata.makeCharRange('a', 'z'), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
     expected =
-        Operations.minus(
+        AutomatonTestUtil.minus(
             expected, Automata.makeCharRange('A', 'Z'), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
     expected =
-        Operations.minus(
+        AutomatonTestUtil.minus(
             expected, Automata.makeCharRange('0', '9'), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
     expected =
-        Operations.minus(
+        AutomatonTestUtil.minus(
             expected, Automata.makeChar('_'), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
     assertSameLanguage(expected, actual);
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/automaton/AutomatonTestUtil.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/automaton/AutomatonTestUtil.java
@@ -52,6 +52,28 @@ public class AutomatonTestUtil extends Assert {
   /** Maximum level of recursion allowed in recursive operations. */
   public static final int MAX_RECURSION_LEVEL = 1000;
 
+  /**
+   * Returns an automaton that accepts the difference of the languages of the given automata.
+   *
+   * <p>This is a test utility method that wraps {@link Operations#intersection} and {@link
+   * Operations#complement}. It is provided here for testing purposes as the minus operation can be
+   * slow and is not recommended for production use.
+   *
+   * @param a1 the first automaton
+   * @param a2 the second automaton
+   * @param determinizeWorkLimit maximum effort to spend determinizing the complement
+   * @return automaton accepting the difference
+   */
+  public static Automaton minus(Automaton a1, Automaton a2, int determinizeWorkLimit) {
+    if (Operations.isEmpty(a1) || a1 == a2) {
+      return org.apache.lucene.util.automaton.Automata.makeEmpty();
+    }
+    if (Operations.isEmpty(a2)) {
+      return a1;
+    }
+    return Operations.intersection(a1, Operations.complement(a2, determinizeWorkLimit));
+  }
+
   /** Returns random string, including full unicode range. */
   public static String randomRegexp(Random r) {
     while (true) {
@@ -288,7 +310,7 @@ public class AutomatonTestUtil extends Assert {
       case 2:
         return Operations.intersection(a1, a2);
       default:
-        return Operations.minus(a1, a2, DEFAULT_MAX_DETERMINIZED_STATES);
+        return minus(a1, a2, DEFAULT_MAX_DETERMINIZED_STATES);
     }
   }
 


### PR DESCRIPTION
## Description
Deprecates `Operations.minus()` and moves it to `AutomatonTestUtil` for testing purposes only, following the recommendation from #15750.

## Changes
- Deprecated `Operations.minus()` (marked for removal in Lucene 12)
- Added `AutomatonTestUtil.minus()` for testing
- Updated all test usages (5 files):
  - TestRegExpParsing.java
  - TestAutomaton.java
  - TestDeterminism.java
  - TestAutomatonQuery.java
  - AutomatonTestUtil.java itself

## Rationale
The minus operation can be slow and is not recommended for production use. Moving it to test utilities makes this clear and follows the pattern suggested by @rmuir in #15750.

## Testing
- All tests pass
- Code formatted with `./gradlew tidy`