### PR TITLE
Simplify TermCounts#sortedTermCounts in luke module

### DIFF
--- a/lucene/luke/src/java/org/apache/lucene/luke/models/overview/TermCounts.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/overview/TermCounts.java
@@ -49,23 +49,13 @@ final class TermCounts {
   Map<String, Long> sortedTermCounts(TermCountsOrder order) {
     Objects.requireNonNull(order);
 
-    Comparator<Map.Entry<String, Long>> comparator;
-    switch (order) {
-      case NAME_ASC:
-        comparator = Map.Entry.comparingByKey();
-        break;
-      case NAME_DESC:
-        comparator = Map.Entry.<String, Long>comparingByKey().reversed();
-        break;
-      case COUNT_ASC:
-        comparator = Map.Entry.comparingByValue();
-        break;
-      case COUNT_DESC:
-        comparator = Map.Entry.<String, Long>comparingByValue().reversed();
-        break;
-      default:
-        comparator = Map.Entry.comparingByKey();
-    }
+    Comparator<Map.Entry<String, Long>> comparator =
+        switch (order) {
+          case NAME_ASC -> Map.Entry.comparingByKey();
+          case NAME_DESC -> Map.Entry.<String, Long>comparingByKey().reversed();
+          case COUNT_ASC -> Map.Entry.comparingByValue();
+          case COUNT_DESC -> Map.Entry.<String, Long>comparingByValue().reversed();
+        };
     return sortedTermCounts(comparator);
   }
 


### PR DESCRIPTION
### Description

When addressing issues in luke module, found that the TermCounts#sortedTermCounts method can be simplified, so this pr changes switch...case to a modern switch expression, and removes the redundant `default` branch since all enum constants are covered(this also improves safety because an compiler error will be thrown once new enum constant is added into TermCountsOrder).
