### PR TITLE
feat : Add `keepDecimalPoint` option to Nori (`KoreanTokenizer`)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -76,6 +76,8 @@ API Changes
 
 New Features
 ---------------------
+* GITHUB#15894: Add keepDecimalPoint option to Nori's KoreanTokenizer to preserve decimal points in numeric tokens. (Somang Lee)
+
 * GITHUB#15505: Upgrade snowball to 2d2e312df56f2ede014a4ffb3e91e6dea43c24be. New stemmer: PolishStemmer (and
   PolishSnowballAnalyzer in the stempel package) (Justas Sakalauskas, Dawid Weiss)
 

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanTokenizer.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanTokenizer.java
@@ -19,7 +19,6 @@ package org.apache.lucene.analysis.ko;
 import java.io.IOException;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.ko.dict.ConnectionCosts;
-import org.apache.lucene.analysis.ko.dict.DictionaryBuilder;
 import org.apache.lucene.analysis.ko.dict.KoMorphData;
 import org.apache.lucene.analysis.ko.dict.TokenInfoDictionary;
 import org.apache.lucene.analysis.ko.dict.TokenInfoFST;
@@ -132,13 +131,41 @@ public final class KoreanTokenizer extends Tokenizer {
         userDictionary,
         mode,
         outputUnknownUnigrams,
-        discardPunctuation);
+        discardPunctuation,
+        false);
   }
 
   /**
-   * Create a new KoreanTokenizer supplying a custom system dictionary and unknown dictionary. This
-   * constructor provides an entry point for users that want to construct custom language models
-   * that can be used as input to {@link DictionaryBuilder}.
+   * Create a new KoreanTokenizer using the system and unknown dictionaries shipped with Lucene.
+   *
+   * @param factory the AttributeFactory to use
+   * @param userDictionary Optional: if non-null, user dictionary.
+   * @param mode Decompound mode.
+   * @param outputUnknownUnigrams if true outputs unigrams for unknown words.
+   * @param discardPunctuation true if punctuation tokens should be dropped from the output.
+   * @param keepDecimalPoint true if decimal points in numbers should be kept as part of the number.
+   */
+  public KoreanTokenizer(
+      AttributeFactory factory,
+      UserDictionary userDictionary,
+      DecompoundMode mode,
+      boolean outputUnknownUnigrams,
+      boolean discardPunctuation,
+      boolean keepDecimalPoint) {
+    this(
+        factory,
+        TokenInfoDictionary.getInstance(),
+        UnknownDictionary.getInstance(),
+        ConnectionCosts.getInstance(),
+        userDictionary,
+        mode,
+        outputUnknownUnigrams,
+        discardPunctuation,
+        keepDecimalPoint);
+  }
+
+  /**
+   * Create a new KoreanTokenizer using the system and unknown dictionaries shipped with Lucene.
    *
    * @param factory the AttributeFactory to use
    * @param systemDictionary a custom known token dictionary
@@ -148,6 +175,7 @@ public final class KoreanTokenizer extends Tokenizer {
    * @param mode Decompound mode.
    * @param outputUnknownUnigrams if true outputs unigrams for unknown words.
    * @param discardPunctuation true if punctuation tokens should be dropped from the output.
+   * @param keepDecimalPoint true if decimal points in numbers should be kept as part of the number.
    * @lucene.experimental
    */
   @IgnoreRandomChains(reason = "Parameters are too complex to be tested")
@@ -159,7 +187,8 @@ public final class KoreanTokenizer extends Tokenizer {
       UserDictionary userDictionary,
       DecompoundMode mode,
       boolean outputUnknownUnigrams,
-      boolean discardPunctuation) {
+      boolean discardPunctuation,
+      boolean keepDecimalPoint) {
     super(factory);
     TokenInfoFST fst = systemDictionary.getFST();
     FST.BytesReader fstReader = fst.getBytesReader();
@@ -183,7 +212,8 @@ public final class KoreanTokenizer extends Tokenizer {
             unkDictionary.getCharacterDefinition(),
             discardPunctuation,
             mode,
-            outputUnknownUnigrams);
+            outputUnknownUnigrams,
+            keepDecimalPoint);
     viterbi.resetBuffer(input);
     viterbi.resetState();
   }

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/Viterbi.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/Viterbi.java
@@ -45,6 +45,7 @@ final class Viterbi
   private final boolean discardPunctuation;
   private final KoreanTokenizer.DecompoundMode mode;
   private final boolean outputUnknownUnigrams;
+  private final boolean keepDecimalPoint;
 
   private GraphvizFormatter<KoMorphData> dotOut;
 
@@ -60,7 +61,8 @@ final class Viterbi
       CharacterDefinition characterDefinition,
       boolean discardPunctuation,
       KoreanTokenizer.DecompoundMode mode,
