### PR TITLE
fix: support all packed value lengths in NumericFieldStats.decodeLong

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -216,9 +216,10 @@ API Changes
 New Features
 ---------------------
 
-* GITHUB#15740: Add NumericFieldStats utility for retrieving global numeric field statistics
-  (min, max, doc count) from index metadata structures. Migrate SortedNumericDocValuesRangeQuery
-  to use this API, fixing the rewrite optimization for fields with PointValues but no skip index.
+* GITHUB#15740, GITHUB#15817: Add NumericFieldStats utility for retrieving global numeric field
+  statistics (min, max, doc count) from index metadata structures. Migrate
+  SortedNumericDocValuesRangeQuery to use this API, fixing the rewrite optimization for fields
+  with PointValues but no skip index. Support all packed value lengths from 1 to 8 bytes.
   (Salvatore Campagna)
 
 Improvements

--- a/lucene/core/src/java/org/apache/lucene/search/NumericFieldStats.java
+++ b/lucene/core/src/java/org/apache/lucene/search/NumericFieldStats.java
@@ -22,7 +22,6 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PointValues;
-import org.apache.lucene.util.NumericUtils;
 
 /**
  * Utility class for retrieving global numeric field statistics from index metadata structures,
@@ -65,7 +64,10 @@ public final class NumericFieldStats {
   private static Stats getStatsFromPoints(IndexReader reader, String field) throws IOException {
     final byte[] minPacked = PointValues.getMinPackedValue(reader, field);
     final byte[] maxPacked = PointValues.getMaxPackedValue(reader, field);
-    if (minPacked == null || maxPacked == null) {
+    if (minPacked == null
+        || maxPacked == null
+        || minPacked.length > Long.BYTES
+        || maxPacked.length > Long.BYTES) {
       return null;
     }
     final int docCount = PointValues.getDocCount(reader, field);
@@ -101,31 +103,17 @@ public final class NumericFieldStats {
   }
 
   /**
-   * Decodes a packed {@code byte[]} point value into a {@code long}. {@link PointValues} stores
-   * numeric values as big-endian byte arrays with the sign bit flipped for sortable ordering.
-   * {@code IntField} produces 4-byte arrays and {@code LongField} produces 8-byte arrays, so we
-   * dispatch on length to call the appropriate {@link NumericUtils} decoder. The {@code int} case
-   * widens to {@code long} via standard Java sign extension, which preserves the original value.
-   *
-   * <p>We return {@code long} unconditionally because the query layer already works with {@code
-   * long} bounds (e.g. {@code SortedNumericDocValuesRangeQuery} stores its range as {@code long}
-   * even for {@code IntField} queries). Callers that need the original {@code int} value can safely
-   * narrow with {@code Math.toIntExact()}, which will never throw for values originating from an
-   * {@code IntField}.
+   * Decodes a packed {@code byte[]} point value into a {@code long}. Handles any packed value
+   * length from 1 to 8 bytes, covering {@code HalfFloatPoint} (2 bytes), {@code IntField} (4
+   * bytes), {@code LongField} (8 bytes), and any other width that uses the standard sortable
+   * encoding (big-endian with sign bit flipped).
    */
   private static long decodeLong(byte[] packed) {
-    return switch (packed.length) {
-      case Integer.BYTES -> NumericUtils.sortableBytesToInt(packed, 0);
-      case Long.BYTES -> NumericUtils.sortableBytesToLong(packed, 0);
-      default ->
-          throw new IllegalArgumentException(
-              "Unsupported packed value length: "
-                  + packed.length
-                  + " (expected "
-                  + Long.BYTES
-                  + " or "
-                  + Integer.BYTES
-                  + ")");
-    };
+    assert packed.length >= 1 && packed.length <= Long.BYTES;
+    long result = (byte) (packed[0] ^ 0x80);
+    for (int i = 1; i < packed.length; i++) {
+      result = (result << 8) | (packed[i] & 0xFF);
+    }
+    return result;
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestNumericFieldStats.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestNumericFieldStats.java
@@ -17,8 +17,11 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
@@ -28,8 +31,54 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.NumericFieldStats.Stats;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.BitUtil;
+import org.apache.lucene.util.BytesRef;
 
 public class TestNumericFieldStats extends LuceneTestCase {
+
+  private static Field newCustomWidthPoint(String name, int numBytes, long value) {
+    FieldType type = new FieldType();
+    type.setDimensions(1, numBytes);
+    type.freeze();
+    byte[] packed = new byte[numBytes];
+    for (int i = numBytes - 1; i >= 0; i--) {
+      packed[i] = (byte) (value & 0xFF);
+      value >>= 8;
+    }
+    packed[0] ^= (byte) 0x80;
+    return new Field(name, new BytesRef(packed), type);
+  }
+
+  private static long minValueForWidth(int numBytes) {
+    return -(1L << (numBytes * 8 - 1));
+  }
+
+  private static long maxValueForWidth(int numBytes) {
+    return (1L << (numBytes * 8 - 1)) - 1;
+  }
+
+  public void testGetStatsWithAllByteWidths() throws IOException {
+    for (int numBytes = 1; numBytes <= Long.BYTES; numBytes++) {
+      long min = minValueForWidth(numBytes);
+      long max = maxValueForWidth(numBytes);
+      try (Directory dir = newDirectory();
+          IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+        for (long value : new long[] {min, 0, max}) {
+          final Document doc = new Document();
+          doc.add(newCustomWidthPoint("field", numBytes, value));
+          w.addDocument(doc);
+        }
+        w.commit();
+        try (IndexReader reader = DirectoryReader.open(w)) {
+          final Stats stats = NumericFieldStats.getStats(reader, "field");
+          assertNotNull("numBytes=" + numBytes, stats);
+          assertEquals("numBytes=" + numBytes, min, stats.min());
+          assertEquals("numBytes=" + numBytes, max, stats.max());
+          assertEquals("numBytes=" + numBytes, 3, stats.docCount());
+        }
+      }
+    }
+  }
 
   public void testGetStatsWithLongField() throws IOException {
     try (Directory dir = newDirectory();
@@ -260,6 +309,19 @@ public class TestNumericFieldStats extends LuceneTestCase {
         assertEquals(100L, stats.min());
         assertEquals(100L, stats.max());
         assertEquals(1, stats.docCount());
+      }
+    }
+  }
+
+  public void testGetStatsReturnsNullForWidePointValues() throws Exception {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc = new Document();
+      doc.add(new InetAddressPoint("field", InetAddress.getByName("192.168.0.1")));
+      w.addDocument(doc);
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        assertNull(NumericFieldStats.getStats(reader, "field"));
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestNumericFieldStats.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestNumericFieldStats.java
@@ -31,7 +31,6 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.NumericFieldStats.Stats;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 
 public class TestNumericFieldStats extends LuceneTestCase {

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/document/TestHalfFloatPoint.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/document/TestHalfFloatPoint.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.NumericFieldStats;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
@@ -242,6 +243,29 @@ public class TestHalfFloatPoint extends LuceneTestCase {
     assertEquals(
         Float.floatToIntBits(-0f), Float.floatToIntBits(HalfFloatPoint.nextUp(-Float.MIN_VALUE)));
     assertEquals(Float.floatToIntBits(0f), Float.floatToIntBits(HalfFloatPoint.nextUp(-0f)));
+  }
+
+  public void testNumericFieldStats() throws Exception {
+    Directory dir = newDirectory();
+    RandomIndexWriter writer = new RandomIndexWriter(random(), dir);
+    Document doc1 = new Document();
+    doc1.add(new HalfFloatPoint("field", -2f));
+    writer.addDocument(doc1);
+    Document doc2 = new Document();
+    doc2.add(new HalfFloatPoint("field", 1.25f));
+    writer.addDocument(doc2);
+    Document doc3 = new Document();
+    doc3.add(new HalfFloatPoint("field", 100f));
+    writer.addDocument(doc3);
+    IndexReader reader = writer.getReader();
+    NumericFieldStats.Stats stats = NumericFieldStats.getStats(reader, "field");
+    assertNotNull(stats);
+    assertTrue(stats.min() < 0);
+    assertTrue(stats.max() > 0);
+    assertEquals(3, stats.docCount());
+    reader.close();
+    writer.close();
+    dir.close();
   }
 
   public void testNextDown() {


### PR DESCRIPTION
## Problem

`NumericFieldStats.decodeLong` (introduced in #15760) only handled 4-byte (`IntField`) and 8-byte (`LongField`) packed point values via a switch on `packed.length`. Any other width caused an `IllegalArgumentException`, crashing the query for queries using byte lengths other than 4 or 8.

`HalfFloatPoint` produces 2-byte packed values. A range query on such a field triggered the exception. The original PR only tested `IntField` (4 bytes) and `LongField` (8 bytes), so CI did not catch the bug:

```
java.lang.IllegalArgumentException: Unsupported packed value length: 2 (expected 8 or 4)
    at org.apache.lucene.search.NumericFieldStats.decodeLong(NumericFieldStats.java:121)
    at org.apache.lucene.search.NumericFieldStats.getStatsFromPoints(NumericFieldStats.java:72)
    at org.apache.lucene.search.NumericFieldStats.getStats(NumericFieldStats.java:58)
    ...
```

## Solution

Replace the switch-based decoder with a generic loop that handles any packed value length from 1 to 8 bytes. All Lucene point types use the same encoding: big-endian byte order with the sign bit flipped. The loop reads the bytes sequentially, re-flips the sign bit on the first byte, and sign-extends the result into a `long`. This is allocation-free, unlike `NumericUtils.sortableBytesToBigInt`, which copies the array and creates a `BigInteger`.

For point fields wider than 8 bytes (e.g. `InetAddressPoint` at 16 bytes, `BigIntegerPoint` at 16 bytes), `getStatsFromPoints` now returns `null` instead of throwing, allowing `getStats` to fall through to the `DocValuesSkipper` path. These wider point types are never used with `SortedNumericDocValuesRangeQuery` in practice, but the graceful fallback avoids unexpected failures.

## Tests

- `TestNumericFieldStats.testGetStatsWithAllByteWidths`: exercises `decodeLong` with min, zero, and max values at every byte width from 1 to 8
- `TestNumericFieldStats.testGetStatsReturnsNullForWidePointValues`: verifies graceful `null` return for `InetAddressPoint` (16 bytes)
- `TestHalfFloatPoint.testNumericFieldStats`: integration test with real `HalfFloatPoint` (2 bytes)

```
./gradlew -p lucene/core test --tests "org.apache.lucene.search.TestNumericFieldStats"
./gradlew -p lucene/sandbox test --tests "org.apache.lucene.sandbox.document.TestHalfFloatPoint.testNumericFieldStats"
```

Follows up on #15760.
