### PR TITLE
Add `NumericFieldStats` for unified numeric field statistics retreival

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -77,6 +77,11 @@ New Features
 Improvements
 ---------------------
 
+* GITHUB#15740: Add NumericFieldStats utility for retrieving global numeric field statistics
+  (min, max, doc count) from index metadata structures. Migrate SortedNumericDocValuesRangeQuery
+  to use this API, fixing the rewrite optimization for fields with PointValues but no skip index.
+  (Salvatore Campagna)
+
 * GITHUB#15682: Use ArrayDeque instead of LinkedList in CompoundWordTokenFilterBase.java. (Renato Haeberli)
 
 * GITHUB#15568: Add markdown support for javadocs and modernize highlighting a bit. (Dawid Weiss)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -199,15 +199,15 @@ API Changes
 
 New Features
 ---------------------
-(No changes)
-
-Improvements
----------------------
 
 * GITHUB#15740: Add NumericFieldStats utility for retrieving global numeric field statistics
   (min, max, doc count) from index metadata structures. Migrate SortedNumericDocValuesRangeQuery
   to use this API, fixing the rewrite optimization for fields with PointValues but no skip index.
   (Salvatore Campagna)
+
+Improvements
+---------------------
+(No changes)
 
 Optimizations
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -77,11 +77,6 @@ New Features
 Improvements
 ---------------------
 
-* GITHUB#15740: Add NumericFieldStats utility for retrieving global numeric field statistics
-  (min, max, doc count) from index metadata structures. Migrate SortedNumericDocValuesRangeQuery
-  to use this API, fixing the rewrite optimization for fields with PointValues but no skip index.
-  (Salvatore Campagna)
-
 * GITHUB#15682: Use ArrayDeque instead of LinkedList in CompoundWordTokenFilterBase.java. (Renato Haeberli)
 
 * GITHUB#15568: Add markdown support for javadocs and modernize highlighting a bit. (Dawid Weiss)
@@ -208,7 +203,11 @@ New Features
 
 Improvements
 ---------------------
-(No changes)
+
+* GITHUB#15740: Add NumericFieldStats utility for retrieving global numeric field statistics
+  (min, max, doc count) from index metadata structures. Migrate SortedNumericDocValuesRangeQuery
+  to use this API, fixing the rewrite optimization for fields with PointValues but no skip index.
+  (Salvatore Campagna)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -34,6 +34,8 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.NumericDocValuesRangeQuery;
+import org.apache.lucene.search.NumericFieldStats;
+import org.apache.lucene.search.NumericFieldStats.Stats;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
@@ -93,16 +95,17 @@ final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery 
     if (lowerValue > upperValue) {
       return MatchNoDocsQuery.INSTANCE;
     }
-    long globalMin = DocValuesSkipper.globalMinValue(indexSearcher.getIndexReader(), field);
-    long globalMax = DocValuesSkipper.globalMaxValue(indexSearcher.getIndexReader(), field);
-    if (lowerValue > globalMax || upperValue < globalMin) {
-      return MatchNoDocsQuery.INSTANCE;
-    }
-    if (lowerValue <= globalMin
-        && upperValue >= globalMax
-        && DocValuesSkipper.globalDocCount(indexSearcher.getIndexReader(), field)
-            == indexSearcher.getIndexReader().maxDoc()) {
-      return MatchAllDocsQuery.INSTANCE;
+    final Stats stats =
+        NumericFieldStats.getStats(indexSearcher.getIndexReader(), field);
+    if (stats != null) {
+      if (lowerValue > stats.max() || upperValue < stats.min()) {
+        return MatchNoDocsQuery.INSTANCE;
+      }
+      if (lowerValue <= stats.min()
+          && upperValue >= stats.max()
+          && stats.docCount() == indexSearcher.getIndexReader().maxDoc()) {
+        return MatchAllDocsQuery.INSTANCE;
+      }
     }
     return super.rewrite(indexSearcher);
   }

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -95,8 +95,7 @@ final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery 
     if (lowerValue > upperValue) {
       return MatchNoDocsQuery.INSTANCE;
     }
