### PR TITLE
Improve BytesRefHash.sort performance by retrieve byte directly from the pool.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -237,6 +237,9 @@ Optimizations
 
 * GITHUB#15742: Optimize int4 dotProduct and squareDistance computations by replacing vector conversions with reinterpret casting + bit manipulation. (Trevor McCulloch, Kaival Parikh)
 
+* GITHUB#15775: Improve BytesRefHash.sort performance by retrieve byte directly from the pool. (tyronecai)
+
+
 Bug Fixes
 ---------------------
 * GITHUB#15668: Fix UnsupportedOperationException in WeightedSpanTermExtractor by

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -239,7 +239,6 @@ Optimizations
 
 * GITHUB#15775: Improve BytesRefHash.sort performance by retrieve byte directly from the pool. (tyronecai)
 
-
 Bug Fixes
 ---------------------
 * GITHUB#15668: Fix UnsupportedOperationException in WeightedSpanTermExtractor by

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefBlockPool.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefBlockPool.java
@@ -195,10 +195,7 @@ public class BytesRefBlockPool implements Accountable {
       length = ((short) BitUtil.VH_BE_SHORT.get(bytes, pos)) & 0x7FFF;
       offset = pos + 2;
     }
-    if (length <= i) {
-      return -1;
-    }
-    return bytes[offset + i] & 0xFF;
+    return i < length ? (bytes[offset + i] & 0xFF) : -1;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefBlockPool.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefBlockPool.java
@@ -170,12 +170,12 @@ public class BytesRefBlockPool implements Accountable {
   }
 
   /**
-   * Get the byte at the given start and given offset. This is equivalent of doing:
+   * Retrieve the byte at the given start and i. This is equivalent of doing:
    *
    * <pre>
    *     BytesRef bytes = new BytesRef();
    *     fillBytesRef(bytes, start);
-   *     if (bytes.length <= i ) { return -1; }
+   *     if (bytes.length <= i) { return -1; }
    *     return bytes.bytes[bytes.offset + i] & 0xFF;
    *  </pre>
    *

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefBlockPool.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefBlockPool.java
@@ -169,6 +169,38 @@ public class BytesRefBlockPool implements Accountable {
     return Arrays.equals(bytes, offset, offset + length, b.bytes, b.offset, b.offset + b.length);
   }
 
+  /**
+   * Get the byte at the given start and given offset. This is equivalent of doing:
+   *
+   * <pre>
+   *     BytesRef bytes = new BytesRef();
+   *     fillBytesRef(bytes, start);
+   *     if (bytes.length <= i ) { return -1; }
+   *     return bytes.bytes[bytes.offset + i] & 0xFF;
+   *  </pre>
+   *
+   * It just saves the work of filling the BytesRef.
+   */
+  public int byteAt(int start, int i) {
+    final byte[] bytes = byteBlockPool.getBuffer(start >> BYTE_BLOCK_SHIFT);
+    int pos = start & BYTE_BLOCK_MASK;
+    final int length;
+    final int offset;
+    if ((bytes[pos] & 0x80) == 0) {
+      // length is 1 byte
+      length = bytes[pos];
+      offset = pos + 1;
+    } else {
+      // length is 2 bytes
+      length = ((short) BitUtil.VH_BE_SHORT.get(bytes, pos)) & 0x7FFF;
+      offset = pos + 2;
+    }
+    if (length <= i) {
+      return -1;
+    }
+    return bytes[offset + i] & 0xFF;
+  }
+
   @Override
   public long ramBytesUsed() {
     return BASE_RAM_BYTES + byteBlockPool.ramBytesUsed();

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
@@ -212,6 +212,12 @@ public final class BytesRefHash implements Accountable {
 
           private int k;
 
+          // gain performance by direct get byte from pool
+          @Override
+          protected int byteAt(int i, int k) {
+            return pool.byteAt(bytesStart[compact[i]], k);
+          }
+
           @Override
           protected void buildHistogram(
               int prefixCommonBucket,

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
@@ -212,7 +212,7 @@ public final class BytesRefHash implements Accountable {
 
           private int k;
 
-          // gain performance by direct get byte from pool
+          // gain performance by directly retrieve byte from pool
           @Override
           protected int byteAt(int i, int k) {
             return pool.byteAt(bytesStart[compact[i]], k);


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->


RadixSort involves a large number of statistical histogram calculations, there are numerous byteAt calls. 
Currently, byteAt calls `get` to retrieve the BytesRef corresponding to position i from the pool, 
and then uses `cmp.ByteAt` to get the value of BytesRef at position k.

Because the byteAt calls are so frequent, they cause an observable performance penalty.
[profile_cpu_44438.html](https://github.com/user-attachments/files/25591196/profile_cpu_44438.html)

<img width="919" height="419" alt="image" src="https://github.com/user-attachments/assets/37773679-7add-4481-8834-3486b0590e6e" />


Therefore, we can directly retrieve the byte values ​​corresponding to start and i from the pool.

Use save environment as https://github.com/apache/lucene/pull/15772

## without #15772 + without pool.byteAt
```
sort 33554432 unique terms in 4543.19 ms
```

## without #15772 + with pool.byteAt
```
sort 33554432 unique terms in 3866.08 ms.      (4543.19 - 3866.08) / 4543.19 = 0.149
```

## with #15772 + without pool.byteAt
```
sort 33554432 unique terms in 3385.94 ms
```

## with #15772 + with pool.byteAt
```
sort 33554432 unique terms in 2937.54 ms.       (3385.94 - 2937.54) / 3385.94 = 0.132
```


However, I'm not sure if this change is appropriate from a code structure perspective, 
although it does improve performance.


@dweiss @mikemccand    please take a look and give some advice
