### PR TITLE
Added simpler TestTesselator test in support of a previous fix

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -247,6 +247,8 @@ Other
 ---------------------
 * GITHUB#15586: Document that scoring and ranking may change across major Lucene versions, and that applications requiring stable ranking should explicitly configure Similarity. (Parveen Saini)
 
+* GITHUB#15764: Added simpler TestTesselator test in support of fix GITHUB#15731. (Craig Taverner)
+
 ======================= Lucene 10.4.0 =======================
 
 API Changes

--- a/lucene/core/src/test/org/apache/lucene/geo/TestTessellator.java
+++ b/lucene/core/src/test/org/apache/lucene/geo/TestTessellator.java
@@ -953,6 +953,28 @@ public class TestTessellator extends LuceneTestCase {
     checkMultiPolygon(polygons, 0.0);
   }
 
+  public void testComplexPolygon65() throws Exception {
+    // Simplified extract of the top-left corner of github-15731.geojson.gz:
+    // shell replaced with a bounding rectangle from the top-left-most shell vertex
+    // to a bottom-right cutoff point, with two surviving holes.
+    String geoJson =
+        """
+        {"type": "Polygon", "coordinates": [
+          [
+            [-97.12583, 32.67035], [-97.12466, 32.67035], [-97.12466, 32.6691],
+            [-97.12583, 32.6691], [-97.12583, 32.67035]
+          ], [
+            [-97.125074, 32.669464], [-97.125051, 32.669857], [-97.124884, 32.669819],
+            [-97.124906, 32.669464], [-97.124922, 32.669464], [-97.125074, 32.669464]
+          ], [
+            [-97.124922, 32.669464], [-97.124716, 32.669445], [-97.124739, 32.669128],
+            [-97.124906, 32.669128], [-97.124922, 32.669464]
+          ]
+        ]}""";
+    Polygon[] polygons = Polygon.fromGeoJSON(geoJson);
+    checkMultiPolygon(polygons, 0.0);
+  }
+
   private static class TestCountingMonitor implements Tessellator.Monitor {
     private int count = 0;
     private int splitsStarted = 0;


### PR DESCRIPTION
The fix at https://github.com/apache/lucene/pull/15739 tested a specific, complex polygon as reported in the issue https://github.com/apache/lucene/issues/15731. This PR adds a much simpler test that just focuses in on the part of that polygon that was causing the problem. Two holes that touch where a vertex of one hole touches an edge of another.