### PR TITLE
Unified API for retrieving global min/max values of a numeric field

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -33,7 +33,12 @@ import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
+<<<<<<< HEAD
 import org.apache.lucene.search.NumericDocValuesRangeQuery;
+=======
+import org.apache.lucene.search.NumericFieldStats;
+import org.apache.lucene.search.NumericFieldStats.MinMax;
+>>>>>>> f5404570ff (feat: add NumericFieldStats for unified global min/max retrieval)
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
@@ -93,16 +98,17 @@ final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery 
     if (lowerValue > upperValue) {
       return MatchNoDocsQuery.INSTANCE;
     }
-    long globalMin = DocValuesSkipper.globalMinValue(indexSearcher.getIndexReader(), field);
-    long globalMax = DocValuesSkipper.globalMaxValue(indexSearcher.getIndexReader(), field);
-    if (lowerValue > globalMax || upperValue < globalMin) {
-      return MatchNoDocsQuery.INSTANCE;
-    }
-    if (lowerValue <= globalMin
-        && upperValue >= globalMax
-        && DocValuesSkipper.globalDocCount(indexSearcher.getIndexReader(), field)
-            == indexSearcher.getIndexReader().maxDoc()) {
-      return MatchAllDocsQuery.INSTANCE;
+    final MinMax minMax = NumericFieldStats.globalMinMax(indexSearcher, field);
+    if (minMax != null) {
+      if (lowerValue > minMax.max() || upperValue < minMax.min()) {
+        return MatchNoDocsQuery.INSTANCE;
+      }
+      if (lowerValue <= minMax.min()
+          && upperValue >= minMax.max()
+          && NumericFieldStats.globalDocCount(indexSearcher, field)
+              == indexSearcher.getIndexReader().maxDoc()) {
+        return MatchAllDocsQuery.INSTANCE;
+      }
     }
     return super.rewrite(indexSearcher);
   }

