### PR TITLE
Suppress SimpleTextCodec in sort optimization tests

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -64,11 +64,13 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.search.CheckHits;
 import org.apache.lucene.tests.search.ScorerIndexSearcher;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 
+@SuppressCodecs("SimpleText")
 public class TestSortOptimization extends LuceneTestCase {
 
   public void testLongSortOptimizationPointIndex() throws Exception {


### PR DESCRIPTION
SimpleTextCodec has a degenerate skipper implementation (it only ever writes a single block), so we can't use it to test sort optimizations based on skippers.

Fixes #15880 
