### PR TITLE
Deprecate Operations.complement() method

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,6 +7,9 @@ http://s.apache.org/luceneversions
 
 API Changes
 ---------------------
+* GITHUB#XXXXX: Deprecate Operations.complement() method. This operation can be slow and is not
+  recommended for production use. It will be removed in Lucene 12. (Saurabh Singh)
+
 * GITHUB#XXXXX: Remove deprecated RegExp complement syntax support. The DEPRECATED_COMPLEMENT flag,
   REGEXP_DEPRECATED_COMPLEMENT enum value, and makeDeprecatedComplement method have been removed.
   Users should use complement bracket expressions ([^...]) instead. (Saurabh Singh)

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
@@ -355,7 +355,10 @@ public final class Operations {
    * @param determinizeWorkLimit maximum effort to spend determinizing the automaton. Set higher to
    *     allow more complex queries and lower to prevent memory exhaustion. {@link
    *     #DEFAULT_DETERMINIZE_WORK_LIMIT} is a good starting default.
+   * @deprecated This operation can be slow and is not recommended for production use. It will be
+   *     removed in Lucene 12.
    */
+  @Deprecated
   public static Automaton complement(Automaton a, int determinizeWorkLimit) {
     a = totalize(determinize(a, determinizeWorkLimit));
     int numStates = a.getNumStates();


### PR DESCRIPTION
## Description
Deprecates `Operations.complement()` method as suggested by @rmuir in #15755 review.

Will try to follow up on the usage cleanup gradually.

## Changes
- Mark `Operations.complement()` as deprecated for removal in Lucene 12
- Add deprecation notice explaining the operation can be slow

## Testing
- All core tests pass