### PR TITLE
Improve caller checks by using new optimized stackwalker

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -209,6 +209,9 @@ Other
 * GITHUB#15844: Detect JVM bitness using Panama's ValueLayout#ADDRESS instead
   of undocumented system properties.  (Uwe Schindler)
 
+* GITHUB#15867: Use StackWalker without method info for caller checks in internal classes and tests.
+  (Uwe Schindler)
+
 ======================= Lucene 10.5.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
@@ -35,8 +35,10 @@ import org.apache.lucene.store.FilterIndexInput;
 public final class TestSecrets {
 
   private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
-  private static final StackWalker STACKWALKER =
+  private static final StackWalker SW_CLASSNAME =
       StackWalker.getInstance(Set.of(Option.DROP_METHOD_INFO), 3);
+  private static final StackWalker SW_CLASSREF =
+      StackWalker.getInstance(Set.of(Option.DROP_METHOD_INFO, Option.RETAIN_CLASS_REFERENCE), 3);
 
   private static void ensureInitialized(Class<?> clazz) {
     try {
@@ -140,12 +142,12 @@ public final class TestSecrets {
 
   private static void ensureCallerForSetter(Class<?> allowedCaller, Object needsNull) {
     final boolean validCaller =
-        STACKWALKER.walk(
+        SW_CLASSREF.walk(
             s ->
                 s.skip(2)
                     .limit(1)
-                    .map(StackFrame::getClassName)
-                    .allMatch(allowedCaller.getName()::equals));
+                    .map(StackFrame::getDeclaringClass)
+                    .allMatch(allowedCaller::equals));
     if (!validCaller || needsNull != null) {
       throw new IllegalCallerException(
           "The accessor can only be set once by " + allowedCaller.getName() + ".");
@@ -154,7 +156,7 @@ public final class TestSecrets {
 
   private static void ensureCallerForGetter() {
     final boolean validCaller =
-        STACKWALKER.walk(
+        SW_CLASSNAME.walk(
             s ->
                 s.skip(2)
                     .limit(1)

--- a/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
@@ -145,7 +145,7 @@ public final class TestSecrets {
                 s.skip(2)
                     .limit(1)
                     .map(StackFrame::getClassName)
-                        .allMatch(allowedCaller.getName()::equals));
+                    .allMatch(allowedCaller.getName()::equals));
     if (!validCaller || needsNull != null) {
       throw new IllegalCallerException(
           "The accessor can only be set once by " + allowedCaller.getName() + ".");

--- a/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
@@ -16,9 +16,11 @@
  */
 package org.apache.lucene.internal.tests;
 
+import java.lang.StackWalker.Option;
 import java.lang.StackWalker.StackFrame;
 import java.lang.invoke.MethodHandles;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
@@ -33,6 +35,8 @@ import org.apache.lucene.store.FilterIndexInput;
 public final class TestSecrets {
 
   private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+  private static final StackWalker STACKWALKER =
+      StackWalker.getInstance(Set.of(Option.DROP_METHOD_INFO), 3);
 
   private static void ensureInitialized(Class<?> clazz) {
     try {
@@ -136,12 +140,11 @@ public final class TestSecrets {
 
   private static void ensureCallerForSetter(Class<?> allowedCaller, Object needsNull) {
     final boolean validCaller =
-        StackWalker.getInstance()
-            .walk(
-                s ->
-                    s.skip(2)
-                        .limit(1)
-                        .map(StackFrame::getClassName)
+        STACKWALKER.walk(
+            s ->
+                s.skip(2)
+                    .limit(1)
+                    .map(StackFrame::getClassName)
                         .allMatch(allowedCaller.getName()::equals));
     if (!validCaller || needsNull != null) {
       throw new IllegalCallerException(
@@ -151,17 +154,15 @@ public final class TestSecrets {
 
   private static void ensureCallerForGetter() {
     final boolean validCaller =
-        StackWalker.getInstance()
-            .walk(
-                s ->
-                    s.skip(2)
-                        .limit(1)
-                        .map(StackFrame::getClassName)
-                        .allMatch(
-                            c ->
-                                c.startsWith("org.apache.lucene.tests.")
-                                    || c.equals(
-                                        "org.apache.lucene.index.TestClassloadingDeadlock")));
+        STACKWALKER.walk(
+            s ->
+                s.skip(2)
+                    .limit(1)
+                    .map(StackFrame::getClassName)
+                    .allMatch(
+                        c ->
+                            c.startsWith("org.apache.lucene.tests.")
+                                || c.equals("org.apache.lucene.index.TestClassloadingDeadlock")));
     if (!validCaller) {
       throw new IllegalCallerException(
           "Lucene TestSecrets can only be used by the test-framework.");

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -18,6 +18,7 @@
 package org.apache.lucene.internal.vectorization;
 
 import java.io.IOException;
+import java.lang.StackWalker.Option;
 import java.lang.StackWalker.StackFrame;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -214,15 +215,14 @@ public abstract class VectorizationProvider {
           "org.apache.lucene.codecs.lucene104.PostingIndexInput",
           "org.apache.lucene.tests.util.TestSysoutsLimits");
 
+  private static final StackWalker STACKWALKER =
+      StackWalker.getInstance(Set.of(Option.DROP_METHOD_INFO), 3);
+
   private static void ensureCaller() {
     final boolean validCaller =
-        StackWalker.getInstance()
-            .walk(
-                s ->
-                    s.skip(2)
-                        .limit(1)
-                        .map(StackFrame::getClassName)
-                        .allMatch(VALID_CALLERS::contains));
+        STACKWALKER.walk(
+            s ->
+                s.skip(2).limit(1).map(StackFrame::getClassName).allMatch(VALID_CALLERS::contains));
     if (!validCaller) {
       throw new IllegalCallerException(
           "VectorizationProvider is internal and can only be used by known Lucene classes.");

--- a/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/tests/TestTestSecrets.java
@@ -37,5 +37,6 @@ public class TestTestSecrets extends LuceneTestCase {
         IllegalCallerException.class, () -> TestSecrets.setConcurrentMergeSchedulerAccess(null));
     expectThrows(IllegalCallerException.class, () -> TestSecrets.setIndexPackageAccess(null));
     expectThrows(IllegalCallerException.class, () -> TestSecrets.setSegmentReaderAccess(null));
+    expectThrows(IllegalCallerException.class, () -> TestSecrets.setFilterInputIndexAccess(null));
   }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -2868,8 +2868,8 @@ public abstract class LuceneTestCase extends Assert {
     }
   }
 
-  private static final StackWalker SW_NO_METHODS = StackWalker.getInstance(Option.DROP_METHOD_INFO);
-  private static final StackWalker SW_WITH_METHODS = StackWalker.getInstance();
+  private static final StackWalker SW_NO_METHODS = StackWalker.getInstance(Option.DROP_METHOD_INFO),
+      SW_WITH_METHODS = StackWalker.getInstance();
 
   /** Inspects stack trace to figure out if a method of a specific class called us. */
   public static boolean callStackContains(Class<?> clazz, String methodName) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCase.java
@@ -55,6 +55,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.lang.StackWalker.Option;
 import java.lang.StackWalker.StackFrame;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -2867,17 +2868,19 @@ public abstract class LuceneTestCase extends Assert {
     }
   }
 
+  private static final StackWalker SW_NO_METHODS = StackWalker.getInstance(Option.DROP_METHOD_INFO);
+  private static final StackWalker SW_WITH_METHODS = StackWalker.getInstance();
+
   /** Inspects stack trace to figure out if a method of a specific class called us. */
   public static boolean callStackContains(Class<?> clazz, String methodName) {
     final String className = clazz.getName();
-    return StackWalker.getInstance()
-        .walk(
-            s ->
-                s.skip(1) // exclude this utility method
-                    .anyMatch(
-                        f ->
-                            className.equals(f.getClassName())
-                                && methodName.equals(f.getMethodName())));
+    return SW_WITH_METHODS.walk(
+        s ->
+            s.skip(1) // exclude this utility method
+                .anyMatch(
+                    f ->
+                        className.equals(f.getClassName())
+                            && methodName.equals(f.getMethodName())));
   }
 
   /**
@@ -2885,22 +2888,20 @@ public abstract class LuceneTestCase extends Assert {
    * called us.
    */
   public static boolean callStackContainsAnyOf(String... methodNames) {
-    return StackWalker.getInstance()
-        .walk(
-            s ->
-                s.skip(1) // exclude this utility method
-                    .map(StackFrame::getMethodName)
-                    .anyMatch(Set.of(methodNames)::contains));
+    return SW_WITH_METHODS.walk(
+        s ->
+            s.skip(1) // exclude this utility method
+                .map(StackFrame::getMethodName)
+                .anyMatch(Set.of(methodNames)::contains));
   }
 
   /** Inspects stack trace if the given class called us. */
   public static boolean callStackContains(Class<?> clazz) {
-    return StackWalker.getInstance()
-        .walk(
-            s ->
-                s.skip(1) // exclude this utility method
-                    .map(StackFrame::getClassName)
-                    .anyMatch(clazz.getName()::equals));
+    return SW_NO_METHODS.walk(
+        s ->
+            s.skip(1) // exclude this utility method
+                .map(StackFrame::getClassName)
+                .anyMatch(clazz.getName()::equals));
   }
 
   /** A runnable that can throw any checked exception. */


### PR DESCRIPTION
Java 22 introduced a new StackWalker implementation that drops all method info. This was made explicitely for logging frameworks or methods that just need to check if a class was called by a specific class where method is irrelevant.

This improves our security checks on VectorizationProvider and TestSecrets, as well as some LuceneTestCase methods. For caller checks we can also give a best gues how many stack elements will be looked at, in most cases this is only 3.