### PR TITLE
docs: improve precommit documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ various parts of the build system, including typical workflow tasks.
 
 ### Code formatting and checks
 
+Lucene uses [prek](https://github.com/j178/prek) for fast pre-commit validation. Validate your staged changes with `uvx prek`, Type `./gradlew helpPrecommit` for more information: [help/precommit.txt](help/precommit.txt).
+
 If you've modified any sources, run `./gradlew tidy` to apply code formatting conventions automatically (see [help/formatting.txt](https://github.com/apache/lucene/blob/main/help/formatting.txt)).
 
 Please make sure that all unit tests and validations succeed before constructing your patch: `./gradlew check`. This will assemble Lucene and run all validation tasks (including tests). There are various commands to check the code; type `./gradlew helpTest` for more information ([help/tests.txt](./help/tests.txt)).

--- a/help/precommit.txt
+++ b/help/precommit.txt
@@ -13,7 +13,8 @@ uvx prek
 
 To install a precommit hook so this happens automatically:
 
-uvx prek install
+uv tool install prek
+prek install
 
 To exhaustively force-check all files (like CI does):
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -175,7 +175,7 @@ Build
 * GITHUB#15629: Introduce prek for fast pre-commit/repository checks.
   Markdown files are now linted with local broken-link detection.
   Python and Shell scripts are now linted system-wide.
-  Install with `uvx prek install`
+  Install with `uv tool install prek; prek install`
   For more see help/precommit.txt or `./gradlew helpPrecommit` (Robert Muir)
 
 Other


### PR DESCRIPTION
add a note to CONTRIBUTING.md about the precommit checks and link to the help file. improve the command for installing the checks, if you want git hooks installed, you should do a proper install of prek, so that the prek binary doesn't fall out of uv cache.

