### PR TITLE
Replace explicit type conversion with instance pattern variable in some non-core modules

### DIFF
--- a/lucene/queries/src/java/org/apache/lucene/queries/function/IndexReaderFunctions.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/IndexReaderFunctions.java
@@ -172,8 +172,7 @@ public final class IndexReaderFunctions {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof NoCacheConstantLongValuesSource)) return false;
-      NoCacheConstantLongValuesSource that = (NoCacheConstantLongValuesSource) o;
+      if (!(o instanceof NoCacheConstantLongValuesSource that)) return false;
       return value == that.value && Objects.equals(parent, that.parent);
     }
 
@@ -393,8 +392,7 @@ public final class IndexReaderFunctions {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof NoCacheConstantDoubleValuesSource)) return false;
-      NoCacheConstantDoubleValuesSource that = (NoCacheConstantDoubleValuesSource) o;
+      if (!(o instanceof NoCacheConstantDoubleValuesSource that)) return false;
       return Double.compare(that.value, value) == 0 && Objects.equals(parent, that.parent);
     }
 

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/ConstValueSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/ConstValueSource.java
@@ -85,8 +85,7 @@ public class ConstValueSource extends ConstNumberSource {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof ConstValueSource)) return false;
-    ConstValueSource other = (ConstValueSource) o;
+    if (!(o instanceof ConstValueSource other)) return false;
     return this.constant == other.constant;
   }
 

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/DoubleConstValueSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/DoubleConstValueSource.java
@@ -88,8 +88,7 @@ public class DoubleConstValueSource extends ConstNumberSource {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof DoubleConstValueSource)) return false;
-    DoubleConstValueSource other = (DoubleConstValueSource) o;
+    if (!(o instanceof DoubleConstValueSource other)) return false;
     return this.constant == other.constant;
   }
 

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/FieldCacheSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/FieldCacheSource.java
@@ -40,8 +40,7 @@ public abstract class FieldCacheSource extends ValueSource {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof FieldCacheSource)) return false;
-    FieldCacheSource other = (FieldCacheSource) o;
+    if (!(o instanceof FieldCacheSource other)) return false;
     return this.field.equals(other.field);
   }
 

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/IDFValueSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/IDFValueSource.java
@@ -61,11 +61,11 @@ public class IDFValueSource extends DocFreqValueSource {
 
   // tries extra hard to cast the sim to TFIDFSimilarity
   static TFIDFSimilarity asTFIDF(Similarity sim, String field) {
-    while (sim instanceof PerFieldSimilarityWrapper) {
-      sim = ((PerFieldSimilarityWrapper) sim).get(field);
+    while (sim instanceof PerFieldSimilarityWrapper pfsw) {
+      sim = pfsw.get(field);
     }
-    if (sim instanceof TFIDFSimilarity) {
-      return (TFIDFSimilarity) sim;
+    if (sim instanceof TFIDFSimilarity tfidfSimilarity) {
+      return tfidfSimilarity;
     } else {
       return null;
     }

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/IfFunction.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/IfFunction.java
@@ -145,8 +145,7 @@ public class IfFunction extends BoolFunction {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof IfFunction)) return false;
-    IfFunction other = (IfFunction) o;
+    if (!(o instanceof IfFunction other)) return false;
     return ifSource.equals(other.ifSource)
         && trueSource.equals(other.trueSource)
         && falseSource.equals(other.falseSource);

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/LiteralValueSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/LiteralValueSource.java
@@ -74,9 +74,7 @@ public class LiteralValueSource extends ValueSource {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof LiteralValueSource)) return false;
-
-    LiteralValueSource that = (LiteralValueSource) o;
+    if (!(o instanceof LiteralValueSource that)) return false;
 
     return string.equals(that.string);
   }

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/VectorValueSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/VectorValueSource.java
@@ -210,9 +210,7 @@ public class VectorValueSource extends MultiValueSource {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof VectorValueSource)) return false;
-
-    VectorValueSource that = (VectorValueSource) o;
+    if (!(o instanceof VectorValueSource that)) return false;
 
     return sources.equals(that.sources);
   }

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/BlockIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/BlockIntervalsSource.java
@@ -37,9 +37,9 @@ class BlockIntervalsSource extends ConjunctionIntervalsSource {
   private static List<IntervalsSource> flatten(List<IntervalsSource> sources) {
     List<IntervalsSource> flattened = new ArrayList<>();
     for (IntervalsSource s : sources) {
-      if (s instanceof BlockIntervalsSource) {
+      if (s instanceof BlockIntervalsSource bis) {
         // Block sources can be flattened because they do not increase the gap (gap = 0)
-        flattened.addAll(((BlockIntervalsSource) s).subSources);
+        flattened.addAll(bis.subSources);
       } else {
         flattened.add(s);
       }
@@ -77,9 +77,10 @@ class BlockIntervalsSource extends ConjunctionIntervalsSource {
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof BlockIntervalsSource == false) return false;
-    BlockIntervalsSource b = (BlockIntervalsSource) other;
-    return Objects.equals(this.subSources, b.subSources);
+    if (other instanceof BlockIntervalsSource b) {
+      return Objects.equals(this.subSources, b.subSources);
+    }
+    return false;
   }
 
   @Override

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/ContainedByIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/ContainedByIntervalsSource.java
@@ -91,9 +91,10 @@ class ContainedByIntervalsSource extends ConjunctionIntervalsSource {
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof ContainedByIntervalsSource == false) return false;
-    ContainedByIntervalsSource o = (ContainedByIntervalsSource) other;
-    return Objects.equals(this.subSources, o.subSources);
+    if (other instanceof ContainedByIntervalsSource o) {
+      return Objects.equals(this.subSources, o.subSources);
+    }
+    return false;
   }
 
   @Override

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/ContainingIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/ContainingIntervalsSource.java
@@ -82,9 +82,10 @@ class ContainingIntervalsSource extends ConjunctionIntervalsSource {
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof ContainingIntervalsSource == false) return false;
-    ConjunctionIntervalsSource o = (ContainingIntervalsSource) other;
-    return Objects.equals(this.subSources, o.subSources);
+    if (other instanceof ContainingIntervalsSource o) {
+      return Objects.equals(this.subSources, o.subSources);
+    }
+    return false;
   }
 
   @Override

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/FilteredIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/FilteredIntervalsSource.java
@@ -142,9 +142,10 @@ public abstract class FilteredIntervalsSource extends IntervalsSource {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || o instanceof FilteredIntervalsSource == false) return false;
-    FilteredIntervalsSource that = (FilteredIntervalsSource) o;
-    return Objects.equals(name, that.name) && Objects.equals(in, that.in);
+    if (o instanceof FilteredIntervalsSource that) {
+      return Objects.equals(name, that.name) && Objects.equals(in, that.in);
+    }
+    return false;
   }
 
   @Override

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/NonOverlappingIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/NonOverlappingIntervalsSource.java
@@ -45,9 +45,11 @@ class NonOverlappingIntervalsSource extends DifferenceIntervalsSource {
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof NonOverlappingIntervalsSource == false) return false;
-    NonOverlappingIntervalsSource o = (NonOverlappingIntervalsSource) other;
-    return Objects.equals(this.minuend, o.minuend) && Objects.equals(this.subtrahend, o.subtrahend);
+    if (other instanceof NonOverlappingIntervalsSource o) {
+      return Objects.equals(this.minuend, o.minuend)
+          && Objects.equals(this.subtrahend, o.subtrahend);
+    }
+    return false;
   }
 
   @Override

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/NotContainedByIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/NotContainedByIntervalsSource.java
@@ -50,9 +50,11 @@ class NotContainedByIntervalsSource extends DifferenceIntervalsSource {
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof NotContainedByIntervalsSource == false) return false;
-    NotContainedByIntervalsSource o = (NotContainedByIntervalsSource) other;
-    return Objects.equals(this.minuend, o.minuend) && Objects.equals(this.subtrahend, o.subtrahend);
+    if (other instanceof NotContainedByIntervalsSource o) {
+      return Objects.equals(this.minuend, o.minuend)
+          && Objects.equals(this.subtrahend, o.subtrahend);
+    }
+    return false;
   }
 
   @Override

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/NotContainingIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/NotContainingIntervalsSource.java
@@ -50,9 +50,11 @@ class NotContainingIntervalsSource extends DifferenceIntervalsSource {
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof NotContainingIntervalsSource == false) return false;
-    NotContainingIntervalsSource o = (NotContainingIntervalsSource) other;
-    return Objects.equals(this.minuend, o.minuend) && Objects.equals(this.subtrahend, o.subtrahend);
+    if (other instanceof NotContainingIntervalsSource o) {
+      return Objects.equals(this.minuend, o.minuend)
+          && Objects.equals(this.subtrahend, o.subtrahend);
+    }
+    return false;
   }
 
   @Override

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/OrderedIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/OrderedIntervalsSource.java
@@ -50,8 +50,8 @@ class OrderedIntervalsSource extends MinimizingConjunctionIntervalsSource {
       }
     }
     deduplicated.add(RepeatingIntervalsSource.build(current.get(0), current.size()));
