### PR TITLE
Enable remote build cache

### DIFF
--- a/gradle/develocity.gradle
+++ b/gradle/develocity.gradle
@@ -36,6 +36,7 @@ buildCache {
     }
 
     remote(develocity.buildCache) {
-        enabled = false
+        enabled = true
+        push = isCIBuild
     }
 }

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -181,6 +181,9 @@ Build
   Install with `uv tool install prek; prek install`
   For more see help/precommit.txt or `./gradlew helpPrecommit` (Robert Muir)
 
+* Enable remote build cache backed by Develocity, with push limited to CI builds.
+  (Gasper Kojek)
+
 Other
 ---------------------
 


### PR DESCRIPTION
## Summary
- Enable the Develocity remote build cache for all builds
- Restrict cache push to CI builds only, so local builds benefit from cache hits without polluting it