### PR TITLE
Tone down TestSearcherManager (Too many open files)

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -63,7 +63,7 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
   public void testSearcherManager() throws Exception {
     pruner =
         new SearcherLifetimeManager.PruneByAge(
-            TEST_NIGHTLY ? TestUtil.nextInt(random(), 1, 20) : 1);
+            TEST_NIGHTLY ? TestUtil.nextInt(random(), 1, 10) : 1);
     runTest("TestSearcherManager");
   }
 
@@ -607,7 +607,7 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
           @Override
           public void run() {
             try {
-              int numDocs = TEST_NIGHTLY ? atLeast(20000) : atLeast(200);
+              int numDocs = TEST_NIGHTLY ? atLeast(10000) : atLeast(200);
               for (int i = 0; i < numDocs; i++) {
                 IndexWriter w = writerRef.get();
                 Document doc = new Document();


### PR DESCRIPTION
Nightly trips on this. I'll just tone it down a bit.

```
1 tests failed.
FAILED:  org.apache.lucene.search.TestSearcherManager.testConcurrentIndexCloseSearchAndRefresh

Error Message:
com.carrotsearch.randomizedtesting.UncaughtExceptionError: Captured an uncaught exception in thread: Thread[id=2285, name=Lucene Merge Thread #7, state=RUNNABLE, group=TGRP-TestSearcherManager]

Stack Trace:
com.carrotsearch.randomizedtesting.UncaughtExceptionError: Captured an uncaught exception in thread: Thread[id=2285, name=Lucene Merge Thread #7, state=RUNNABLE, group=TGRP-TestSearcherManager]
Caused by: org.apache.lucene.index.MergePolicy$MergeException: java.lang.IllegalStateException: this writer hit an unrecoverable error; cannot merge
        at __randomizedtesting.SeedInfo.seed([EE8448A47857401D]:0)
        at org.apache.lucene.index.ConcurrentMergeScheduler.handleMergeException(ConcurrentMergeScheduler.java:761)
        at org.apache.lucene.index.ConcurrentMergeScheduler$MergeThread.run(ConcurrentMergeScheduler.java:753)
Caused by: java.lang.IllegalStateException: this writer hit an unrecoverable error; cannot merge
        at org.apache.lucene.index.IndexWriter.hasPendingMerges(IndexWriter.java:2442)
        at org.apache.lucene.index.IndexWriter$IndexWriterMergeSource.hasPendingMerges(IndexWriter.java:6539)
        at org.apache.lucene.index.ConcurrentMergeScheduler.maybeStall(ConcurrentMergeScheduler.java:611)
        at org.apache.lucene.index.ConcurrentMergeScheduler.merge(ConcurrentMergeScheduler.java:566)
        at org.apache.lucene.index.ConcurrentMergeScheduler.runOnMergeFinished(ConcurrentMergeScheduler.java:686)
        at org.apache.lucene.index.ConcurrentMergeScheduler$MergeThread.run(ConcurrentMergeScheduler.java:742)
Caused by: java.nio.file.FileSystemException: /home/jenkins/workspace/Lucene-nightly-main-Linux/lucene/core/build/tests-tmp/lucene.search.TestSearcherManager_EE8448A47857401D-001/tempDir-001/_1gn_Lucene90TermVectorsIndex-doc_ids_7he.tmp: Too many open files
        at org.apache.lucene.tests.mockfile.HandleLimitFS.onOpen(HandleLimitFS.java:67)
        at org.apache.lucene.tests.mockfile.HandleTrackingFS.callOpenHook(HandleTrackingFS.java:82)
        at org.apache.lucene.tests.mockfile.HandleTrackingFS.newOutputStream(HandleTrackingFS.java:163)
        at org.apache.lucene.tests.mockfile.FilterFileSystemProvider.newOutputStream(FilterFileSystemProvider.java:200)
        at java.base/java.nio.file.Files.newOutputStream(Files.java:215)
        at org.apache.lucene.store.FSDirectory$FSIndexOutput.<init>(FSDirectory.java:385)
        at org.apache.lucene.store.FSDirectory.createTempOutput(FSDirectory.java:229)
        at org.apache.lucene.tests.store.MockDirectoryWrapper.createTempOutput(MockDirectoryWrapper.java:751)
        at org.apache.lucene.store.FilterDirectory.createTempOutput(FilterDirectory.java:81)
        at org.apache.lucene.store.TrackingDirectoryWrapper.createTempOutput(TrackingDirectoryWrapper.java:49)
        at org.apache.lucene.codecs.lucene90.compressing.FieldsIndexWriter.<init>(FieldsIndexWriter.java:83)
        at org.apache.lucene.codecs.lucene90.compressing.Lucene90CompressingTermVectorsWriter.<init>(Lucene90CompressingTermVectorsWriter.java:285)
        at org.apache.lucene.codecs.lucene90.compressing.Lucene90CompressingTermVectorsFormat.vectorsWriter(Lucene90CompressingTermVectorsFormat.java:103)
        at org.apache.lucene.tests.codecs.asserting.AssertingTermVectorsFormat.vectorsWriter(AssertingTermVectorsFormat.java:51)
        at org.apache.lucene.index.TermVectorsConsumer.initTermVectorsWriter(TermVectorsConsumer.java:106)
        at org.apache.lucene.index.TermVectorsConsumer.finishDocument(TermVectorsConsumer.java:126)
        at org.apache.lucene.index.TermsHash.finishDocument(TermsHash.java:95)
        at org.apache.lucene.index.IndexingChain.processDocument(IndexingChain.java:624)
        at org.apache.lucene.index.DocumentsWriterPerThread.updateDocuments(DocumentsWriterPerThread.java:274)
        at org.apache.lucene.index.DocumentsWriter.updateDocuments(DocumentsWriter.java:427)
        at org.apache.lucene.index.IndexWriter.updateDocuments(IndexWriter.java:1563)
        at org.apache.lucene.index.IndexWriter.updateDocument(IndexWriter.java:1845)
        at org.apache.lucene.index.IndexWriter.addDocument(IndexWriter.java:1489)
        at org.apache.lucene.search.TestSearcherManager$8.run(TestSearcherManager.java:619)
```