### PR TITLE
Improve build cache compatibility for test, ecjLint, and forbiddenApis tasks

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ApplyForbiddenApisPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ApplyForbiddenApisPlugin.java
@@ -36,6 +36,7 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskContainer;
@@ -205,7 +206,9 @@ public class ApplyForbiddenApisPlugin extends LuceneGradlePlugin {
     var allSignatureFiles = project.files(signatureFiles);
     var existingSignatureFiles = allSignatureFiles.filter(File::exists);
 
-    task.getInputs().files(existingSignatureFiles);
+    task.getInputs()
+        .files(existingSignatureFiles)
+        .withPathSensitivity(PathSensitivity.RELATIVE);
     task.setSignaturesFiles(task.getSignaturesFiles().plus(existingSignatureFiles));
 
     addBuiltInSignatures(task, allDependenciesProvider);

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ApplyForbiddenApisPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ApplyForbiddenApisPlugin.java
@@ -206,9 +206,7 @@ public class ApplyForbiddenApisPlugin extends LuceneGradlePlugin {
     var allSignatureFiles = project.files(signatureFiles);
     var existingSignatureFiles = allSignatureFiles.filter(File::exists);
 
-    task.getInputs()
-        .files(existingSignatureFiles)
-        .withPathSensitivity(PathSensitivity.RELATIVE);
+    task.getInputs().files(existingSignatureFiles).withPathSensitivity(PathSensitivity.RELATIVE);
     task.setSignaturesFiles(task.getSignaturesFiles().plus(existingSignatureFiles));
 
     addBuiltInSignatures(task, allDependenciesProvider);

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/EcjLintPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/EcjLintPlugin.java
@@ -35,6 +35,8 @@ import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.ClasspathNormalizer;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.process.CommandLineArgumentProvider;
@@ -120,7 +122,8 @@ public class EcjLintPlugin extends LuceneGradlePlugin {
     args.add("-proc:none");
     args.add("-nowarn");
     args.add("-enableJavadoc");
-    args.addAll(List.of("-properties", javadocPrefsPath.toAbsolutePath().toString()));
+    // Note: -properties path is added at execution time (in doFirst) to avoid
+    // absolute paths in the cache key. The file content is tracked separately.
 
     // We depend on modular paths.
     ModularPathsExtension modularPaths =
@@ -133,15 +136,22 @@ public class EcjLintPlugin extends LuceneGradlePlugin {
     // Collect modular dependencies and their transitive dependencies to module path.
     CommandLineArgumentProvider compilationArguments = modularPaths.getCompilationArguments();
     // this isn't exactly right but the returned CommandLineArgumentProvider isn't serializable...
-    task.getInputs().files(sourceSet.getCompileClasspath());
+    task.getInputs()
+        .files(sourceSet.getCompileClasspath())
+        .withNormalizer(ClasspathNormalizer.class);
 
     // Collect classpath locations
     FileCollection classpathArguments = modularPaths.getCompilationClasspath().filter(File::exists);
-    task.getInputs().files(classpathArguments);
+    task.getInputs().files(classpathArguments).withNormalizer(ClasspathNormalizer.class);
 
     // Input sources.
     var inputSources = sourceSet.getJava().getAsFileTree();
-    task.getInputs().files(inputSources);
+    task.getInputs().files(inputSources).withPathSensitivity(PathSensitivity.RELATIVE);
+
+    // Track the javadoc prefs file as an input with relative path sensitivity.
+    task.getInputs()
+        .file(javadocPrefsPath.toFile())
+        .withPathSensitivity(PathSensitivity.RELATIVE);
 
     // Add all arguments so far as inputs.
     task.getInputs().property("args", args);
@@ -163,6 +173,7 @@ public class EcjLintPlugin extends LuceneGradlePlugin {
     task.doFirst(
         _ -> {
           List<String> allArgs = new ArrayList<>(args);
+          allArgs.addAll(List.of("-properties", javadocPrefsPath.toAbsolutePath().toString()));
 
           compilationArguments.asArguments().forEach(allArgs::add);
           if (!classpathArguments.isEmpty()) {

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/EcjLintPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/EcjLintPlugin.java
@@ -149,9 +149,7 @@ public class EcjLintPlugin extends LuceneGradlePlugin {
     task.getInputs().files(inputSources).withPathSensitivity(PathSensitivity.RELATIVE);
 
     // Track the javadoc prefs file as an input with relative path sensitivity.
-    task.getInputs()
-        .file(javadocPrefsPath.toFile())
-        .withPathSensitivity(PathSensitivity.RELATIVE);
+    task.getInputs().file(javadocPrefsPath.toFile()).withPathSensitivity(PathSensitivity.RELATIVE);
 
     // Add all arguments so far as inputs.
     task.getInputs().property("args", args);

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ModularPathsPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ModularPathsPlugin.java
@@ -32,6 +32,7 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.ClasspathNormalizer;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.bundling.Jar;
@@ -101,7 +102,9 @@ public class ModularPathsPlugin extends LuceneGradlePlugin {
                     // on the task itself... but I don't know how to implement this on an
                     // existing class.
                     // this is a workaround but should work just fine though.
-                    task.getInputs().files(modularPaths.getCompileModulePathConfiguration());
+                    task.getInputs()
+                        .files(modularPaths.getCompileModulePathConfiguration())
+                        .withNormalizer(ClasspathNormalizer.class);
 
                     // LUCENE-10327: don't allow gradle to emit an empty sourcepath as it would
                     // break

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
@@ -603,7 +603,9 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
     @Internal
     public abstract DirectoryProperty getTempDir();
 
-    /** java.io.tmpdir for forked test JVMs. Marked @Internal to avoid absolute paths in cache key. */
+    /**
+     * java.io.tmpdir for forked test JVMs. Marked @Internal to avoid absolute paths in cache key.
+     */
     @Internal
     public abstract DirectoryProperty getJavaTmpDir();
 

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
@@ -539,7 +539,9 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
               }
 
               // Set up cwd and temp locations.
-              task.systemProperty("java.io.tmpdir", testsTmpDir);
+              // java.io.tmpdir is passed via the LoggingFileArgumentProvider (marked @Internal)
+              // instead of systemProperty to avoid absolute paths affecting the build cache key.
+              loggingFileProvider.getJavaTmpDir().set(workDirOption.get());
 
               task.doFirst(
                   _ -> {
@@ -601,12 +603,17 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
     @Internal
     public abstract DirectoryProperty getTempDir();
 
+    /** java.io.tmpdir for forked test JVMs. Marked @Internal to avoid absolute paths in cache key. */
+    @Internal
+    public abstract DirectoryProperty getJavaTmpDir();
+
     @Override
     public Iterable<String> asArguments() {
       return List.of(
           "-Djava.util.logging.config.file="
               + getLoggingConfigFile().getAsFile().get().getAbsolutePath(),
-          "-DtempDir=" + getTempDir().get().getAsFile().getAbsolutePath());
+          "-DtempDir=" + getTempDir().get().getAsFile().getAbsolutePath(),
+          "-Djava.io.tmpdir=" + getJavaTmpDir().get().getAsFile().getAbsolutePath());
     }
   }
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -181,6 +181,11 @@ Build
   Install with `uv tool install prek; prek install`
   For more see help/precommit.txt or `./gradlew helpPrecommit` (Robert Muir)
 
+* Improve build cache compatibility for test, ecjLint, and forbiddenApis tasks.
+  Use path-sensitive annotations and argument providers instead of embedding absolute
+  paths in cache keys, improving cache hit rates across different project locations.
+  (Gasper Kojek)
+
 Other
 ---------------------
 


### PR DESCRIPTION
### Description

Three changes to improve build cache hit rates when the project is built at different filesystem locations:

**1. TestsAndRandomizationPlugin: `java.io.tmpdir` system property**

The `java.io.tmpdir` system property was set via `task.systemProperty()`, which includes its absolute path value in the task's cache key via the `systemProperties` map. This caused cache misses for all 37 test tasks when the project was built at different filesystem locations.

Fix: Move it to the existing `LoggingFileArgumentProvider` as an `@Internal` property, so the absolute path value is passed to the forked test JVM without affecting the cache key.

**2. EcjLintPlugin: file input path sensitivity**

File inputs for classpath, source files, and the javadoc prefs configuration file all used default `ABSOLUTE` path sensitivity. Additionally, the javadoc prefs file path was embedded as an absolute string in the `args` property.

Fix:
- Classpath inputs now use `ClasspathNormalizer`
- Source file inputs use `RELATIVE` path sensitivity
- Javadoc prefs file is tracked as a separate file input with `RELATIVE` sensitivity, and its absolute path is added to arguments only at execution time

**3. ApplyForbiddenApisPlugin: signature file path sensitivity**

Signature file inputs used default `ABSOLUTE` path sensitivity.

Fix: Add `RELATIVE` path sensitivity to signature file inputs.

### How it was found

Running the [Develocity Build Validation Scripts](https://github.com/gradle/develocity-build-validation-scripts) experiments against the Lucene build showed:
- Experiment 2 (same location): all 37 test tasks missed the build cache due to `outputs.upToDateWhen` returning false (separate issue — controlled by `tests.rerun` option)
- Experiment 3 (different locations): 106 cacheable tasks missed the build cache due to absolute paths in task inputs