### PR TITLE
Coordinate DocValuesSkipper across fields for multi-range conjunctions

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -74,6 +74,8 @@ API Changes
 
 * GITHUB#15295 : Switched to a fixed CFS threshold (Shubham Sharma)
 
+* GITHUB#15793 : Coordinate DocValuesSkipper across fields for multi-range conjunctions
+
 New Features
 ---------------------
 

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/MultiFieldDocValuesRangeBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/MultiFieldDocValuesRangeBenchmark.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MMapDirectory;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmarks BooleanQuery with multiple numeric range FILTER clauses.
+ *
+ * <p>Run with and without the MultiFieldDocValuesRangeQuery coordination changes to compare. To
+ * benchmark the baseline, revert the BooleanQuery.rewrite() coordination rule and re-run.
+ *
+ * <p>Data patterns:
+ *
+ * <ul>
+ *   <li>clustered: values increase with docID (tight skip blocks, many YES/NO). Best case.
+ *   <li>mixed: field0 monotonic, field1 low-cardinality, rest random. Realistic.
+ *   <li>sorted: field0 monotonic (index sort key), rest random. Tests pre-sorted indexes.
+ *   <li>random: all fields uniform random. Worst case.
+ * </ul>
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 5, time = 5)
+@Fork(value = 1, warmups = 1)
+public class MultiFieldDocValuesRangeBenchmark {
+
+  private static final String CLUSTERED = "clustered";
+  private static final String MIXED = "mixed";
+  private static final String SORTED = "sorted";
+  private static final String RANDOM = "random";
+
+  private Directory dir;
+  private IndexReader reader;
+  private Path path;
+  private BooleanQuery query;
+
+  @State(Scope.Benchmark)
+  public static class Params {
+    @Param({"1000000", "10000000"})
+    public int docCount;
+
+    @Param({"3", "5"})
+    public int fieldCount;
+
+    @Param({CLUSTERED, MIXED, RANDOM, SORTED})
+    public String dataPattern;
+  }
+
+  @Setup(Level.Trial)
+  public void setup(Params params) throws Exception {
+    path = Files.createTempDirectory("multiFieldBench");
+    dir = MMapDirectory.open(path);
+
+    IndexWriterConfig iwc = new IndexWriterConfig();
+    if (params.dataPattern.equals(SORTED)) {
+      iwc.setIndexSort(
+          new org.apache.lucene.search.Sort(
+              new org.apache.lucene.search.SortField(
+                  "field0", org.apache.lucene.search.SortField.Type.LONG)));
+    }
+
+    IndexWriter w = new IndexWriter(dir, iwc);
+    Random r = new Random(42);
+
+    for (int i = 0; i < params.docCount; i++) {
+      Document doc = new Document();
+      for (int f = 0; f < params.fieldCount; f++) {
+        long value = generateValue(params.dataPattern, f, i, params.docCount, r);
+        doc.add(NumericDocValuesField.indexedField("field" + f, value));
+      }
+      w.addDocument(doc);
+    }
+    w.forceMerge(1);
+    reader = DirectoryReader.open(w);
+    w.close();
+
+    BooleanQuery.Builder bqBuilder = new BooleanQuery.Builder();
+    for (int f = 0; f < params.fieldCount; f++) {
+      long[] range = getQueryRange(params.dataPattern, f, params.docCount);
+      bqBuilder.add(
+          SortedNumericDocValuesField.newSlowRangeQuery("field" + f, range[0], range[1]),
+          Occur.FILTER);
+    }
+    query = bqBuilder.build();
+  }
+
+  private static long generateValue(
+      String pattern, int fieldIdx, int docIdx, int docCount, Random r) {
+    switch (pattern) {
+      case CLUSTERED:
+        long scale = (fieldIdx + 1) * 100L;
+        long noise = r.nextInt(50);
+        return (docIdx * scale / docCount) * docCount / scale * scale + noise;
+      case MIXED:
+        if (fieldIdx == 0) {
+          return (long) docIdx * 1000L + r.nextInt(100);
+        } else if (fieldIdx == 1) {
+          return r.nextInt(20);
+        } else {
+          return r.nextLong(0, docCount);
+        }
+      case SORTED:
+        // field0: monotonically increasing (will be the index sort key)
+        // field1+: random values (not sorted — these benefit from coordination)
+        if (fieldIdx == 0) {
+          return (long) docIdx * 1000L + r.nextInt(100);
+        } else {
+          return r.nextLong(0, docCount);
+        }
+      case RANDOM:
+        return r.nextLong(0, docCount);
+      default:
+        throw new IllegalArgumentException("Unknown pattern: " + pattern);
+    }
+  }
+
+  private static long[] getQueryRange(String pattern, int fieldIdx, int docCount) {
+    switch (pattern) {
+      case CLUSTERED:
+        long scale = (fieldIdx + 1) * 100L;
+        long maxVal = scale;
+        long rangeSize = maxVal / 10;
+        long offset = (fieldIdx * maxVal / 5);
+        return new long[] {offset, offset + rangeSize};
+      case MIXED:
+        if (fieldIdx == 0) {
+          long maxVal2 = (long) docCount * 1000L + 100;
+          return new long[] {(long) (maxVal2 * 0.9), maxVal2};
+        } else if (fieldIdx == 1) {
+          return new long[] {15, 19};
+        } else {
+          long rangeSize2 = docCount / 10;
+          long lower2 = (docCount - rangeSize2) / 2;
+          return new long[] {lower2, lower2 + rangeSize2};
+        }
+      case SORTED:
+        if (fieldIdx == 0) {
+          long maxVal3 = (long) docCount * 1000L + 100;
+          return new long[] {(long) (maxVal3 * 0.9), maxVal3};
+        } else {
+          long rangeSize3 = docCount / 10;
+          long lower3 = (docCount - rangeSize3) / 2;
+          return new long[] {lower3, lower3 + rangeSize3};
+        }
+      case RANDOM:
+        long rangeSize4 = docCount / 5;
+        long lower4 = (docCount - rangeSize4) / 2;
+        return new long[] {lower4, lower4 + rangeSize4};
+      default:
+        throw new IllegalArgumentException("Unknown pattern: " + pattern);
+    }
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws Exception {
+    reader.close();
+    if (dir != null) {
+      dir.close();
+      dir = null;
+    }
+    if (Files.exists(path)) {
+      try (Stream<Path> walk = Files.walk(path)) {
+        walk.sorted(Comparator.reverseOrder())
+            .forEach(
+                p -> {
+                  try {
+                    Files.delete(p);
+                  } catch (IOException _) {
+                  }
+                });
+      }
+    }
+  }
+
+  @Benchmark
+  public int searchMultiFieldRange() throws IOException {
+    IndexSearcher searcher = new IndexSearcher(reader);
+    return searcher.count(query);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
@@ -643,6 +643,42 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
       }
     }
 
+    // Coordinate multiple required NumericDocValuesRangeQuery clauses on different fields
+    // into a single MultiFieldDocValuesRangeQuery that coordinates their skip lists.
+    List<BooleanClause> rangeClauses = new ArrayList<>();
+    Set<String> rangeFields = new HashSet<>();
+    for (BooleanClause clause : clauses) {
+      if (clause.isRequired() && clause.query() instanceof NumericDocValuesRangeQuery nrq) {
+        rangeClauses.add(clause);
+        rangeFields.add(nrq.getField());
+      }
+    }
+    // Need 2+ range clauses on distinct fields
+    if (rangeClauses.size() >= 2 && rangeFields.size() == rangeClauses.size()) {
+      // Build the field ranges and the fallback conjunction
+      List<MultiFieldDocValuesRangeQuery.FieldRange> fieldRanges = new ArrayList<>();
+      BooleanQuery.Builder fallbackBuilder = new BooleanQuery.Builder();
+      for (BooleanClause rc : rangeClauses) {
+        NumericDocValuesRangeQuery nrq = (NumericDocValuesRangeQuery) rc.query();
+        fieldRanges.add(
+            new MultiFieldDocValuesRangeQuery.FieldRange(
+                nrq.getField(), nrq.lowerValue(), nrq.upperValue()));
+        fallbackBuilder.add(rc.query(), Occur.FILTER);
+      }
+      Query coordinated = new MultiFieldDocValuesRangeQuery(fieldRanges, fallbackBuilder.build());
+
+      // Rebuild: coordinated query as FILTER + all non-range clauses
+      BooleanQuery.Builder builder =
+          new BooleanQuery.Builder().setMinimumNumberShouldMatch(getMinimumNumberShouldMatch());
+      builder.add(coordinated, Occur.FILTER);
+      for (BooleanClause clause : clauses) {
+        if (!rangeClauses.contains(clause)) {
+          builder.add(clause);
+        }
+      }
+      return builder.build();
+    }
+
     return super.rewrite(indexSearcher);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/MultiFieldDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiFieldDocValuesRangeQuery.java
@@ -1,0 +1,507 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+
+/**
+ * A query that efficiently evaluates multiple numeric doc-values range filters in conjunction by
+ * coordinating their {@link DocValuesSkipper} instances. When one field's skip list determines a
+ * block has no matching documents, all other fields skip that block without reading their skip
+ * metadata.
+ *
+ * <p>This is equivalent to a BooleanQuery with FILTER clauses for each range, but avoids redundant
+ * skip-list reads and per-document evaluations for blocks eliminated by any single field.
+ *
+ * <p>When a segment lacks skip indices for any field, this query falls back to the original
+ * individual range queries run as a conjunction.
+ *
+ * @lucene.experimental
+ */
+public class MultiFieldDocValuesRangeQuery extends Query {
+
+  /** A single field's range predicate. */
+  public record FieldRange(String field, long lowerValue, long upperValue) {
+    public FieldRange {
+      Objects.requireNonNull(field, "field must not be null");
+      if (lowerValue > upperValue) {
+        throw new IllegalArgumentException(
+            "lowerValue must be <= upperValue, got " + lowerValue + " > " + upperValue);
+      }
+    }
+  }
+
+  private final FieldRange[] fieldRanges;
+  private final Query fallbackQuery;
+
+  /**
+   * Create a multi-field range query.
+   *
+   * @param fieldRanges the per-field range predicates (must have at least 2)
+   * @param fallbackQuery a conjunction of the individual range queries, used when skip coordination
+   *     is not possible for a segment (e.g., a field lacks a skip index)
+   */
+  public MultiFieldDocValuesRangeQuery(List<FieldRange> fieldRanges, Query fallbackQuery) {
+    if (fieldRanges.size() < 2) {
+      throw new IllegalArgumentException("Need at least 2 field ranges, got " + fieldRanges.size());
+    }
+    this.fieldRanges = fieldRanges.toArray(new FieldRange[0]);
+    this.fallbackQuery = Objects.requireNonNull(fallbackQuery, "fallbackQuery must not be null");
+  }
+
+  /** Returns the field ranges this query filters on. */
+  public List<FieldRange> getFieldRanges() {
+    return List.of(fieldRanges);
+  }
+
+  /** Returns the fallback query used when skip coordination is not possible. */
+  public Query getFallbackQuery() {
+    return fallbackQuery;
+  }
+
+  @Override
+  public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost)
+      throws IOException {
+    Weight fallbackWeight = fallbackQuery.createWeight(searcher, scoreMode, boost);
+
+    return new ConstantScoreWeight(this, boost) {
+
+      @Override
+      public boolean isCacheable(LeafReaderContext ctx) {
+        return fallbackWeight.isCacheable(ctx);
+      }
+
+      @Override
+      public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+        LeafReader reader = context.reader();
+        int maxDoc = reader.maxDoc();
+
+        // Check if all fields have skip indices in this segment
+        boolean allHaveSkippers = true;
+        for (FieldRange fr : fieldRanges) {
+          if (reader.getFieldInfos().fieldInfo(fr.field()) == null
+              || reader.getDocValuesSkipper(fr.field()) == null) {
+            allHaveSkippers = false;
+            break;
+          }
+        }
+
+        if (!allHaveSkippers) {
+          // Fall back to the original conjunction of individual range queries
+          return fallbackWeight.scorerSupplier(context);
+        }
+
+        // Build coordinated skip evaluation
+        List<FieldState> states = new ArrayList<>(fieldRanges.length);
+        for (FieldRange fr : fieldRanges) {
+          DocValuesSkipper skipper = reader.getDocValuesSkipper(fr.field());
+
+          // Global min/max check
+          if (skipper.minValue() > fr.upperValue() || skipper.maxValue() < fr.lowerValue()) {
+            return null; // entire segment out of range for this field
+          }
+
+          SortedNumericDocValues values = DocValues.getSortedNumeric(reader, fr.field());
+          NumericDocValues singleton = DocValues.unwrapSingleton(values);
+          TwoPhaseIterator twoPhase;
+          if (singleton != null) {
+            twoPhase = buildSingletonTwoPhase(singleton, fr);
+          } else {
+            twoPhase = buildMultiValueTwoPhase(values, fr);
+          }
+
+          long fieldSpan = skipper.maxValue() - skipper.minValue();
+          long querySpan = fr.upperValue() - fr.lowerValue();
+          double selectivity = fieldSpan == 0 ? 1.0 : Math.min(1.0, (double) querySpan / fieldSpan);
+          states.add(new FieldState(fr, skipper, twoPhase, selectivity));
+        }
+
+        // Sort by selectivity: most selective first
+        states.sort(Comparator.comparingDouble(s -> s.selectivity));
+        FieldState[] sorted = states.toArray(new FieldState[0]);
+        DocIdSetIterator iterator = new CoordinatedIterator(sorted, maxDoc);
+        return ConstantScoreScorerSupplier.fromIterator(iterator, score(), scoreMode, maxDoc);
+      }
+    };
+  }
+
+  private static TwoPhaseIterator buildSingletonTwoPhase(
+      NumericDocValues singleton, FieldRange fr) {
+    return new TwoPhaseIterator(singleton) {
+      @Override
+      public boolean matches() throws IOException {
+        long value = singleton.longValue();
+        return value >= fr.lowerValue() && value <= fr.upperValue();
+      }
+
+      @Override
+      public float matchCost() {
+        return 2;
+      }
+    };
+  }
+
+  private static TwoPhaseIterator buildMultiValueTwoPhase(
+      SortedNumericDocValues values, FieldRange fr) {
+    return new TwoPhaseIterator(values) {
+      @Override
+      public boolean matches() throws IOException {
+        for (int i = 0, count = values.docValueCount(); i < count; ++i) {
+          long value = values.nextValue();
+          if (value < fr.lowerValue()) continue;
+          return value <= fr.upperValue();
+        }
+        return false;
+      }
+
+      @Override
+      public float matchCost() {
+        return 2;
+      }
+    };
+  }
+
+  /** Per-field state held during query execution. */
+  private static class FieldState {
+    final FieldRange range;
+    final DocValuesSkipper skipper;
+    final TwoPhaseIterator twoPhase;
+    final double selectivity;
+    int blockMaxDocID = -1;
+
+    FieldState(
+        FieldRange range, DocValuesSkipper skipper, TwoPhaseIterator twoPhase, double selectivity) {
+      this.range = range;
+      this.skipper = skipper;
+      this.twoPhase = twoPhase;
+      this.selectivity = selectivity;
+    }
+
+    DocValuesRangeIterator.Match classify() {
+      return classifyAtLevel(0);
+    }
+
+    DocValuesRangeIterator.Match classifyAtLevel(int level) {
+      long minVal = skipper.minValue(level);
+      long maxVal = skipper.maxValue(level);
+      if (minVal > range.upperValue() || maxVal < range.lowerValue()) {
+        return DocValuesRangeIterator.Match.NO;
+      } else if (minVal >= range.lowerValue() && maxVal <= range.upperValue()) {
+        if (skipper.docCount(level) == skipper.maxDocID(level) - skipper.minDocID(level) + 1) {
+          return DocValuesRangeIterator.Match.YES;
+        } else {
+          return DocValuesRangeIterator.Match.IF_DOC_HAS_VALUE;
+        }
+      }
+      return DocValuesRangeIterator.Match.MAYBE;
+    }
+  }
+
+  /**
+   * The coordinated iterator. Advances all fields' skippers together, short-circuiting on the first
+   * field that classifies a block as NO.
+   */
+  private static class CoordinatedIterator extends DocIdSetIterator {
+    private final FieldState[] fields;
+    private final int maxDoc;
+    private int doc = -1;
+
+    private int blockStart;
+    private int blockEnd;
+    private DocValuesRangeIterator.Match[] matches;
+
+    CoordinatedIterator(FieldState[] fields, int maxDoc) {
+      this.fields = fields;
+      this.maxDoc = maxDoc;
+      this.matches = new DocValuesRangeIterator.Match[fields.length];
+    }
+
+    @Override
+    public int docID() {
+      return doc;
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+      return advance(doc + 1);
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+      while (target < maxDoc) {
+        // Phase 1: Advance lead field's skipper (most selective)
+        FieldState lead = fields[0];
+        if (target > lead.blockMaxDocID) {
+          lead.skipper.advance(target);
+          if (lead.skipper.minDocID(0) == NO_MORE_DOCS) {
+            return doc = NO_MORE_DOCS;
+          }
+          lead.blockMaxDocID = lead.skipper.maxDocID(0);
+        }
+        target = Math.max(target, lead.skipper.minDocID(0));
+
+        // Classify lead field
+        matches[0] = lead.classify();
+        if (matches[0] == DocValuesRangeIterator.Match.NO) {
+          int skipTo = lead.blockMaxDocID;
+          for (int level = 1; level < lead.skipper.numLevels(); level++) {
+            if (lead.classifyAtLevel(level) == DocValuesRangeIterator.Match.NO) {
+              skipTo = lead.skipper.maxDocID(level);
+            } else {
+              break;
+            }
+          }
+          target = skipTo + 1;
+          continue;
+        }
+
+        // Phase 2: Check remaining fields, short-circuit on first NO
+        blockStart = lead.skipper.minDocID(0);
+        blockEnd = lead.blockMaxDocID;
+        boolean anyNo = false;
+        boolean allFullMatch = isFullMatch(matches[0]);
+
+        for (int f = 1; f < fields.length; f++) {
+          FieldState fs = fields[f];
+          if (target > fs.blockMaxDocID) {
+            fs.skipper.advance(target);
+            if (fs.skipper.minDocID(0) == NO_MORE_DOCS) {
+              return doc = NO_MORE_DOCS;
+            }
+            fs.blockMaxDocID = fs.skipper.maxDocID(0);
+          }
+
+          blockStart = Math.max(blockStart, fs.skipper.minDocID(0));
+          blockEnd = Math.min(blockEnd, fs.blockMaxDocID);
+
+          if (blockStart > blockEnd) {
+            target = blockEnd + 1;
+            anyNo = true;
+            break;
+          }
+
+          matches[f] = fs.classify();
+          if (matches[f] == DocValuesRangeIterator.Match.NO) {
+            anyNo = true;
+            target = blockEnd + 1;
+            break;
+          }
+          if (!isFullMatch(matches[f])) {
+            allFullMatch = false;
+          }
+        }
+
+        if (anyNo) {
+          continue;
+        }
+
+        target = Math.max(target, blockStart);
+
+        // Level promotion: widen block range if all fields agree
+        if (allFullMatch) {
+          int nextLevel = 1;
+          while (true) {
+            boolean allSameAtLevel = true;
+            int promotedEnd = Integer.MAX_VALUE;
+            for (int f = 0; f < fields.length; f++) {
+              if (nextLevel >= fields[f].skipper.numLevels()) {
+                allSameAtLevel = false;
+                break;
+              }
+              DocValuesRangeIterator.Match higherMatch = fields[f].classifyAtLevel(nextLevel);
+              if (!isFullMatch(higherMatch)) {
+                allSameAtLevel = false;
+                break;
+              }
+              promotedEnd = Math.min(promotedEnd, fields[f].skipper.maxDocID(nextLevel));
+            }
+            if (allSameAtLevel && promotedEnd > blockEnd) {
+              blockEnd = promotedEnd;
+              nextLevel++;
+            } else {
+              break;
+            }
+          }
+        }
+
+        if (allFullMatch) {
+          boolean allTrueYes = true;
+          for (int f = 0; f < fields.length; f++) {
+            if (matches[f] != DocValuesRangeIterator.Match.YES) {
+              allTrueYes = false;
+              break;
+            }
+          }
+          if (allTrueYes) {
+            return doc = target;
+          }
+          int result = evaluatePerDoc(target, blockEnd);
+          if (result != NO_MORE_DOCS) {
+            return doc = result;
+          }
+          target = blockEnd + 1;
+          continue;
+        }
+
+        // Phase 3: MAYBE — per-doc evaluation
+        int result = evaluatePerDoc(target, blockEnd);
+        if (result != NO_MORE_DOCS) {
+          return doc = result;
+        }
+        target = blockEnd + 1;
+      }
+      return doc = NO_MORE_DOCS;
+    }
+
+    private static boolean isFullMatch(DocValuesRangeIterator.Match m) {
+      return m == DocValuesRangeIterator.Match.YES
+          || m == DocValuesRangeIterator.Match.IF_DOC_HAS_VALUE;
+    }
+
+    private int evaluatePerDoc(int start, int end) throws IOException {
+      int leadIdx = 0;
+      for (int f = 0; f < fields.length; f++) {
+        if (matches[f] == DocValuesRangeIterator.Match.MAYBE) {
+          leadIdx = f;
+          break;
+        }
+        if (matches[f] == DocValuesRangeIterator.Match.IF_DOC_HAS_VALUE) {
+          leadIdx = f;
+        }
+      }
+
+      DocIdSetIterator leadApprox = fields[leadIdx].twoPhase.approximation();
+      int candidate = leadApprox.docID();
+      if (candidate < start) {
+        candidate = leadApprox.advance(start);
+      }
+
+      while (candidate != NO_MORE_DOCS && candidate <= end) {
+        int result = tryMatchAllFields(candidate, end, leadIdx, leadApprox);
+        if (result == candidate) {
+          return candidate;
+        }
+        candidate = result;
+      }
+      return NO_MORE_DOCS;
+    }
+
+    private int tryMatchAllFields(int candidate, int end, int leadIdx, DocIdSetIterator leadApprox)
+        throws IOException {
+      for (int f = 0; f < fields.length; f++) {
+        if (matches[f] == DocValuesRangeIterator.Match.YES) {
+          continue;
+        }
+
+        DocIdSetIterator approx = fields[f].twoPhase.approximation();
+        int approxDoc = approx.docID();
+
+        if (approxDoc < candidate) {
+          approxDoc = approx.advance(candidate);
+        }
+
+        if (approxDoc != candidate) {
+          return advanceToNext(approxDoc, end, leadApprox);
+        }
+
+        if (matches[f] == DocValuesRangeIterator.Match.MAYBE) {
+          if (!fields[f].twoPhase.matches()) {
+            int next = leadApprox.advance(candidate + 1);
+            if (next > end || next == NO_MORE_DOCS) {
+              return NO_MORE_DOCS;
+            }
+            return next;
+          }
+        }
+      }
+      return candidate;
+    }
+
+    private int advanceToNext(int target, int end, DocIdSetIterator leadApprox) throws IOException {
+      if (target > end || target == NO_MORE_DOCS) {
+        return NO_MORE_DOCS;
+      }
+      if (leadApprox.docID() < target) {
+        target = leadApprox.advance(target);
+        if (target > end || target == NO_MORE_DOCS) {
+          return NO_MORE_DOCS;
+        }
+      }
+      return target;
+    }
+
+    @Override
+    public long cost() {
+      long minCost = Long.MAX_VALUE;
+      for (FieldState fs : fields) {
+        minCost = Math.min(minCost, fs.twoPhase.approximation().cost());
+      }
+      return minCost;
+    }
+  }
+
+  @Override
+  public String toString(String defaultField) {
+    StringBuilder sb = new StringBuilder("MultiFieldDocValuesRange(");
+    for (int i = 0; i < fieldRanges.length; i++) {
+      if (i > 0) sb.append(" AND ");
+      FieldRange fr = fieldRanges[i];
+      sb.append(fr.field())
+          .append(":[")
+          .append(fr.lowerValue())
+          .append(" TO ")
+          .append(fr.upperValue())
+          .append("]");
+    }
+    sb.append(")");
+    return sb.toString();
+  }
+
+  @Override
+  public void visit(QueryVisitor visitor) {
+    for (FieldRange fr : fieldRanges) {
+      if (visitor.acceptField(fr.field())) {
+        visitor.visitLeaf(this);
+        return;
+      }
+    }
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (!(obj instanceof MultiFieldDocValuesRangeQuery other)) return false;
+    return Arrays.equals(fieldRanges, other.fieldRanges)
+        && Objects.equals(fallbackQuery, other.fallbackQuery);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(classHash(), Arrays.hashCode(fieldRanges), fallbackQuery);
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
@@ -34,6 +34,8 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
@@ -1414,5 +1416,221 @@ public class TestBooleanQuery extends LuceneTestCase {
     assertThrows(
         UnsupportedOperationException.class,
         () -> bq.clauses().add(new BooleanClause(MatchNoDocsQuery.INSTANCE, Occur.SHOULD)));
+  }
+
+  /** Helper to check if a rewritten query contains a MultiFieldDocValuesRangeQuery clause. */
+  private boolean containsMultiFieldCoordination(Query rewritten) {
+    if (rewritten instanceof BooleanQuery bq) {
+      for (BooleanClause clause : bq.clauses()) {
+        if (clause.query() instanceof MultiFieldDocValuesRangeQuery) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Two required numeric range queries on different fields should be coordinated into a
+   * MultiFieldDocValuesRangeQuery.
+   */
+  public void testRewriteCoordinatesTwoRangeFilters() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, new IndexWriterConfig())) {
+      Document doc = new Document();
+      doc.add(new NumericDocValuesField("price", 100));
+      doc.add(new NumericDocValuesField("qty", 5));
+      w.addDocument(doc);
+      w.forceMerge(1);
+
+      try (DirectoryReader reader = DirectoryReader.open(w)) {
+        IndexSearcher searcher = newSearcher(reader);
+        BooleanQuery bq =
+            new BooleanQuery.Builder()
+                .add(SortedNumericDocValuesField.newSlowRangeQuery("price", 50, 200), Occur.FILTER)
+                .add(SortedNumericDocValuesField.newSlowRangeQuery("qty", 1, 10), Occur.FILTER)
+                .build();
+
+        Query rewritten = bq.rewrite(searcher);
+        assertTrue(
+            "Two required range filters on different fields should coordinate",
+            containsMultiFieldCoordination(rewritten));
+      }
+    }
+  }
+
+  /** A single range query should NOT trigger coordination. */
+  public void testRewriteNoCoordinationForSingleRange() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, new IndexWriterConfig())) {
+      Document doc = new Document();
+      doc.add(new NumericDocValuesField("price", 100));
+      w.addDocument(doc);
+      w.forceMerge(1);
+
+      try (DirectoryReader reader = DirectoryReader.open(w)) {
+        IndexSearcher searcher = newSearcher(reader);
+        BooleanQuery bq =
+            new BooleanQuery.Builder()
+                .add(SortedNumericDocValuesField.newSlowRangeQuery("price", 50, 200), Occur.FILTER)
+                .build();
+
+        Query rewritten = bq.rewrite(searcher);
+        assertFalse(
+            "Single range query should not be coordinated",
+            containsMultiFieldCoordination(rewritten));
+      }
+    }
+  }
+
+  /** Two range queries on the SAME field should NOT be coordinated (need distinct fields). */
+  public void testRewriteNoCoordinationForSameField() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, new IndexWriterConfig())) {
+      Document doc = new Document();
+      doc.add(new NumericDocValuesField("price", 100));
+      w.addDocument(doc);
+      w.forceMerge(1);
+
+      try (DirectoryReader reader = DirectoryReader.open(w)) {
+        IndexSearcher searcher = newSearcher(reader);
+        BooleanQuery bq =
+            new BooleanQuery.Builder()
+                .add(SortedNumericDocValuesField.newSlowRangeQuery("price", 50, 200), Occur.FILTER)
+                .add(SortedNumericDocValuesField.newSlowRangeQuery("price", 100, 300), Occur.FILTER)
+                .build();
+
+        Query rewritten = bq.rewrite(searcher);
+        assertFalse(
+            "Two range queries on the same field should not be coordinated",
+            containsMultiFieldCoordination(rewritten));
+      }
+    }
+  }
+
+  /** SHOULD range clauses should NOT trigger coordination (only required clauses qualify). */
+  public void testRewriteNoCoordinationForShouldClauses() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, new IndexWriterConfig())) {
+      Document doc = new Document();
+      doc.add(new NumericDocValuesField("price", 100));
+      doc.add(new NumericDocValuesField("qty", 5));
+      w.addDocument(doc);
+      w.forceMerge(1);
+
+      try (DirectoryReader reader = DirectoryReader.open(w)) {
+        IndexSearcher searcher = newSearcher(reader);
+        BooleanQuery bq =
+            new BooleanQuery.Builder()
+                .add(SortedNumericDocValuesField.newSlowRangeQuery("price", 50, 200), Occur.SHOULD)
+                .add(SortedNumericDocValuesField.newSlowRangeQuery("qty", 1, 10), Occur.SHOULD)
+                .build();
+
+        Query rewritten = bq.rewrite(searcher);
+        assertFalse(
+            "SHOULD range clauses should not be coordinated",
+            containsMultiFieldCoordination(rewritten));
+      }
+    }
+  }
+
+  /** Non-range clauses should be preserved alongside the coordinated query. */
+  public void testRewritePreservesNonRangeClauses() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, new IndexWriterConfig())) {
+      Document doc = new Document();
+      doc.add(new NumericDocValuesField("price", 100));
+      doc.add(new NumericDocValuesField("qty", 5));
+      doc.add(new StringField("status", "active", Field.Store.NO));
+      w.addDocument(doc);
+      w.forceMerge(1);
+
+      try (DirectoryReader reader = DirectoryReader.open(w)) {
+        IndexSearcher searcher = newSearcher(reader);
+        TermQuery termClause = new TermQuery(new Term("status", "active"));
+        BooleanQuery bq =
+            new BooleanQuery.Builder()
+                .add(SortedNumericDocValuesField.newSlowRangeQuery("price", 50, 200), Occur.FILTER)
+                .add(SortedNumericDocValuesField.newSlowRangeQuery("qty", 1, 10), Occur.FILTER)
+                .add(termClause, Occur.MUST)
+                .build();
+
+        Query rewritten = bq.rewrite(searcher);
+        assertTrue(
+            "Should still coordinate range clauses when mixed with non-range",
+            containsMultiFieldCoordination(rewritten));
+
+        // The non-range clause should still be present
+        BooleanQuery rewrittenBq = (BooleanQuery) rewritten;
+        boolean foundTermClause = false;
+        for (BooleanClause clause : rewrittenBq.clauses()) {
+          if (clause.query() instanceof TermQuery) {
+            foundTermClause = true;
+            assertEquals(Occur.MUST, clause.occur());
+          }
+        }
+        assertTrue("Non-range TermQuery clause should be preserved", foundTermClause);
+      }
+    }
+  }
+
+  /** Rewriting an already-coordinated query should not re-coordinate (no infinite loop). */
+  public void testRewriteDoesNotReCoordinate() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, new IndexWriterConfig())) {
+      Document doc = new Document();
+      doc.add(new NumericDocValuesField("price", 100));
+      doc.add(new NumericDocValuesField("qty", 5));
+      w.addDocument(doc);
+      w.forceMerge(1);
+
+      try (DirectoryReader reader = DirectoryReader.open(w)) {
+        IndexSearcher searcher = newSearcher(reader);
+        BooleanQuery bq =
+            new BooleanQuery.Builder()
+                .add(SortedNumericDocValuesField.newSlowRangeQuery("price", 50, 200), Occur.FILTER)
+                .add(SortedNumericDocValuesField.newSlowRangeQuery("qty", 1, 10), Occur.FILTER)
+                .build();
+
+        Query firstRewrite = bq.rewrite(searcher);
+        assertTrue(containsMultiFieldCoordination(firstRewrite));
+
+        // Rewriting again should be stable — no StackOverflowError, no double-wrapping.
+        // The second rewrite may simplify the BooleanQuery (e.g. single-clause unwrap),
+        // but it must NOT produce a second MultiFieldDocValuesRangeQuery.
+        Query secondRewrite = firstRewrite.rewrite(searcher);
+
+        // Walk the full rewrite chain to a fixed point — must terminate (no infinite loop)
+        Query current = secondRewrite;
+        for (int i = 0; i < 100; i++) {
+          Query next = current.rewrite(searcher);
+          if (next == current) break;
+          current = next;
+        }
+        // If we got here without StackOverflowError, the guard works.
+
+        // Count MultiFieldDocValuesRangeQuery at any depth — should be at most 1
+        int coordCount = countMultiFieldQueries(current);
+        assertTrue(
+            "Rewrite chain should contain at most 1 MultiFieldDocValuesRangeQuery, found "
+                + coordCount,
+            coordCount <= 1);
+      }
+    }
+  }
+
+  /** Recursively count MultiFieldDocValuesRangeQuery instances in a query tree. */
+  private int countMultiFieldQueries(Query q) {
+    if (q instanceof MultiFieldDocValuesRangeQuery) {
+      return 1;
+    }
+    if (q instanceof BooleanQuery bq) {
+      int count = 0;
+      for (BooleanClause clause : bq.clauses()) {
+        count += countMultiFieldQueries(clause.query());
+      }
+      return count;
+    }
+    return 0;
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiFieldDocValuesRangeQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiFieldDocValuesRangeQuery.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.MultiFieldDocValuesRangeQuery.FieldRange;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+/**
+ * Tests for {@link MultiFieldDocValuesRangeQuery}. Verifies that the coordinated multi-field skip
+ * evaluation produces the same results as independent BooleanQuery FILTER clauses.
+ */
+public class TestMultiFieldDocValuesRangeQuery extends LuceneTestCase {
+
+  /** Helper to build a MultiFieldDocValuesRangeQuery with a proper fallback. */
+  private static MultiFieldDocValuesRangeQuery buildQuery(List<FieldRange> ranges) {
+    BooleanQuery.Builder fallback = new BooleanQuery.Builder();
+    for (FieldRange fr : ranges) {
+      fallback.add(
+          SortedNumericDocValuesField.newSlowRangeQuery(
+              fr.field(), fr.lowerValue(), fr.upperValue()),
+          BooleanClause.Occur.FILTER);
+    }
+    return new MultiFieldDocValuesRangeQuery(ranges, fallback.build());
+  }
+
+  /**
+   * Compare coordinated query results against a BooleanQuery with independent range filters. They
+   * must return exactly the same documents.
+   */
+  public void testMatchesBooleanQuery() throws IOException {
+    try (Directory dir = newDirectory()) {
+      int numDocs = 20000;
+      try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          doc.add(new NumericDocValuesField("price", i % 100));
+          doc.add(new NumericDocValuesField("rating", i % 5));
+          doc.add(new NumericDocValuesField("stock", i % 1000));
+          writer.addDocument(doc);
+        }
+        writer.forceMerge(1);
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        IndexSearcher searcher = newSearcher(reader);
+
+        MultiFieldDocValuesRangeQuery coordinated =
+            buildQuery(
+                List.of(
+                    new FieldRange("price", 20, 40),
+                    new FieldRange("rating", 2, 4),
+                    new FieldRange("stock", 100, 500)));
+
+        BooleanQuery.Builder bq = new BooleanQuery.Builder();
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("price", 20, 40),
+            BooleanClause.Occur.FILTER);
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("rating", 2, 4),
+            BooleanClause.Occur.FILTER);
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("stock", 100, 500),
+            BooleanClause.Occur.FILTER);
+
+        int coordCount = searcher.count(coordinated);
+        int boolCount = searcher.count(bq.build());
+        assertEquals(
+            "Coordinated query must match same doc count as BooleanQuery", boolCount, coordCount);
+      }
+    }
+  }
+
+  /** Test with no matching documents — all fields out of range. */
+  public void testNoMatches() throws IOException {
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+        for (int i = 0; i < 10000; i++) {
+          Document doc = new Document();
+          doc.add(new NumericDocValuesField("a", i));
+          doc.add(new NumericDocValuesField("b", i));
+          writer.addDocument(doc);
+        }
+        writer.forceMerge(1);
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        IndexSearcher searcher = newSearcher(reader);
+        MultiFieldDocValuesRangeQuery q =
+            buildQuery(List.of(new FieldRange("a", 0, 100), new FieldRange("b", 5000, 9999)));
+        assertEquals(0, searcher.count(q));
+      }
+    }
+  }
+
+  /** Test where one field matches everything and the other is selective. */
+  public void testOneFieldMatchesAll() throws IOException {
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+        for (int i = 0; i < 10000; i++) {
+          Document doc = new Document();
+          doc.add(new NumericDocValuesField("wide", i));
+          doc.add(new NumericDocValuesField("narrow", i % 10));
+          writer.addDocument(doc);
+        }
+        writer.forceMerge(1);
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        IndexSearcher searcher = newSearcher(reader);
+        MultiFieldDocValuesRangeQuery q =
+            buildQuery(List.of(new FieldRange("wide", 0, 99999), new FieldRange("narrow", 3, 5)));
+
+        BooleanQuery.Builder bq = new BooleanQuery.Builder();
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("wide", 0, 99999),
+            BooleanClause.Occur.FILTER);
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("narrow", 3, 5),
+            BooleanClause.Occur.FILTER);
+
+        assertEquals(searcher.count(bq.build()), searcher.count(q));
+      }
+    }
+  }
+
+  /** Test with negative values. */
+  public void testNegativeValues() throws IOException {
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+        for (int i = 0; i < 10000; i++) {
+          Document doc = new Document();
+          doc.add(new NumericDocValuesField("a", i - 5000));
+          doc.add(new NumericDocValuesField("b", (i - 5000) * 2));
+          writer.addDocument(doc);
+        }
+        writer.forceMerge(1);
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        IndexSearcher searcher = newSearcher(reader);
+        MultiFieldDocValuesRangeQuery q =
+            buildQuery(List.of(new FieldRange("a", -1000, 1000), new FieldRange("b", -500, 500)));
+
+        BooleanQuery.Builder bq = new BooleanQuery.Builder();
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("a", -1000, 1000),
+            BooleanClause.Occur.FILTER);
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("b", -500, 500),
+            BooleanClause.Occur.FILTER);
+
+        assertEquals(searcher.count(bq.build()), searcher.count(q));
+      }
+    }
+  }
+
+  /** Test with multi-valued fields (SortedNumericDocValues). */
+  public void testMultiValuedFields() throws IOException {
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+        for (int i = 0; i < 10000; i++) {
+          Document doc = new Document();
+          doc.add(new SortedNumericDocValuesField("prices", i * 10));
+          doc.add(new SortedNumericDocValuesField("prices", i * 10 + 5));
+          doc.add(new SortedNumericDocValuesField("ratings", i % 5));
+          doc.add(new SortedNumericDocValuesField("ratings", (i % 5) + 1));
+          writer.addDocument(doc);
+        }
+        writer.forceMerge(1);
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        IndexSearcher searcher = newSearcher(reader);
+        MultiFieldDocValuesRangeQuery q =
+            buildQuery(
+                List.of(new FieldRange("prices", 500, 2000), new FieldRange("ratings", 3, 5)));
+
+        BooleanQuery.Builder bq = new BooleanQuery.Builder();
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("prices", 500, 2000),
+            BooleanClause.Occur.FILTER);
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("ratings", 3, 5),
+            BooleanClause.Occur.FILTER);
+
+        assertEquals(searcher.count(bq.build()), searcher.count(q));
+      }
+    }
+  }
+
+  /** Test with 5 fields. */
+  public void testFiveFields() throws IOException {
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+        for (int i = 0; i < 50000; i++) {
+          Document doc = new Document();
+          doc.add(new NumericDocValuesField("f1", i % 100));
+          doc.add(new NumericDocValuesField("f2", i % 50));
+          doc.add(new NumericDocValuesField("f3", i % 200));
+          doc.add(new NumericDocValuesField("f4", i % 10));
+          doc.add(new NumericDocValuesField("f5", i % 500));
+          writer.addDocument(doc);
+        }
+        writer.forceMerge(1);
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        IndexSearcher searcher = newSearcher(reader);
+        MultiFieldDocValuesRangeQuery q =
+            buildQuery(
+                List.of(
+                    new FieldRange("f1", 10, 30),
+                    new FieldRange("f2", 5, 15),
+                    new FieldRange("f3", 50, 100),
+                    new FieldRange("f4", 2, 4),
+                    new FieldRange("f5", 100, 200)));
+
+        BooleanQuery.Builder bq = new BooleanQuery.Builder();
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("f1", 10, 30),
+            BooleanClause.Occur.FILTER);
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("f2", 5, 15), BooleanClause.Occur.FILTER);
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("f3", 50, 100),
+            BooleanClause.Occur.FILTER);
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("f4", 2, 4), BooleanClause.Occur.FILTER);
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("f5", 100, 200),
+            BooleanClause.Occur.FILTER);
+
+        assertEquals(searcher.count(bq.build()), searcher.count(q));
+      }
+    }
+  }
+
+  /** Test that the query rejects fewer than 2 field ranges. */
+  public void testMinimumTwoFields() {
+    BooleanQuery fallback =
+        new BooleanQuery.Builder()
+            .add(
+                SortedNumericDocValuesField.newSlowRangeQuery("single", 0, 100),
+                BooleanClause.Occur.FILTER)
+            .build();
+    expectThrows(
+        IllegalArgumentException.class,
+        () ->
+            new MultiFieldDocValuesRangeQuery(List.of(new FieldRange("single", 0, 100)), fallback));
+  }
+
+  /** Test that BooleanQuery.rewrite detects and rewrites to MultiFieldDocValuesRangeQuery. */
+  public void testBooleanQueryRewrite() throws IOException {
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+        for (int i = 0; i < 10000; i++) {
+          Document doc = new Document();
+          doc.add(new NumericDocValuesField("a", i % 100));
+          doc.add(new NumericDocValuesField("b", i % 50));
+          writer.addDocument(doc);
+        }
+        writer.forceMerge(1);
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        IndexSearcher searcher = newSearcher(reader);
+
+        // Build a BooleanQuery with 2 required numeric range queries
+        BooleanQuery.Builder bq = new BooleanQuery.Builder();
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("a", 10, 30), BooleanClause.Occur.FILTER);
+        bq.add(
+            SortedNumericDocValuesField.newSlowRangeQuery("b", 5, 15), BooleanClause.Occur.FILTER);
+
+        Query rewritten = bq.build().rewrite(searcher);
+
+        // The rewritten query should contain a MultiFieldDocValuesRangeQuery
+        boolean foundMultiField = false;
+        if (rewritten instanceof BooleanQuery rewrittenBq) {
+          for (BooleanClause clause : rewrittenBq.clauses()) {
+            if (clause.query() instanceof MultiFieldDocValuesRangeQuery) {
+              foundMultiField = true;
+              break;
+            }
+          }
+        }
+        assertTrue(
+            "BooleanQuery with 2+ numeric range filters should rewrite to include MultiFieldDocValuesRangeQuery",
+            foundMultiField);
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

