### PR TITLE
Exclude JNA Cleaner thread from ThreadLeak detection

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -271,6 +271,8 @@ Other
 * GITHUB#15783: Refactor QuantizedVectorsReader to be able to access lucene 104 quantized values through this API.
   (Ignacio Vera)
 
+* GITHUB#15799: Exclude JNA Cleaner from thread leak detection by LuceneTestCase. (Alan Woodward)
+
 ======================= Lucene 10.4.0 =======================
 
 API Changes

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/QuickPatchThreadsFilter.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/QuickPatchThreadsFilter.java
@@ -52,6 +52,8 @@ public class QuickPatchThreadsFilter implements ThreadFilter {
       return true;
     }
 
-    return false;
+    // Also filter out JNA Cleaner threads, which is static per-JVM and not under the
+    // control of a test suite.
+    return t.getName().equals("JNA Cleaner");
   }
 }


### PR DESCRIPTION
JNA Cleaner is a static per-JVM thread that may start up during the
execution of a test if JNA is being used elsewhere in the test suite,
and shouldn't be considered as a leak from any individual test.