### PR TITLE
Build immutable clause list directly in BooleanQuery.Builder, avoiding redundant collection conversions

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -199,6 +199,9 @@ Other
 * GITHUB#14607: Index open performs version check on each segment, ignores indexCreatedVersionMajor (Rahul Goswami)
 * GITHUB#15454: Restore binary readability for 8.x indexes like previously and throw IndexFormatTooOldException for an older default codec not found on classpath (Rahul Goswami)
 
+GITHUB#15821: Pass immutable list directly from BooleanQuery.Builder to private constructor,
+  avoiding unnecessary list→array→list conversions. (Sagar Upadhyaya)
+
 ======================= Lucene 10.5.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
@@ -18,7 +18,6 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -129,7 +128,7 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
 
   private BooleanQuery(int minimumNumberShouldMatch, BooleanClause[] clauses) {
     this.minimumNumberShouldMatch = minimumNumberShouldMatch;
-    this.clauses = Collections.unmodifiableList(Arrays.asList(clauses));
+    this.clauses = List.of(clauses);
     clauseSets = new EnumMap<>(Occur.class);
     // duplicates matter for SHOULD and MUST
     clauseSets.put(Occur.SHOULD, new Multiset<>());

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
@@ -117,7 +117,7 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
      * Create a new {@link BooleanQuery} based on the parameters that have been set on this builder.
      */
     public BooleanQuery build() {
-      return new BooleanQuery(minimumNumberShouldMatch, clauses.toArray(new BooleanClause[0]));
+      return new BooleanQuery(minimumNumberShouldMatch, List.copyOf(clauses));
     }
   }
 
@@ -126,9 +126,9 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
   // WARNING: Do not let clauseSets escape from this class as it breaks immutability:
   private final Map<Occur, Collection<Query>> clauseSets; // used for equals/hashCode
 
-  private BooleanQuery(int minimumNumberShouldMatch, BooleanClause[] clauses) {
+  private BooleanQuery(int minimumNumberShouldMatch, List<BooleanClause> clauses) {
     this.minimumNumberShouldMatch = minimumNumberShouldMatch;
-    this.clauses = List.of(clauses);
+    this.clauses = clauses;
     clauseSets = new EnumMap<>(Occur.class);
     // duplicates matter for SHOULD and MUST
     clauseSets.put(Occur.SHOULD, new Multiset<>());


### PR DESCRIPTION

### Description

BooleanQuery's Builder.build() was converting its ArrayList to an array via toArray(), then the private constructor wrapped it back into a list with two objects: Arrays$ArrayList (via Arrays.asList) then UnmodifiableList (via Collections.unmodifiableList):
```
this.clauses = Collections.unmodifiableList(Arrays.asList(clauses));
```
Instead, Builder.build() now creates an immutable list directly via List.copyOf(clauses) and passes it to the private constructor, which accepts it as-is. This avoids the redundant list-to-array-to-list conversion and the two wrapper objects.
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
