### PR TITLE
Prevent class initialization failure when JVM has no support for native code at all (wrong platform)

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
@@ -497,6 +497,7 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
                             ":lucene:distribution.tests",
                             ":lucene:test-framework" ->
                             "ALL-UNNAMED";
+                        case ":lucene:sandbox" -> "org.apache.lucene.core,ALL-UNNAMED";
                         default -> "org.apache.lucene.core";
                       });
               task.jvmArgs("--illegal-native-access=deny");

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
@@ -499,6 +499,7 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
                             "ALL-UNNAMED";
                         default -> "org.apache.lucene.core";
                       });
+              task.jvmArgs("--illegal-native-access=deny");
 
               var loggingFileProvider =
                   project.getObjects().newInstance(LoggingFileArgumentProvider.class);

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -192,14 +192,21 @@ Other
 * GITHUB#14613: Rewrite APIJAR extractor to use Java 24 classfile API and kill ASM dependency also for build system.  (Uwe Schindler)
 
 * GITHUB#14705: Use Comparators for some PriorityQueue implementations. (Simon Cooper)
+
 * GITHUB#14761: Use more Comparators for PriorityQueue implementations. (Simon Cooper)
+
 * GITHUB#14817: Refactor some complex uses of PriorityQueue to use Comparators. (Simon Cooper)
 
 * GITHUB#14607: Index open performs version check on each segment, ignores indexCreatedVersionMajor (Rahul Goswami)
+
 * GITHUB#15454: Restore binary readability for 8.x indexes like previously and throw IndexFormatTooOldException for an older default codec not found on classpath (Rahul Goswami)
 
-GITHUB#15821: Pass immutable list directly from BooleanQuery.Builder to private constructor,
+* GITHUB#15821: Pass immutable list directly from BooleanQuery.Builder to private constructor,
   avoiding unnecessary list→array→list conversions. (Sagar Upadhyaya)
+
+* GITHUB#15844: Detect JVM bitness using Panama's ValueLayout#ADDRESS instead
+  of undocumented system properties.  (Uwe Schindler)
+
 
 ======================= Lucene 10.5.0 =======================
 
@@ -269,7 +276,8 @@ Bug Fixes
 * GITHUB#15656: Fix wrong BitSet result in MemoryAccountingBitsetCollector (Binlong Gao)
 
 * GITHUB#15844: Prevent class initialization failure when JVM has no support for
-  native code at all (wrong platform).  (Uwe Schindler, thanks to Christian Ortlepp for finding the issue)
+  native code at all (wrong platform); disable native code on 32 bit platforms.
+  (Uwe Schindler, thanks to Christian Ortlepp for finding the issue)
 
 Other
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -268,6 +268,9 @@ Bug Fixes
 
 * GITHUB#15656: Fix wrong BitSet result in MemoryAccountingBitsetCollector (Binlong Gao)
 
+* GITHUB#15844: Prevent class initialization failure when JVM has no support for
+  native code at all (wrong platform).  (Uwe Schindler, thanks to Christian Ortlepp for finding the issue)
+
 Other
 ---------------------
 * GITHUB#15586: Document that scoring and ranking may change across major Lucene versions, and that applications requiring stable ranking should explicitly configure Similarity. (Parveen Saini)

