### PR TITLE
Add ReaderUtil#partitionByLeaf to partition sorted global doc IDs by …

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -213,8 +213,8 @@ API Changes
 
 * GITHUB#15751: Prevent zero vectors in knn fields with cosine similarity configured (Vigya Sharma)
 
-* GITHUB#15803: Add ReaderUtil#partitionByLeaf to partition sorted global
-  doc IDs by leaf reader. (Zihan Xu)
+* GITHUB#15803: Add ReaderUtil#partitionByLeaf to partition doc IDs from
+  ScoreDoc hits by leaf reader. (Zihan Xu)
 
 New Features
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -548,6 +548,10 @@ API Changes
   instance instead of a Bits instance to identify document IDs to filter.
   (Shubham Chaudhary, Adrien Grand)
 
+* GITHUB#XXXX: Add ReaderUtil#partitionByLeaf to partition sorted global
+  doc IDs by leaf reader. (Zihan Xu)
+
+
 New Features
 ---------------------
 * GITHUB#15015: MultiIndexMergeScheduler: a production multi-tenant merge scheduler (Shawn Yarbrough)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -548,7 +548,7 @@ API Changes
   instance instead of a Bits instance to identify document IDs to filter.
   (Shubham Chaudhary, Adrien Grand)
 
-* GITHUB#XXXX: Add ReaderUtil#partitionByLeaf to partition sorted global
+* GITHUB#15803: Add ReaderUtil#partitionByLeaf to partition sorted global
   doc IDs by leaf reader. (Zihan Xu)
 
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -213,6 +213,9 @@ API Changes
 
 * GITHUB#15751: Prevent zero vectors in knn fields with cosine similarity configured (Vigya Sharma)
 
+* GITHUB#15803: Add ReaderUtil#partitionByLeaf to partition sorted global
+  doc IDs by leaf reader. (Zihan Xu)
+
 New Features
 ---------------------
 
@@ -547,10 +550,6 @@ API Changes
 * GITHUB#15011: LeafReader#searchNearestVectors now accepts an AcceptDocs
   instance instead of a Bits instance to identify document IDs to filter.
   (Shubham Chaudhary, Adrien Grand)
