### PR TITLE
#15024: Improve prefix sum in Lucene99HnswVectorsReader

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -113,6 +113,8 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#15024: Improve prefix sum computation in Lucene99HnswVectorsReader for faster neighbor decoding. (Luis Negrin)
+
 * GITHUB#15681: Replace pre-sized array or empty array with lambda expression to call Collection#toArray. (Zhou Hui)
 
 * GITHUB#13782: Replace handwritten loops compare with Arrays.compareUnsigned in TermsEnum and TermsEnumFrame classes. (Zhou Hui)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -113,8 +113,6 @@ Improvements
 
 Optimizations
 ---------------------
-* GITHUB#15024: Improve prefix sum computation in Lucene99HnswVectorsReader for faster neighbor decoding. (Luis Negrin)
-
 * GITHUB#15681: Replace pre-sized array or empty array with lambda expression to call Collection#toArray. (Zhou Hui)
 
 * GITHUB#13782: Replace handwritten loops compare with Arrays.compareUnsigned in TermsEnum and TermsEnumFrame classes. (Zhou Hui)
@@ -240,6 +238,8 @@ Optimizations
 * GITHUB#15772: improve BytesRefHash.sort performance by rearranging ids#15772 (tyronecai)
 
 * GITHUB#15742: Optimize int4 dotProduct and squareDistance computations by replacing vector conversions with reinterpret casting + bit manipulation. (Trevor McCulloch, Kaival Parikh)
+
+* GITHUB#15024: Improve prefix sum computation in Lucene99HnswVectorsReader for faster neighbor decoding. (Luis Negrin)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
@@ -560,16 +560,18 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
       dataIn.seek(graphLevelNodeOffsets.get(targetIndex + graphLevelNodeIndexOffsets[level]));
       arcCount = dataIn.readVInt();
       assert arcCount <= currentNeighborsBuffer.length : "too many neighbors: " + arcCount;
+      int sum = 0;
       if (arcCount > 0) {
         if (version >= VERSION_GROUPVARINT) {
           GroupVIntUtil.readGroupVInts(dataIn, currentNeighborsBuffer, arcCount);
-          for (int i = 1; i < arcCount; i++) {
-            currentNeighborsBuffer[i] = currentNeighborsBuffer[i - 1] + currentNeighborsBuffer[i];
+          for (int i = 0; i < arcCount; i++) {
+            sum += currentNeighborsBuffer[i];
+            currentNeighborsBuffer[i] = sum;
           }
         } else {
-          currentNeighborsBuffer[0] = dataIn.readVInt();
-          for (int i = 1; i < arcCount; i++) {
-            currentNeighborsBuffer[i] = currentNeighborsBuffer[i - 1] + dataIn.readVInt();
+          for (int i = 0; i < arcCount; i++) {
+            sum += dataIn.readVInt();
+            currentNeighborsBuffer[i] = sum;
           }
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
@@ -560,8 +560,8 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
       dataIn.seek(graphLevelNodeOffsets.get(targetIndex + graphLevelNodeIndexOffsets[level]));
       arcCount = dataIn.readVInt();
       assert arcCount <= currentNeighborsBuffer.length : "too many neighbors: " + arcCount;
-      int sum = 0;
       if (arcCount > 0) {
+        int sum = 0;
         if (version >= VERSION_GROUPVARINT) {
           GroupVIntUtil.readGroupVInts(dataIn, currentNeighborsBuffer, arcCount);
           for (int i = 0; i < arcCount; i++) {


### PR DESCRIPTION
## Summary

This PR implements the optimization suggested in #15024, replacing the two-step prefix sum loop in `Lucene99HnswVectorsReader` with a single-pass accumulator variant that avoids redundant memory reads.

**Before:**
```java
currentNeighborsBuffer[0] = dataIn.readVInt();
for (int i = 1; i < arcCount; i++) {
  currentNeighborsBuffer[i] = currentNeighborsBuffer[i - 1] + dataIn.readVInt();
}
```

**After:**
```java
int sum = 0;
for (int i = 0; i < arcCount; i++) {
  sum += dataIn.readVInt();
  currentNeighborsBuffer[i] = sum;
}
```

This is a follow-up to #15027 by @yossev who proposed the same fix. Since that PR went stale (merge conflicts, formatting), I'm resubmitting with conflicts resolved, formatting fixed via `./gradlew tidy`, and benchmark results included.

I found this while looking for a good first issue to learn the contribution process — happy to adjust anything based on feedback!

## Benchmark Results

Benchmarks were run using [luceneutil](https://github.com/mikemccand/luceneutil) KNN benchmark (`knnPerfTest.py`).

**Machine:** Intel Core i5-10210U, 8 logical cores, ~15 GB RAM
**Dataset:** cohere-v3-wikipedia-en 1024d, 400k docs, 10k queries, 8-bit quantized, dot_product

**Baseline:**
```
recall  latency(ms)  netCPU  avgCpuCount    nDoc  topK  fanout  maxConn  beamWidth  quantized  visited  index(s)  index_docs/s  force_merge(s)  num_segments  index_size(MB)
 0.977        9.920   9.893        0.997  400000   100     100       64        250     8 bits     7955    486.32        822.50          437.90             1         2015.68
```

**Candidate (this PR):**
```
recall  latency(ms)  netCPU  avgCpuCount    nDoc  topK  fanout  maxConn  beamWidth  quantized  visited  index(s)  index_docs/s  force_merge(s)  num_segments  index_size(MB)
 0.977        9.861   9.833        0.997  400000   100     100       64        250     8 bits     7955    486.32        822.50          437.90             1         2015.68
```

Recall is identical. Results are from a single run so small differences may fall within normal measurement variance.
