### PR TITLE
Fix existential quantification bug in caller checks

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -291,7 +291,7 @@ Bug Fixes
 * GITHUB#12419, GITHUB#15119, GITHUB#15864: Fix circular dependency deadlock in
   TestSecrets initialization (Namgyu Kim, Uwe Schindler)
 
-* GITHUB#15867: Use IllegalCallerException to signal wrong caller in internal classes
+* GITHUB#15878: Fix existential quantification bug in caller checks
   (VectorizationProvider, TestSecrets).  (Uwe Schindler)
 
 Other
@@ -310,6 +310,9 @@ Other
 * GITHUB#15799: Exclude JNA Cleaner from thread leak detection by LuceneTestCase. (Alan Woodward)
 
 * GITHUB#15826: Use ArrayUtil#copyOfSubArray to simplify manual array copy patterns. (Zhang Chao)
+
+* GITHUB#15867: Use IllegalCallerException to signal wrong caller in internal classes
+  (VectorizationProvider, TestSecrets).  (Uwe Schindler)
 
 ======================= Lucene 10.4.0 =======================
 

--- a/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/tests/TestSecrets.java
@@ -142,7 +142,7 @@ public final class TestSecrets {
                     s.skip(2)
                         .limit(1)
                         .map(StackFrame::getClassName)
-                        .allMatch(allowedCaller.getName()::equals));
+                        .anyMatch(allowedCaller.getName()::equals));
     if (!validCaller || needsNull != null) {
       throw new IllegalCallerException(
           "The accessor can only be set once by " + allowedCaller.getName() + ".");
@@ -157,7 +157,7 @@ public final class TestSecrets {
                     s.skip(2)
                         .limit(1)
                         .map(StackFrame::getClassName)
-                        .allMatch(
+                        .anyMatch(
                             c ->
                                 c.startsWith("org.apache.lucene.tests.")
                                     || c.equals(

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -222,7 +222,7 @@ public abstract class VectorizationProvider {
                     s.skip(2)
                         .limit(1)
                         .map(StackFrame::getClassName)
-                        .allMatch(VALID_CALLERS::contains));
+                        .anyMatch(VALID_CALLERS::contains));
     if (!validCaller) {
       throw new IllegalCallerException(
           "VectorizationProvider is internal and can only be used by known Lucene classes.");


### PR DESCRIPTION
This is a bug which may happen with empty caller stack. Not urgent, but logic was wrong due to existential quantification (allMatch returns true if stream is empty); anyMatch not. As we have a stream with at max one entry, the condition anyMatch is the only correct one to identify a valid caller.