--- a/lucene/core/src/java/org/apache/lucene/search/NumericFieldStats.java
+++ b/lucene/core/src/java/org/apache/lucene/search/NumericFieldStats.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * Utility class for retrieving global numeric field statistics (min/max values, document counts)
+ * across all segments of an index. This class abstracts over {@link PointValues} and {@link
+ * DocValuesSkipper}, probing {@link PointValues} first and falling back to {@link
+ * DocValuesSkipper}.
+ *
+ * @lucene.experimental
+ */
+public final class NumericFieldStats {
+
+  private NumericFieldStats() {}
+
+  /**
+   * Holds the global minimum and maximum values for a numeric field.
+   *
+   * @param min the global minimum value
+   * @param max the global maximum value
+   */
+  public record MinMax(long min, long max) {}
+
+  /**
+   * Returns the global minimum and maximum values for the given numeric field across all segments.
+   * Probes {@link PointValues} first; if unavailable, falls back to {@link DocValuesSkipper}.
+   *
+   * @param searcher the {@link IndexSearcher} to query
+   * @param field the name of the numeric field
+   * @return a {@link MinMax} containing the global min and max, or {@code null} if neither {@link
+   *     PointValues} nor {@link DocValuesSkipper} are available for the field
+   * @throws IOException if an I/O error occurs
+   */
+  public static MinMax globalMinMax(IndexSearcher searcher, String field) throws IOException {
+    final MinMax result = globalMinMaxFromPoints(searcher.getIndexReader(), field);
+    if (result != null) {
+      return result;
+    }
+    return globalMinMaxFromSkipper(searcher, field);
+  }
+
+  /**
+   * Returns the global document count for the given numeric field across all segments. Probes
+   * {@link PointValues} first; if unavailable, falls back to {@link DocValuesSkipper}.
+   *
+   * @param searcher the {@link IndexSearcher} to query
+   * @param field the name of the numeric field
+   * @return the total number of documents containing the field, or {@code 0} if neither {@link
+   *     PointValues} nor {@link DocValuesSkipper} are available
+   * @throws IOException if an I/O error occurs
+   */
+  public static int globalDocCount(IndexSearcher searcher, String field) throws IOException {
+    final int pointDocCount = PointValues.getDocCount(searcher.getIndexReader(), field);
+    if (pointDocCount > 0) {
+      return pointDocCount;
+    }
+    return DocValuesSkipper.globalDocCount(searcher, field);
+  }
+
+  private static MinMax globalMinMaxFromPoints(IndexReader reader, String field)
+      throws IOException {
+    final byte[] minPacked = PointValues.getMinPackedValue(reader, field);
+    final byte[] maxPacked = PointValues.getMaxPackedValue(reader, field);
+    if (minPacked == null || maxPacked == null) {
+      return null;
+    }
+    return new MinMax(decodeLong(minPacked), decodeLong(maxPacked));
+  }
+
+  private static MinMax globalMinMaxFromSkipper(IndexSearcher searcher, String field)
+      throws IOException {
+    Long min = null;
+    Long max = null;
+    for (LeafReaderContext ctx : searcher.getLeafContexts()) {
+      final LeafReader reader = ctx.reader();
+      if (reader.getFieldInfos().fieldInfo(field) == null) {
+        continue;
+      }
+      final DocValuesSkipper skipper = reader.getDocValuesSkipper(field);
+      if (skipper == null) {
+        return null;
+      }
+      if (min == null) {
+        min = skipper.minValue();
+        max = skipper.maxValue();
+      } else {
+        min = Math.min(min, skipper.minValue());
+        max = Math.max(max, skipper.maxValue());
+      }
+    }
+    if (min == null || max == null) {
+      return null;
+    }
+    return new MinMax(min, max);
+  }
+
+  /**
+   * Decodes a packed {@code byte[]} point value into a {@code long}. {@link PointValues} stores
+   * numeric values as big-endian byte arrays with the sign bit flipped for sortable ordering.
+   * {@code IntField} produces 4-byte arrays and {@code LongField} produces 8-byte arrays, so we
+   * dispatch on length to call the appropriate {@link NumericUtils} decoder. The {@code int} case
+   * widens to {@code long} via standard Java sign extension, which preserves the original value.
+   *
+   * <p>We return {@code long} unconditionally because the query layer already works with {@code
+   * long} bounds (e.g. {@code SortedNumericDocValuesRangeQuery} stores its range as {@code long}
+   * even for {@code IntField} queries). Callers that need the original {@code int} value can safely
+   * narrow with {@code Math.toIntExact()}, which will never throw for values originating from an
+   * {@code IntField}.
+   */
+  private static long decodeLong(byte[] packed) {
+    return switch (packed.length) {
+      case Integer.BYTES -> NumericUtils.sortableBytesToInt(packed, 0);
+      case Long.BYTES -> NumericUtils.sortableBytesToLong(packed, 0);
+      default ->
+          throw new IllegalArgumentException(
+              "Unsupported packed value length: "
+                  + packed.length
+                  + " (expected "
+                  + Long.BYTES
+                  + " or "
+                  + Integer.BYTES
+                  + ")");
+    };
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/NumericFieldStats.java
+++ b/lucene/core/src/java/org/apache/lucene/search/NumericFieldStats.java
@@ -103,7 +103,7 @@ public final class NumericFieldStats {
       if (skipper == null) {
         return null;
       }
-      if (min == null) {
+      if (min == null && max == null) {
         min = skipper.minValue();
         max = skipper.maxValue();
       } else {

--- a/lucene/core/src/test/org/apache/lucene/search/TestNumericFieldStats.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestNumericFieldStats.java
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+import java.io.IOException;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.NumericFieldStats.MinMax;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestNumericFieldStats extends LuceneTestCase {
+
+  public void testGlobalMinMaxWithLongField() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      for (long value : new long[] {10L, 20L, 30L}) {
+        final Document doc = new Document();
+        doc.add(new LongField("field", value, Field.Store.NO));
+        w.addDocument(doc);
+      }
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        final MinMax minMax = NumericFieldStats.globalMinMax(searcher, "field");
+        assertNotNull(minMax);
+        assertEquals(10L, minMax.min());
+        assertEquals(30L, minMax.max());
+      }
+    }
+  }
+
+  public void testGlobalMinMaxWithIntField() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      for (int value : new int[] {-5, 0, 42}) {
+        final Document doc = new Document();
+        doc.add(new IntField("field", value, Field.Store.NO));
+        w.addDocument(doc);
+      }
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        final MinMax minMax = NumericFieldStats.globalMinMax(searcher, "field");
+        assertNotNull(minMax);
+        assertEquals(-5L, minMax.min());
+        assertEquals(42L, minMax.max());
+      }
+    }
+  }
+
+  public void testGlobalMinMaxFromDocValuesSkipper() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      for (long value : new long[] {100L, 200L, 300L}) {
+        final Document doc = new Document();
+        doc.add(SortedNumericDocValuesField.indexedField("field", value));
+        w.addDocument(doc);
+      }
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        final MinMax minMax = NumericFieldStats.globalMinMax(searcher, "field");
+        assertNotNull(minMax);
+        assertEquals(100L, minMax.min());
+        assertEquals(300L, minMax.max());
+      }
+    }
+  }
+
+  public void testGlobalMinMaxEmptyIndex() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        final MinMax minMax = NumericFieldStats.globalMinMax(searcher, "field");
+        assertNull(minMax);
+        assertEquals(0, NumericFieldStats.globalDocCount(searcher, "field"));
+      }
+    }
+  }
+
+  public void testGlobalMinMaxNonexistentField() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc = new Document();
+      doc.add(new LongField("other_field", 42L, Field.Store.NO));
+      w.addDocument(doc);
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        final MinMax minMax = NumericFieldStats.globalMinMax(searcher, "field");
+        assertNull(minMax);
+        assertEquals(0, NumericFieldStats.globalDocCount(searcher, "field"));
+      }
+    }
+  }
+
+  public void testGlobalMinMaxDocValuesWithoutSkipIndex() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      for (long value : new long[] {10L, 20L, 30L}) {
+        final Document doc = new Document();
+        doc.add(new SortedNumericDocValuesField("field", value));
+        w.addDocument(doc);
+      }
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        final MinMax minMax = NumericFieldStats.globalMinMax(searcher, "field");
+        assertNull(minMax);
+      }
+    }
+  }
+
+  public void testGlobalDocCountWithLongField() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      for (long value : new long[] {10L, 20L, 30L}) {
+        final Document doc = new Document();
+        doc.add(new LongField("field", value, Field.Store.NO));
+        w.addDocument(doc);
+      }
+      w.addDocument(new Document());
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        assertEquals(3, NumericFieldStats.globalDocCount(searcher, "field"));
+      }
+    }
+  }
+
+  public void testGlobalDocCountFromDocValuesSkipper() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      for (long value : new long[] {10L, 20L, 30L}) {
+        final Document doc = new Document();
+        doc.add(SortedNumericDocValuesField.indexedField("field", value));
+        w.addDocument(doc);
+      }
+      w.addDocument(new Document());
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        assertEquals(3, NumericFieldStats.globalDocCount(searcher, "field"));
+      }
+    }
+  }
+
+  public void testGlobalMinMaxWithExtremeLongValues() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc1 = new Document();
+      doc1.add(new LongField("field", Long.MIN_VALUE, Field.Store.NO));
+      w.addDocument(doc1);
+      final Document doc2 = new Document();
+      doc2.add(new LongField("field", Long.MAX_VALUE, Field.Store.NO));
+      w.addDocument(doc2);
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        final MinMax minMax = NumericFieldStats.globalMinMax(searcher, "field");
+        assertNotNull(minMax);
+        assertEquals(Long.MIN_VALUE, minMax.min());
+        assertEquals(Long.MAX_VALUE, minMax.max());
+      }
+    }
+  }
+
+  public void testGlobalMinMaxWithExtremeIntValues() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc1 = new Document();
+      doc1.add(new IntField("field", Integer.MIN_VALUE, Field.Store.NO));
+      w.addDocument(doc1);
+      final Document doc2 = new Document();
+      doc2.add(new IntField("field", Integer.MAX_VALUE, Field.Store.NO));
+      w.addDocument(doc2);
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        final MinMax minMax = NumericFieldStats.globalMinMax(searcher, "field");
+        assertNotNull(minMax);
+        assertEquals(Integer.MIN_VALUE, minMax.min());
+        assertEquals(Integer.MAX_VALUE, minMax.max());
+      }
+    }
+  }
+
+  public void testGlobalMinMaxMultiValuedField() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc1 = new Document();
+      doc1.add(SortedNumericDocValuesField.indexedField("field", 5L));
+      doc1.add(SortedNumericDocValuesField.indexedField("field", 50L));
+      w.addDocument(doc1);
+      final Document doc2 = new Document();
+      doc2.add(SortedNumericDocValuesField.indexedField("field", 25L));
+      w.addDocument(doc2);
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        final MinMax minMax = NumericFieldStats.globalMinMax(searcher, "field");
+        assertNotNull(minMax);
+        assertEquals(5L, minMax.min());
+        assertEquals(50L, minMax.max());
+      }
+    }
+  }
+
+  public void testGlobalMinMaxMultipleSegments() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc1 = new Document();
+      doc1.add(new LongField("field", 100L, Field.Store.NO));
+      w.addDocument(doc1);
+      w.commit();
+
+      final Document doc2 = new Document();
+      doc2.add(new LongField("field", 50L, Field.Store.NO));
+      w.addDocument(doc2);
+      w.commit();
+
+      final Document doc3 = new Document();
+      doc3.add(new LongField("field", 200L, Field.Store.NO));
+      w.addDocument(doc3);
+      w.commit();
+
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        assertTrue(reader.leaves().size() > 1);
+        final IndexSearcher searcher = newSearcher(reader);
+        final MinMax minMax = NumericFieldStats.globalMinMax(searcher, "field");
+        assertNotNull(minMax);
+        assertEquals(50L, minMax.min());
+        assertEquals(200L, minMax.max());
+        assertEquals(3, NumericFieldStats.globalDocCount(searcher, "field"));
+      }
+    }
+  }
+
+  public void testGlobalMinMaxWithSegmentsWithAndWithoutField() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc = new Document();
+      doc.add(new LongField("field", 100L, Field.Store.NO));
+      w.addDocument(doc);
+      w.commit();
+
+      w.addDocument(new Document());
+      w.commit();
+
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        final MinMax minMax = NumericFieldStats.globalMinMax(searcher, "field");
+        assertNotNull(minMax);
+        assertEquals(100L, minMax.min());
+        assertEquals(100L, minMax.max());
+        assertEquals(1, NumericFieldStats.globalDocCount(searcher, "field"));
+      }
+    }
+  }
+
+  public void testRewriteWorksWithPointsButNoSkipIndex() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      for (int i = 0; i < 100; i++) {
+        final Document doc = new Document();
+        doc.add(new LongField("field", 100 + i, Field.Store.NO));
+        w.addDocument(doc);
+      }
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = new IndexSearcher(reader);
+        // Query range [0, 50] is entirely below field range [100, 199]
+        Query query = SortedNumericDocValuesField.newSlowRangeQuery("field", 0, 50);
+        Query rewritten = searcher.rewrite(query);
+        assertThat(rewritten, instanceOf(MatchNoDocsQuery.class));
+
+        // Query range [0, 250] covers entire field range [100, 199]
+        // and all docs have a value
+        query = SortedNumericDocValuesField.newSlowRangeQuery("field", 0, 250);
+        rewritten = searcher.rewrite(query);
+        assertThat(rewritten, instanceOf(MatchAllDocsQuery.class));
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Lucene currently has two independent APIs for retrieving the global min/max of a numeric field:

