### PR TITLE
ci: pin zizmor nightly online run

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,12 +20,23 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          version-file: dev-tools/pyproject.toml
+          enable-cache: true
+          save-cache: false
+          cache-dependency-glob: dev-tools/uv.lock
+          cache-suffix: dev-tools
+
       - name: Run zizmor
-        run: uvx zizmor --pedantic --format=sarif . > results.sarif
+        run: uv run zizmor --pedantic --format=sarif . > results.sarif
         env:
+          UV_PROJECT: dev-tools
+          UV_FROZEN: "1"
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
         with:

--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
         with:
-          version: "0.9.27"
+          version-file: dev-tools/pyproject.toml
           enable-cache: true
           prune-cache: false
           save-cache: ${{ github.event_name != 'pull_request' }}

--- a/dev-tools/pyproject.toml
+++ b/dev-tools/pyproject.toml
@@ -22,3 +22,6 @@ dev = [
   # validates various
   "ast-grep-cli==0.41.1",
 ]
+
+[tool.uv]
+required-version = ">=0.9.27"


### PR DESCRIPTION
zizmor runs in the prek phase of CI (version/sha from uv lock file), but it also runs at night, where it does additional "online" checks with the github token.

In this case it checks our dependencies does some git inspection and vulnerability checking and so on. If there are problems, they are reported to the security tab.

Don't just install "latest" from pypi, instead use the same pinned version used by prek. Reuse the build cache from prek to avoid downloads.

Move uv minimum version specifier from setup-uv action into the pyproject.toml. The value is unchanged, but it keeps it in a single place.