-    final Stats stats =
-        NumericFieldStats.getStats(indexSearcher.getIndexReader(), field);
+    final Stats stats = NumericFieldStats.getStats(indexSearcher.getIndexReader(), field);
     if (stats != null) {
       if (lowerValue > stats.max() || upperValue < stats.min()) {
         return MatchNoDocsQuery.INSTANCE;

--- a/lucene/core/src/java/org/apache/lucene/search/NumericFieldStats.java
+++ b/lucene/core/src/java/org/apache/lucene/search/NumericFieldStats.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * Utility class for retrieving global numeric field statistics from index metadata structures,
+ * without accessing individual documents. It probes {@link PointValues} first and falls back to
+ * {@link DocValuesSkipper}. Returns {@code null} when neither structure is available for the field.
+ *
+ * @lucene.experimental
+ */
+public final class NumericFieldStats {
+
+  private NumericFieldStats() {}
+
+  /**
+   * Holds the global statistics for a numeric field.
+   *
+   * @param min the global minimum value
+   * @param max the global maximum value
+   * @param docCount the total number of documents containing the field
+   */
+  public record Stats(long min, long max, int docCount) {}
+
+  /**
+   * Returns the global statistics for the given numeric field across all segments. Probes {@link
+   * PointValues} first; if unavailable, falls back to {@link DocValuesSkipper}.
+   *
+   * @param reader the {@link IndexReader} to query
+   * @param field the name of the numeric field
+   * @return a {@link Stats} containing the global min, max, and doc count, or {@code null} if
+   *     neither {@link PointValues} nor {@link DocValuesSkipper} are available for the field
+   * @throws IOException if an I/O error occurs
+   */
+  public static Stats getStats(IndexReader reader, String field) throws IOException {
+    final Stats result = getStatsFromPoints(reader, field);
+    if (result != null) {
+      return result;
+    }
+    return getStatsFromSkipper(reader, field);
+  }
+
+  private static Stats getStatsFromPoints(IndexReader reader, String field)
+      throws IOException {
+    final byte[] minPacked = PointValues.getMinPackedValue(reader, field);
+    final byte[] maxPacked = PointValues.getMaxPackedValue(reader, field);
+    if (minPacked == null || maxPacked == null) {
+      return null;
+    }
+    final int docCount = PointValues.getDocCount(reader, field);
+    return new Stats(decodeLong(minPacked), decodeLong(maxPacked), docCount);
+  }
+
+  private static Stats getStatsFromSkipper(IndexReader reader, String field)
+      throws IOException {
+    Long min = null;
+    Long max = null;
+    int docCount = 0;
+    for (LeafReaderContext ctx : reader.leaves()) {
+      final LeafReader leafReader = ctx.reader();
+      if (leafReader.getFieldInfos().fieldInfo(field) == null) {
+        continue;
+      }
+      final DocValuesSkipper skipper = leafReader.getDocValuesSkipper(field);
+      if (skipper == null) {
+        return null;
+      }
+      if (min == null && max == null) {
+        min = skipper.minValue();
+        max = skipper.maxValue();
+      } else {
+        min = Math.min(min, skipper.minValue());
+        max = Math.max(max, skipper.maxValue());
+      }
+      docCount += skipper.docCount();
+    }
+    if (min == null || max == null) {
+      return null;
+    }
+    return new Stats(min, max, docCount);
+  }
+
+  /**
+   * Decodes a packed {@code byte[]} point value into a {@code long}. {@link PointValues} stores
+   * numeric values as big-endian byte arrays with the sign bit flipped for sortable ordering.
+   * {@code IntField} produces 4-byte arrays and {@code LongField} produces 8-byte arrays, so we
+   * dispatch on length to call the appropriate {@link NumericUtils} decoder. The {@code int} case
+   * widens to {@code long} via standard Java sign extension, which preserves the original value.
+   *
+   * <p>We return {@code long} unconditionally because the query layer already works with {@code
+   * long} bounds (e.g. {@code SortedNumericDocValuesRangeQuery} stores its range as {@code long}
+   * even for {@code IntField} queries). Callers that need the original {@code int} value can safely
+   * narrow with {@code Math.toIntExact()}, which will never throw for values originating from an
+   * {@code IntField}.
+   */
+  private static long decodeLong(byte[] packed) {
+    return switch (packed.length) {
+      case Integer.BYTES -> NumericUtils.sortableBytesToInt(packed, 0);
+      case Long.BYTES -> NumericUtils.sortableBytesToLong(packed, 0);
+      default ->
+          throw new IllegalArgumentException(
+              "Unsupported packed value length: "
+                  + packed.length
+                  + " (expected "
+                  + Long.BYTES
+                  + " or "
+                  + Integer.BYTES
+                  + ")");
+    };
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/NumericFieldStats.java
+++ b/lucene/core/src/java/org/apache/lucene/search/NumericFieldStats.java
@@ -62,8 +62,7 @@ public final class NumericFieldStats {
     return getStatsFromSkipper(reader, field);
   }
 
-  private static Stats getStatsFromPoints(IndexReader reader, String field)
-      throws IOException {
+  private static Stats getStatsFromPoints(IndexReader reader, String field) throws IOException {
     final byte[] minPacked = PointValues.getMinPackedValue(reader, field);
     final byte[] maxPacked = PointValues.getMaxPackedValue(reader, field);
     if (minPacked == null || maxPacked == null) {
@@ -73,8 +72,7 @@ public final class NumericFieldStats {
     return new Stats(decodeLong(minPacked), decodeLong(maxPacked), docCount);
   }
 
-  private static Stats getStatsFromSkipper(IndexReader reader, String field)
-      throws IOException {
+  private static Stats getStatsFromSkipper(IndexReader reader, String field) throws IOException {
     Long min = null;
     Long max = null;
     int docCount = 0;

--- a/lucene/core/src/test/org/apache/lucene/search/TestNumericFieldStats.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestNumericFieldStats.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.NumericFieldStats.Stats;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestNumericFieldStats extends LuceneTestCase {
+
+  public void testGetStatsWithLongField() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      for (long value : new long[] {10L, 20L, 30L}) {
+        final Document doc = new Document();
+        doc.add(new LongField("field", value, Field.Store.NO));
+        w.addDocument(doc);
+      }
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final Stats stats = NumericFieldStats.getStats(reader, "field");
+        assertNotNull(stats);
+        assertEquals(10L, stats.min());
+        assertEquals(30L, stats.max());
+      }
+    }
+  }
+
+  public void testGetStatsWithIntField() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      for (int value : new int[] {-5, 0, 42}) {
+        final Document doc = new Document();
+        doc.add(new IntField("field", value, Field.Store.NO));
+        w.addDocument(doc);
+      }
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final Stats stats = NumericFieldStats.getStats(reader, "field");
+        assertNotNull(stats);
+        assertEquals(-5L, stats.min());
+        assertEquals(42L, stats.max());
+      }
+    }
+  }
+
+  public void testGetStatsFromDocValuesSkipper() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      for (long value : new long[] {100L, 200L, 300L}) {
+        final Document doc = new Document();
+        doc.add(SortedNumericDocValuesField.indexedField("field", value));
+        w.addDocument(doc);
+      }
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final Stats stats = NumericFieldStats.getStats(reader, "field");
+        assertNotNull(stats);
+        assertEquals(100L, stats.min());
+        assertEquals(300L, stats.max());
+      }
+    }
+  }
+
+  public void testGetStatsEmptyIndex() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        assertNull(NumericFieldStats.getStats(reader, "field"));
+      }
+    }
+  }
+
+  public void testGetStatsNonexistentField() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc = new Document();
+      doc.add(new LongField("other_field", 42L, Field.Store.NO));
+      w.addDocument(doc);
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        assertNull(NumericFieldStats.getStats(reader, "field"));
+      }
+    }
+  }
+
+  public void testGetStatsDocValuesWithoutSkipIndex() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      for (long value : new long[] {10L, 20L, 30L}) {
+        final Document doc = new Document();
+        doc.add(new SortedNumericDocValuesField("field", value));
+        w.addDocument(doc);
+      }
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final Stats stats = NumericFieldStats.getStats(reader, "field");
+        assertNull(stats);
+      }
+    }
+  }
+
+  public void testDocCountWithLongField() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      for (long value : new long[] {10L, 20L, 30L}) {
+        final Document doc = new Document();
+        doc.add(new LongField("field", value, Field.Store.NO));
+        w.addDocument(doc);
+      }
+      w.addDocument(new Document());
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        assertEquals(3, NumericFieldStats.getStats(reader, "field").docCount());
+      }
+    }
+  }
+
+  public void testDocCountFromDocValuesSkipper() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      for (long value : new long[] {10L, 20L, 30L}) {
+        final Document doc = new Document();
+        doc.add(SortedNumericDocValuesField.indexedField("field", value));
+        w.addDocument(doc);
+      }
+      w.addDocument(new Document());
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        assertEquals(3, NumericFieldStats.getStats(reader, "field").docCount());
+      }
+    }
+  }
+
+  public void testGetStatsWithExtremeLongValues() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc1 = new Document();
+      doc1.add(new LongField("field", Long.MIN_VALUE, Field.Store.NO));
+      w.addDocument(doc1);
+      final Document doc2 = new Document();
+      doc2.add(new LongField("field", Long.MAX_VALUE, Field.Store.NO));
+      w.addDocument(doc2);
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final Stats stats = NumericFieldStats.getStats(reader, "field");
+        assertNotNull(stats);
+        assertEquals(Long.MIN_VALUE, stats.min());
+        assertEquals(Long.MAX_VALUE, stats.max());
+      }
+    }
+  }
+
+  public void testGetStatsWithExtremeIntValues() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc1 = new Document();
+      doc1.add(new IntField("field", Integer.MIN_VALUE, Field.Store.NO));
+      w.addDocument(doc1);
+      final Document doc2 = new Document();
+      doc2.add(new IntField("field", Integer.MAX_VALUE, Field.Store.NO));
+      w.addDocument(doc2);
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final Stats stats = NumericFieldStats.getStats(reader, "field");
+        assertNotNull(stats);
+        assertEquals(Integer.MIN_VALUE, stats.min());
+        assertEquals(Integer.MAX_VALUE, stats.max());
+      }
+    }
+  }
+
+  public void testGetStatsMultiValuedField() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc1 = new Document();
+      doc1.add(SortedNumericDocValuesField.indexedField("field", 5L));
+      doc1.add(SortedNumericDocValuesField.indexedField("field", 50L));
+      w.addDocument(doc1);
+      final Document doc2 = new Document();
+      doc2.add(SortedNumericDocValuesField.indexedField("field", 25L));
+      w.addDocument(doc2);
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final Stats stats = NumericFieldStats.getStats(reader, "field");
+        assertNotNull(stats);
+        assertEquals(5L, stats.min());
+        assertEquals(50L, stats.max());
+      }
+    }
+  }
+
+  public void testGetStatsMultipleSegments() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc1 = new Document();
+      doc1.add(new LongField("field", 100L, Field.Store.NO));
+      w.addDocument(doc1);
+      w.commit();
+
+      final Document doc2 = new Document();
+      doc2.add(new LongField("field", 50L, Field.Store.NO));
+      w.addDocument(doc2);
+      w.commit();
+
+      final Document doc3 = new Document();
+      doc3.add(new LongField("field", 200L, Field.Store.NO));
+      w.addDocument(doc3);
+      w.commit();
+
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        assertTrue(reader.leaves().size() > 1);
+        final Stats stats = NumericFieldStats.getStats(reader, "field");
+        assertNotNull(stats);
+        assertEquals(50L, stats.min());
+        assertEquals(200L, stats.max());
+        assertEquals(3, stats.docCount());
+      }
+    }
+  }
+
+  public void testGetStatsWithSegmentsWithAndWithoutField() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc = new Document();
+      doc.add(new LongField("field", 100L, Field.Store.NO));
+      w.addDocument(doc);
+      w.commit();
+
+      w.addDocument(new Document());
+      w.commit();
+
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final Stats stats = NumericFieldStats.getStats(reader, "field");
+        assertNotNull(stats);
+        assertEquals(100L, stats.min());
+        assertEquals(100L, stats.max());
+        assertEquals(1, stats.docCount());
+      }
+    }
+  }
+
+}

