### PR TITLE
Remove deprecated Operations.concatenate and union methods

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,6 +7,10 @@ http://s.apache.org/luceneversions
 
 API Changes
 ---------------------
+* GITHUB#XXXXX: Remove deprecated Operations.concatenate(Automaton, Automaton) and
+  Operations.union(Automaton, Automaton) methods. Use the List/Collection variants instead.
+  (Saurabh Singh)
+
 * GITHUB#XXXXX: Remove deprecated RegExp complement syntax support. The DEPRECATED_COMPLEMENT flag,
   REGEXP_DEPRECATED_COMPLEMENT enum value, and makeDeprecatedComplement method have been removed.
   Users should use complement bracket expressions ([^...]) instead. (Saurabh Singh)

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
@@ -69,18 +69,6 @@ public final class Operations {
    *
    * <p>Complexity: linear in total number of states.
    *
-   * @deprecated use {@link #concatenate(List)} instead
-   */
-  @Deprecated
-  public static Automaton concatenate(Automaton a1, Automaton a2) {
-    return concatenate(Arrays.asList(a1, a2));
-  }
-
-  /**
-   * Returns an automaton that accepts the concatenation of the languages of the given automata.
-   *
-   * <p>Complexity: linear in total number of states.
-   *
    * @param list List of automata to be joined
    */
   public static Automaton concatenate(List<Automaton> list) {
@@ -472,18 +460,6 @@ public final class Operations {
     BitSet reachableFromAccept = getLiveStatesToAccept(a);
     reachableFromAccept.andNot(reachableFromInitial);
     return reachableFromAccept.isEmpty() == false;
-  }
-
-  /**
-   * Returns an automaton that accepts the union of the languages of the given automata.
-   *
-   * <p>Complexity: linear in number of states.
-   *
-   * @deprecated use {@link #union(Collection)} instead
-   */
-  @Deprecated
-  public static Automaton union(Automaton a1, Automaton a2) {
-    return union(Arrays.asList(a1, a2));
   }
 
   /**


### PR DESCRIPTION
## Title
Remove deprecated Operations.concatenate and union methods


## Description
Removes deprecated `Operations.concatenate(Automaton, Automaton)` and `Operations.union(Automaton, Automaton)` methods as suggested by @rmuir in #15750.

### Changes
- Removed `Operations.concatenate(Automaton, Automaton)`
- Removed `Operations.union(Automaton, Automaton)`
- Updated CHANGES.txt

### Rationale
These methods were deprecated in favor of the List/Collection variants and are no longer used anywhere in the codebase. The removed methods were simple wrappers that just called `concatenate(Arrays.asList(a1, a2))` and `union(Arrays.asList(a1, a2))`.

### Migration
Users should replace:
- `Operations.concatenate(a1, a2)` → `Operations.concatenate(List.of(a1, a2))`
- `Operations.union(a1, a2)` → `Operations.union(List.of(a1, a2))`

### Testing
- All core tests pass
- No usages of the deprecated methods found in the codebase