### PR TITLE
Marking experimental things as such for 104 formats

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104HnswScalarQuantizedVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104HnswScalarQuantizedVectorsFormat.java
@@ -40,6 +40,8 @@ import org.apache.lucene.util.hnsw.HnswGraph;
 /**
  * A vectors format that uses HNSW graph to store and search for vectors. But vectors are binary
  * quantized using {@link Lucene104ScalarQuantizedVectorsFormat} before being stored in the graph.
+ *
+ * @lucene.experimental
  */
 public class Lucene104HnswScalarQuantizedVectorsFormat extends KnnVectorsFormat {
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsFormat.java
@@ -89,6 +89,8 @@ import org.apache.lucene.index.SegmentWriteState;
  *   <li><b>float</b> the centroid square magnitude
  *   <li>The sparse vector information, if required, mapping vector ordinal to doc ID
  * </ul>
+ *
+ * @lucene.experimental
  */
 public class Lucene104ScalarQuantizedVectorsFormat extends FlatVectorsFormat {
   public static final String QUANTIZED_VECTOR_COMPONENT = "QVEC";

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsReader.java
@@ -55,7 +55,11 @@ import org.apache.lucene.util.quantization.OptimizedScalarQuantizer;
 import org.apache.lucene.util.quantization.QuantizedVectorsReader;
 import org.apache.lucene.util.quantization.ScalarQuantizer;
 
-/** Reader for scalar quantized vectors in the Lucene 10.4 format. */
+/**
+ * Reader for scalar quantized vectors in the Lucene 10.4 format.
+ *
+ * @lucene.experimental
+ */
 public class Lucene104ScalarQuantizedVectorsReader extends FlatVectorsReader
     implements QuantizedVectorsReader {
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/QuantizedByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/QuantizedByteVectorValues.java
@@ -24,7 +24,11 @@ import org.apache.lucene.search.VectorScorer;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.quantization.OptimizedScalarQuantizer;
 
-/** Scalar quantized byte vector values */
+/**
+ * Scalar quantized byte vector values
+ *
+ * @lucene.experimental
+ */
 public abstract class QuantizedByteVectorValues extends ByteVectorValues implements HasIndexSlice {
 
   /**


### PR DESCRIPTION
This is an oversight in the javadocs. These are actually experimental/expert APIs that can change (just like other vector formats).