--- a/lucene/core/src/test/org/apache/lucene/search/TestNumericFieldStats.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestNumericFieldStats.java
@@ -263,5 +263,4 @@ public class TestNumericFieldStats extends LuceneTestCase {
       }
     }
   }
-
 }


### PR DESCRIPTION
## Problem

Lucene has two independent APIs for retrieving the global min/max of a numeric field: `PointValues.getMinPackedValue()` / `PointValues.getMaxPackedValue()` (returns `byte[]` or `null`) and `DocValuesSkipper.globalMinValue()` / `DocValuesSkipper.globalMaxValue()` (returns `long` with sentinel values for "no data"). The sentinel approach is problematic because `Long.MIN_VALUE`/`Long.MAX_VALUE` are legitimate field values, making "no data" indistinguishable from real values.

This caused `SortedNumericDocValuesRangeQuery.rewrite()` to silently skip its optimization when only PointValues were available (no skip index), since the sentinel-based range check could never trigger.

## Solution

`NumericFieldStats` is a utility class that retrieves global field statistics from index metadata structures (`PointValues`, `DocValuesSkipper`) without per-document access. It exposes a single method:

`getStats(IndexReader, String)` returns a `Stats` record `(long min, long max, int docCount)`, or `null` when no metadata structure is available.

It probes `PointValues` first (always available for standard numeric fields, null-based "no data"), then falls back to `DocValuesSkipper` (covers doc-values-only fields with skip index).

