### PR TITLE
Mute TestByteVectorSimilarityQuery.testSomeDeletes unit test until fix

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 
+import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -291,6 +292,7 @@ abstract class BaseVectorSimilarityQueryTestCase<
     }
   }
 
+  @AwaitsFix(bugUrl = "https://github.com/apache/lucene/issues/15816")
   public void testSomeDeletes() throws IOException {
     // Delete a sub-range from 0 to numDocs
     int startIndex = random().nextInt(numDocs);

--- a/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
@@ -48,7 +48,6 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.hnsw.HnswUtil;
 
@@ -292,7 +291,7 @@ abstract class BaseVectorSimilarityQueryTestCase<
     }
   }
 
-  @AwaitsFix(bugUrl = "https://github.com/apache/lucene/issues/15816")
+  @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/apache/lucene/issues/15816")
   public void testSomeDeletes() throws IOException {
     // Delete a sub-range from 0 to numDocs
     int startIndex = random().nextInt(numDocs);

--- a/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 
-import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -49,6 +48,7 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.hnsw.HnswUtil;
 


### PR DESCRIPTION
### Description

The above test is flaky and there is already an issue for it - https://github.com/apache/lucene/issues/15816

But considering it requires more investigation to root cause and fix the test, I propose we mute the test and move on for now. As it is causing build failure on other PRs.

Once it is fixed, we can unmute the test. 

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
