### PR TITLE
Fix circular dependency deadlock in TestSecrets initialization

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -156,8 +156,6 @@ Bug Fixes
 * GITHUB#14971: Fix CachedExecutor thread pool leak in ConcurrentMergeScheduler
   when IndexWriter initialization fails. (Su Beom)
 
-* GITHUB#12419, GITHUB#15119: Fix circular dependency deadlock in TestSecrets initialization (Namgyu Kim)
-
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14187: The query cache is now disabled by default. (Adrien Grand)
@@ -269,6 +267,8 @@ Bug Fixes
   we might fail to detect it and choose a wrong bridge to eliminate the hole. (Ignacio Vera)
 
 * GITHUB#15656: Fix wrong BitSet result in MemoryAccountingBitsetCollector (Binlong Gao)
+
+* GITHUB#12419, GITHUB#15119: Fix circular dependency deadlock in TestSecrets initialization (Namgyu Kim)
 
 Other
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -156,6 +156,8 @@ Bug Fixes
 * GITHUB#14971: Fix CachedExecutor thread pool leak in ConcurrentMergeScheduler
   when IndexWriter initialization fails. (Su Beom)
 
+* GITHUB#12419, GITHUB#15119: Fix circular dependency deadlock in TestSecrets initialization (Namgyu Kim)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14187: The query cache is now disabled by default. (Adrien Grand)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -282,7 +282,8 @@ Bug Fixes
   native code at all (wrong platform); disable native code on 32 bit platforms.
   (Uwe Schindler, thanks to Christian Ortlepp for finding the issue)
 