--- a/lucene/core/src/java/org/apache/lucene/store/NativeAccess.java
+++ b/lucene/core/src/java/org/apache/lucene/store/NativeAccess.java
@@ -39,7 +39,7 @@ abstract class NativeAccess {
    * MacOS.
    */
   public static Optional<NativeAccess> getImplementation() {
-    if (Constants.LINUX || Constants.MAC_OS_X) {
+    if (Constants.JRE_IS_64BIT && (Constants.LINUX || Constants.MAC_OS_X)) {
       return PosixNativeAccess.getInstance();
     }
     return Optional.empty();

--- a/lucene/core/src/java/org/apache/lucene/store/NativeAccess.java
+++ b/lucene/core/src/java/org/apache/lucene/store/NativeAccess.java
@@ -39,7 +39,7 @@ abstract class NativeAccess {
    * MacOS.
    */
   public static Optional<NativeAccess> getImplementation() {
-    if (Constants.JRE_IS_64BIT && (Constants.LINUX || Constants.MAC_OS_X)) {
+    if (Constants.LINUX || Constants.MAC_OS_X) {
       return PosixNativeAccess.getInstance();
     }
     return Optional.empty();

--- a/lucene/core/src/java/org/apache/lucene/store/PosixNativeAccess.java
+++ b/lucene/core/src/java/org/apache/lucene/store/PosixNativeAccess.java
@@ -70,7 +70,7 @@ final class PosixNativeAccess extends NativeAccess {
       pagesize = (int) lookupGetPageSize(linker, stdlib).invokeExact();
       instance = new PosixNativeAccess();
     } catch (UnsupportedOperationException uoe) {
-      LOG.warning(uoe.getMessage());
+      LOG.warning("Cannot initialize native function bindings: " + uoe.getMessage());
     } catch (IllegalCallerException _) {
       LOG.warning(
           String.format(
@@ -79,7 +79,10 @@ final class PosixNativeAccess extends NativeAccess {
                   + "pass the following on command line: --enable-native-access=%s",
               Optional.ofNullable(PosixNativeAccess.class.getModule().getName())
                   .orElse("ALL-UNNAMED")));
-    } catch (RuntimeException | Error e) {
+    } catch (RuntimeException re) {
+      LOG.warning(
+          "Cannot initialize native function bindings (linker is incompatible): " + re.toString());
+    } catch (Error e) {
       throw e;
     } catch (Throwable e) {
       throw new AssertionError(e);

--- a/lucene/core/src/java/org/apache/lucene/store/PosixNativeAccess.java
+++ b/lucene/core/src/java/org/apache/lucene/store/PosixNativeAccess.java
@@ -60,12 +60,12 @@ final class PosixNativeAccess extends NativeAccess {
   }
 
   static {
-    final Linker linker = Linker.nativeLinker();
-    final SymbolLookup stdlib = linker.defaultLookup();
     MethodHandle adviseHandle = null;
     int pagesize = -1;
     PosixNativeAccess instance = null;
     try {
+      final Linker linker = Linker.nativeLinker();
+      final SymbolLookup stdlib = linker.defaultLookup();
       adviseHandle = lookupMadvise(linker, stdlib);
       pagesize = (int) lookupGetPageSize(linker, stdlib).invokeExact();
       instance = new PosixNativeAccess();

--- a/lucene/core/src/java/org/apache/lucene/store/PosixNativeAccess.java
+++ b/lucene/core/src/java/org/apache/lucene/store/PosixNativeAccess.java
@@ -63,29 +63,33 @@ final class PosixNativeAccess extends NativeAccess {
     MethodHandle adviseHandle = null;
     int pagesize = -1;
     PosixNativeAccess instance = null;
-    try {
-      final Linker linker = Linker.nativeLinker();
-      final SymbolLookup stdlib = linker.defaultLookup();
-      adviseHandle = lookupMadvise(linker, stdlib);
-      pagesize = (int) lookupGetPageSize(linker, stdlib).invokeExact();
-      instance = new PosixNativeAccess();
-    } catch (UnsupportedOperationException uoe) {
-      LOG.warning("Cannot initialize native function bindings: " + uoe.getMessage());
-    } catch (IllegalCallerException _) {
-      LOG.warning(
-          String.format(
-              Locale.ENGLISH,
-              "Lucene has no access to native functions. To enable access to native functions, "
-                  + "pass the following on command line: --enable-native-access=%s",
-              Optional.ofNullable(PosixNativeAccess.class.getModule().getName())
-                  .orElse("ALL-UNNAMED")));
-    } catch (RuntimeException re) {
-      LOG.warning(
-          "Cannot initialize native function bindings (linker is incompatible): " + re.toString());
-    } catch (Error e) {
-      throw e;
-    } catch (Throwable e) {
-      throw new AssertionError(e);
+    if (ValueLayout.ADDRESS.byteSize() == Long.BYTES) {
+      // we only support 64 bits at the moment
+      try {
+        final Linker linker = Linker.nativeLinker();
+        final SymbolLookup stdlib = linker.defaultLookup();
+        adviseHandle = lookupMadvise(linker, stdlib);
+        pagesize = (int) lookupGetPageSize(linker, stdlib).invokeExact();
+        instance = new PosixNativeAccess();
+      } catch (UnsupportedOperationException uoe) {
+        LOG.warning("Cannot initialize native function bindings: " + uoe.getMessage());
+      } catch (IllegalCallerException _) {
+        LOG.warning(
+            String.format(
+                Locale.ENGLISH,
+                "Lucene has no access to native functions. To enable access to native functions, "
+                    + "pass the following on command line: --enable-native-access=%s",
+                Optional.ofNullable(PosixNativeAccess.class.getModule().getName())
+                    .orElse("ALL-UNNAMED")));
+      } catch (RuntimeException re) {
+        LOG.warning(
+            "Cannot initialize native function bindings (linker is incompatible): "
+                + re.toString());
+      } catch (Error e) {
+        throw e;
+      } catch (Throwable e) {
+        throw new AssertionError(e);
+      }
     }
     MH$posix_madvise = adviseHandle;
     PAGE_SIZE = pagesize;

--- a/lucene/core/src/java/org/apache/lucene/util/Constants.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Constants.java
@@ -72,7 +72,7 @@ public final class Constants {
       HotspotVMOptions.get("UseJVMCICompiler").map(Boolean::valueOf).orElse(false);
 
   /** True iff running on a 64bit JVM */
-  public static final boolean JRE_IS_64BIT = (ValueLayout.ADDRESS.byteSize() == 8L);
+  public static final boolean JRE_IS_64BIT = (ValueLayout.ADDRESS.byteSize() == Long.BYTES);
 
   /** true if FMA likely means a cpu instruction and not BigDecimal logic. */
   private static final boolean HAS_FMA =

--- a/lucene/core/src/java/org/apache/lucene/util/Constants.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Constants.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.util;
 
+import java.lang.foreign.ValueLayout;
 import java.util.Locale;
 import java.util.Optional;
 import org.apache.lucene.store.ReadAdvice;
@@ -71,16 +72,7 @@ public final class Constants {
       HotspotVMOptions.get("UseJVMCICompiler").map(Boolean::valueOf).orElse(false);
 
   /** True iff running on a 64bit JVM */
-  public static final boolean JRE_IS_64BIT = is64Bit();
-
-  private static boolean is64Bit() {
-    final String datamodel = getSysProp("sun.arch.data.model");
-    if (datamodel != null) {
-      return datamodel.contains("64");
-    } else {
-      return (OS_ARCH != null && OS_ARCH.contains("64"));
-    }
-  }
+  public static final boolean JRE_IS_64BIT = (ValueLayout.ADDRESS.byteSize() == 8L);
 
   /** true if FMA likely means a cpu instruction and not BigDecimal logic. */
   private static final boolean HAS_FMA =

--- a/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
@@ -106,8 +106,8 @@ public class TestMMapDirectory extends BaseDirectoryTestCase {
 
   public void testMadviseAvail() throws Exception {
     assertEquals(
-        "madvise should be supported on Linux and Macos",
-        Constants.LINUX || Constants.MAC_OS_X,
+        "madvise should be supported on Linux and Macos (64 bit)",
+        Constants.JRE_IS_64BIT && (Constants.LINUX || Constants.MAC_OS_X),
         MMapDirectory.supportsMadvise());
   }
 


### PR DESCRIPTION
See #15843 for more details. Actually the problem is that looking up the default linker may throw UnuspportedEx when the platform does not allow native code at all. 

This was caused by the refactoring where the symbol and linker lookup was moved outside the try-catch: https://github.com/apache/lucene/commit/3003731aa94225b3a07cb9fb667fc8fd62bb2d10

This could cause class loading issue es described in #15834 because it may break initializing of NativeAccess class.

The PR also catches the general problem case if the underlying linker does not support the `FunctionDescriptor`.

It also disables madvise on 32 bits: We could support it, but then we would need to ask the linker for the java type behind `size_t` (this works), but depending on the type we would need to map the returned `MethodHandle` by explicit casting to adapt to long (our Java call signature). This is not worth it, because MMapDir is not used on 32 bit platforms by defaulr.