`SortedNumericDocValuesRangeQuery.rewrite()` now uses this API, fixing the optimization for fields with PointValues but no skip index.

## Packed value decoding

PointValues stores values as big-endian byte arrays with the sign bit flipped. IntField produces 4-byte arrays, LongField produces 8-byte arrays. The internal `decodeLong` method dispatches on array length to call the right `NumericUtils` decoder. The int case widens to long via Java sign extension, which preserves the value. The API returns long unconditionally because the query layer already works with long bounds internally (even for IntField queries). Callers that need int can safely narrow with `Math.toIntExact()`.

## Why not fix DocValuesSkipper directly?

Changing `DocValuesSkipper.globalMinValue()`/`globalMaxValue()` to return `Long` instead of `long` would fix the sentinel ambiguity at the source. But the per-segment `minValue()`/`maxValue()` methods are called on hot scoring paths where boxing would add overhead, and the static global methods are public API so changing their return type would break existing callers. A higher-level utility avoids both issues.

## Tests

Multiple tests in `TestNumericFieldStats` cover both PointValues and DocValuesSkipper data sources, edge cases (empty index, nonexistent field, doc values without skip index, mixed segments), boundary values, multi-valued fields, and doc count.

An integration test in `TestDocValuesQueries` verifies that `rewrite()` now correctly produces `MatchNoDocsQuery`/`MatchAllDocsQuery` when only PointValues are available.

```
./gradlew -p lucene/core test --tests "org.apache.lucene.search.TestNumericFieldStats"
./gradlew -p lucene/core test --tests "org.apache.lucene.search.TestDocValuesQueries"
```

Closes #15740

