### PR TITLE
Change access modifier for readAdvise in MMapDirectory

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -336,6 +336,8 @@ Other
 * GITHUB#15867: Use IllegalCallerException to signal wrong caller in internal classes
   (VectorizationProvider, TestSecrets).  (Uwe Schindler)
 
+* GITHUB#15892: Change access modifier for readAdvise in MMapDirectory (Navneet Verma)
+
 ======================= Lucene 10.4.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -169,7 +169,7 @@ public class MMapDirectory extends FSDirectory {
         return Optional.of(Constants.DEFAULT_READADVICE);
       };
 
-  private BiFunction<String, IOContext, Optional<ReadAdvice>> readAdvice =
+  protected BiFunction<String, IOContext, Optional<ReadAdvice>> readAdvice =
       (_, _) -> Optional.empty();
 
   private BiPredicate<String, IOContext> preload = NO_FILES;


### PR DESCRIPTION
### Description
Change access modifier for readAdvise in MMapDirectory. Made the access modifier protected so that classes which overrides MMapDirectory can use the readAdvise or if needed expose them. 

I considered adding a getter for this parameter too, but went against it since the return type is pretty weird. I am open to adding a getting too. If we are happy with a getter like this:

```
public BiFunction<String, IOContext, Optional<ReadAdvice>> getReadAdvise() {
  return readAdvice;
}
```
or we can also expose a function like
```
public ReadAdvice getReadAdviseForFile(String filename, IOContext ioContext) {
    return readAdvice.apply(filename, ioContext);
}
```
This will ensure that consumers can validate if readAdvise is correctly set or not.


<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