`PointValues.getMinPackedValue()` returns a `byte[]` or `null` when no data exists.
`DocValuesSkipper.globalMinValue()` returns a `long`, but uses sentinel values (`Long.MIN_VALUE` / `Long.MAX_VALUE`) when no data exists.

Callers have to figure out which data structure is available, call the right API, and deal with two different "no data" conventions. The sentinel approach is particularly problematic because `Long.MIN_VALUE` and `Long.MAX_VALUE` are also legitimate field values, so there is no way for a caller to distinguish "no data" from "the actual min is Long.MIN_VALUE".

This inconsistency might lead to subtle bugs. For example, `SortedNumericDocValuesRangeQuery.rewrite()` was using `DocValuesSkipper` exclusively. When the skip index was absent (it requires opt-in via `DocValuesSkipIndexType.RANGE`), the sentinel values made the rewrite optimization a no-op: the range check `lowerValue > Long.MAX_VALUE` is always false, so the query could never short-circuit to `MatchNoDocsQuery` even when the query range was completely outside the field's actual value range.

## Solution

This PR introduces `NumericFieldStats`, a utility class in `org.apache.lucene.search` that provides a unified API with clean null semantics. It exposes two static methods:

`globalMinMax(IndexSearcher, String)` returns a `MinMax` record containing the global min and max as `long` values, or `null` when the stats cannot be determined.