-
-* GITHUB#15803: Add ReaderUtil#partitionByLeaf to partition sorted global
-  doc IDs by leaf reader. (Zihan Xu)
-
 
 New Features
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/index/ReaderUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReaderUtil.java
@@ -103,17 +103,17 @@ public final class ReaderUtil {
    * @return array indexed by leaf ord, containing global doc IDs for that leaf (empty if no hits)
    */
   public static int[][] partitionByLeaf(ScoreDoc[] hits, List<LeafReaderContext> leaves) {
+    int numLeaves = leaves.size();
+    int[][] result = new int[numLeaves][];
+    if (hits.length == 0) {
+      Arrays.fill(result, EMPTY_INT_ARRAY);
+      return result;
+    }
     int[] sortedDocIds = new int[hits.length];
     for (int i = 0; i < hits.length; i++) {
       sortedDocIds[i] = hits[i].doc;
     }
     Arrays.sort(sortedDocIds);
-    int numLeaves = leaves.size();
-    int[][] result = new int[numLeaves][];
-    if (sortedDocIds.length == 0) {
-      Arrays.fill(result, EMPTY_INT_ARRAY);
-      return result;
-    }
     int leafStart = 0;
     int leafIdx = 0;
     LeafReaderContext leaf = leaves.getFirst();

--- a/lucene/core/src/java/org/apache/lucene/index/ReaderUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReaderUtil.java
@@ -16,7 +16,9 @@
  */
 package org.apache.lucene.index;
 
+import java.util.Arrays;
 import java.util.List;
+import org.apache.lucene.search.ScoreDoc;
 
 /**
  * Common util methods for dealing with {@link IndexReader}s and {@link IndexReaderContext}s.
@@ -24,6 +26,8 @@ import java.util.List;
  * @lucene.internal
  */
 public final class ReaderUtil {
+
+  private static final int[] EMPTY_INT_ARRAY = new int[0];
 
   private ReaderUtil() {} // no instance
 
@@ -91,6 +95,23 @@ public final class ReaderUtil {
   }
 
   /**
+   * Partitions global doc IDs from ScoreDoc array by leaf. Extracts doc IDs, sorts them, and
+   * partitions across leaves.
+   *
+   * @param hits the ScoreDoc array (typically from TopDocs.scoreDocs)
+   * @param leaves the index reader's leaves
+   * @return array indexed by leaf ord, containing global doc IDs for that leaf (empty if no hits)
+   */
+  public static int[][] partitionByLeaf(ScoreDoc[] hits, List<LeafReaderContext> leaves) {
+    int[] docIds = new int[hits.length];
+    for (int i = 0; i < hits.length; i++) {
+      docIds[i] = hits[i].doc;
+    }
+    Arrays.sort(docIds);
+    return partitionByLeaf(docIds, leaves);
+  }
+
+  /**
    * Partitions sorted global doc IDs by leaf.
    *
    * @param sortedDocIds global doc IDs, must be sorted ascending
@@ -98,47 +119,55 @@ public final class ReaderUtil {
    * @return array indexed by leaf ord, containing global doc IDs for that leaf (empty if no hits)
    */
   public static int[][] partitionByLeaf(int[] sortedDocIds, List<LeafReaderContext> leaves) {
-    assert isSorted(sortedDocIds) : "sortedDocIds must be sorted ascending";
+    assert isSorted(sortedDocIds) : "docIds must be sorted";
     int numLeaves = leaves.size();
     int[][] result = new int[numLeaves][];
     if (sortedDocIds.length == 0) {
       for (int i = 0; i < numLeaves; i++) {
-        result[i] = new int[0];
+        result[i] = EMPTY_INT_ARRAY;
       }
       return result;
     }
-    // Pass 1: Count and allocate
-    int hitsCount = 0;
+    int leafStart = 0;
     int leafIdx = 0;
     LeafReaderContext leaf = leaves.get(0);
     int leafEnd = leaf.docBase + leaf.reader().maxDoc();
-    for (int docId : sortedDocIds) {
+    for (int i = 0; i < sortedDocIds.length; i++) {
+      int docId = sortedDocIds[i];
       while (docId >= leafEnd) {
-        result[leafIdx] = new int[hitsCount];
-        hitsCount = 0;
+        int count = i - leafStart;
+        if (count == 0) {
+          result[leafIdx] = EMPTY_INT_ARRAY;
+        } else {
+          result[leafIdx] = new int[count];
+          System.arraycopy(sortedDocIds, leafStart, result[leafIdx], 0, count);
+        }
+        leafStart = i;
         leafIdx++;
         leaf = leaves.get(leafIdx);
         leafEnd = leaf.docBase + leaf.reader().maxDoc();
       }
-      hitsCount++;
     }
-    result[leafIdx] = new int[hitsCount];
+    // Handle last leaf
+    int count = sortedDocIds.length - leafStart;
+    if (count == 0) {
+      result[leafIdx] = EMPTY_INT_ARRAY;
+    } else {
+      result[leafIdx] = new int[count];
+      System.arraycopy(sortedDocIds, leafStart, result[leafIdx], 0, count);
+    }
     // Fill remaining empty leaves
     for (int i = leafIdx + 1; i < numLeaves; i++) {
-      result[i] = new int[0];
-    }
-    // Pass 2: Copy docIds to result arrays
-    int srcPos = 0;
-    for (int[] leafDocs : result) {
-      System.arraycopy(sortedDocIds, srcPos, leafDocs, 0, leafDocs.length);
-      srcPos += leafDocs.length;
+      result[i] = EMPTY_INT_ARRAY;
     }
     return result;
   }
 
   private static boolean isSorted(int[] a) {
     for (int i = 1; i < a.length; i++) {
-      if (a[i] < a[i - 1]) return false;
+      if (a[i] < a[i - 1]) {
+        throw new AssertionError("docId " + a[i] + " appears after " + a[i - 1]);
+      }
     }
     return true;
   }

--- a/lucene/core/src/java/org/apache/lucene/index/ReaderUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReaderUtil.java
@@ -103,34 +103,20 @@ public final class ReaderUtil {
    * @return array indexed by leaf ord, containing global doc IDs for that leaf (empty if no hits)
    */
   public static int[][] partitionByLeaf(ScoreDoc[] hits, List<LeafReaderContext> leaves) {
-    int[] docIds = new int[hits.length];
+    int[] sortedDocIds = new int[hits.length];
     for (int i = 0; i < hits.length; i++) {
-      docIds[i] = hits[i].doc;
+      sortedDocIds[i] = hits[i].doc;
     }
-    Arrays.sort(docIds);
-    return partitionByLeaf(docIds, leaves);
-  }
-
-  /**
-   * Partitions sorted global doc IDs by leaf.
-   *
-   * @param sortedDocIds global doc IDs, must be sorted ascending
-   * @param leaves the index reader's leaves
-   * @return array indexed by leaf ord, containing global doc IDs for that leaf (empty if no hits)
-   */
-  public static int[][] partitionByLeaf(int[] sortedDocIds, List<LeafReaderContext> leaves) {
-    assert isSorted(sortedDocIds) : "docIds must be sorted";
+    Arrays.sort(sortedDocIds);
     int numLeaves = leaves.size();
     int[][] result = new int[numLeaves][];
     if (sortedDocIds.length == 0) {
-      for (int i = 0; i < numLeaves; i++) {
-        result[i] = EMPTY_INT_ARRAY;
-      }
+      Arrays.fill(result, EMPTY_INT_ARRAY);
       return result;
     }
     int leafStart = 0;
     int leafIdx = 0;
-    LeafReaderContext leaf = leaves.get(0);
+    LeafReaderContext leaf = leaves.getFirst();
     int leafEnd = leaf.docBase + leaf.reader().maxDoc();
     for (int i = 0; i < sortedDocIds.length; i++) {
       int docId = sortedDocIds[i];
@@ -148,27 +134,13 @@ public final class ReaderUtil {
         leafEnd = leaf.docBase + leaf.reader().maxDoc();
       }
     }
-    // Handle last leaf
+    // Handle remaining docIDs
     int count = sortedDocIds.length - leafStart;
-    if (count == 0) {
-      result[leafIdx] = EMPTY_INT_ARRAY;
-    } else {
-      result[leafIdx] = new int[count];
-      System.arraycopy(sortedDocIds, leafStart, result[leafIdx], 0, count);
-    }
+    assert count > 0;
+    result[leafIdx] = new int[count];
+    System.arraycopy(sortedDocIds, leafStart, result[leafIdx], 0, count);
     // Fill remaining empty leaves
-    for (int i = leafIdx + 1; i < numLeaves; i++) {
-      result[i] = EMPTY_INT_ARRAY;
-    }
+    Arrays.fill(result, leafIdx + 1, numLeaves, EMPTY_INT_ARRAY);
     return result;
-  }
-
-  private static boolean isSorted(int[] a) {
-    for (int i = 1; i < a.length; i++) {
-      if (a[i] < a[i - 1]) {
-        throw new AssertionError("docId " + a[i] + " appears after " + a[i - 1]);
-      }
-    }
-    return true;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/ReaderUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReaderUtil.java
@@ -98,6 +98,7 @@ public final class ReaderUtil {
    * @return array indexed by leaf ord, containing global doc IDs for that leaf (empty if no hits)
    */
   public static int[][] partitionByLeaf(int[] sortedDocIds, List<LeafReaderContext> leaves) {
+    assert isSorted(sortedDocIds) : "sortedDocIds must be sorted ascending";
     int numLeaves = leaves.size();
     int[][] result = new int[numLeaves][];
     if (sortedDocIds.length == 0) {
@@ -133,5 +134,12 @@ public final class ReaderUtil {
       srcPos += leafDocs.length;
     }
     return result;
+  }
+
+  private static boolean isSorted(int[] a) {
+    for (int i = 1; i < a.length; i++) {
+      if (a[i] < a[i - 1]) return false;
+    }
+    return true;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/ReaderUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReaderUtil.java
@@ -89,4 +89,49 @@ public final class ReaderUtil {
     }
     return hi;
   }
+
+  /**
+   * Partitions sorted global doc IDs by leaf.
+   *
+   * @param sortedDocIds global doc IDs, must be sorted ascending
+   * @param leaves the index reader's leaves
+   * @return array indexed by leaf ord, containing global doc IDs for that leaf (empty if no hits)
+   */
+  public static int[][] partitionByLeaf(int[] sortedDocIds, List<LeafReaderContext> leaves) {
+    int numLeaves = leaves.size();
+    int[][] result = new int[numLeaves][];
+    if (sortedDocIds.length == 0) {
+      for (int i = 0; i < numLeaves; i++) {
+        result[i] = new int[0];
+      }
+      return result;
+    }
+    // Pass 1: Count and allocate
+    int hitsCount = 0;
+    int leafIdx = 0;
+    LeafReaderContext leaf = leaves.get(0);
+    int leafEnd = leaf.docBase + leaf.reader().maxDoc();
+    for (int docId : sortedDocIds) {
+      while (docId >= leafEnd) {
+        result[leafIdx] = new int[hitsCount];
+        hitsCount = 0;
+        leafIdx++;
+        leaf = leaves.get(leafIdx);
+        leafEnd = leaf.docBase + leaf.reader().maxDoc();
+      }
+      hitsCount++;
+    }
+    result[leafIdx] = new int[hitsCount];
+    // Fill remaining empty leaves
+    for (int i = leafIdx + 1; i < numLeaves; i++) {
+      result[i] = new int[0];
+    }
+    // Pass 2: Copy docIds to result arrays
+    int srcPos = 0;
+    for (int[] leafDocs : result) {
+      System.arraycopy(sortedDocIds, srcPos, leafDocs, 0, leafDocs.length);
+      srcPos += leafDocs.length;
+    }
+    return result;
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestReaderUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestReaderUtil.java
@@ -17,8 +17,12 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
@@ -61,7 +65,8 @@ public class TestReaderUtil extends LuceneTestCase {
 
   public void testPartitionByLeafMultipleSegments() throws IOException {
     try (Directory dir = newDirectory();
-        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+        IndexWriter writer =
+            new IndexWriter(dir, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
       for (int i = 0; i < 10; i++) {
         writer.addDocument(new Document());
       }
@@ -90,9 +95,10 @@ public class TestReaderUtil extends LuceneTestCase {
     }
   }
 
-  public void testPartitionByLeafSkipsEmptySegments() throws IOException {
+  public void testPartitionByLeafSkipsSegmentsWithNoHits() throws IOException {
     try (Directory dir = newDirectory();
-        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+        IndexWriter writer =
+            new IndexWriter(dir, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
       // Create 3 segments
       for (int seg = 0; seg < 3; seg++) {
         for (int i = 0; i < 10; i++) {
@@ -113,6 +119,97 @@ public class TestReaderUtil extends LuceneTestCase {
         assertArrayEquals(new int[] {3}, result[0]);
         assertEquals(0, result[1].length); // middle segment has no hits
         assertArrayEquals(new int[] {25}, result[2]);
+      }
+    }
+  }
+
+  public void testPartitionByLeafRandomized() throws IOException {
+    for (int iter = 0; iter < 100; iter++) {
+      int numSegments = random().nextInt(10) + 1;
+      int totalDocs = 0;
+      int[] docsPerSegment = new int[numSegments];
+      for (int i = 0; i < numSegments; i++) {
+        docsPerSegment[i] = random().nextInt(100) + 1;
+        totalDocs += docsPerSegment[i];
+      }
+
+      try (Directory dir = newDirectory();
+          IndexWriter writer =
+              new IndexWriter(
+                  dir, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
+        for (int seg = 0; seg < numSegments; seg++) {
+          for (int i = 0; i < docsPerSegment[seg]; i++) {
+            writer.addDocument(new Document());
+          }
+          writer.commit();
+        }
+
+        try (DirectoryReader reader = DirectoryReader.open(writer)) {
+          List<LeafReaderContext> leaves = reader.leaves();
+          assertEquals(numSegments, leaves.size());
+
+          // Generate random hits (0 to totalDocs inclusive - covers empty and all-match)
+          int numHits = random().nextInt(totalDocs + 1);
+          Set<Integer> hitSet = new HashSet<>();
+          while (hitSet.size() < numHits) {
+            hitSet.add(random().nextInt(totalDocs));
+          }
+          int[] docIds = hitSet.stream().mapToInt(Integer::intValue).sorted().toArray();
+
+          int[][] result = ReaderUtil.partitionByLeaf(docIds, leaves);
+
+          // Verify: result length matches leaves
+          assertEquals(numSegments, result.length);
+
+          // Verify: total hits preserved
+          int totalResultDocs = Arrays.stream(result).mapToInt(a -> a.length).sum();
+          assertEquals(docIds.length, totalResultDocs);
+
+          // Verify: each doc in correct leaf and sorted
+          for (int leafIdx = 0; leafIdx < result.length; leafIdx++) {
+            int[] leafDocs = result[leafIdx];
+            LeafReaderContext leaf = leaves.get(leafIdx);
+            int docBase = leaf.docBase;
+            int maxDoc = leaf.reader().maxDoc();
+            for (int i = 0; i < leafDocs.length; i++) {
+              int docId = leafDocs[i];
+              assertTrue(docId >= docBase && docId < docBase + maxDoc);
+              if (i > 0) {
+                assertTrue(leafDocs[i] > leafDocs[i - 1]);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  public void testPartitionByLeafScoreDoc() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer =
+            new IndexWriter(dir, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
+      for (int i = 0; i < 10; i++) {
+        writer.addDocument(new Document());
+      }
+      writer.commit();
+
+      for (int i = 0; i < 10; i++) {
+        writer.addDocument(new Document());
+      }
+      writer.commit();
+
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        List<LeafReaderContext> leaves = reader.leaves();
+        assertEquals(2, leaves.size());
+
+        // ScoreDocs in non-sorted order (as they might come from ranking)
+        ScoreDoc[] hits = {new ScoreDoc(18, 1.0f), new ScoreDoc(5, 0.9f), new ScoreDoc(12, 0.8f)};
+        int[][] result = ReaderUtil.partitionByLeaf(hits, leaves);
+
+        assertEquals(2, result.length);
+        // Should be sorted within each leaf
+        assertArrayEquals(new int[] {5}, result[0]);
+        assertArrayEquals(new int[] {12, 18}, result[1]);
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/index/TestReaderUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestReaderUtil.java
@@ -35,7 +35,7 @@ public class TestReaderUtil extends LuceneTestCase {
       writer.addDocument(new Document());
       try (DirectoryReader reader = DirectoryReader.open(writer)) {
         List<LeafReaderContext> leaves = reader.leaves();
-        int[][] result = ReaderUtil.partitionByLeaf(new int[0], leaves);
+        int[][] result = ReaderUtil.partitionByLeaf(new ScoreDoc[0], leaves);
         assertEquals(leaves.size(), result.length);
         for (int[] leaf : result) {
           assertEquals(0, leaf.length);
@@ -54,11 +54,13 @@ public class TestReaderUtil extends LuceneTestCase {
         List<LeafReaderContext> leaves = reader.leaves();
         assertEquals(1, leaves.size());
 
-        int[] docIds = {0, 3, 5, 9};
-        int[][] result = ReaderUtil.partitionByLeaf(docIds, leaves);
+        ScoreDoc[] hits = {
+          new ScoreDoc(0, 1f), new ScoreDoc(3, 1f), new ScoreDoc(5, 1f), new ScoreDoc(9, 1f)
+        };
+        int[][] result = ReaderUtil.partitionByLeaf(hits, leaves);
 
         assertEquals(1, result.length);
-        assertArrayEquals(docIds, result[0]);
+        assertArrayEquals(new int[] {0, 3, 5, 9}, result[0]);
       }
     }
   }
@@ -83,8 +85,10 @@ public class TestReaderUtil extends LuceneTestCase {
         assertEquals(2, leaves.size());
 
         // Hits in both segments
-        int[] docIds = {2, 9, 10, 18};
-        int[][] result = ReaderUtil.partitionByLeaf(docIds, leaves);
+        ScoreDoc[] hits = {
+          new ScoreDoc(2, 1f), new ScoreDoc(9, 1f), new ScoreDoc(10, 1f), new ScoreDoc(18, 1f)
+        };
+        int[][] result = ReaderUtil.partitionByLeaf(hits, leaves);
 
         assertEquals(2, result.length);
         // First segment: docs 0-9
@@ -112,8 +116,8 @@ public class TestReaderUtil extends LuceneTestCase {
         assertEquals(3, leaves.size());
 
         // Hits only in first and third segment (skip middle)
-        int[] docIds = {3, 25};
-        int[][] result = ReaderUtil.partitionByLeaf(docIds, leaves);
+        ScoreDoc[] hits = {new ScoreDoc(3, 1f), new ScoreDoc(25, 1f)};
+        int[][] result = ReaderUtil.partitionByLeaf(hits, leaves);
 
         assertEquals(3, result.length);
         assertArrayEquals(new int[] {3}, result[0]);
@@ -154,9 +158,13 @@ public class TestReaderUtil extends LuceneTestCase {
           while (hitSet.size() < numHits) {
             hitSet.add(random().nextInt(totalDocs));
           }
-          int[] docIds = hitSet.stream().mapToInt(Integer::intValue).sorted().toArray();
+          int[] docIds = hitSet.stream().mapToInt(Integer::intValue).toArray();
+          ScoreDoc[] hits = new ScoreDoc[docIds.length];
+          for (int i = 0; i < docIds.length; i++) {
+            hits[i] = new ScoreDoc(docIds[i], 1f);
+          }
 
-          int[][] result = ReaderUtil.partitionByLeaf(docIds, leaves);
+          int[][] result = ReaderUtil.partitionByLeaf(hits, leaves);
 
           // Verify: result length matches leaves
           assertEquals(numSegments, result.length);
@@ -180,36 +188,6 @@ public class TestReaderUtil extends LuceneTestCase {
             }
           }
         }
-      }
-    }
-  }
-
-  public void testPartitionByLeafScoreDoc() throws IOException {
-    try (Directory dir = newDirectory();
-        IndexWriter writer =
-            new IndexWriter(dir, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
-      for (int i = 0; i < 10; i++) {
-        writer.addDocument(new Document());
-      }
-      writer.commit();
-
-      for (int i = 0; i < 10; i++) {
-        writer.addDocument(new Document());
-      }
-      writer.commit();
-
-      try (DirectoryReader reader = DirectoryReader.open(writer)) {
-        List<LeafReaderContext> leaves = reader.leaves();
-        assertEquals(2, leaves.size());
-
-        // ScoreDocs in non-sorted order (as they might come from ranking)
-        ScoreDoc[] hits = {new ScoreDoc(18, 1.0f), new ScoreDoc(5, 0.9f), new ScoreDoc(12, 0.8f)};
-        int[][] result = ReaderUtil.partitionByLeaf(hits, leaves);
-
-        assertEquals(2, result.length);
-        // Should be sorted within each leaf
-        assertArrayEquals(new int[] {5}, result[0]);
-        assertArrayEquals(new int[] {12, 18}, result[1]);
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/index/TestReaderUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestReaderUtil.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.index;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestReaderUtil extends LuceneTestCase {
+
+  public void testPartitionByLeafEmptyDocIds() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+      writer.addDocument(new Document());
+      writer.addDocument(new Document());
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        List<LeafReaderContext> leaves = reader.leaves();
+        int[][] result = ReaderUtil.partitionByLeaf(new int[0], leaves);
+        assertEquals(leaves.size(), result.length);
+        for (int[] leaf : result) {
+          assertEquals(0, leaf.length);
+        }
+      }
+    }
+  }
+
+  public void testPartitionByLeafSingleSegment() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+      for (int i = 0; i < 10; i++) {
+        writer.addDocument(new Document());
+      }
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        List<LeafReaderContext> leaves = reader.leaves();
+        assertEquals(1, leaves.size());
+
+        int[] docIds = {0, 3, 5, 9};
+        int[][] result = ReaderUtil.partitionByLeaf(docIds, leaves);
+
+        assertEquals(1, result.length);
+        assertArrayEquals(docIds, result[0]);
+      }
+    }
+  }
+
+  public void testPartitionByLeafMultipleSegments() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+      for (int i = 0; i < 10; i++) {
+        writer.addDocument(new Document());
+      }
+      writer.commit();
+
+      // Create second segment
+      for (int i = 0; i < 10; i++) {
+        writer.addDocument(new Document());
+      }
+      writer.commit();
+
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        List<LeafReaderContext> leaves = reader.leaves();
+        assertEquals(2, leaves.size());
+
+        // Hits in both segments
+        int[] docIds = {2, 9, 10, 18};
+        int[][] result = ReaderUtil.partitionByLeaf(docIds, leaves);
+
+        assertEquals(2, result.length);
+        // First segment: docs 0-9
+        assertArrayEquals(new int[] {2, 9}, result[0]);
+        // Second segment: docs 10-19
+        assertArrayEquals(new int[] {10, 18}, result[1]);
+      }
+    }
+  }
+
+  public void testPartitionByLeafSkipsEmptySegments() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+      // Create 3 segments
+      for (int seg = 0; seg < 3; seg++) {
+        for (int i = 0; i < 10; i++) {
+          writer.addDocument(new Document());
+        }
+        writer.commit();
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        List<LeafReaderContext> leaves = reader.leaves();
+        assertEquals(3, leaves.size());
+
+        // Hits only in first and third segment (skip middle)
+        int[] docIds = {3, 25};
+        int[][] result = ReaderUtil.partitionByLeaf(docIds, leaves);
+
+        assertEquals(3, result.length);
+        assertArrayEquals(new int[] {3}, result[0]);
+        assertEquals(0, result[1].length); // middle segment has no hits
+        assertArrayEquals(new int[] {25}, result[2]);
+      }
+    }
+  }
+}


### PR DESCRIPTION
…leaf reader

### Summary

This PR adds a new utility method `ReaderUtil.partitionByLeaf(int[] sortedDocIds, List<LeafReaderContext> leaves)` that efficiently partitions a sorted array of global doc IDs across the leaves of an `IndexReader`.

### Motivation

A common pattern when working with top-N hits is to map global doc IDs back to their per-segment leaves. The existing `ReaderUtil.subIndex` does a binary search per doc ID (`O(n * log(n))`), but when you need to partition *all* hits at once, a merge-sort-style linear scan is more efficient:

1. Sort the input doc IDs: `O(n * log(n))` with small constant (primitive int sort, potentially SIMD-accelerated).
2. Linear pass intersecting sorted doc IDs with leaf boundaries: `O(n)`.

### Changes

- Added `ReaderUtil.partitionByLeaf(int[] sortedDocIds, List<LeafReaderContext> leaves)`, two-pass linear algorithm:
  - **Pass 1 (count + allocate)**: walk doc IDs and leaf boundaries together, count hits per leaf, allocate result arrays
  - **Pass 2 (copy)**: `System.arraycopy` each leaf's contiguous slice from the sorted input
- Added `TestReaderUtil` with coverage for empty input, single segment, multiple segments, and segments with no hits

### Example Use Case

```java
int[] sortedTopDocIds = ...; // sorted global doc IDs from top-N collection
List<LeafReaderContext> leaves = reader.leaves();

int[][] perLeafDocIds = ReaderUtil.partitionByLeaf(sortedTopDocIds, leaves);

for (int i = 0; i < leaves.size(); i++) {
    if (perLeafDocIds[i].length == 0) {
        continue; // skip segments with no hits
    }
    // process hits for this leaf
    processLeaf(leaves.get(i), perLeafDocIds[i]);
}
```