### PR TITLE
Skipper-based numeric pruning should work from the start of a segment

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -203,7 +203,7 @@ New Features
 
 Improvements
 ---------------------
-(No changes)
+* GITHUB#15757: Better skipper-based numeric sort pruning from the start of segments (Alan Woodward)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/test/org/apache/lucene/search/comparators/TestNumericComparator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/comparators/TestNumericComparator.java
@@ -215,6 +215,7 @@ public class TestNumericComparator extends LuceneTestCase {
     comparator1.hitsThresholdReached = true;
     comparator1.bottom = bottom;
     var leafComparator = comparator1.getLeafComparator(leafContext);
+    leafComparator.setScorer(null);
     assertEquals(DocIdSetIterator.NO_MORE_DOCS, leafComparator.competitiveIterator().nextDoc());
   }
 
@@ -229,6 +230,7 @@ public class TestNumericComparator extends LuceneTestCase {
     comparator1.hitsThresholdReached = true;
     comparator1.bottom = bottom;
     var leafComparator = comparator1.getLeafComparator(leafContext);
+    leafComparator.setScorer(null);
     assertEquals(DocIdSetIterator.NO_MORE_DOCS, leafComparator.competitiveIterator().nextDoc());
   }
 
@@ -243,6 +245,7 @@ public class TestNumericComparator extends LuceneTestCase {
     comparator1.hitsThresholdReached = true;
     comparator1.bottom = bottom;
     var leafComparator = comparator1.getLeafComparator(leafContext);
+    leafComparator.setScorer(null);
     assertEquals(DocIdSetIterator.NO_MORE_DOCS, leafComparator.competitiveIterator().nextDoc());
   }
 
@@ -257,6 +260,7 @@ public class TestNumericComparator extends LuceneTestCase {
     comparator1.hitsThresholdReached = true;
     comparator1.bottom = bottom;
     var leafComparator = comparator1.getLeafComparator(leafContext);
+    leafComparator.setScorer(null);
     assertEquals(DocIdSetIterator.NO_MORE_DOCS, leafComparator.competitiveIterator().nextDoc());
   }
 }


### PR DESCRIPTION
Currently, the postInitializeCompetitiveIterator method called on a new segment can only skip whole segments. This commit removes the method and instead calls updateCompetitiveIterator() from the builder's setScorer() implementation, by analogy with the points-based version, which allows selective block-based pruning right from the start of a segment.