`globalDocCount(IndexSearcher, String)` returns the total number of documents that have a value for the field, or `0`.

Both methods probe `PointValues` first and fall back to `DocValuesSkipper`. PointValues goes first because it is always available for standard numeric fields (LongField, IntField, etc.), already returns null for "no data" (no sentinel ambiguity), and does not require any opt-in configuration. The DocValuesSkipper fallback covers doc-values-only fields that were indexed with a skip index but without points.

## Why not fix DocValuesSkipper directly?

An alternative would be to change `DocValuesSkipper.globalMinValue()`/`globalMaxValue()` to return `Long` instead of `long`, eliminating the sentinel ambiguity at the source. However, the per-segment `minValue()`/`maxValue()` methods are called on hot scoring paths where boxing to `Long` on every call would add overhead. The static `globalMinValue`/`globalMaxValue` methods are also public API, so changing their return type would break all existing callers. A higher-level utility that abstracts over both data structures avoids these issues while giving callers the clean null semantics they need.

## Packed value decoding

PointValues stores numeric values as big-endian byte arrays with the sign bit flipped for sortable byte ordering. IntField produces 4-byte packed values and LongField produces 8-byte packed values. The internal `decodeLong` method dispatches on the array length to call the appropriate `NumericUtils` decoder (`sortableBytesToInt` for 4 bytes, `sortableBytesToLong` for 8 bytes).

