### PR TITLE
Update documentation in main branch for installing precommit check when you want to work on older release branches

### DIFF
--- a/help/precommit.txt
+++ b/help/precommit.txt
@@ -7,14 +7,18 @@ Checks use the prek tool:
   * src: https://github.com/j178/prek
   * docs: https://prek.j178.dev/
 
-To run checks before committing:
+To run checks automatically before committing:
 
 uvx prek
 
 To install a precommit hook so this happens automatically:
 
 uv tool install prek
-prek install
+prek install --allow-missing-config
+
+Please note: The "--allow-missing-config" option is only required if you
+intend to also work on older release branches that do not yet have support
+for prek.
 
 To exhaustively force-check all files (like CI does):
 


### PR DESCRIPTION
This PR updates the documentation on how to install the prek precommit task:

At moment it is required to add the option `--allow-missing-config` when installing `prek` in the precommit hooks of your local repository, because when you want to work on older release branches like `branch_10x` and cherry pick commits, you can't commit them otherwise because `prek` complains about missing config.