-* GITHUB#12419, GITHUB#15119: Fix circular dependency deadlock in TestSecrets initialization (Namgyu Kim)
+* GITHUB#12419, GITHUB#15119, GITHUB#15864: Fix circular dependency deadlock in
+  TestSecrets initialization (Namgyu Kim, Uwe Schindler)
 
 Other
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
@@ -173,7 +173,7 @@ public final class TestSecrets {
                             c ->
                                 c.startsWith("org.apache.lucene.tests.")
                                     || c.equals(
-                                        "org.apache.lucene.codecs.TestCodecLoadingDeadlock")));
+                                        "org.apache.lucene.index.TestClassloadingDeadlock")));
     if (!validCaller) {
       throw new UnsupportedOperationException(
           "Lucene TestSecrets can only be used by the test-framework.");

--- a/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
@@ -141,7 +141,7 @@ public final class TestSecrets {
 
   private static void ensureNull(Object ob) {
     if (ob != null) {
-      throw new AssertionError(
+      throw new UnsupportedOperationException(
           "The accessor is already set. It can only be called from inside Lucene Core.");
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
@@ -32,6 +32,16 @@ import org.apache.lucene.store.FilterIndexInput;
  */
 public final class TestSecrets {
 
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+  private static void ensureInitialized(Class<?> clazz) {
+    try {
+      LOOKUP.ensureInitialized(clazz);
+    } catch (IllegalAccessException e) {
+      throw new AssertionError(e);
+    }
+  }
+
   @SuppressWarnings("NonFinalStaticField")
   private static IndexPackageAccess indexPackageAccess;
 
@@ -129,14 +139,6 @@ public final class TestSecrets {
     TestSecrets.filterIndexInputAccess = filterIndexInputAccess;
   }
 
-  private static void ensureInitialized(Class<?> clazz) {
-    try {
-      MethodHandles.lookup().ensureInitialized(clazz);
-    } catch (IllegalAccessException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   private static void ensureNull(Object ob) {
     if (ob != null) {
       throw new AssertionError(
@@ -154,7 +156,8 @@ public final class TestSecrets {
                         .map(StackFrame::getClassName)
                         .allMatch(c -> Objects.equals(c, allowedCaller.getName())));
     if (!validCaller) {
-      throw new AssertionError("The accessor can only be set by " + allowedCaller.getName() + ".");
+      throw new UnsupportedOperationException(
+          "The accessor can only be set by " + allowedCaller.getName() + ".");
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
@@ -31,26 +31,20 @@ import org.apache.lucene.store.FilterIndexInput;
  * initialized once on startup.
  */
 public final class TestSecrets {
-  static {
-    Consumer<Class<?>> ensureInitialized =
-        clazz -> {
-          try {
-            // A no-op forName here has a side-effect of ensuring the class is loaded and
-            // initialized.
-            // This only happens once. We could just leverage the JLS and invoke a static
-            // method (or a constructor) on the target class but the method below seems simpler.
-            // TODO: In Java 15 there's MethodHandles.lookup().ensureInitialized(clazz)
-            Class.forName(clazz.getName());
-          } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-          }
-        };
 
-    ensureInitialized.accept(ConcurrentMergeScheduler.class);
-    ensureInitialized.accept(SegmentReader.class);
-    ensureInitialized.accept(IndexWriter.class);
-    ensureInitialized.accept(FilterIndexInput.class);
-  }
+  private static final Consumer<Class<?>> ensureInitialized =
+      clazz -> {
+        try {
+          // A no-op forName here has a side-effect of ensuring the class is loaded and
+          // initialized.
+          // This only happens once. We could just leverage the JLS and invoke a static
+          // method (or a constructor) on the target class but the method below seems simpler.
+          // TODO: In Java 15 there's MethodHandles.lookup().ensureInitialized(clazz)
+          Class.forName(clazz.getName());
+        } catch (ClassNotFoundException e) {
+          throw new RuntimeException(e);
+        }
+      };
 
   @SuppressWarnings("NonFinalStaticField")
   private static IndexPackageAccess indexPackageAccess;
@@ -71,60 +65,80 @@ public final class TestSecrets {
 
   /** Return the accessor to internal secrets for an {@link IndexReader}. */
   public static IndexPackageAccess getIndexPackageAccess() {
-    ensureCaller();
+    ensureCallerForGetter();
+    if (indexWriterAccess == null) {
+      ensureInitialized.accept(IndexWriter.class);
+    }
     return Objects.requireNonNull(indexPackageAccess);
   }
 
   /** Return the accessor to internal secrets for an {@link ConcurrentMergeScheduler}. */
   public static ConcurrentMergeSchedulerAccess getConcurrentMergeSchedulerAccess() {
-    ensureCaller();
+    ensureCallerForGetter();
+    if (cmsAccess == null) {
+      ensureInitialized.accept(ConcurrentMergeScheduler.class);
+    }
     return Objects.requireNonNull(cmsAccess);
   }
 
   /** Return the accessor to internal secrets for an {@link SegmentReader}. */
   public static SegmentReaderAccess getSegmentReaderAccess() {
-    ensureCaller();
+    ensureCallerForGetter();
+    if (segmentReaderAccess == null) {
+      ensureInitialized.accept(SegmentReader.class);
+    }
     return Objects.requireNonNull(segmentReaderAccess);
   }
 
   /** Return the accessor to internal secrets for an {@link IndexWriter}. */
   public static IndexWriterAccess getIndexWriterAccess() {
-    ensureCaller();
+    ensureCallerForGetter();
+    if (indexWriterAccess == null) {
+      ensureInitialized.accept(IndexWriter.class);
+    }
     return Objects.requireNonNull(indexWriterAccess);
   }
 
   /** Return the accessor to internal secrets for an {@link FilterIndexInput}. */
   public static FilterIndexInputAccess getFilterInputIndexAccess() {
-    ensureCaller();
+    ensureCallerForGetter();
+    if (filterIndexInputAccess == null) {
+      ensureInitialized.accept(FilterIndexInput.class);
+    }
     return Objects.requireNonNull(filterIndexInputAccess);
   }
 
   /** For internal initialization only. */
   public static void setIndexWriterAccess(IndexWriterAccess indexWriterAccess) {
+    ensureCallerForSetter(IndexWriter.class);
     ensureNull(TestSecrets.indexWriterAccess);
     TestSecrets.indexWriterAccess = indexWriterAccess;
   }
 
   /** For internal initialization only. */
   public static void setIndexPackageAccess(IndexPackageAccess indexPackageAccess) {
+    ensureCallerForSetter(IndexWriter.class);
     ensureNull(TestSecrets.indexPackageAccess);
     TestSecrets.indexPackageAccess = indexPackageAccess;
   }
 
   /** For internal initialization only. */
   public static void setConcurrentMergeSchedulerAccess(ConcurrentMergeSchedulerAccess cmsAccess) {
+    ensureCallerForSetter(ConcurrentMergeScheduler.class);
     ensureNull(TestSecrets.cmsAccess);
     TestSecrets.cmsAccess = cmsAccess;
   }
 
   /** For internal initialization only. */
   public static void setSegmentReaderAccess(SegmentReaderAccess segmentReaderAccess) {
+    ensureCallerForSetter(SegmentReader.class);
     ensureNull(TestSecrets.segmentReaderAccess);
     TestSecrets.segmentReaderAccess = segmentReaderAccess;
   }
 
   /** For internal initialization only. */
   public static void setFilterInputIndexAccess(FilterIndexInputAccess filterIndexInputAccess) {
+    ensureCallerForSetter(FilterIndexInput.class);
     ensureNull(TestSecrets.filterIndexInputAccess);
     TestSecrets.filterIndexInputAccess = filterIndexInputAccess;
   }
@@ -136,7 +150,21 @@ public final class TestSecrets {
     }
   }
 
-  private static void ensureCaller() {
+  private static void ensureCallerForSetter(Class<?> allowedCaller) {
+    final boolean validCaller =
+        StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
+            .walk(
+                s ->
+                    s.skip(2)
+                        .limit(1)
+                        .map(StackFrame::getDeclaringClass)
+                        .allMatch(c -> c == allowedCaller));
+    if (!validCaller) {
+      throw new AssertionError("The accessor can only be set by " + allowedCaller.getName() + ".");
+    }
+  }
+
+  private static void ensureCallerForGetter() {
     final boolean validCaller =
         StackWalker.getInstance()
             .walk(

--- a/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
@@ -17,8 +17,8 @@
 package org.apache.lucene.internal.tests;
 
 import java.lang.StackWalker.StackFrame;
+import java.lang.invoke.MethodHandles;
 import java.util.Objects;
-import java.util.function.Consumer;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
@@ -31,20 +31,6 @@ import org.apache.lucene.store.FilterIndexInput;
  * initialized once on startup.
  */
 public final class TestSecrets {
-
-  private static final Consumer<Class<?>> ensureInitialized =
-      clazz -> {
-        try {
-          // A no-op forName here has a side-effect of ensuring the class is loaded and
-          // initialized.
-          // This only happens once. We could just leverage the JLS and invoke a static
-          // method (or a constructor) on the target class but the method below seems simpler.
-          // TODO: In Java 15 there's MethodHandles.lookup().ensureInitialized(clazz)
-          Class.forName(clazz.getName());
-        } catch (ClassNotFoundException e) {
-          throw new RuntimeException(e);
-        }
-      };
 
   @SuppressWarnings("NonFinalStaticField")
   private static IndexPackageAccess indexPackageAccess;
@@ -67,7 +53,7 @@ public final class TestSecrets {
   public static IndexPackageAccess getIndexPackageAccess() {
     ensureCallerForGetter();
     if (indexWriterAccess == null) {
-      ensureInitialized.accept(IndexWriter.class);
+      ensureInitialized(IndexWriter.class);
     }
     return Objects.requireNonNull(indexPackageAccess);
   }
@@ -76,7 +62,7 @@ public final class TestSecrets {
   public static ConcurrentMergeSchedulerAccess getConcurrentMergeSchedulerAccess() {
     ensureCallerForGetter();
     if (cmsAccess == null) {
-      ensureInitialized.accept(ConcurrentMergeScheduler.class);
+      ensureInitialized(ConcurrentMergeScheduler.class);
     }
     return Objects.requireNonNull(cmsAccess);
   }
@@ -85,7 +71,7 @@ public final class TestSecrets {
   public static SegmentReaderAccess getSegmentReaderAccess() {
     ensureCallerForGetter();
     if (segmentReaderAccess == null) {
-      ensureInitialized.accept(SegmentReader.class);
+      ensureInitialized(SegmentReader.class);
     }
     return Objects.requireNonNull(segmentReaderAccess);
   }
@@ -94,7 +80,7 @@ public final class TestSecrets {
   public static IndexWriterAccess getIndexWriterAccess() {
     ensureCallerForGetter();
     if (indexWriterAccess == null) {
-      ensureInitialized.accept(IndexWriter.class);
+      ensureInitialized(IndexWriter.class);
     }
     return Objects.requireNonNull(indexWriterAccess);
   }
@@ -103,7 +89,7 @@ public final class TestSecrets {
   public static FilterIndexInputAccess getFilterInputIndexAccess() {
     ensureCallerForGetter();
     if (filterIndexInputAccess == null) {
-      ensureInitialized.accept(FilterIndexInput.class);
+      ensureInitialized(FilterIndexInput.class);
     }
     return Objects.requireNonNull(filterIndexInputAccess);
   }
@@ -143,6 +129,14 @@ public final class TestSecrets {
     TestSecrets.filterIndexInputAccess = filterIndexInputAccess;
   }
 
+  private static void ensureInitialized(Class<?> clazz) {
+    try {
+      MethodHandles.lookup().ensureInitialized(clazz);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   private static void ensureNull(Object ob) {
     if (ob != null) {
       throw new AssertionError(
@@ -152,13 +146,13 @@ public final class TestSecrets {
 
   private static void ensureCallerForSetter(Class<?> allowedCaller) {
     final boolean validCaller =
-        StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
+        StackWalker.getInstance()
             .walk(
                 s ->
                     s.skip(2)
                         .limit(1)
-                        .map(StackFrame::getDeclaringClass)
-                        .allMatch(c -> c == allowedCaller));
+                        .map(StackFrame::getClassName)
+                        .allMatch(c -> Objects.equals(c, allowedCaller.getName())));
     if (!validCaller) {
       throw new AssertionError("The accessor can only be set by " + allowedCaller.getName() + ".");
     }

--- a/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
@@ -169,7 +169,11 @@ public final class TestSecrets {
                     s.skip(2)
                         .limit(1)
                         .map(StackFrame::getClassName)
-                        .allMatch(c -> c.startsWith("org.apache.lucene.tests.")));
+                        .allMatch(
+                            c ->
+                                c.startsWith("org.apache.lucene.tests.")
+                                    || c.equals(
+                                        "org.apache.lucene.codecs.TestCodecLoadingDeadlock")));
     if (!validCaller) {
       throw new UnsupportedOperationException(
           "Lucene TestSecrets can only be used by the test-framework.");

--- a/lucene/core/src/test/org/apache/lucene/codecs/TestCodecLoadingDeadlock.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/TestCodecLoadingDeadlock.java
@@ -20,6 +20,7 @@ import com.carrotsearch.randomizedtesting.LifecycleScope;
 import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
+import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -29,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
@@ -36,6 +38,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.NamedThreadFactory;
 import org.apache.lucene.util.SuppressForbidden;
@@ -99,7 +104,21 @@ public class TestCodecLoadingDeadlock extends Assert {
     final String pfName = args[1];
     final String dvfName = args[2];
 
-    final int numThreads = 14; // two times the modulo in switch statement below
+    final var lookup = MethodHandles.lookup();
+    final List<Callable<?>> tasks =
+        List.of(
+            Codec::getDefault,
+            () -> Codec.forName(codecName),
+            () -> PostingsFormat.forName(pfName),
+            () -> DocValuesFormat.forName(dvfName),
+            Codec::availableCodecs,
+            PostingsFormat::availablePostingsFormats,
+            DocValuesFormat::availableDocValuesFormats,
+            TestSecrets::getIndexWriterAccess,
+            () -> lookup.ensureInitialized(IndexWriter.class),
+            () -> lookup.ensureInitialized(SegmentReader.class));
+
+    final int numTasks = tasks.size(), numThreads = numTasks * 2;
     final CopyOnWriteArrayList<Thread> allThreads = new CopyOnWriteArrayList<>();
     final ExecutorService pool =
         Executors.newFixedThreadPool(
@@ -123,36 +142,11 @@ public class TestCodecLoadingDeadlock extends Assert {
                         // Await a common barrier point for all threads and then
                         // run racy code. This is intentional.
                         barrier.await();
-                        switch (taskNo % 7) {
-                          case 0:
-                            Codec.getDefault();
-                            break;
-                          case 1:
-                            Codec.forName(codecName);
-                            break;
-                          case 2:
-                            PostingsFormat.forName(pfName);
-                            break;
-                          case 3:
-                            DocValuesFormat.forName(dvfName);
-                            break;
-                          case 4:
-                            Codec.availableCodecs();
-                            break;
-                          case 5:
-                            PostingsFormat.availablePostingsFormats();
-                            break;
-                          case 6:
-                            DocValuesFormat.availableDocValuesFormats();
-                            break;
-                          default:
-                            throw new AssertionError();
-                        }
+                        tasks.get(taskNo % numTasks).call();
                       } catch (Throwable t) {
                         synchronized (args) {
                           System.err.println(
-                              Thread.currentThread().getName()
-                                  + " failed to lookup codec service:");
+                              Thread.currentThread().getName() + " failed to call racy method:");
                           t.printStackTrace(System.err);
                         }
                         Runtime.getRuntime().halt(1); // signal failure to caller

--- a/lucene/core/src/test/org/apache/lucene/index/TestClassloadingDeadlock.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestClassloadingDeadlock.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.lucene.codecs;
+package org.apache.lucene.index;
 
 import com.carrotsearch.randomizedtesting.LifecycleScope;
 import com.carrotsearch.randomizedtesting.RandomizedContext;
@@ -38,8 +38,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.NamedThreadFactory;
@@ -52,7 +53,7 @@ import org.junit.runner.RunWith;
  * initialization when spawned as subprocess (and please let default codecs alive)! */
 
 @RunWith(RandomizedRunner.class)
-public class TestCodecLoadingDeadlock extends Assert {
+public class TestClassloadingDeadlock extends Assert {
   private static final int MAX_TIME_SECONDS = 30;
 
   @Test

--- a/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
@@ -16,7 +16,16 @@
  */
 package org.apache.lucene.internal.tests;
 
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 
 public class TestTestSecrets extends LuceneTestCase {
 
@@ -36,5 +45,71 @@ public class TestTestSecrets extends LuceneTestCase {
     expectThrows(AssertionError.class, () -> TestSecrets.setConcurrentMergeSchedulerAccess(null));
     expectThrows(AssertionError.class, () -> TestSecrets.setIndexPackageAccess(null));
     expectThrows(AssertionError.class, () -> TestSecrets.setSegmentReaderAccess(null));
+  }
+
+  public void testDeadlock() throws Exception {
+    String javaHome = System.getProperty("java.home");
+    String javaBin = Paths.get(javaHome, "bin", "java").toString();
+    String classpath = System.getProperty("java.class.path");
+
+    // Execute the DeadlockTest#main in a new JVM process (for isolation)
+    ProcessBuilder builder = new ProcessBuilder(
+        javaBin, "-cp", classpath, DeadlockTest.class.getName()
+    ).inheritIO();
+    boolean finished;
+    Process process = builder.start();
+    // If the process doesn't finish within 10 seconds, consider it deadlocked
+    finished = process.waitFor(10, TimeUnit.SECONDS);
+
+    if (!finished) {
+      process.destroyForcibly();
+    }
+
+    // If 'finished' is false, it means timeout (deadlock occurred)
+    assertTrue("Deadlock occurred in TestSecrets", finished);
+  }
+
+  public static class DeadlockTest {
+
+    static void main() throws InterruptedException, IOException {
+      System.out.println("Test started!");
+      // Set a CyclicBarrier to make the two threads start as simultaneously as possible
+      final CyclicBarrier barrier = new CyclicBarrier(2);
+
+      Thread indexThread = new Thread(() -> {
+        System.out.println("Thread #1 - Trigger to initialize IndexWriter");
+        try {
+          barrier.await();
+          Class.forName("org.apache.lucene.index.IndexWriter");
+        } catch (Exception e) {
+          System.err.println("Exception in Thread #1: " + e);
+        }
+      });
+
+      Thread searchThread = new Thread(() -> {
+        System.out.println("Thread #2 - Trigger to initialize SegmentReader");
+        try {
+          barrier.await();
+          Class.forName("org.apache.lucene.index.SegmentReader");
+        } catch (Exception e) {
+          System.err.println("Exception in Thread #2: " + e);
+        }
+      });
+
+      indexThread.start();
+      searchThread.start();
+
+      try (Directory directory = new ByteBuffersDirectory()) {
+        System.out.println("Created Directory object");
+        try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
+          System.out.println("Created IndexWriter object");
+          indexWriter.addDocument(new Document());
+          System.out.println("Called addDocument");
+        }
+      }
+      indexThread.join();
+      searchThread.join();
+      System.out.println("Test finished!");
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
@@ -71,7 +71,7 @@ public class TestTestSecrets extends LuceneTestCase {
 
   public static class DeadlockTest {
 
-    static void main() throws InterruptedException, IOException {
+    public static void main() throws InterruptedException, IOException {
       System.out.println("Test started!");
       // Set a CyclicBarrier to make the two threads start as simultaneously as possible
       final CyclicBarrier barrier = new CyclicBarrier(2);

--- a/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
@@ -16,16 +16,16 @@
  */
 package org.apache.lucene.internal.tests;
 
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.TimeUnit;
 
 public class TestTestSecrets extends LuceneTestCase {
 
@@ -53,9 +53,8 @@ public class TestTestSecrets extends LuceneTestCase {
     String classpath = System.getProperty("java.class.path");
 
     // Execute the DeadlockTest#main in a new JVM process (for isolation)
-    ProcessBuilder builder = new ProcessBuilder(
-        javaBin, "-cp", classpath, DeadlockTest.class.getName()
-    ).inheritIO();
+    ProcessBuilder builder =
+        new ProcessBuilder(javaBin, "-cp", classpath, DeadlockTest.class.getName()).inheritIO();
     boolean finished;
     Process process = builder.start();
     // If the process doesn't finish within 10 seconds, consider it deadlocked
@@ -76,25 +75,29 @@ public class TestTestSecrets extends LuceneTestCase {
       // Set a CyclicBarrier to make the two threads start as simultaneously as possible
       final CyclicBarrier barrier = new CyclicBarrier(2);
 
-      Thread indexThread = new Thread(() -> {
-        System.out.println("Thread #1 - Trigger to initialize IndexWriter");
-        try {
-          barrier.await();
-          Class.forName("org.apache.lucene.index.IndexWriter");
-        } catch (Exception e) {
-          System.err.println("Exception in Thread #1: " + e);
-        }
-      });
+      Thread indexThread =
+          new Thread(
+              () -> {
+                System.out.println("Thread #1 - Trigger to initialize IndexWriter");
+                try {
+                  barrier.await();
+                  Class.forName("org.apache.lucene.index.IndexWriter");
+                } catch (Exception e) {
+                  System.err.println("Exception in Thread #1: " + e);
+                }
+              });
 
-      Thread searchThread = new Thread(() -> {
-        System.out.println("Thread #2 - Trigger to initialize SegmentReader");
-        try {
-          barrier.await();
-          Class.forName("org.apache.lucene.index.SegmentReader");
-        } catch (Exception e) {
-          System.err.println("Exception in Thread #2: " + e);
-        }
-      });
+      Thread searchThread =
+          new Thread(
+              () -> {
+                System.out.println("Thread #2 - Trigger to initialize SegmentReader");
+                try {
+                  barrier.await();
+                  Class.forName("org.apache.lucene.index.SegmentReader");
+                } catch (Exception e) {
+                  System.err.println("Exception in Thread #2: " + e);
+                }
+              });
 
       indexThread.start();
       searchThread.start();

--- a/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
@@ -16,15 +16,6 @@
  */
 package org.apache.lucene.internal.tests;
 
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.TimeUnit;
-import org.apache.lucene.document.Document;
-import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.store.ByteBuffersDirectory;
-import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestTestSecrets extends LuceneTestCase {
@@ -49,74 +40,5 @@ public class TestTestSecrets extends LuceneTestCase {
         UnsupportedOperationException.class, () -> TestSecrets.setIndexPackageAccess(null));
     expectThrows(
         UnsupportedOperationException.class, () -> TestSecrets.setSegmentReaderAccess(null));
-  }
-
-  public void testDeadlock() throws Exception {
-    String javaHome = System.getProperty("java.home");
-    String javaBin = Paths.get(javaHome, "bin", "java").toString();
-    String classpath = System.getProperty("java.class.path");
-
-    // Execute the DeadlockTest#main in a new JVM process (for isolation)
-    ProcessBuilder builder =
-        new ProcessBuilder(javaBin, "-cp", classpath, DeadlockTest.class.getName()).inheritIO();
-    boolean finished;
-    Process process = builder.start();
-    // If the process doesn't finish within 10 seconds, consider it deadlocked
-    finished = process.waitFor(10, TimeUnit.SECONDS);
-
-    if (!finished) {
-      process.destroyForcibly();
-    }
-
-    // If 'finished' is false, it means timeout (deadlock occurred)
-    assertTrue("Deadlock occurred in TestSecrets", finished);
-  }
-
-  public static class DeadlockTest {
-
-    public static void main() throws InterruptedException, IOException {
-      System.out.println("Test started!");
-      // Set a CyclicBarrier to make the two threads start as simultaneously as possible
-      final CyclicBarrier barrier = new CyclicBarrier(2);
-
-      Thread indexThread =
-          new Thread(
-              () -> {
-                System.out.println("Thread #1 - Trigger to initialize IndexWriter");
-                try {
-                  barrier.await();
-                  Class.forName("org.apache.lucene.index.IndexWriter");
-                } catch (Exception e) {
-                  System.err.println("Exception in Thread #1: " + e);
-                }
-              });
-
-      Thread searchThread =
-          new Thread(
-              () -> {
-                System.out.println("Thread #2 - Trigger to initialize SegmentReader");
-                try {
-                  barrier.await();
-                  Class.forName("org.apache.lucene.index.SegmentReader");
-                } catch (Exception e) {
-                  System.err.println("Exception in Thread #2: " + e);
-                }
-              });
-
-      indexThread.start();
-      searchThread.start();
-
-      try (Directory directory = new ByteBuffersDirectory()) {
-        System.out.println("Created Directory object");
-        try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
-          System.out.println("Created IndexWriter object");
-          indexWriter.addDocument(new Document());
-          System.out.println("Called addDocument");
-        }
-      }
-      indexThread.join();
-      searchThread.join();
-      System.out.println("Test finished!");
-    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
@@ -41,10 +41,14 @@ public class TestTestSecrets extends LuceneTestCase {
   }
 
   public void testCannotSet() {
-    expectThrows(AssertionError.class, () -> TestSecrets.setIndexWriterAccess(null));
-    expectThrows(AssertionError.class, () -> TestSecrets.setConcurrentMergeSchedulerAccess(null));
-    expectThrows(AssertionError.class, () -> TestSecrets.setIndexPackageAccess(null));
-    expectThrows(AssertionError.class, () -> TestSecrets.setSegmentReaderAccess(null));
+    expectThrows(UnsupportedOperationException.class, () -> TestSecrets.setIndexWriterAccess(null));
+    expectThrows(
+        UnsupportedOperationException.class,
+        () -> TestSecrets.setConcurrentMergeSchedulerAccess(null));
+    expectThrows(
+        UnsupportedOperationException.class, () -> TestSecrets.setIndexPackageAccess(null));
+    expectThrows(
+        UnsupportedOperationException.class, () -> TestSecrets.setSegmentReaderAccess(null));
   }
 
   public void testDeadlock() throws Exception {


### PR DESCRIPTION
## Related Issues
* #15119
* #12419

## Overview
A deadlock occurred during static initialization due to the JVM Class Initialization Lock.
This issue occurs through mutual references between `org.apache.lucene.index.IndexWriter`(CMS, SegmentReader, FilterIndexInput also) and `org.apache.lucene.internal.tests.TestSecrets`.

## Cause
### Circular Dependency
IndexWriter invokes TestSecrets during its initialization, while TestSecrets conversely attempts to force-load IndexWriter during its own initialization.

### JVM Class Loading Lock
When the JVM loads a class for the first time, it acquires a global lock on that class object.
A deadlock occurs when two threads each hold a lock on different classes and wait for the other thread to release the lock for the class they are trying to load.

## Code structure

* **IndexWriter.java, ConcurrentMergeScheduler.java, SegmentReader.java, FilterIndexInput.java**

```java
static {
    // Trigger initialization by calling TestSecrets
    TestSecrets.set...Access(new ...Access() { ... });
}
```
* **TestSecrets.java**
```java
static {
    ...
    ensureInitialized.accept(ConcurrentMergeScheduler.class);
    ensureInitialized.accept(SegmentReader.class);
    ensureInitialized.accept(IndexWriter.class); // Deadlock trigger point
    ensureInitialized.accept(FilterIndexInput.class);
}
```
## Deadlock Scenario

This deadlock occurs in a multi-threaded environment when two classes are accessed for the first time almost simultaneously.
| Step | Thread A | Thread B |
| :--- | :--- | :--- |
| **1** | First access to `IndexWriter` class. | First access to `SegmentReader` class. |
| **2** | Acquires lock on `IndexWriter.class` and starts initialization. | Acquires lock on `SegmentReader.class` and starts initialization. |
| **3** | Calls `TestSecrets` → Acquires lock on `TestSecrets.class`. | Attempts to call `TestSecrets`. |
| **4** | (Initialization in progress) | **Blocked**: Waiting for `TestSecrets` lock (held by Thread A). |
| **5** | `TestSecrets` static block calls `Class.forName("SegmentReader")`. | (Waiting...) |
| **6** | **Blocked**: Waiting for `SegmentReader` lock (held by Thread B). | (Waiting...) |

**Result:** A permanent deadlock occurs where Thread A waits for the `SegmentReader` lock while Thread B waits for the `TestSecrets` lock.

## Steps to Reproduce

Without applying my `TestSecrets` fix:
1) Run the `main()` of the `DeadlockTest` class in `TestTestSecrets`.
2) Run `testDeadlock()` in `TestTestSecrets`.

## Solution - Lazy Initialization

All `Class.forName` calls that forcibly load target classes within the static initialization block of `TestSecrets` have been removed.
Instead, the logic has been updated to perform initialization individually within each Getter method at the actual time of invocation.

* TestSecrets.java 

```java
public final class TestSecrets {
    private static IndexWriterAccess indexWriterAccess;
    private static ConcurrentMergeSchedulerAccess cmsAccess;
    private static SegmentReaderAccess segmentReaderAccess;

    // All ensureInitialized calls within the static initialization block have been removed.

    public static IndexWriterAccess getIndexWriterAccess() {
        ensureCallerForGetter();
        if (indexWriterAccess == null) {
            ensureInitialized.accept(IndexWriter.class);
        }
        return Objects.requireNonNull(indexWriterAccess);
    }
    // Same pattern applies to other getters (CMS, SegmentReader, etc.)
}
```

## Diagram
```mermaid
graph TD
    subgraph "Thread A (Initializes IndexWriter)"
        A1[IndexWriter class load] --> A2["IndexWriter.<clinit> (Lock IndexWriter.class)"]
        A2 --> A3["Call TestSecrets.setIndexWriterAccess()"]
        A3 --> A4["Trigger TestSecrets.<clinit> (Lock TestSecrets.class)"]
        A4 --> A5["TestSecrets.<clinit> calls Class.forName('SegmentReader')"]
        A5 -- "Wait for SegmentReader.class lock" --> B2
    end

    subgraph "Thread B (Initializes SegmentReader)"
        B1[SegmentReader class load] --> B2["SegmentReader.<clinit> (Lock SegmentReader.class)"]
        B2 --> B3["Call TestSecrets.setSegmentReaderAccess()"]
        B3 -- "Wait for TestSecrets.class lock" --> A4
    end

    A5 -. Deadlock .-> B2
    B3 -. Deadlock .-> A4
```