Related issue for more details - https://github.com/apache/lucene/issues/15770

 - This PR adds MultiFieldDocValuesRangeQuery, which coordinates DocValuesSkipper evaluation across fields. BooleanQuery.rewrite() detects the pattern (2+ required NumericDocValuesRangeQuery clauses on distinct fields) and replaces them with a single coordinated query.

 - MultiFieldDocValuesRangeQuery contains Concatenated iterator where the main logic lies. It work together with all the desired fields docValueSkipper and move them together.

- Also contains a jmh benchmark to validate this.

- Tested across different data patterns, document counts, and number of concurrent range fields.



## JMH Benchmark Results


| Pattern   | Docs | Fields | Without Optimization | With optimization | Speedup |
|-----------|------|--------|---------------------|--------------|---------|
| clustered | 1M   | 3      | 16,417              | 61,342       | **3.7x** |
| clustered | 1M   | 5      | 11,523              | 57,487       | **5.0x** |
| clustered | 10M  | 3      | 16,148              | 55,677       | **3.4x** |
| clustered | 10M  | 5      | 13,128              | 42,154       | **3.2x** |
| mixed     | 1M   | 3      | 859                 | 1,001        | **1.17x** |
| mixed     | 1M   | 5      | 514                 | 873          | **1.70x** |
| mixed     | 10M  | 3      | 76                  | 79           | **1.03x** |
| mixed     | 10M  | 5      | 50                  | 69           | **1.38x** |
| random    | 1M   | 3      | 62                  | 68           | **1.10x** |
| random    | 1M   | 5      | 45                  | 64           | **1.42x** |
| random    | 10M  | 3      | 4.3                 | 6.5          | **1.51x** |
| random    | 10M  | 5      | 3.5                 | 5.8          | **1.65x** |
| sorted    | 1M   | 3      | 920                 | 841          | 0.91x |
| sorted    | 1M   | 5      | 611                 | 882          | **1.44x** |
| sorted    | 10M  | 3      | 69                  | 78           | **1.14x** |
| sorted    | 10M  | 5      | 55                  | 68           | **1.22x** |


**Query used**
```
{"bool":{"filter":[{"range":{"field0":{"gte":"X","lte":"Y"}}},{"range":{"field1":{"gte":"A","lte":"B"}}},{"range":{"field2":{"gte":"M","lte":"N"}}}]}}
```

**Data Pattern:** 
 - **clustered**: All field values increase with docID (e.g., time-series data where timestamp, sequence number, and sensor readings grow together). Narrow query ranges eliminate most blocks. Best case for coordination (3.2–5.0x).

- **mixed**: Combination of monotonic (timestamp), low-cardinality (20 values, like order status), and random fields (price). Resembles e-commerce order filtering. Moderate gains (1.2–1.7x).

- **sorted**: Index sorted by one field (timestamp), other fields random. Resembles time-series indexed by ingestion time but queried on unsorted metric fields. Similar to mixed (1.1–1.4x).

- **random**: All fields uniformly random with wide query ranges. Worst case, but still gains (1.1–1.7x) — when one field eliminates a block, it saves checking all others.