-    if (deduplicated.size() == 1 && deduplicated.get(0) instanceof RepeatingIntervalsSource) {
-      ((RepeatingIntervalsSource) deduplicated.get(0)).setName("ORDERED");
+    if (deduplicated.size() == 1 && deduplicated.get(0) instanceof RepeatingIntervalsSource ris) {
+      ris.setName("ORDERED");
     }
     return deduplicated;
   }
@@ -86,9 +86,10 @@ class OrderedIntervalsSource extends MinimizingConjunctionIntervalsSource {
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof OrderedIntervalsSource == false) return false;
-    OrderedIntervalsSource s = (OrderedIntervalsSource) other;
-    return Objects.equals(subSources, s.subSources);
+    if (other instanceof OrderedIntervalsSource s) {
+      return Objects.equals(subSources, s.subSources);
+    }
+    return false;
   }
 
   @Override

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/OverlappingIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/OverlappingIntervalsSource.java
@@ -89,9 +89,10 @@ class OverlappingIntervalsSource extends ConjunctionIntervalsSource {
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof OverlappingIntervalsSource == false) return false;
-    OverlappingIntervalsSource o = (OverlappingIntervalsSource) other;
-    return Objects.equals(this.subSources, o.subSources);
+    if (other instanceof OverlappingIntervalsSource o) {
+      return Objects.equals(this.subSources, o.subSources);
+    }
+    return false;
   }
 
   @Override

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/RepeatingIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/RepeatingIntervalsSource.java
@@ -107,9 +107,10 @@ class RepeatingIntervalsSource extends IntervalsSource {
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof RepeatingIntervalsSource == false) return false;
-    RepeatingIntervalsSource o = (RepeatingIntervalsSource) other;
-    return Objects.equals(this.in, o.in) && this.childCount == o.childCount;
+    if (other instanceof RepeatingIntervalsSource o) {
+      return Objects.equals(this.in, o.in) && this.childCount == o.childCount;
+    }
+    return false;
   }
 
   @Override

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/UnorderedIntervalsSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/UnorderedIntervalsSource.java
@@ -50,8 +50,8 @@ class UnorderedIntervalsSource extends MinimizingConjunctionIntervalsSource {
     for (IntervalsSource source : counts.keySet()) {
       deduplicated.add(RepeatingIntervalsSource.build(source, counts.get(source)));
     }
-    if (deduplicated.size() == 1 && deduplicated.get(0) instanceof RepeatingIntervalsSource) {
-      ((RepeatingIntervalsSource) deduplicated.get(0)).setName("UNORDERED");
+    if (deduplicated.size() == 1 && deduplicated.get(0) instanceof RepeatingIntervalsSource ris) {
+      ris.setName("UNORDERED");
     }
     return deduplicated;
   }
@@ -86,9 +86,10 @@ class UnorderedIntervalsSource extends MinimizingConjunctionIntervalsSource {
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof UnorderedIntervalsSource == false) return false;
-    UnorderedIntervalsSource o = (UnorderedIntervalsSource) other;
-    return Objects.equals(this.subSources, o.subSources);
+    if (other instanceof UnorderedIntervalsSource o) {
+      return Objects.equals(this.subSources, o.subSources);
+    }
+    return false;
   }
 
   @Override

