### PR TITLE
fix failing TestHnswFloatVectorGraph test

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/RamUsageTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/RamUsageTester.java
@@ -38,6 +38,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
 import java.util.function.ToLongFunction;
@@ -289,8 +290,13 @@ public final class RamUsageTester {
               a(File.class, v -> charArraySize(v.toString().length()));
               a(Path.class, v -> charArraySize(v.toString().length()));
 
-              // Ignorable JDK classes.
+              // Ignorable JDK classes. LongAdder (and Striped64) do not open their
+              // internal fields to reflection; use shallow size only.
               a(ByteOrder.class, _ -> 0);
+
+              // For LongAdder, assume it has the size of a single long, as we can't access its internal fields and it
+              // is designed to be space efficient when not contended.
+              a(LongAdder.class, _ -> Long.SIZE);
             }
 
             @SuppressWarnings("unchecked")

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/RamUsageTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/RamUsageTester.java
@@ -290,8 +290,7 @@ public final class RamUsageTester {
               a(File.class, v -> charArraySize(v.toString().length()));
               a(Path.class, v -> charArraySize(v.toString().length()));
 
-              // Ignorable JDK classes. LongAdder (and Striped64) do not open their
-              // internal fields to reflection; use shallow size only.
+              // Ignorable JDK classes.
               a(ByteOrder.class, _ -> 0);
 
               // For LongAdder, assume it has the size of a single long, as we can't access its internal fields and it

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/RamUsageTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/RamUsageTester.java
@@ -293,7 +293,8 @@ public final class RamUsageTester {
               // Ignorable JDK classes.
               a(ByteOrder.class, _ -> 0);
 
-              // For LongAdder, assume it has the size of a single long, as we can't access its internal fields and it
+              // For LongAdder, assume it has the size of a single long, as we can't access its
+              // internal fields and it
               // is designed to be space efficient when not contended.
               a(LongAdder.class, _ -> Long.SIZE);
             }


### PR DESCRIPTION
### Description

`TestHnswFloatVectorGraph.testRamUsageEstimate` is failing due to ```java.lang.RuntimeException: Can't access field 'cells' of class 'java.util.concurrent.atomic.LongAdder' for RAM estimation.``` exception. Looking at the change, it looks like it is due to [this](https://github.com/apache/lucene/pull/15590) PR. 

The fix is to assume that `LongAdder` has the same size as a `Long` for RAM estimation purposes. 