-      boolean outputUnknownUnigrams) {
+      boolean outputUnknownUnigrams,
+      boolean keepDecimalPoint) {
     super(
         fst, fstReader, dictionary, userFST, userFSTReader, userDictionary, costs, Position.class);
     this.unkDictionary = unkDictionary;
@@ -70,6 +72,7 @@ final class Viterbi
     this.outputUnknownUnigrams = outputUnknownUnigrams;
     this.enableSpacePenaltyFactor = true;
     this.outputLongestUserEntryOnly = true;
+    this.keepDecimalPoint = keepDecimalPoint;
     dictionaryMap.put(TokenType.KNOWN, dictionary);
     dictionaryMap.put(TokenType.UNKNOWN, unkDictionary);
     dictionaryMap.put(TokenType.USER, userDictionary);
@@ -88,7 +91,8 @@ final class Viterbi
         unknownWordLength = 1;
       } else {
         // Extract unknown word. Characters with the same script are considered to be part of
-        // unknown word
+        // unknown word.
+        // Also handles decimal points in numbers if keepDecimalPoint is true.
         unknownWordLength = 1;
         Character.UnicodeScript scriptCode = Character.UnicodeScript.of(firstCharacter);
         final boolean isPunct = isPunctuation(firstCharacter);
@@ -106,16 +110,21 @@ final class Viterbi
                   // Non-spacing marks inherit the script of their base character,
                   // following recommendations from UTR #24.
                   || chType == Character.NON_SPACING_MARK;
+          if (sameScript && characterDefinition.isGroup(ch)) {
+            // Check if current character matches the start character's type (punctuation/digit).
+            boolean matchBasic =
+                isPunctuation(ch, chType) == isPunct && Character.isDigit(ch) == isDigit;
 
-          if (sameScript
-              // split on punctuation
-              && isPunctuation(ch, chType) == isPunct
-              // split on digit
-              && Character.isDigit(ch) == isDigit
-              && characterDefinition.isGroup(ch)) {
-            unknownWordLength++;
-          } else {
-            break;
+            // Handle decimal points: if current char is '.' and is followed by a digit,
+            // treat it as part of the number.
+            final boolean isDecimalPoint =
+                this.keepDecimalPoint && ch == '.' && Character.isDigit(buffer.get(posAhead + 1));
+
+            if (matchBasic || isDecimalPoint) {
+              unknownWordLength++;
+            } else {
+              break;
+            }
           }
           // Update the script code and character class if the original script
           // is Inherited or Common.

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanTokenizer.java
@@ -39,7 +39,8 @@ public class TestKoreanTokenizer extends BaseTokenStreamTestCase {
       analyzerUnigram,
       analyzerDecompound,
       analyzerDecompoundKeep,
-      analyzerReading;
+      analyzerReading,
+      analyzerWithKeepDecimalPoint;
 
   public static UserDictionary readDict() {
     InputStream is = TestKoreanTokenizer.class.getResourceAsStream("userdict.txt");
@@ -79,6 +80,17 @@ public class TestKoreanTokenizer extends BaseTokenStreamTestCase {
             Tokenizer tokenizer =
                 new KoreanTokenizer(
                     newAttributeFactory(), userDictionary, DecompoundMode.NONE, false, false);
+            return new TokenStreamComponents(tokenizer, tokenizer);
+          }
+        };
+    analyzerWithKeepDecimalPoint =
+        new Analyzer() {
+          @Override
+          protected TokenStreamComponents createComponents(String fieldName) {
+            Tokenizer tokenizer =
+                new KoreanTokenizer(
+                    newAttributeFactory(), userDictionary, DecompoundMode.NONE, false, true, true);
+
             return new TokenStreamComponents(tokenizer, tokenizer);
           }
         };
@@ -141,6 +153,56 @@ public class TestKoreanTokenizer extends BaseTokenStreamTestCase {
         new int[] {0, 2, 3},
         new int[] {1, 3, 6},
         new int[] {1, 1, 1});
+  }
+
+  public void testFloatingPointNumberWithKeepDecimalPoint() throws IOException {
+    assertAnalyzesTo(
+        analyzerWithKeepDecimalPoint,
+        "10.1 인치 모니터",
+        new String[] {"10.1", "인치", "모니터"},
+        new int[] {0, 5, 8},
+        new int[] {4, 7, 11},
+        new int[] {1, 1, 1});
+
+    assertAnalyzesTo(
+        analyzerWithKeepDecimalPoint,
+        "가격은 10.1달러이다.",
+        new String[] {"가격", "은", "10.1", "달러", "이", "다"},
+        new int[] {0, 2, 4, 8, 10, 11},
+        new int[] {2, 3, 8, 10, 11, 12},
+        new int[] {1, 1, 1, 1, 1, 1});
+
+    assertAnalyzesTo(
+        analyzerWithKeepDecimalPoint,
+        "10..1",
+        new String[] {"10", "1"},
+        new int[] {0, 4},
+        new int[] {2, 5},
+        new int[] {1, 1});
+
+    assertAnalyzesTo(
+        analyzerWithKeepDecimalPoint,
+        "10. 1",
+        new String[] {"10", "1"},
+        new int[] {0, 4},
+        new int[] {2, 5},
+        new int[] {1, 1});
+
+    assertAnalyzesTo(
+        analyzerWithKeepDecimalPoint,
+        "10.1.2",
+        new String[] {"10.1.2"},
+        new int[] {0},
+        new int[] {6},
+        new int[] {1});
+
+    assertAnalyzesTo(
+        analyzerWithKeepDecimalPoint,
+        "10.1.",
+        new String[] {"10.1"},
+        new int[] {0},
+        new int[] {4},
+        new int[] {1});
   }
 
   public void testSpaces() throws IOException {


### PR DESCRIPTION
### Description


This PR implements the `keepDecimalPoint` configuration option for `KoreanTokenizer` in the Nori module, as proposed in issue #15894 .

The goal is to prevent numeric values containing decimal points (e.g., "10.1") from being fragmented into multiple tokens during the lattice construction phase. This ensures that the semantic integrity of measurements, version numbers, and economic data is preserved from the initial analysis stage.


<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
