### PR TITLE
Fix: don't force native access if disabled (#15815)

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/NativeAccess.java
+++ b/lucene/core/src/java/org/apache/lucene/store/NativeAccess.java
@@ -39,7 +39,8 @@ abstract class NativeAccess {
    * MacOS.
    */
   public static Optional<NativeAccess> getImplementation() {
-    if (Constants.LINUX || Constants.MAC_OS_X) {
+    if ((Constants.LINUX || Constants.MAC_OS_X)
+        && NativeAccess.class.getModule().isNativeAccessEnabled()) {
       return PosixNativeAccess.getInstance();
     }
     return Optional.empty();

--- a/lucene/core/src/java/org/apache/lucene/store/PosixNativeAccess.java
+++ b/lucene/core/src/java/org/apache/lucene/store/PosixNativeAccess.java
@@ -28,6 +28,14 @@ import java.util.Optional;
 import java.util.logging.Logger;
 
 final class PosixNativeAccess extends NativeAccess {
+  private enum PosixNativeAccessSingletonHolder {
+    INSTANCE(constructInstance());
+    private Optional<NativeAccess> posixNativeAccess;
+
+    PosixNativeAccessSingletonHolder(Optional<NativeAccess> posixNativeAccess) {
+      this.posixNativeAccess = posixNativeAccess;
+    }
+  }
 
   private static final Logger LOG = Logger.getLogger(PosixNativeAccess.class.getName());
 
@@ -48,29 +56,23 @@ final class PosixNativeAccess extends NativeAccess {
   /** Don't need these pages. */
   public static final int POSIX_MADV_DONTNEED = 4;
 
-  private static final MethodHandle MH$posix_madvise;
-  private static final int PAGE_SIZE;
+  private final MethodHandle MH$posix_madvise;
+  private final int PAGE_SIZE;
 
-  private static final Optional<NativeAccess> INSTANCE;
-
-  private PosixNativeAccess() {}
-
-  static Optional<NativeAccess> getInstance() {
-    return INSTANCE;
-  }
-
-  static {
+  private PosixNativeAccess() throws Throwable {
     final Linker linker = Linker.nativeLinker();
     final SymbolLookup stdlib = linker.defaultLookup();
-    MethodHandle adviseHandle = null;
-    int pagesize = -1;
-    PosixNativeAccess instance = null;
+    MH$posix_madvise = lookupMadvise(linker, stdlib);
+    PAGE_SIZE = (int) lookupGetPageSize(linker, stdlib).invokeExact();
+  }
+
+  static Optional<NativeAccess> getInstance() {
+    return PosixNativeAccessSingletonHolder.INSTANCE.posixNativeAccess;
+  }
+
+  private static Optional<NativeAccess> constructInstance() {
     try {
-      adviseHandle = lookupMadvise(linker, stdlib);
-      pagesize = (int) lookupGetPageSize(linker, stdlib).invokeExact();
-      instance = new PosixNativeAccess();
-    } catch (UnsupportedOperationException uoe) {
-      LOG.warning(uoe.getMessage());
+      return Optional.of(new PosixNativeAccess());
     } catch (IllegalCallerException _) {
       LOG.warning(
           String.format(
@@ -79,14 +81,12 @@ final class PosixNativeAccess extends NativeAccess {
                   + "pass the following on command line: --enable-native-access=%s",
               Optional.ofNullable(PosixNativeAccess.class.getModule().getName())
                   .orElse("ALL-UNNAMED")));
-    } catch (RuntimeException | Error e) {
-      throw e;
     } catch (Throwable e) {
-      throw new AssertionError(e);
+      LOG.warning(
+          String.format(
+              Locale.ENGLISH, "could not enable native access, cause: %s", e.getMessage()));
     }
-    MH$posix_madvise = adviseHandle;
-    PAGE_SIZE = pagesize;
-    INSTANCE = Optional.ofNullable(instance);
+    return Optional.empty();
   }
 
   private static MethodHandle lookupMadvise(Linker linker, SymbolLookup stdlib) {

--- a/lucene/core/src/java/org/apache/lucene/store/PosixNativeAccess.java
+++ b/lucene/core/src/java/org/apache/lucene/store/PosixNativeAccess.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 final class PosixNativeAccess extends NativeAccess {
   private enum PosixNativeAccessSingletonHolder {
     INSTANCE(constructInstance());
-    private Optional<NativeAccess> posixNativeAccess;
+    private final Optional<NativeAccess> posixNativeAccess;
 
     PosixNativeAccessSingletonHolder(Optional<NativeAccess> posixNativeAccess) {
       this.posixNativeAccess = posixNativeAccess;


### PR DESCRIPTION
The current implementation of `PosixNativeAccess` always tries to use native access, even if this is disallowed by the JVM. This can lead to warnings on JDK24+ and will eventually be the default setting in future JVM versions. Additionally the current singleton implementation in `PosixNativeAccess` is problematic because it does the native setup during class initialization (`<clinit>`). This makes the timing of that setup unpredictable (because the JVM may load classes at any time, not just before first use) and can cause the entire application to fail if an exception is thrown (and not caught) during this setup (even if the application would work fine without native access).

This PR:
- changes the implementation to only attempt enabling native access if this is allowed by the running JVM
- changes the singleton in `PosixNativeAccess` to use an enum pattern