--- a/lucene/queries/src/java/org/apache/lucene/queries/payloads/PayloadScoreQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/payloads/PayloadScoreQuery.java
@@ -90,8 +90,8 @@ public class PayloadScoreQuery extends SpanQuery {
   @Override
   public Query rewrite(IndexSearcher indexSearcher) throws IOException {
     Query matchRewritten = wrappedQuery.rewrite(indexSearcher);
-    if (wrappedQuery != matchRewritten && matchRewritten instanceof SpanQuery) {
-      return new PayloadScoreQuery((SpanQuery) matchRewritten, function, decoder, includeSpanScore);
+    if (wrappedQuery != matchRewritten && matchRewritten instanceof SpanQuery sq) {
+      return new PayloadScoreQuery(sq, function, decoder, includeSpanScore);
     }
     return super.rewrite(indexSearcher);
   }

--- a/lucene/queries/src/java/org/apache/lucene/queries/payloads/SpanPayloadCheckQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/payloads/SpanPayloadCheckQuery.java
@@ -119,9 +119,8 @@ public class SpanPayloadCheckQuery extends SpanQuery {
   @Override
   public Query rewrite(IndexSearcher indexSearcher) throws IOException {
     Query matchRewritten = match.rewrite(indexSearcher);
-    if (match != matchRewritten && matchRewritten instanceof SpanQuery) {
-      return new SpanPayloadCheckQuery(
-          (SpanQuery) matchRewritten, payloadToMatch, payloadType, operation);
+    if (match != matchRewritten && matchRewritten instanceof SpanQuery sq) {
+      return new SpanPayloadCheckQuery(sq, payloadToMatch, payloadType, operation);
     }
     return super.rewrite(indexSearcher);
   }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/MultiFieldQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/MultiFieldQueryParser.java
@@ -108,10 +108,9 @@ public class MultiFieldQueryParser extends QueryParser {
   }
 
   private Query applySlop(Query q, int slop) {
-    if (q instanceof PhraseQuery) {
+    if (q instanceof PhraseQuery pq) {
       PhraseQuery.Builder builder = new PhraseQuery.Builder();
       builder.setSlop(slop);
-      PhraseQuery pq = (PhraseQuery) q;
       org.apache.lucene.index.Term[] terms = pq.getTerms();
       int[] positions = pq.getPositions();
       for (int i = 0; i < terms.length; ++i) {
@@ -150,8 +149,8 @@ public class MultiFieldQueryParser extends QueryParser {
       for (int i = 0; i < fields.length; i++) {
         Query q = super.getFieldQuery(fields[i], queryText, quoted);
         if (q != null) {
-          if (q instanceof BooleanQuery) {
-            maxTerms = Math.max(maxTerms, ((BooleanQuery) q).clauses().size());
+          if (q instanceof BooleanQuery boolQ) {
+            maxTerms = Math.max(maxTerms, boolQ.clauses().size());
           } else {
             maxTerms = Math.max(1, maxTerms);
           }
@@ -163,8 +162,8 @@ public class MultiFieldQueryParser extends QueryParser {
         for (int i = 0; i < fields.length; i++) {
           if (fieldQueries[i] != null) {
             Query q = null;
-            if (fieldQueries[i] instanceof BooleanQuery) {
-              List<BooleanClause> nestedClauses = ((BooleanQuery) fieldQueries[i]).clauses();
+            if (fieldQueries[i] instanceof BooleanQuery boolQ) {
+              List<BooleanClause> nestedClauses = boolQ.clauses();
               if (termNum < nestedClauses.size()) {
                 q = nestedClauses.get(termNum).query();
               }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/MultiFieldQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/MultiFieldQueryParser.java
@@ -149,8 +149,8 @@ public class MultiFieldQueryParser extends QueryParser {
       for (int i = 0; i < fields.length; i++) {
         Query q = super.getFieldQuery(fields[i], queryText, quoted);
         if (q != null) {
-          if (q instanceof BooleanQuery boolQ) {
-            maxTerms = Math.max(maxTerms, boolQ.clauses().size());
+          if (q instanceof BooleanQuery bq) {
+            maxTerms = Math.max(maxTerms, bq.clauses().size());
           } else {
             maxTerms = Math.max(1, maxTerms);
           }
@@ -162,8 +162,8 @@ public class MultiFieldQueryParser extends QueryParser {
         for (int i = 0; i < fields.length; i++) {
           if (fieldQueries[i] != null) {
             Query q = null;
-            if (fieldQueries[i] instanceof BooleanQuery boolQ) {
-              List<BooleanClause> nestedClauses = boolQ.clauses();
+            if (fieldQueries[i] instanceof BooleanQuery bq) {
+              List<BooleanClause> nestedClauses = bq.clauses();
               if (termNum < nestedClauses.size()) {
                 q = nestedClauses.get(termNum).query();
               }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
@@ -425,9 +425,9 @@ public abstract class QueryParserBase extends QueryBuilder
       return;
     }
     boolean allNestedTermQueries = false;
-    if (q instanceof BooleanQuery) {
+    if (q instanceof BooleanQuery boolQ) {
       allNestedTermQueries = true;
-      for (BooleanClause clause : ((BooleanQuery) q).clauses()) {
+      for (BooleanClause clause : boolQ.clauses()) {
         if (!(clause.query() instanceof TermQuery)) {
           allNestedTermQueries = false;
           break;
@@ -439,8 +439,8 @@ public abstract class QueryParserBase extends QueryBuilder
     } else {
       BooleanClause.Occur occur =
           operator == OR_OPERATOR ? BooleanClause.Occur.SHOULD : BooleanClause.Occur.MUST;
-      if (q instanceof BooleanQuery) {
-        for (BooleanClause clause : ((BooleanQuery) q).clauses()) {
+      if (q instanceof BooleanQuery bq) {
+        for (BooleanClause clause : bq.clauses()) {
           clauses.add(newBooleanClause(clause.query(), occur));
         }
       } else {
@@ -480,8 +480,8 @@ public abstract class QueryParserBase extends QueryBuilder
   protected Query getFieldQuery(String field, String queryText, int slop) throws ParseException {
     Query query = getFieldQuery(field, queryText, true);
 
-    if (query instanceof PhraseQuery) {
-      query = addSlopToPhrase((PhraseQuery) query, slop);
+    if (query instanceof PhraseQuery pq) {
+      query = addSlopToPhrase(pq, slop);
     } else if (query instanceof MultiPhraseQuery mpq) {
       if (slop != mpq.getSlop()) {
         query = new MultiPhraseQuery.Builder(mpq).setSlop(slop).build();

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
@@ -425,9 +425,9 @@ public abstract class QueryParserBase extends QueryBuilder
       return;
     }
     boolean allNestedTermQueries = false;
-    if (q instanceof BooleanQuery boolQ) {
+    if (q instanceof BooleanQuery bq) {
       allNestedTermQueries = true;
-      for (BooleanClause clause : boolQ.clauses()) {
+      for (BooleanClause clause : bq.clauses()) {
         if (!(clause.query() instanceof TermQuery)) {
           allNestedTermQueries = false;
           break;

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/complexPhrase/ComplexPhraseQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/complexPhrase/ComplexPhraseQueryParser.java
@@ -267,7 +267,7 @@ public class ComplexPhraseQueryParser extends QueryParser {
       // clauses can be complex
       // Booleans e.g. nots and ors etc
       int numNegatives = 0;
-      if (!(contents instanceof BooleanQuery)) {
+      if (!(contents instanceof BooleanQuery bq)) {
         throw new IllegalArgumentException(
             "Unknown query type \""
                 + contents.getClass().getName()
@@ -275,7 +275,6 @@ public class ComplexPhraseQueryParser extends QueryParser {
                 + phrasedQueryStringContents
                 + "\"");
       }
-      BooleanQuery bq = (BooleanQuery) contents;
       SpanQuery[] allSpanClauses = new SpanQuery[bq.clauses().size()];
       // For all clauses e.g. one* two~
       int i = 0;
@@ -288,14 +287,14 @@ public class ComplexPhraseQueryParser extends QueryParser {
           numNegatives++;
         }
 
-        while (qc instanceof BoostQuery) {
-          qc = ((BoostQuery) qc).getQuery();
+        while (qc instanceof BoostQuery boostQ) {
+          qc = boostQ.getQuery();
         }
 
         if (qc instanceof BooleanQuery || qc instanceof SynonymQuery) {
           ArrayList<SpanQuery> sc = new ArrayList<>();
           BooleanQuery booleanClause =
-              qc instanceof BooleanQuery ? (BooleanQuery) qc : convert((SynonymQuery) qc);
+              qc instanceof BooleanQuery boolQ ? boolQ : convert((SynonymQuery) qc);
           addComplexPhraseClause(sc, booleanClause);
           if (sc.size() > 0) {
             allSpanClauses[i] = sc.get(0);

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/complexPhrase/ComplexPhraseQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/complexPhrase/ComplexPhraseQueryParser.java
@@ -287,14 +287,14 @@ public class ComplexPhraseQueryParser extends QueryParser {
           numNegatives++;
         }
 
-        while (qc instanceof BoostQuery boostQ) {
-          qc = boostQ.getQuery();
+        while (qc instanceof BoostQuery boostQuery) {
+          qc = boostQuery.getQuery();
         }
 
         if (qc instanceof BooleanQuery || qc instanceof SynonymQuery) {
           ArrayList<SpanQuery> sc = new ArrayList<>();
           BooleanQuery booleanClause =
-              qc instanceof BooleanQuery boolQ ? boolQ : convert((SynonymQuery) qc);
+              qc instanceof BooleanQuery booleanQuery ? booleanQuery : convert((SynonymQuery) qc);
           addComplexPhraseClause(sc, booleanClause);
           if (sc.size() > 0) {
             allSpanClauses[i] = sc.get(0);

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/builders/QueryTreeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/builders/QueryTreeBuilder.java
@@ -116,8 +116,8 @@ public class QueryTreeBuilder implements QueryBuilder {
   private QueryBuilder getBuilder(QueryNode node) {
     QueryBuilder builder = null;
 
-    if (this.fieldNameBuilders != null && node instanceof FieldableNode) {
-      CharSequence field = ((FieldableNode) node).getField();
+    if (this.fieldNameBuilders != null && node instanceof FieldableNode fieldableNode) {
+      CharSequence field = fieldableNode.getField();
 
       if (field != null) {
         field = field.toString();

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/PhraseSlopQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/PhraseSlopQueryNode.java
@@ -85,8 +85,8 @@ public class PhraseSlopQueryNode extends QueryNodeImpl implements FieldableNode 
   public CharSequence getField() {
     QueryNode child = getChild();
 
-    if (child instanceof FieldableNode) {
-      return ((FieldableNode) child).getField();
+    if (child instanceof FieldableNode fieldableNode) {
+      return fieldableNode.getField();
     }
 
     return null;
@@ -96,8 +96,8 @@ public class PhraseSlopQueryNode extends QueryNodeImpl implements FieldableNode 
   public void setField(CharSequence fieldName) {
     QueryNode child = getChild();
 
-    if (child instanceof FieldableNode) {
-      ((FieldableNode) child).setField(fieldName);
+    if (child instanceof FieldableNode fieldableNode) {
+      fieldableNode.setField(fieldName);
     }
   }
 }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/SlopQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/SlopQueryNode.java
@@ -88,8 +88,8 @@ public class SlopQueryNode extends QueryNodeImpl implements FieldableNode {
   public CharSequence getField() {
     QueryNode child = getChild();
 
-    if (child instanceof FieldableNode) {
-      return ((FieldableNode) child).getField();
+    if (child instanceof FieldableNode fieldableNode) {
+      return fieldableNode.getField();
     }
 
     return null;
@@ -99,8 +99,8 @@ public class SlopQueryNode extends QueryNodeImpl implements FieldableNode {
   public void setField(CharSequence fieldName) {
     QueryNode child = getChild();
 
-    if (child instanceof FieldableNode) {
-      ((FieldableNode) child).setField(fieldName);
+    if (child instanceof FieldableNode fieldableNode) {
+      fieldableNode.setField(fieldName);
     }
   }
 }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/TokenizedPhraseQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/TokenizedPhraseQueryNode.java
@@ -72,8 +72,8 @@ public class TokenizedPhraseQueryNode extends QueryNodeImpl implements Fieldable
     List<QueryNode> children = getChildren();
     if (children != null) {
       for (QueryNode child : children) {
-        if (child instanceof FieldableNode) {
-          return ((FieldableNode) child).getField();
+        if (child instanceof FieldableNode fieldableNode) {
+          return fieldableNode.getField();
         }
       }
     }
@@ -85,8 +85,8 @@ public class TokenizedPhraseQueryNode extends QueryNodeImpl implements Fieldable
     List<QueryNode> children = getChildren();
     if (children != null) {
       for (QueryNode child : children) {
-        if (child instanceof FieldableNode) {
-          ((FieldableNode) child).setField(fieldName);
+        if (child instanceof FieldableNode fieldableNode) {
+          fieldableNode.setField(fieldName);
         }
       }
     }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/util/UnescapedCharSequence.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/util/UnescapedCharSequence.java
@@ -113,15 +113,14 @@ public final class UnescapedCharSequence implements CharSequence {
   }
 
   public static boolean wasEscaped(CharSequence text, int index) {
-    if (text instanceof UnescapedCharSequence)
-      return ((UnescapedCharSequence) text).wasEscaped[index];
+    if (text instanceof UnescapedCharSequence ucs) return ucs.wasEscaped[index];
     else return false;
   }
 
   public static CharSequence toLowerCase(CharSequence text, Locale locale) {
-    if (text instanceof UnescapedCharSequence) {
+    if (text instanceof UnescapedCharSequence ucs) {
       char[] chars = text.toString().toLowerCase(locale).toCharArray();
-      boolean[] wasEscaped = ((UnescapedCharSequence) text).wasEscaped;
+      boolean[] wasEscaped = ucs.wasEscaped;
       return new UnescapedCharSequence(chars, wasEscaped, 0, chars.length);
     } else return new UnescapedCharSequence(text.toString().toLowerCase(locale));
   }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/precedence/processors/BooleanModifiersQueryNodeProcessor.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/precedence/processors/BooleanModifiersQueryNodeProcessor.java
@@ -102,11 +102,10 @@ public class BooleanModifiersQueryNodeProcessor extends QueryNodeProcessorImpl {
   private QueryNode applyModifier(QueryNode node, ModifierQueryNode.Modifier mod) {
 
     // check if modifier is not already defined and is default
-    if (!(node instanceof ModifierQueryNode)) {
+    if (!(node instanceof ModifierQueryNode modNode)) {
       return new ModifierQueryNode(node, mod);
 
     } else {
-      ModifierQueryNode modNode = (ModifierQueryNode) node;
 
       if (modNode.getModifier() == ModifierQueryNode.Modifier.MOD_NONE) {
         return new ModifierQueryNode(modNode.getChild(), mod);

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/BooleanQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/BooleanQueryNodeBuilder.java
@@ -81,8 +81,7 @@ public class BooleanQueryNodeBuilder implements StandardQueryBuilder {
 
   private static BooleanClause.Occur getModifierValue(QueryNode node) {
 
-    if (node instanceof ModifierQueryNode) {
-      ModifierQueryNode mNode = ((ModifierQueryNode) node);
+    if (node instanceof ModifierQueryNode mNode) {
       switch (mNode.getModifier()) {
         case MOD_REQ:
           return BooleanClause.Occur.MUST;

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/SlopQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/SlopQueryNodeBuilder.java
@@ -42,10 +42,9 @@ public class SlopQueryNodeBuilder implements StandardQueryBuilder {
     Query query =
         (Query) phraseSlopNode.getChild().getTag(QueryTreeBuilder.QUERY_TREE_BUILDER_TAGID);
 
-    if (query instanceof PhraseQuery) {
+    if (query instanceof PhraseQuery pq) {
       PhraseQuery.Builder builder = new PhraseQuery.Builder();
       builder.setSlop(phraseSlopNode.getValue());
-      PhraseQuery pq = (PhraseQuery) query;
       org.apache.lucene.index.Term[] terms = pq.getTerms();
       int[] positions = pq.getPositions();
       for (int i = 0; i < terms.length; ++i) {

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/nodes/MultiPhraseQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/nodes/MultiPhraseQueryNode.java
@@ -91,8 +91,8 @@ public class MultiPhraseQueryNode extends QueryNodeImpl implements FieldableNode
 
       for (QueryNode child : children) {
 
-        if (child instanceof FieldableNode) {
-          ((FieldableNode) child).setField(fieldName);
+        if (child instanceof FieldableNode fieldableNode) {
+          fieldableNode.setField(fieldName);
         }
       }
     }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/EscapeQuerySyntaxImpl.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/EscapeQuerySyntaxImpl.java
@@ -169,8 +169,8 @@ public class EscapeQuerySyntaxImpl implements EscapeQuerySyntax {
 
     // escape wildcards and the escape char (this has to be performed before anything else)
     // since we need to preserve the UnescapedCharSequence and escape the original escape chars
-    if (text instanceof UnescapedCharSequence) {
-      text = ((UnescapedCharSequence) text).toStringEscaped(wildcardChars);
+    if (text instanceof UnescapedCharSequence ucs) {
+      text = ucs.toStringEscaped(wildcardChars);
     } else {
       text = new UnescapedCharSequence(text).toStringEscaped(wildcardChars);
     }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/processors/BooleanQuery2ModifierNodeProcessor.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/processors/BooleanQuery2ModifierNodeProcessor.java
@@ -144,11 +144,10 @@ public class BooleanQuery2ModifierNodeProcessor implements QueryNodeProcessor {
   private QueryNode applyModifier(QueryNode node, Modifier mod) {
 
     // check if modifier is not already defined and is default
-    if (!(node instanceof ModifierQueryNode)) {
+    if (!(node instanceof ModifierQueryNode modNode)) {
       return new BooleanModifierNode(node, mod);
 
     } else {
-      ModifierQueryNode modNode = (ModifierQueryNode) node;
 
       if (modNode.getModifier() == Modifier.MOD_NONE) {
         return new ModifierQueryNode(modNode.getChild(), mod);

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/processors/PointRangeQueryNodeProcessor.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/processors/PointRangeQueryNodeProcessor.java
@@ -57,11 +57,10 @@ public class PointRangeQueryNodeProcessor extends QueryNodeProcessorImpl {
   @Override
   protected QueryNode postProcessNode(QueryNode node) throws QueryNodeException {
 
-    if (node instanceof TermRangeQueryNode) {
+    if (node instanceof TermRangeQueryNode termRangeNode) {
       QueryConfigHandler config = getQueryConfigHandler();
 
       if (config != null) {
-        TermRangeQueryNode termRangeNode = (TermRangeQueryNode) node;
         FieldConfig fieldConfig =
             config.getFieldConfig(StringUtils.toString(termRangeNode.getField()));
 

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/BasicQueryFactory.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/BasicQueryFactory.java
@@ -91,8 +91,7 @@ public class BasicQueryFactory {
    */
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof BasicQueryFactory)) return false;
-    BasicQueryFactory other = (BasicQueryFactory) obj;
+    if (!(obj instanceof BasicQueryFactory other)) return false;
     return atMax() == other.atMax();
   }
 }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/OrQuery.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/OrQuery.java
@@ -40,8 +40,8 @@ public class OrQuery extends ComposedQuery implements DistanceSubQuery {
     Iterator<SrndQuery> sqi = getSubQueriesIterator();
     while (sqi.hasNext()) {
       SrndQuery leq = sqi.next();
-      if (leq instanceof DistanceSubQuery) {
-        String m = ((DistanceSubQuery) leq).distanceSubQueryNotAllowed();
+      if (leq instanceof DistanceSubQuery dsq) {
+        String m = dsq.distanceSubQueryNotAllowed();
         if (m != null) {
           return m;
         }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/SpanNearClauseFactory.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/SpanNearClauseFactory.java
@@ -114,10 +114,10 @@ public class SpanNearClauseFactory { // FIXME: rename to SpanClauseFactory
 
   public void addSpanQuery(Query q) {
     if (q.getClass() == MatchNoDocsQuery.class) return;
-    if (!(q instanceof SpanQuery))
+    if (!(q instanceof SpanQuery sq))
       throw new AssertionError("Expected SpanQuery: " + q.toString(getFieldName()));
     float boost = 1f;
-    addSpanQueryWeighted((SpanQuery) q, boost);
+    addSpanQueryWeighted(sq, boost);
   }
 
   public SpanQuery makeSpanClause() {

--- a/lucene/sandbox/src/java/org/apache/lucene/payloads/PayloadSpanUtil.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/payloads/PayloadSpanUtil.java
@@ -72,21 +72,21 @@ public class PayloadSpanUtil {
   }
 
   private void queryToSpanQuery(Query query, Collection<byte[]> payloads) throws IOException {
-    if (query instanceof BooleanQuery) {
-      for (BooleanClause clause : (BooleanQuery) query) {
+    if (query instanceof BooleanQuery bq) {
+      for (BooleanClause clause : bq) {
         if (!clause.isProhibited()) {
           queryToSpanQuery(clause.query(), payloads);
         }
       }
 
-    } else if (query instanceof PhraseQuery) {
-      Term[] phraseQueryTerms = ((PhraseQuery) query).getTerms();
+    } else if (query instanceof PhraseQuery pq) {
+      Term[] phraseQueryTerms = pq.getTerms();
       SpanQuery[] clauses = new SpanQuery[phraseQueryTerms.length];
       for (int i = 0; i < phraseQueryTerms.length; i++) {
         clauses[i] = new SpanTermQuery(phraseQueryTerms[i]);
       }
 
-      int slop = ((PhraseQuery) query).getSlop();
+      int slop = pq.getSlop();
       boolean inorder = false;
 
       if (slop == 0) {
@@ -95,15 +95,14 @@ public class PayloadSpanUtil {
 
       SpanNearQuery sp = new SpanNearQuery(clauses, slop, inorder);
       getPayloads(payloads, sp);
-    } else if (query instanceof TermQuery) {
-      SpanTermQuery stq = new SpanTermQuery(((TermQuery) query).getTerm());
+    } else if (query instanceof TermQuery tq) {
+      SpanTermQuery stq = new SpanTermQuery(tq.getTerm());
       getPayloads(payloads, stq);
-    } else if (query instanceof SpanQuery) {
-      getPayloads(payloads, (SpanQuery) query);
-    } else if (query instanceof DisjunctionMaxQuery) {
+    } else if (query instanceof SpanQuery sq) {
+      getPayloads(payloads, sq);
+    } else if (query instanceof DisjunctionMaxQuery dmq) {
 
-      for (Iterator<Query> iterator = ((DisjunctionMaxQuery) query).iterator();
-          iterator.hasNext(); ) {
+      for (Iterator<Query> iterator = dmq.iterator(); iterator.hasNext(); ) {
         queryToSpanQuery(iterator.next(), payloads);
       }
 

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/idversion/IDVersionPostingsReader.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/idversion/IDVersionPostingsReader.java
@@ -71,8 +71,8 @@ final class IDVersionPostingsReader extends PostingsReaderBase {
     if (PostingsEnum.featureRequested(flags, PostingsEnum.POSITIONS)) {
       SinglePostingsEnum posEnum;
 
-      if (reuse instanceof SinglePostingsEnum) {
-        posEnum = (SinglePostingsEnum) reuse;
+      if (reuse instanceof SinglePostingsEnum spe) {
+        posEnum = spe;
       } else {
         posEnum = new SinglePostingsEnum();
       }
@@ -81,8 +81,8 @@ final class IDVersionPostingsReader extends PostingsReaderBase {
       return posEnum;
     }
 
-    if (reuse instanceof SingleDocsEnum) {
-      docsEnum = (SingleDocsEnum) reuse;
+    if (reuse instanceof SingleDocsEnum sde) {
+      docsEnum = sde;
     } else {
       docsEnum = new SingleDocsEnum();
     }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/PhraseWildcardQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/PhraseWildcardQuery.java
@@ -323,10 +323,9 @@ public class PhraseWildcardQuery extends Query {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof PhraseWildcardQuery)) {
+    if (!(o instanceof PhraseWildcardQuery pwq)) {
       return false;
     }
-    PhraseWildcardQuery pwq = (PhraseWildcardQuery) o;
     return slop == pwq.slop && phraseTerms.equals(pwq.phraseTerms);
   }
 
@@ -778,10 +777,9 @@ public class PhraseWildcardQuery extends Query {
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof SingleTerm)) {
+      if (!(o instanceof SingleTerm singleTerm)) {
         return false;
       }
-      SingleTerm singleTerm = (SingleTerm) o;
       return term.equals(singleTerm.term);
     }
 
@@ -831,10 +829,9 @@ public class PhraseWildcardQuery extends Query {
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof MultiTerm)) {
+      if (!(o instanceof MultiTerm multiTerm)) {
         return false;
       }
-      MultiTerm multiTerm = (MultiTerm) o;
       return query.equals(multiTerm.query);
     }
 

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/DateRangePrefixTree.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/DateRangePrefixTree.java
@@ -291,11 +291,11 @@ public class DateRangePrefixTree extends NumberRangePrefixTree {
    */
   @Override
   public UnitNRShape toUnitShape(Object value) {
-    if (value instanceof Calendar) {
-      return toShape((Calendar) value);
-    } else if (value instanceof Date) {
+    if (value instanceof Calendar cal) {
+      return toShape(cal);
+    } else if (value instanceof Date date) {
       Calendar cal = newCal();
-      cal.setTime((Date) value);
+      cal.setTime(date);
       return toShape(cal);
     }
     throw new IllegalArgumentException("Expecting Calendar or Date but got: " + value.getClass());

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/LegacyCell.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/LegacyCell.java
@@ -133,8 +133,8 @@ public abstract class LegacyCell implements CellCanPrune {
   @Override
   public CellIterator getNextLevelCells(Shape shapeFilter) {
     assert getLevel() < getGrid().getMaxLevels();
-    if (shapeFilter instanceof Point) {
-      LegacyCell cell = getSubCell((Point) shapeFilter);
+    if (shapeFilter instanceof Point point) {
+      LegacyCell cell = getSubCell(point);
       cell.shapeRel = SpatialRelation.CONTAINS;
       return new SingletonCellIterator(cell);
     } else {

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/NumberRangePrefixTree.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/tree/NumberRangePrefixTree.java
@@ -335,7 +335,7 @@ public abstract class NumberRangePrefixTree extends SpatialPrefixTree {
     public SpatialRelation relate(Shape shape) {
       //      if (shape instanceof UnitNRShape)
       //        return relate((UnitNRShape)shape);
-      if (shape instanceof SpanUnitsNRShape) return relate((SpanUnitsNRShape) shape);
+      if (shape instanceof SpanUnitsNRShape spanShape) return relate(spanShape);
       return shape.relate(this).transpose(); // probably a UnitNRShape
     }
 
@@ -745,7 +745,7 @@ public abstract class NumberRangePrefixTree extends SpatialPrefixTree {
 
     private void initIter(Shape filter) {
       cellNumber = -1;
-      if (filter instanceof UnitNRShape && ((UnitNRShape) filter).getLevel() == 0)
+      if (filter instanceof UnitNRShape unitShape && unitShape.getLevel() == 0)
         filter = null; // world means everything -- no filter
       iterFilter = filter;
 
@@ -765,8 +765,7 @@ public abstract class NumberRangePrefixTree extends SpatialPrefixTree {
       final UnitNRShape minLV;
       final UnitNRShape maxLV;
       final int lastLevelInCommon; // between minLV & maxLV
-      if (filter instanceof SpanUnitsNRShape) {
-        SpanUnitsNRShape spanShape = (SpanUnitsNRShape) iterFilter;
+      if (filter instanceof SpanUnitsNRShape spanShape) {
         minLV = spanShape.getMinUnit();
         maxLV = spanShape.getMaxUnit();
         lastLevelInCommon = spanShape.getLevelsInCommon();
@@ -903,8 +902,8 @@ public abstract class NumberRangePrefixTree extends SpatialPrefixTree {
     public SpatialRelation relate(Shape shape) {
       assertDecoded();
       if (shape == iterFilter && cellShapeRel != null) return cellShapeRel;
-      if (shape instanceof UnitNRShape) return relate((UnitNRShape) shape);
-      if (shape instanceof SpanUnitsNRShape) return relate((SpanUnitsNRShape) shape);
+      if (shape instanceof UnitNRShape unitShape) return relate(unitShape);
+      if (shape instanceof SpanUnitsNRShape spanShape) return relate(spanShape);
       return shape.relate(this).transpose();
     }
 

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dDistanceCalculator.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dDistanceCalculator.java
@@ -42,9 +42,9 @@ public class Geo3dDistanceCalculator implements DistanceCalculator {
 
   @Override
   public double distance(Point from, Point to) {
-    if (from instanceof Geo3dPointShape && to instanceof Geo3dPointShape) {
-      GeoPointShape pointShape1 = ((Geo3dPointShape) from).shape;
-      GeoPointShape pointShape2 = ((Geo3dPointShape) to).shape;
+    if (from instanceof Geo3dPointShape gps1 && to instanceof Geo3dPointShape gps2) {
+      GeoPointShape pointShape1 = gps1.shape;
+      GeoPointShape pointShape2 = gps2.shape;
       return planetModel.surfaceDistance(pointShape1.getCenter(), pointShape2.getCenter())
           * DistanceUtils.RADIANS_TO_DEGREES;
     }
@@ -54,8 +54,8 @@ public class Geo3dDistanceCalculator implements DistanceCalculator {
   @Override
   public double distance(Point from, double toX, double toY) {
     GeoPoint fromGeoPoint;
-    if (from instanceof Geo3dPointShape) {
-      fromGeoPoint = (((Geo3dPointShape) from).shape).getCenter();
+    if (from instanceof Geo3dPointShape gps) {
+      fromGeoPoint = (gps.shape).getCenter();
     } else {
       fromGeoPoint =
           new GeoPoint(

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dShape.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dShape.java
@@ -54,12 +54,12 @@ public class Geo3dShape<T extends GeoAreaShape> implements Shape {
   @Override
   public SpatialRelation relate(Shape other) {
     int relationship;
-    if (other instanceof Geo3dShape<?>) {
-      relationship = relate((Geo3dShape<?>) other);
-    } else if (other instanceof Rectangle) {
-      relationship = relate((Rectangle) other);
-    } else if (other instanceof Point) {
-      relationship = relate((Point) other);
+    if (other instanceof Geo3dShape<?> geo3dShape) {
+      relationship = relate(geo3dShape);
+    } else if (other instanceof Rectangle rect) {
+      relationship = relate(rect);
+    } else if (other instanceof Point pt) {
+      relationship = relate(pt);
     } else {
       throw new RuntimeException(
           "Unimplemented shape relationship determination: " + other.getClass());

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dShape.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dShape.java
@@ -53,30 +53,25 @@ public class Geo3dShape<T extends GeoAreaShape> implements Shape {
 
   @Override
   public SpatialRelation relate(Shape other) {
-    int relationship;
-    if (other instanceof Geo3dShape<?> geo3dShape) {
-      relationship = relate(geo3dShape);
-    } else if (other instanceof Rectangle rect) {
-      relationship = relate(rect);
-    } else if (other instanceof Point pt) {
-      relationship = relate(pt);
-    } else {
-      throw new RuntimeException(
-          "Unimplemented shape relationship determination: " + other.getClass());
-    }
+    int relationship =
+        switch (other) {
+          case Geo3dShape<?> geo3dShape -> relate(geo3dShape);
+          case Rectangle rect -> relate(rect);
+          case Point pt -> relate(pt);
+          default ->
+              throw new RuntimeException(
+                  "Unimplemented shape relationship determination: " + other.getClass());
+        };
 
-    switch (relationship) {
-      case GeoArea.DISJOINT:
-        return SpatialRelation.DISJOINT;
-      case GeoArea.OVERLAPS:
-        return (other instanceof Point ? SpatialRelation.CONTAINS : SpatialRelation.INTERSECTS);
-      case GeoArea.CONTAINS:
-        return (other instanceof Point ? SpatialRelation.CONTAINS : SpatialRelation.WITHIN);
-      case GeoArea.WITHIN:
-        return SpatialRelation.CONTAINS;
-    }
-
-    throw new RuntimeException("Undetermined shape relationship: " + relationship);
+    return switch (relationship) {
+      case GeoArea.DISJOINT -> SpatialRelation.DISJOINT;
+      case GeoArea.OVERLAPS ->
+          (other instanceof Point ? SpatialRelation.CONTAINS : SpatialRelation.INTERSECTS);
+      case GeoArea.CONTAINS ->
+          (other instanceof Point ? SpatialRelation.CONTAINS : SpatialRelation.WITHIN);
+      case GeoArea.WITHIN -> SpatialRelation.CONTAINS;
+      default -> throw new RuntimeException("Undetermined shape relationship: " + relationship);
+    };
   }
 
   private int relate(Geo3dShape<?> s) {
@@ -164,8 +159,7 @@ public class Geo3dShape<T extends GeoAreaShape> implements Shape {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof Geo3dShape<?>)) return false;
-    final Geo3dShape<?> other = (Geo3dShape<?>) o;
+    if (!(o instanceof Geo3dShape<?> other)) return false;
     return (other.spatialcontext.equals(spatialcontext) && other.shape.equals(shape));
   }
 

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/vector/PointVectorStrategy.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/vector/PointVectorStrategy.java
@@ -153,7 +153,7 @@ public class PointVectorStrategy extends SpatialStrategy {
 
   @Override
   public Field[] createIndexableFields(Shape shape) {
-    if (shape instanceof Point) return createIndexableFields((Point) shape);
+    if (shape instanceof Point point) return createIndexableFields(point);
     throw new UnsupportedOperationException("Can only index Point, not " + shape);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/BasePlanetObject.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/BasePlanetObject.java
@@ -55,9 +55,9 @@ public abstract class BasePlanetObject implements PlanetObject {
 
   @Override
   public boolean equals(final Object o) {
-    if (!(o instanceof BasePlanetObject)) {
+    if (!(o instanceof BasePlanetObject other)) {
       return false;
     }
-    return planetModel.equals(((BasePlanetObject) o).planetModel);
+    return planetModel.equals(other.planetModel);
   }
 }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/BaseXYZSolid.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/BaseXYZSolid.java
@@ -172,10 +172,9 @@ abstract class BaseXYZSolid extends BasePlanetObject implements XYZSolid {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof BaseXYZSolid)) {
+    if (!(o instanceof BaseXYZSolid other)) {
       return false;
     }
-    BaseXYZSolid other = (BaseXYZSolid) o;
     return super.equals(other);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoBaseCompositeShape.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoBaseCompositeShape.java
@@ -144,10 +144,9 @@ public abstract class GeoBaseCompositeShape<T extends GeoShape> extends BasePlan
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoBaseCompositeShape<?>)) {
+    if (!(o instanceof GeoBaseCompositeShape<?> other)) {
       return false;
     }
-    GeoBaseCompositeShape<?> other = (GeoBaseCompositeShape<?>) o;
     return super.equals(other) && shapes.equals(other.shapes);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoComplexPolygon.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoComplexPolygon.java
@@ -2362,8 +2362,9 @@ class GeoComplexPolygon extends GeoBasePolygon {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoComplexPolygon)) return false;
-    final GeoComplexPolygon other = (GeoComplexPolygon) o;
+    if (!(o instanceof GeoComplexPolygon other)) {
+      return false;
+    }
     return super.equals(other)
         && testPoint1InSet == other.testPoint1InSet
         && testPoint1.equals(other.testPoint1)

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoConcavePolygon.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoConcavePolygon.java
@@ -559,10 +559,9 @@ class GeoConcavePolygon extends GeoBasePolygon {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoConcavePolygon)) {
+    if (!(o instanceof GeoConcavePolygon other)) {
       return false;
     }
-    final GeoConcavePolygon other = (GeoConcavePolygon) o;
     if (!super.equals(other)) {
       return false;
     }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoConvexPolygon.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoConvexPolygon.java
@@ -539,10 +539,9 @@ class GeoConvexPolygon extends GeoBasePolygon {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoConvexPolygon)) {
+    if (!(o instanceof GeoConvexPolygon other)) {
       return false;
     }
-    final GeoConvexPolygon other = (GeoConvexPolygon) o;
     if (!super.equals(other)) {
       return false;
     }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegenerateHorizontalLine.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegenerateHorizontalLine.java
@@ -245,10 +245,9 @@ class GeoDegenerateHorizontalLine extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoDegenerateHorizontalLine)) {
+    if (!(o instanceof GeoDegenerateHorizontalLine other)) {
       return false;
     }
-    GeoDegenerateHorizontalLine other = (GeoDegenerateHorizontalLine) o;
     return super.equals(other) && other.LHC.equals(LHC) && other.RHC.equals(RHC);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegenerateLatitudeZone.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegenerateLatitudeZone.java
@@ -148,10 +148,9 @@ class GeoDegenerateLatitudeZone extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoDegenerateLatitudeZone)) {
+    if (!(o instanceof GeoDegenerateLatitudeZone other)) {
       return false;
     }
-    GeoDegenerateLatitudeZone other = (GeoDegenerateLatitudeZone) o;
     return super.equals(other) && other.latitude == latitude;
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegenerateLongitudeSlice.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegenerateLongitudeSlice.java
@@ -162,10 +162,9 @@ class GeoDegenerateLongitudeSlice extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoDegenerateLongitudeSlice)) {
+    if (!(o instanceof GeoDegenerateLongitudeSlice other)) {
       return false;
     }
-    GeoDegenerateLongitudeSlice other = (GeoDegenerateLongitudeSlice) o;
     return super.equals(other) && other.longitude == longitude;
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegeneratePath.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegeneratePath.java
@@ -368,10 +368,9 @@ class GeoDegeneratePath extends GeoBasePath {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoDegeneratePath)) {
+    if (!(o instanceof GeoDegeneratePath p)) {
       return false;
     }
-    GeoDegeneratePath p = (GeoDegeneratePath) o;
     if (!super.equals(p)) {
       return false;
     }
@@ -582,10 +581,9 @@ class GeoDegeneratePath extends GeoBasePath {
 
     @Override
     public boolean equals(Object o) {
-      if (!(o instanceof SegmentEndpoint)) {
+      if (!(o instanceof SegmentEndpoint other)) {
         return false;
       }
-      SegmentEndpoint other = (SegmentEndpoint) o;
       return point.equals(other.point);
     }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegeneratePoint.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegeneratePoint.java
@@ -119,10 +119,9 @@ class GeoDegeneratePoint extends GeoPoint implements GeoPointShape {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoDegeneratePoint)) {
+    if (!(o instanceof GeoDegeneratePoint other)) {
       return false;
     }
-    GeoDegeneratePoint other = (GeoDegeneratePoint) o;
     return super.equals(other) && other.latitude == latitude && other.longitude == longitude;
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegenerateVerticalLine.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoDegenerateVerticalLine.java
@@ -255,10 +255,9 @@ public class GeoDegenerateVerticalLine extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoDegenerateVerticalLine)) {
+    if (!(o instanceof GeoDegenerateVerticalLine other)) {
       return false;
     }
-    GeoDegenerateVerticalLine other = (GeoDegenerateVerticalLine) o;
     return super.equals(other) && other.UHC.equals(UHC) && other.LHC.equals(LHC);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoExactCircle.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoExactCircle.java
@@ -317,10 +317,9 @@ class GeoExactCircle extends GeoBaseCircle {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoExactCircle)) {
+    if (!(o instanceof GeoExactCircle other)) {
       return false;
     }
-    GeoExactCircle other = (GeoExactCircle) o;
     return super.equals(other)
         && other.center.equals(center)
         && other.radius == radius

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoLatitudeZone.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoLatitudeZone.java
@@ -191,10 +191,9 @@ class GeoLatitudeZone extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoLatitudeZone)) {
+    if (!(o instanceof GeoLatitudeZone other)) {
       return false;
     }
-    GeoLatitudeZone other = (GeoLatitudeZone) o;
     return super.equals(other)
         && other.topBoundaryPoint.equals(topBoundaryPoint)
         && other.bottomBoundaryPoint.equals(bottomBoundaryPoint);

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoLongitudeSlice.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoLongitudeSlice.java
@@ -208,10 +208,9 @@ class GeoLongitudeSlice extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoLongitudeSlice)) {
+    if (!(o instanceof GeoLongitudeSlice other)) {
       return false;
     }
-    GeoLongitudeSlice other = (GeoLongitudeSlice) o;
     return super.equals(other) && other.leftLon == leftLon && other.rightLon == rightLon;
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoNorthLatitudeZone.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoNorthLatitudeZone.java
@@ -149,10 +149,9 @@ class GeoNorthLatitudeZone extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoNorthLatitudeZone)) {
+    if (!(o instanceof GeoNorthLatitudeZone other)) {
       return false;
     }
-    GeoNorthLatitudeZone other = (GeoNorthLatitudeZone) o;
     return super.equals(other) && other.bottomBoundaryPoint.equals(bottomBoundaryPoint);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoNorthRectangle.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoNorthRectangle.java
@@ -299,10 +299,9 @@ class GeoNorthRectangle extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoNorthRectangle)) {
+    if (!(o instanceof GeoNorthRectangle other)) {
       return false;
     }
-    GeoNorthRectangle other = (GeoNorthRectangle) o;
     return super.equals(other) && other.LLHC.equals(LLHC) && other.LRHC.equals(LRHC);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoRectangle.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoRectangle.java
@@ -349,10 +349,9 @@ class GeoRectangle extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoRectangle)) {
+    if (!(o instanceof GeoRectangle other)) {
       return false;
     }
-    GeoRectangle other = (GeoRectangle) o;
     return super.equals(other) && other.ULHC.equals(ULHC) && other.LRHC.equals(LRHC);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoS2Shape.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoS2Shape.java
@@ -197,10 +197,9 @@ class GeoS2Shape extends GeoBasePolygon {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoS2Shape)) {
+    if (!(o instanceof GeoS2Shape other)) {
       return false;
     }
-    GeoS2Shape other = (GeoS2Shape) o;
     return super.equals(other)
         && other.point1.equals(point1)
         && other.point2.equals(point2)

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoSouthLatitudeZone.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoSouthLatitudeZone.java
@@ -151,8 +151,9 @@ class GeoSouthLatitudeZone extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoSouthLatitudeZone)) return false;
-    GeoSouthLatitudeZone other = (GeoSouthLatitudeZone) o;
+    if (!(o instanceof GeoSouthLatitudeZone other)) {
+      return false;
+    }
     return super.equals(other) && other.topBoundaryPoint.equals(topBoundaryPoint);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoSouthRectangle.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoSouthRectangle.java
@@ -270,10 +270,9 @@ class GeoSouthRectangle extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoSouthRectangle)) {
+    if (!(o instanceof GeoSouthRectangle other)) {
       return false;
     }
-    GeoSouthRectangle other = (GeoSouthRectangle) o;
     return super.equals(other) && other.ULHC.equals(ULHC) && other.URHC.equals(URHC);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoStandardCircle.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoStandardCircle.java
@@ -227,10 +227,9 @@ class GeoStandardCircle extends GeoBaseCircle {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoStandardCircle)) {
+    if (!(o instanceof GeoStandardCircle other)) {
       return false;
     }
-    GeoStandardCircle other = (GeoStandardCircle) o;
     return super.equals(other) && other.center.equals(center) && other.cutoffAngle == cutoffAngle;
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoStandardPath.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoStandardPath.java
@@ -395,10 +395,9 @@ class GeoStandardPath extends GeoBasePath {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoStandardPath)) {
+    if (!(o instanceof GeoStandardPath p)) {
       return false;
     }
-    GeoStandardPath p = (GeoStandardPath) o;
     if (!super.equals(p)) {
       return false;
     }
@@ -799,8 +798,8 @@ class GeoStandardPath extends GeoBasePath {
 
     @Override
     public void getBounds(final Bounds bounds) {
-      if (bounds instanceof XYZBounds) {
-        this.bounds.addBounds((XYZBounds) bounds);
+      if (bounds instanceof XYZBounds xyzBounds) {
+        this.bounds.addBounds(xyzBounds);
       } else {
         child1.getBounds(bounds);
         child2.getBounds(bounds);
@@ -971,10 +970,9 @@ class GeoStandardPath extends GeoBasePath {
 
     @Override
     public boolean equals(final Object o) {
-      if (!(o instanceof BaseSegmentEndpoint)) {
+      if (!(o instanceof BaseSegmentEndpoint other)) {
         return false;
       }
-      final BaseSegmentEndpoint other = (BaseSegmentEndpoint) o;
       return point.equals(other.point) && planetModel.equals(other.planetModel);
     }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideDegenerateHorizontalLine.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideDegenerateHorizontalLine.java
@@ -255,10 +255,9 @@ class GeoWideDegenerateHorizontalLine extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoWideDegenerateHorizontalLine)) {
+    if (!(o instanceof GeoWideDegenerateHorizontalLine other)) {
       return false;
     }
-    GeoWideDegenerateHorizontalLine other = (GeoWideDegenerateHorizontalLine) o;
     return super.equals(other) && other.LHC.equals(LHC) && other.RHC.equals(RHC);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideLongitudeSlice.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideLongitudeSlice.java
@@ -210,10 +210,9 @@ class GeoWideLongitudeSlice extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoWideLongitudeSlice)) {
+    if (!(o instanceof GeoWideLongitudeSlice other)) {
       return false;
     }
-    GeoWideLongitudeSlice other = (GeoWideLongitudeSlice) o;
     return super.equals(other) && other.leftLon == leftLon && other.rightLon == rightLon;
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideNorthRectangle.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideNorthRectangle.java
@@ -276,10 +276,9 @@ class GeoWideNorthRectangle extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoWideNorthRectangle)) {
+    if (!(o instanceof GeoWideNorthRectangle other)) {
       return false;
     }
-    GeoWideNorthRectangle other = (GeoWideNorthRectangle) o;
     return super.equals(other) && other.LLHC.equals(LLHC) && other.LRHC.equals(LRHC);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideRectangle.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideRectangle.java
@@ -341,10 +341,9 @@ class GeoWideRectangle extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoWideRectangle)) {
+    if (!(o instanceof GeoWideRectangle other)) {
       return false;
     }
-    GeoWideRectangle other = (GeoWideRectangle) o;
     return super.equals(other) && other.ULHC.equals(ULHC) && other.LRHC.equals(LRHC);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideSouthRectangle.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/GeoWideSouthRectangle.java
@@ -264,10 +264,9 @@ class GeoWideSouthRectangle extends GeoBaseBBox {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof GeoWideSouthRectangle)) {
+    if (!(o instanceof GeoWideSouthRectangle other)) {
       return false;
     }
-    GeoWideSouthRectangle other = (GeoWideSouthRectangle) o;
     return super.equals(o) && other.ULHC.equals(ULHC) && other.URHC.equals(URHC);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/Plane.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/Plane.java
@@ -3366,10 +3366,9 @@ public class Plane extends Vector {
     if (!super.equals(o)) {
       return false;
     }
-    if (!(o instanceof Plane)) {
+    if (!(o instanceof Plane other)) {
       return false;
     }
-    Plane other = (Plane) o;
     return other.D == D;
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/PlanetModel.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/PlanetModel.java
@@ -872,10 +872,9 @@ public class PlanetModel implements SerializableObject {
 
   @Override
   public boolean equals(final Object o) {
-    if (!(o instanceof PlanetModel)) {
+    if (!(o instanceof PlanetModel other)) {
       return false;
     }
-    final PlanetModel other = (PlanetModel) o;
     return a == other.a && b == other.b;
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/SerializableObject.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/SerializableObject.java
@@ -62,11 +62,11 @@ public interface SerializableObject {
   public static PlanetObject readPlanetObject(final InputStream inputStream) throws IOException {
     final PlanetModel pm = new PlanetModel(inputStream);
     final SerializableObject so = readObject(pm, inputStream);
-    if (!(so instanceof PlanetObject)) {
+    if (!(so instanceof PlanetObject po)) {
       throw new IOException(
           "Type of object is not expected PlanetObject: " + so.getClass().getName());
     }
-    return (PlanetObject) so;
+    return po;
   }
 
   /**
@@ -131,11 +131,11 @@ public interface SerializableObject {
       // Invoke it
       final Object object = c.newInstance(planetModel, inputStream);
       // check whether caste will work
-      if (!(object instanceof SerializableObject)) {
+      if (!(object instanceof SerializableObject so)) {
         throw new IOException(
             "Object " + clazz.getName() + " does not implement SerializableObject");
       }
-      return (SerializableObject) object;
+      return so;
     } catch (InstantiationException e) {
       throw new IOException(
           "Instantiation exception for class " + clazz.getName() + ": " + e.getMessage(), e);
@@ -165,11 +165,11 @@ public interface SerializableObject {
       // Invoke it
       final Object object = c.newInstance(inputStream);
       // check whether caste will work
-      if (!(object instanceof SerializableObject)) {
+      if (!(object instanceof SerializableObject so)) {
         throw new IOException(
             "Object " + clazz.getName() + " does not implement SerializableObject");
       }
-      return (SerializableObject) object;
+      return so;
     } catch (InstantiationException e) {
       throw new IOException(
           "Instantiation exception for class " + clazz.getName() + ": " + e.getMessage(), e);

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/SidedPlane.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/SidedPlane.java
@@ -339,14 +339,12 @@ public class SidedPlane extends Plane implements Membership {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof SidedPlane)) {
+    if (!(o instanceof SidedPlane that)) {
       return false;
     }
     if (!super.equals(o)) {
       return false;
     }
-
-    SidedPlane that = (SidedPlane) o;
 
     return Double.compare(that.sigNum, sigNum) == 0;
   }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/StandardXYZSolid.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/StandardXYZSolid.java
@@ -614,10 +614,9 @@ class StandardXYZSolid extends BaseXYZSolid {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof StandardXYZSolid)) {
+    if (!(o instanceof StandardXYZSolid other)) {
       return false;
     }
-    StandardXYZSolid other = (StandardXYZSolid) o;
     if (!super.equals(other) || other.isWholeWorld != isWholeWorld) {
       return false;
     }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/Vector.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/Vector.java
@@ -573,10 +573,9 @@ public class Vector {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof Vector)) {
+    if (!(o instanceof Vector other)) {
       return false;
     }
-    Vector other = (Vector) o;
     return (other.x == x && other.y == y && other.z == z);
   }
 

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/XYdZSolid.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/XYdZSolid.java
@@ -250,10 +250,9 @@ class XYdZSolid extends BaseXYZSolid {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof XYdZSolid)) {
+    if (!(o instanceof XYdZSolid other)) {
       return false;
     }
-    XYdZSolid other = (XYdZSolid) o;
     if (!super.equals(other)) {
       return false;
     }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/XdYZSolid.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/XdYZSolid.java
@@ -248,10 +248,9 @@ class XdYZSolid extends BaseXYZSolid {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof XdYZSolid)) {
+    if (!(o instanceof XdYZSolid other)) {
       return false;
     }
-    XdYZSolid other = (XdYZSolid) o;
     if (!super.equals(other)) {
       return false;
     }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/XdYdZSolid.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/XdYdZSolid.java
@@ -147,10 +147,9 @@ class XdYdZSolid extends BaseXYZSolid {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof XdYdZSolid)) {
+    if (!(o instanceof XdYdZSolid other)) {
       return false;
     }
-    XdYdZSolid other = (XdYdZSolid) o;
     if (!super.equals(other) || surfacePoints.length != other.surfacePoints.length) {
       return false;
     }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/dXYZSolid.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/dXYZSolid.java
@@ -257,10 +257,9 @@ class dXYZSolid extends BaseXYZSolid {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof dXYZSolid)) {
+    if (!(o instanceof dXYZSolid other)) {
       return false;
     }
-    dXYZSolid other = (dXYZSolid) o;
     if (!super.equals(other)) {
       return false;
     }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/dXYdZSolid.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/dXYdZSolid.java
@@ -149,10 +149,9 @@ class dXYdZSolid extends BaseXYZSolid {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof dXYdZSolid)) {
+    if (!(o instanceof dXYdZSolid other)) {
       return false;
     }
-    dXYdZSolid other = (dXYdZSolid) o;
     if (!super.equals(other) || surfacePoints.length != other.surfacePoints.length) {
       return false;
     }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/dXdYZSolid.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/dXdYZSolid.java
@@ -149,10 +149,9 @@ class dXdYZSolid extends BaseXYZSolid {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof dXdYZSolid)) {
+    if (!(o instanceof dXdYZSolid other)) {
       return false;
     }
-    dXdYZSolid other = (dXdYZSolid) o;
     if (!super.equals(other) || surfacePoints.length != other.surfacePoints.length) {
       return false;
     }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/dXdYdZSolid.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/dXdYdZSolid.java
@@ -154,10 +154,9 @@ class dXdYdZSolid extends BaseXYZSolid {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof dXdYdZSolid)) {
+    if (!(o instanceof dXdYdZSolid other)) {
       return false;
     }
-    dXdYdZSolid other = (dXdYdZSolid) o;
     if (!super.equals(other) || other.isOnSurface != isOnSurface) {
       return false;
     }

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/TopSuggestDocs.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/TopSuggestDocs.java
@@ -74,11 +74,10 @@ public class TopSuggestDocs extends TopDocs {
 
     @Override
     public boolean equals(Object other) {
-      if (other instanceof SuggestScoreDoc == false) {
-        return false;
-      } else {
-        return key.equals(((SuggestScoreDoc) other).key);
+      if (other instanceof SuggestScoreDoc ssd) {
+        return key.equals(ssd.key);
       }
+      return false;
     }
 
     @Override

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/FSTCompletionBuilder.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/fst/FSTCompletionBuilder.java
@@ -190,8 +190,8 @@ public class FSTCompletionBuilder {
   public FSTCompletion build() throws IOException {
     this.automaton = buildAutomaton(sorter);
 
-    if (sorter instanceof Closeable) {
-      ((Closeable) sorter).close();
+    if (sorter instanceof Closeable closeable) {
+      closeable.close();
     }
 
     return new FSTCompletion(automaton);


### PR DESCRIPTION
### Description

As a follow-up of https://github.com/apache/lucene/pull/15837, replace all explicit type conversions with instanceof pattern variable in part non-core modules like queries, queryParser, sandbox, spatial3d, etc, using the modern style aims to improve the code readability and reduces potential ClassCastException risks.
