### PR TITLE
Remove lock in StringHelper, using atomic getAndUpdate instead

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Methods for manipulating strings.
@@ -360,11 +361,9 @@ public abstract class StringHelper {
   }
 
   // Holds 128 bit unsigned value:
-  @SuppressWarnings("NonFinalStaticField")
-  private static BigInteger nextId;
+  private static final AtomicReference<BigInteger> nextId;
 
   private static final BigInteger mask128;
-  private static final Object idLock = new Object();
 
   static {
     // 128 bit unsigned mask
@@ -435,7 +434,7 @@ public abstract class StringHelper {
     BigInteger unsignedX1 = BigInteger.valueOf(x1).and(mask64);
 
     // Concatentate bits of x0 and x1, as unsigned 128 bit integer:
-    nextId = unsignedX0.shiftLeft(64).or(unsignedX1);
+    nextId = new AtomicReference<>(unsignedX0.shiftLeft(64).or(unsignedX1));
   }
 
   /** length in bytes of an ID */
@@ -458,11 +457,9 @@ public abstract class StringHelper {
     //     what impact that has on the period, whereas the simple ++ (mod 2^128)
     //     we use here is guaranteed to have the full period.
 
-    byte[] bits;
-    synchronized (idLock) {
-      bits = nextId.toByteArray();
-      nextId = nextId.add(BigInteger.ONE).and(mask128);
-    }
+
+    BigInteger next = nextId.getAndUpdate(n -> n.add(BigInteger.ONE).and(mask128));
+    byte[] bits = next.toByteArray();
 
     // toByteArray() always returns a sign bit, so it may require an extra byte (always zero)
     if (bits.length > ID_LENGTH) {

--- a/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StringHelper.java
@@ -457,7 +457,6 @@ public abstract class StringHelper {
     //     what impact that has on the period, whereas the simple ++ (mod 2^128)
     //     we use here is guaranteed to have the full period.
 
-
     BigInteger next = nextId.getAndUpdate(n -> n.add(BigInteger.ONE).and(mask128));
     byte[] bits = next.toByteArray();
 


### PR DESCRIPTION
### Description

This should reduce lock contention in `StringHelper.randomId()` by replacing with optimistic locking. We also move the `toByteArray()` call out of the lock/concurrent update as suggested by @easyice in https://github.com/apache/lucene/pull/15631.

As a bonus, we clean up one more instance of a non-final static field by replacing it with a `final AtomicReference`.
