### PR TITLE
Simplify SearchImpl#createSimilarity in luke module

### DIFF
--- a/lucene/luke/src/java/org/apache/lucene/luke/models/search/SearchImpl.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/search/SearchImpl.java
@@ -391,18 +391,9 @@ public final class SearchImpl extends LukeModel implements Search {
   }
 
   private Similarity createSimilarity(SimilarityConfig config) {
-    Similarity similarity;
-
-    if (config.isUseClassicSimilarity()) {
-      ClassicSimilarity tfidf = new ClassicSimilarity(config.isDiscountOverlaps());
-      similarity = tfidf;
-    } else {
-      BM25Similarity bm25 =
-          new BM25Similarity(config.getK1(), config.getB(), config.isDiscountOverlaps());
-      similarity = bm25;
-    }
-
-    return similarity;
+    return config.isUseClassicSimilarity()
+        ? new ClassicSimilarity(config.isDiscountOverlaps())
+        : new BM25Similarity(config.getK1(), config.getB(), config.isDiscountOverlaps());
   }
 
   @Override


### PR DESCRIPTION
### Description

Simplify the SearchImpl#createSimilarity method in luke module, collapse the if-else into a single ternary assignment and remove the redundant local variables to make the code more clear.