### PR TITLE
Make some native vectorization classes package private to be consistent and a minor fix

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -171,7 +171,7 @@ public abstract class VectorizationProvider {
     return new DefaultVectorizationProvider();
   }
 
-  static VectorizationProvider lookup(String className) {
+  private static VectorizationProvider lookup(String className) {
     try {
       // we use method handles with lookup, so we do not need to deal with setAccessible as we
       // have private access through the lookup:

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/NativeVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/NativeVectorUtilSupport.java
@@ -259,9 +259,7 @@ final class NativeVectorUtilSupport implements VectorUtilSupport {
   private static <T> T invokeOrDelegate(MethodHandle mh, Supplier<T> delegate, Object... args) {
     if (mh != null) {
       try {
-        // TODO: This is slow and we should avoid dynamic invocations and improve the test coverage
-        // (https://github.com/apache/lucene/issues/15840)
-        return (T) mh.invokeWithArguments(args);
+        return (T) mh.asSpreader(Object[].class, args.length).invokeExact(args);
       } catch (Throwable ex) {
         throw new AssertionError("should not reach here", ex);
       }

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/NativeVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/NativeVectorUtilSupport.java
@@ -259,7 +259,9 @@ final class NativeVectorUtilSupport implements VectorUtilSupport {
   private static <T> T invokeOrDelegate(MethodHandle mh, Supplier<T> delegate, Object... args) {
     if (mh != null) {
       try {
-        return (T) mh.asSpreader(Object[].class, args.length).invokeExact(args);
+        // TODO: This is slow and we should avoid dynamic invocations and improve the test coverage
+        // (https://github.com/apache/lucene/issues/15840)
+        return (T) mh.invokeWithArguments(args);
       } catch (Throwable ex) {
         throw new AssertionError("should not reach here", ex);
       }

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/NativeVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/NativeVectorUtilSupport.java
@@ -50,7 +50,7 @@ import org.apache.lucene.util.Constants;
  * overhead of ensuring MemorySegments are allocated off-heap before native calls.
  */
 @SuppressWarnings("restricted")
-public final class NativeVectorUtilSupport implements VectorUtilSupport {
+final class NativeVectorUtilSupport implements VectorUtilSupport {
 
   private final VectorUtilSupport delegateVectorUtilSupport;
 
@@ -259,7 +259,9 @@ public final class NativeVectorUtilSupport implements VectorUtilSupport {
   private static <T> T invokeOrDelegate(MethodHandle mh, Supplier<T> delegate, Object... args) {
     if (mh != null) {
       try {
-        return (T) mh.invokeExact(args);
+        // TODO: This is slow and we should avoid dynamic invocations and improve the test coverage
+        // (https://github.com/apache/lucene/issues/15840)
+        return (T) mh.invokeWithArguments(args);
       } catch (Throwable ex) {
         throw new AssertionError("should not reach here", ex);
       }

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/NativeVectorizationProvider.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/NativeVectorizationProvider.java
@@ -26,7 +26,7 @@ import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.SuppressForbidden;
 
 /** Native provider returning native implementations which delegates to Panama implementation. */
-public final class NativeVectorizationProvider extends VectorizationProvider {
+final class NativeVectorizationProvider extends VectorizationProvider {
 
   private final VectorizationProvider delegateVectorUtilProvider =
       new PanamaVectorizationProvider();


### PR DESCRIPTION
### Description

- Addresses some comments on [#15508](https://github.com/apache/lucene/pull/15508) to make some classes package private for consistency and a minor fix to method name (we'll eventually planning to remove it in https://github.com/apache/lucene/issues/15840). 
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
