### PR TITLE
Fix incorrect parameter names in GradientFormatter error messages

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -157,6 +157,11 @@ Bug Fixes
 * GITHUB#14971: Fix CachedExecutor thread pool leak in ConcurrentMergeScheduler
   when IndexWriter initialization fails. (Su Beom)
 
+* GITHUB#15781: Fix incorrect parameter names in GradientFormatter error messages. Validation of
+  maxForegroundColor and maxBackgroundColor incorrectly referenced "minForegroundColor" and
+  "minBackgroundColor" in their error messages. Also removed dead code and a redundant
+  zero-check. (Vinay Krishna Pudyodu)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14187: The query cache is now disabled by default. (Adrien Grand)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -157,10 +157,7 @@ Bug Fixes
 * GITHUB#14971: Fix CachedExecutor thread pool leak in ConcurrentMergeScheduler
   when IndexWriter initialization fails. (Su Beom)
 
-* GITHUB#15781: Fix incorrect parameter names in GradientFormatter error messages. Validation of
-  maxForegroundColor and maxBackgroundColor incorrectly referenced "minForegroundColor" and
-  "minBackgroundColor" in their error messages. Also removed dead code and a redundant
-  zero-check. (Vinay Krishna Pudyodu)
+* GITHUB#15781: Fix incorrect parameter names in GradientFormatter error messages. (Vinay Krishna Pudyodu)
 
 Changes in Runtime Behavior
 ---------------------

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/GradientFormatter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/GradientFormatter.java
@@ -58,7 +58,7 @@ public class GradientFormatter implements Formatter {
       }
       if (maxForegroundColor.length() != 7) {
         throw new IllegalArgumentException(
-            "minForegroundColor is not 7 bytes long eg a hex " + "RGB value such as #FFFFFF");
+            "maxForegroundColor is not 7 bytes long eg a hex " + "RGB value such as #FFFFFF");
       }
       fgRMin = hexToInt(minForegroundColor.substring(1, 3));
       fgGMin = hexToInt(minForegroundColor.substring(3, 5));
@@ -77,7 +77,7 @@ public class GradientFormatter implements Formatter {
       }
       if (maxBackgroundColor.length() != 7) {
         throw new IllegalArgumentException(
-            "minBackgroundColor is not 7 bytes long eg a hex " + "RGB value such as #FFFFFF");
+            "maxBackgroundColor is not 7 bytes long eg a hex " + "RGB value such as #FFFFFF");
       }
       bgRMin = hexToInt(minBackgroundColor.substring(1, 3));
       bgGMin = hexToInt(minBackgroundColor.substring(3, 5));
@@ -87,14 +87,11 @@ public class GradientFormatter implements Formatter {
       bgGMax = hexToInt(maxBackgroundColor.substring(3, 5));
       bgBMax = hexToInt(maxBackgroundColor.substring(5, 7));
     }
-    //        this.corpusReader = corpusReader;
     this.maxScore = maxScore;
-    //        totalNumDocs = corpusReader.numDocs();
   }
 
   @Override
   public String highlightTerm(String originalText, TokenGroup tokenGroup) {
-    if (tokenGroup.getTotalScore() == 0) return originalText;
     float score = tokenGroup.getTotalScore();
     if (score == 0) {
       return originalText;


### PR DESCRIPTION
### Description

- Fix error message for maxForegroundColor validation that incorrectly referenced "minForegroundColor"
- Fix error message for maxBackgroundColor validation that incorrectly referenced "minBackgroundColor"
- Remove commented-out dead code (corpusReader, totalNumDocs)
- Remove redundant duplicate zero-check in highlightTerm()
