### PR TITLE
build: allow java 26

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -75,7 +75,7 @@ public class WrapperDownloader {
 
   public static void checkVersion() {
     int major = Runtime.version().feature();
-    if (major < 25 || major > 26 ) {
+    if (major < 25 || major > 26) {
       throw new IllegalStateException("java version must be 25..26, your version: " + major);
     }
   }

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -75,8 +75,8 @@ public class WrapperDownloader {
 
   public static void checkVersion() {
     int major = Runtime.version().feature();
-    if (major != 25) {
-      throw new IllegalStateException("java version must be 25, your version: " + major);
+    if (major < 25 || major > 26 ) {
+      throw new IllegalStateException("java version must be 25..26, your version: " + major);
     }
   }
 


### PR DESCRIPTION
java 26 has been released, and the gradle version supports it. don't explicitly require java 25 in the build.