### PR TITLE
Streamline segment info logged by infostream, esp. when merging

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -317,6 +317,8 @@ Other
 * GITHUB#15867: Use IllegalCallerException to signal wrong caller in internal classes
   (VectorizationProvider, TestSecrets).  (Uwe Schindler)
 
+* GITHUB#15885: Slenderize SegmentInfo.toString() and use beefy version in infostream only once
+
 ======================= Lucene 10.4.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -2844,7 +2844,7 @@ public class IndexWriter
       ensureOpen(false);
 
       if (infoStream.isEnabled("IW")) {
-        infoStream.message("IW", "publishFlushedSegment " + newSegment);
+        infoStream.message("IW", "publishFlushedSegment " + newSegment.toStringVerbose());
       }
 
       if (globalPacket != null && globalPacket.any()) {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3344,6 +3344,9 @@ public class IndexWriter
       try {
         writer.addIndexesReaderMerge(merge);
         success = true;
+        if (infoStream != null && infoStream.isEnabled("IW")) {
+          infoStream.message("IW", "merged new segment " + merge.info.toStringVerbose());
+        }
       } catch (Throwable t) {
         handleMergeException(t, merge);
       } finally {
@@ -4776,6 +4779,7 @@ public class IndexWriter
 
     if (merge.info != null && merge.isAborted() == false) {
       if (infoStream.isEnabled("IW")) {
+        infoStream.message("IW", "merged new segment " + merge.info.toStringVerbose());
         infoStream.message(
             "IW",
             "merge time "

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1047,7 +1047,6 @@ public class IndexWriter
         // Must clone because we don't want the incoming NRT reader to "see" any changes this writer
         // now makes:
         segmentInfos = reader.segmentInfos.clone();
-
         SegmentInfos lastCommit;
         try {
           lastCommit = SegmentInfos.readCommit(directoryOrig, segmentInfos.getSegmentsFileName());
@@ -1111,7 +1110,9 @@ public class IndexWriter
 
         rollbackSegments = segmentInfos.createBackupSegmentInfos();
       }
-
+      if (infoStream.isEnabled("IW")) {
+        infoStream.message("IW", " initial segments: " + segmentInfos.toStringVerbose());
+      }
       commitUserData = new HashMap<>(segmentInfos.getUserData()).entrySet();
 
       pendingNumDocs.set(segmentInfos.totalMaxDoc());

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3345,7 +3345,11 @@ public class IndexWriter
         writer.addIndexesReaderMerge(merge);
         success = true;
         if (infoStream != null && infoStream.isEnabled("IW")) {
-          infoStream.message("IW", "merged new segment " + merge.info.toStringVerbose());
+          if (merge.info == null) {
+            infoStream.message("IW", "dropped 100% deleted segment");
+          } else {
+            infoStream.message("IW", "merged new segment " + merge.info.toStringVerbose());
+          }
         }
       } catch (Throwable t) {
         handleMergeException(t, merge);

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1111,7 +1111,7 @@ public class IndexWriter
         rollbackSegments = segmentInfos.createBackupSegmentInfos();
       }
       if (infoStream.isEnabled("IW")) {
-        infoStream.message("IW", " initial segments: " + segmentInfos.toStringVerbose());
+        infoStream.message("IW", "init " + segmentInfos.toStringVerbose());
       }
       commitUserData = new HashMap<>(segmentInfos.getUserData()).entrySet();
 

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentCommitInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentCommitInfo.java
@@ -349,7 +349,19 @@ public class SegmentCommitInfo {
 
   /** Returns a description of this segment. */
   public String toString(int pendingDelCount) {
-    String s = info.toString(delCount + pendingDelCount);
+    return info.toString(delCount + pendingDelCount);
+  }
+
+  @Override
+  public String toString() {
+    return info.toString();
+  }
+
+  public String toStringVerbose() {
+    String s = info.toStringVerbose();
+    if (this.id != null) {
+      s += " :id=" + StringHelper.idToString(id);
+    }
     if (delGen != -1) {
       s += ":delGen=" + delGen;
     }
@@ -365,13 +377,7 @@ public class SegmentCommitInfo {
     if (this.id != null) {
       s += " :id=" + StringHelper.idToString(id);
     }
-
     return s;
-  }
-
-  @Override
-  public String toString() {
-    return toString(0);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentCommitInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentCommitInfo.java
@@ -352,12 +352,14 @@ public class SegmentCommitInfo {
     return info.toString(delCount + pendingDelCount);
   }
 
+  /** Returns a description of this segment. */
   @Override
   public String toString() {
     return info.toString();
   }
 
-  public String toStringVerbose() {
+  /** Returns a more verbose description of this segment for use in infostream logging */
+  String toStringVerbose() {
     String s = info.toStringVerbose();
     if (this.id != null) {
       s += " :id=" + StringHelper.idToString(id);

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentCommitInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentCommitInfo.java
@@ -376,9 +376,6 @@ public class SegmentCommitInfo {
     if (softDelCount > 0) {
       s += " :softDel=" + softDelCount;
     }
-    if (this.id != null) {
-      s += " :id=" + StringHelper.idToString(id);
-    }
     return s;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
@@ -211,6 +211,14 @@ public final class SegmentInfo {
     return Collections.unmodifiableSet(setFiles);
   }
 
+  /**
+   * Used for debugging. Format may suddenly change.
+   *
+   * <p>Current format looks like <code>_a(3.1):c45/4</code>, which means the segment's name is
+   * <code>_a</code>; it was created with Lucene 3.1 (or '?' if it's unknown); it's using compound
+   * file format (would be <code>C</code> if not compound); it has 45 documents; it has 4 deletions
+   * (this part is left off when there are no deletions).
+   */
   public String toString(int delCount) {
     StringBuilder s = new StringBuilder();
     s.append(name).append('(').append(version == null ? "?" : version).append(')').append(':');
@@ -229,15 +237,10 @@ public final class SegmentInfo {
   }
 
   /**
-   * Used for debugging. Format may suddenly change.
-   *
-   * <p>Current format looks like <code>_a(3.1):c45/4:[sorter=&lt;long: "timestamp"&gt;!]</code>,
-   * which means the segment's name is <code>_a</code>; it was created with Lucene 3.1 (or '?' if
-   * it's unknown); it's using compound file format (would be <code>C</code> if not compound); it
-   * has 45 documents; it has 4 deletions (this part is left off when there are no deletions); it is
-   * sorted by the timestamp field in descending order (this part is omitted for unsorted segments).
+   * Logged by InfoStream when the segment is first flushed. Format may change. Appends more
+   * information to the basic toString().
    */
-  public String toStringVerbose() {
+  String toStringVerbose() {
     StringBuilder s = new StringBuilder();
     s.append(toString(0));
 

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
@@ -211,6 +211,18 @@ public final class SegmentInfo {
     return Collections.unmodifiableSet(setFiles);
   }
 
+  public String toString(int delCount) {
+    StringBuilder s = new StringBuilder();
+    s.append(name).append('(').append(version == null ? "?" : version).append(')').append(':');
+    char cfs = getUseCompoundFile() ? 'c' : 'C';
+    s.append(cfs);
+    s.append(maxDoc);
+    if (delCount != 0) {
+      s.append('/').append(delCount);
+    }
+    return s.toString();
+  }
+
   @Override
   public String toString() {
     return toString(0);
@@ -225,17 +237,9 @@ public final class SegmentInfo {
    * has 45 documents; it has 4 deletions (this part is left off when there are no deletions); it is
    * sorted by the timestamp field in descending order (this part is omitted for unsorted segments).
    */
-  public String toString(int delCount) {
+  public String toStringVerbose() {
     StringBuilder s = new StringBuilder();
-    s.append(name).append('(').append(version == null ? "?" : version).append(')').append(':');
-    char cfs = getUseCompoundFile() ? 'c' : 'C';
-    s.append(cfs);
-
-    s.append(maxDoc);
-
-    if (delCount != 0) {
-      s.append('/').append(delCount);
-    }
+    s.append(toString(0));
 
     if (indexSort != null) {
       s.append(":[indexSort=");

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
@@ -219,7 +219,7 @@ public final class SegmentInfo {
    * file format (would be <code>C</code> if not compound); it has 45 documents; it has 4 deletions
    * (this part is left off when there are no deletions).
    *
-   * There is also {@link #toStringVerbose()} that includes more info about the segment. It is be
+   * <p>There is also {@link #toStringVerbose()} that includes more info about the segment. It is be
    * used to print detailed info when the segment is first written or read.
    */
   public String toString(int delCount) {

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
@@ -218,6 +218,9 @@ public final class SegmentInfo {
    * <code>_a</code>; it was created with Lucene 3.1 (or '?' if it's unknown); it's using compound
    * file format (would be <code>C</code> if not compound); it has 45 documents; it has 4 deletions
    * (this part is left off when there are no deletions).
+   *
+   * There is also {@link #toStringVerbose()} that includes more info about the segment. It is be
+   * used to print detailed info when the segment is first written or read.
    */
   public String toString(int delCount) {
     StringBuilder s = new StringBuilder();

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -985,6 +985,14 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
   /** Returns readable description of this segment. */
   @Override
   public String toString() {
+    return toString(false);
+  }
+
+  String toStringVerbose() {
+    return toString(true);
+  }
+
+  String toString(boolean verbose) {
     StringBuilder buffer = new StringBuilder();
     buffer.append(getSegmentsFileName()).append(": ");
     final int count = size();
@@ -992,8 +1000,11 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
       if (i > 0) {
         buffer.append(' ');
       }
-      final SegmentCommitInfo info = info(i);
-      buffer.append(info.toString(0));
+      if (verbose) {
+        buffer.append(info(i).toStringVerbose());
+      } else {
+        buffer.append(info(i).toString(0));
+      }
     }
     return buffer.toString();
   }

--- a/lucene/core/src/test/org/apache/lucene/index/TestInfoStream.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestInfoStream.java
@@ -17,6 +17,10 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.store.Directory;
@@ -85,5 +89,49 @@ public class TestInfoStream extends LuceneTestCase {
     iw.close();
     dir.close();
     assertTrue(seenTestPoint.get());
+  }
+
+  public void testMergeSmallIndex() throws Exception {
+    // examine info stream output from IW, MP, MS
+    IndexWriterConfig iwc = new IndexWriterConfig(null);
+    Set<String> components = Set.of("IW", "MP", "MS", "BD", "BU");
+    List<String> infoStream = new ArrayList<>();
+    iwc.setInfoStream(
+        new InfoStream() {
+          @Override
+          public void close() throws IOException {}
+
+          @Override
+          public void message(String component, String message) {
+            if (components.contains(component)) {
+              infoStream.add(String.format(Locale.ROOT, "[%s] %s\n", component, message));
+            }
+          }
+
+          @Override
+          public boolean isEnabled(String component) {
+            return components.contains(component);
+          }
+        });
+    try (Directory dir = newDirectory();
+        IndexWriter iw = new IndexWriter(dir, iwc)) {
+      iw.addDocument(new Document());
+      iw.commit();
+      iw.addDocument(new Document());
+      iw.addDocument(new Document());
+      try (IndexReader reader = DirectoryReader.open(iw)) {
+        assertTrue(iw.tryDeleteDocument(reader, 2) > 0);
+      }
+      iw.commit();
+      iw.forceMerge(1);
+    }
+    for (String message : infoStream) {
+      // we don't want to be printing full diagnostics every time a segment is mentioned in the log,
+      // only when it is first flushed
+      if (message.contains("diagnostics")) {
+        assertTrue(message.startsWith("[IW] publishFlushedSegment"));
+      }
+      // System.out.print(message);
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestInfoStream.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestInfoStream.java
@@ -125,13 +125,19 @@ public class TestInfoStream extends LuceneTestCase {
       iw.commit();
       iw.forceMerge(1);
     }
+    boolean foundInit = false;
     for (String message : infoStream) {
       // we don't want to be printing full diagnostics every time a segment is mentioned in the log,
       // only when it is first flushed
       if (message.contains("diagnostics")) {
         assertTrue(message.startsWith("[IW] publishFlushedSegment"));
       }
+      if (message.contains("init segments")) {
+        assertEquals("[IW] init segments: \n", message);
+        foundInit = true;
+      }
       // System.out.print(message);
     }
+    assertTrue("init message not found", foundInit);
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestInfoStream.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestInfoStream.java
@@ -126,11 +126,19 @@ public class TestInfoStream extends LuceneTestCase {
       iw.forceMerge(1);
     }
     boolean foundInit = false;
+    int flushedCount = 0;
+    int mergedCount = 0;
     for (String message : infoStream) {
       // we don't want to be printing full diagnostics every time a segment is mentioned in the log,
       // only when it is first flushed
       if (message.contains("diagnostics")) {
-        assertTrue(message.startsWith("[IW] publishFlushedSegment"));
+        if (message.startsWith("[IW] publishFlushedSegment")) {
+          flushedCount++;
+        } else if (message.startsWith("[IW] merged new segment")) {
+          mergedCount++;
+        } else {
+          fail("message contains diagnostics: " + message);
+        }
       }
       if (message.contains("init segments")) {
         assertEquals("[IW] init segments: \n", message);
@@ -139,5 +147,7 @@ public class TestInfoStream extends LuceneTestCase {
       // System.out.print(message);
     }
     assertTrue("init message not found", foundInit);
+    assertEquals(2, flushedCount);
+    assertEquals(1, mergedCount);
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentInfos.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentInfos.java
@@ -185,9 +185,7 @@ public class TestSegmentInfos extends LuceneTestCase {
     assertEquals(
         "TEST(" + Version.LATEST.toString() + ")" + ":C10000" + ":[indexSort=<doc>]",
         si.toStringVerbose());
-    assertEquals(
-        "TEST(" + Version.LATEST.toString() + ")" + ":C10000",
-        si.toString());
+    assertEquals("TEST(" + Version.LATEST.toString() + ")" + ":C10000", si.toString());
 
     // diagnostics O, attributes X
     si =
@@ -214,9 +212,7 @@ public class TestSegmentInfos extends LuceneTestCase {
             + diagnostics
             + "]",
         si.toStringVerbose());
-    assertEquals(
-        "TEST(" + Version.LATEST.toString() + ")" + ":C10000",
-        si.toString());
+    assertEquals("TEST(" + Version.LATEST.toString() + ")" + ":C10000", si.toString());
 
     // diagnostics X, attributes O
     si =
@@ -243,9 +239,7 @@ public class TestSegmentInfos extends LuceneTestCase {
             + attributes
             + "]",
         si.toStringVerbose());
-    assertEquals(
-        "TEST(" + Version.LATEST.toString() + ")" + ":C10000",
-        si.toString());
+    assertEquals("TEST(" + Version.LATEST.toString() + ")" + ":C10000", si.toString());
 
     // diagnostics O, attributes O
     si =
@@ -275,9 +269,7 @@ public class TestSegmentInfos extends LuceneTestCase {
             + attributes
             + "]",
         si.toStringVerbose());
-    assertEquals(
-        "TEST(" + Version.LATEST.toString() + ")" + ":C10000",
-        si.toString());
+    assertEquals("TEST(" + Version.LATEST.toString() + ")" + ":C10000", si.toString());
 
     dir.close();
   }

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentInfos.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentInfos.java
@@ -184,6 +184,9 @@ public class TestSegmentInfos extends LuceneTestCase {
             Sort.INDEXORDER);
     assertEquals(
         "TEST(" + Version.LATEST.toString() + ")" + ":C10000" + ":[indexSort=<doc>]",
+        si.toStringVerbose());
+    assertEquals(
+        "TEST(" + Version.LATEST.toString() + ")" + ":C10000",
         si.toString());
 
     // diagnostics O, attributes X
@@ -210,6 +213,9 @@ public class TestSegmentInfos extends LuceneTestCase {
             + ":[diagnostics="
             + diagnostics
             + "]",
+        si.toStringVerbose());
+    assertEquals(
+        "TEST(" + Version.LATEST.toString() + ")" + ":C10000",
         si.toString());
 
     // diagnostics X, attributes O
@@ -236,6 +242,9 @@ public class TestSegmentInfos extends LuceneTestCase {
             + ":[attributes="
             + attributes
             + "]",
+        si.toStringVerbose());
+    assertEquals(
+        "TEST(" + Version.LATEST.toString() + ")" + ":C10000",
         si.toString());
 
     // diagnostics O, attributes O
@@ -265,6 +274,9 @@ public class TestSegmentInfos extends LuceneTestCase {
             + ":[attributes="
             + attributes
             + "]",
+        si.toStringVerbose());
+    assertEquals(
+        "TEST(" + Version.LATEST.toString() + ")" + ":C10000",
         si.toString());
 
     dir.close();


### PR DESCRIPTION
### Description

We've been logging infostreams in our production system and find they are overly verbose and repetitive in some ways.  This takes the edge off by logging segment "diagnostic" info once per segment rather than every time the segment is mentioned, eg when listed as part of a merge