The API always returns `long` rather than exposing `byte[]` or providing separate int/long variants. This matches how the query layer works internally: even IntField queries widen to `long` bounds by the time they reach `SortedNumericDocValuesRangeQuery`. When an int field's packed value is decoded, the resulting `int` widens to `long` via standard Java sign extension, which preserves the original numeric value. Callers that need an `int` back can safely use `Math.toIntExact()`, which will never throw for values that originated from an IntField.

## Migration: SortedNumericDocValuesRangeQuery.rewrite()

The `rewrite()` method previously called `DocValuesSkipper.globalMinValue/globalMaxValue` directly. It now calls `NumericFieldStats.globalMinMax()` instead. This is not just a refactor; it is a behavioral improvement. Before, if a field had PointValues but no DocValuesSkipper, the rewrite optimization was dead code. Now it works for any numeric field that has either data structure available.

## Tests

14 tests covering both data sources (PointValues and DocValuesSkipper paths), edge cases (empty index, nonexistent field, doc values without skip index, segments where some have the field and some do not), boundary values (Long.MIN_VALUE/Long.MAX_VALUE with LongField, Integer.MIN_VALUE/Integer.MAX_VALUE with IntField to verify int-to-long sign extension), multi-valued fields, multi-segment indexes, and doc count from both PointValues and DocValuesSkipper.

There is also an integration test verifying that `SortedNumericDocValuesRangeQuery.rewrite()` now correctly rewrites to MatchNoDocsQuery and MatchAllDocsQuery when only PointValues are available (no skip index). This scenario was missing before this change.

`TestNumericFieldStats` (14 tests):
```
./gradlew -p lucene/core test --tests "org.apache.lucene.search.TestNumericFieldStats"
```

`TestSortedNumericDocValuesRangeQuery` (existing tests, validates no regressions):
```
./gradlew -p lucene/core test --tests "org.apache.lucene.document.TestSortedNumericDocValuesRangeQuery"
```

Closes #15740
