### PR TITLE
Ensure that index is actually there in LegacyBaseDocValuesFormatTestCase

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -249,6 +249,8 @@ Other
 
 * GITHUB#15764: Added simpler TestTesselator test in support of fix GITHUB#15731. (Craig Taverner)
 
+* GITHUB#15767: Fix random test failures in LegacyBaseDocValuesFormatTestCase caused by missing commit. (Alan Woodward)
+
 ======================= Lucene 10.4.0 =======================
 
 API Changes

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/LegacyBaseDocValuesFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/LegacyBaseDocValuesFormatTestCase.java
@@ -1544,6 +1544,9 @@ public abstract class LegacyBaseDocValuesFormatTestCase extends BaseIndexFileFor
       int id = random().nextInt(numDocs);
       writer.deleteDocuments(new Term("id", Integer.toString(id)));
     }
+
+    writer.commit();
+
     try (DirectoryReader reader = maybeWrapWithMergingReader(DirectoryReader.open(dir))) {
       TestUtil.checkReader(reader);
       compareStoredFieldWithSortedNumericsDV(reader, "stored", "dv");


### PR DESCRIPTION
In rare cases, testSortedNumericsSingleValuedMissingVsStoredFields in
LegacyBaseDocValuesFormatTestCase can fail because the various random
parameters determining flush and commit rates line up badly, and we don't
actually write any data to the test index before trying to open it.  This adds
an explicit commit() call so that we avoid spurious failures, in line with other
similar tests in this suite.