### PR TITLE
Simplify SearchGroup#equals and SearchGroup.MergedGroup#equals

### DIFF
--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/SearchGroup.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/SearchGroup.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
+import java.util.Objects;
 import java.util.TreeSet;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.Pruning;
@@ -62,17 +63,7 @@ public class SearchGroup<T> {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
 
-    SearchGroup<?> that = (SearchGroup<?>) o;
-
-    if (groupValue == null) {
-      if (that.groupValue != null) {
-        return false;
-      }
-    } else if (!groupValue.equals(that.groupValue)) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals(groupValue, ((SearchGroup<?>) o).groupValue);
   }
 
   @Override

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/SearchGroup.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/SearchGroup.java
@@ -132,16 +132,7 @@ public class SearchGroup<T> {
       // same groupValue
       assert neverEquals(_other);
 
-      if (_other instanceof MergedGroup) {
-        MergedGroup<?> other = (MergedGroup<?>) _other;
-        if (groupValue == null) {
-          return other.groupValue == null;
-        } else {
-          return groupValue.equals(other.groupValue);
-        }
-      } else {
-        return false;
-      }
+      return _other instanceof MergedGroup<?> other && Objects.equals(groupValue, other.groupValue);
     }
 
     @Override


### PR DESCRIPTION
### Description

Use Objects.equals() to handle both null and non-null values in SearchGroup#equals().