### PR TITLE
Load lucene103 blocktree trie index on-heap to fix seekExact regression

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -113,6 +113,10 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#15820: Load lucene103 blocktree trie index on-heap to avoid memory-mapped file overhead
+  on seekExact calls, restoring lucene90 FST-like performance for high-frequency _id lookups.
+  (Sarah Syarofina)
+
 * GITHUB#15681: Replace pre-sized array or empty array with lambda expression to call Collection#toArray. (Zhou Hui)
 
 * GITHUB#13782: Replace handwritten loops compare with Arrays.compareUnsigned in TermsEnum and TermsEnumFrame classes. (Zhou Hui)

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/FieldReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/FieldReader.java
@@ -17,10 +17,15 @@
 package org.apache.lucene.codecs.lucene103.blocktree;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.store.ByteBuffersDataInput;
+import org.apache.lucene.store.ByteBuffersIndexInput;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
@@ -84,7 +89,20 @@ public final class FieldReader extends Terms {
   }
 
   private TrieReader newReader() throws IOException {
-    return new TrieReader(indexIn.slice("trie index", indexStart, indexEnd - indexStart), rootFP);
+    // Load the trie index into heap memory to avoid memory-mapped file overhead.
+    // Each RandomAccessInput read on mmap triggers Panama Foreign Memory API bounds checks
+    // (checkValidStateRaw), which is expensive for high-frequency seekExact calls (e.g., _id
+    // lookups during indexing). Loading on-heap matches the lucene90 FST behavior where the
+    // term index was always heap-resident.
+    long length = indexEnd - indexStart;
+    IndexInput slice = indexIn.slice("trie index", indexStart, length);
+    byte[] bytes = new byte[(int) length];
+    slice.readBytes(bytes, 0, bytes.length);
+    slice.close();
+    ByteBuffersDataInput bbdi =
+        new ByteBuffersDataInput(List.of(ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)));
+    ByteBuffersIndexInput heapInput = new ByteBuffersIndexInput(bbdi, "heap trie index");
+    return new TrieReader(heapInput, rootFP);
   }
 
   @Override


### PR DESCRIPTION
## Summary

Fixes #15820

The lucene103 blocktree codec replaced the in-memory FST term index with an on-disk `TrieReader` backed by memory-mapped `RandomAccessInput`. Every `readLong`/`readByte` call on the mmap triggers Panama Foreign Memory API bounds checks (`MemorySessionImpl.checkValidStateRaw()`), causing a **~6x regression** in `seekExact` performance compared to the lucene90 FST which was always heap-resident.

This PR loads the trie index bytes into a heap-backed `ByteBuffersDataInput` at `TermsEnum` creation time in `FieldReader.newReader()`, so that trie navigation uses pure Java array reads instead of mmap reads.

### Why this works

- `ByteBuffersDataInput` backed by a single heap `ByteBuffer` takes the fast path: `blocks[0].getLong(blockOffset)` — a direct Java array read with no mmap or Panama bounds checks
- The trie index is typically small relative to the terms data, so heap overhead is minimal
- This matches the lucene90 behavior where the FST term index was always heap-resident

### Changes

- **`FieldReader.java`**: Modified `newReader()` to read the trie index slice into a `byte[]`, wrap it in `ByteBuffersDataInput`/`ByteBuffersIndexInput`, and pass the heap-backed input to `TrieReader`
- **`CHANGES.txt`**: Added optimization entry under Lucene 11.0.0

## Test plan

- [x] All existing blocktree tests pass (`TestTrie`, etc.)
- [x] All Lucene103/104 codec tests pass (869+ tests)
- [x] Code formatting verified via `./gradlew tidy`
- [ ] Benchmark seekExact throughput with UUID-based _id field across many segments to validate regression fix