### PR TITLE
Add LongConsumer progress callback to Operations.determinize 

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,6 +7,10 @@ http://s.apache.org/luceneversions
 
 API Changes
 ---------------------
+* GITHUB#15937: Add Operations.determinize overload accepting a LongConsumer progress callback,
+  invoked with estimated memory cost each time a new DFA state is created during powerset
+  construction. This allows callers to monitor or limit memory growth during determinization.
+  (Dimitris Rempapis)
 
 * GITHUB#15763: Deprecate Operations.complement() method. This operation can be slow and is not
   recommended for production use. It will be removed in Lucene 12. (Saurabh Singh)

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automaton.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automaton.java
@@ -902,6 +902,12 @@ public class Automaton implements Accountable, TransitionAccessor {
       return nextState;
     }
 
+    /** Estimated RAM used by the backing transitions array. */
+    long getTransitionsArrayRamBytes() {
+      return RamUsageEstimator.alignObjectSize(
+          (long) transitions.length * Integer.BYTES + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER);
+    }
+
     /** Copies over all states/transitions from other. */
     public void copy(Automaton other) {
       int offset = getNumStates();

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Operations.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.LongConsumer;
 import org.apache.lucene.internal.hppc.BitMixer;
 import org.apache.lucene.internal.hppc.IntCursor;
 import org.apache.lucene.internal.hppc.IntHashSet;
@@ -61,6 +62,8 @@ public final class Operations {
    * throwing {@link TooComplexToDeterminizeException}.
    */
   public static final int DEFAULT_DETERMINIZE_WORK_LIMIT = 10000;
+
+  private static final long DETERMINIZE_PROGRESS_REPORT_BYTES = 16L * 1024;
 
   private Operations() {}
 
@@ -651,6 +654,33 @@ public final class Operations {
    *     "effort"
    */
   public static Automaton determinize(Automaton a, int workLimit) {
+    return determinize(a, workLimit, null);
+  }
+
+  /**
+   * Determinizes the given automaton, optionally reporting estimated memory usage to a callback.
+   *
+   * <p>Worst case complexity: exponential in number of states.
+   *
+   * <p>The memory values reported to {@code progressCallback} are best-effort estimates, not exact
+   * accounting. They are intended for coarse-grained safety controls (for example circuit breakers)
+   * and may under- or over-estimate real heap usage.
+   *
+   * @param workLimit Maximum amount of "work" that the powerset construction will spend before
+   *     throwing {@link TooComplexToDeterminizeException}. Higher numbers allow this operation to
+   *     consume more memory and CPU but allow more complex automatons. Use {@link
+   *     #DEFAULT_DETERMINIZE_WORK_LIMIT} as a decent default if you don't otherwise know what to
+   *     specify.
+   * @param progressCallback If non-null, this callback is invoked periodically with an accumulated
+   *     <em>estimated</em> number of bytes for newly created DFA states (including the {@link
+   *     FrozenIntSet}, {@code HashMap} entry, and worklist slot) and backing transition array
+   *     growth inside {@link Automaton.Builder}. Any remaining bytes below the reporting threshold
+   *     are sent once at the end. The callback may throw a {@link RuntimeException} to abort
+   *     determinization early (e.g. to enforce a memory limit).
+   * @throws TooComplexToDeterminizeException if determinizing requires more than {@code workLimit}
+   *     "effort"
+   */
+  public static Automaton determinize(Automaton a, int workLimit, LongConsumer progressCallback) {
     if (a.isDeterministic()) {
       // Already determinized
       return a;
@@ -693,6 +723,9 @@ public final class Operations {
     // LUCENE-9981: approximate conversion from what used to be a limit on number of states, to
     // maximum "effort":
     long effortLimit = workLimit * (long) 10;
+    long pendingEstimatedBytes = 0;
+    long lastBuilderTransitionsArrayRamBytes =
+        progressCallback == null ? 0 : b.getTransitionsArrayRamBytes();
 
     while (worklist.size() > 0) {
       // TODO (LUCENE-9983): these int sets really do not need to be sorted, and we are paying
@@ -747,6 +780,13 @@ public final class Operations {
             worklist.add(p);
             b.setAccept(q, accCount > 0);
             newstate.put(p, q);
+            if (progressCallback != null) {
+              pendingEstimatedBytes += estimateDeterminizeStateRamBytes(p);
+              if (pendingEstimatedBytes >= DETERMINIZE_PROGRESS_REPORT_BYTES) {
+                progressCallback.accept(pendingEstimatedBytes);
+                pendingEstimatedBytes = 0;
+              }
+            }
           } else {
             assert (accCount > 0 ? true : false) == b.isAccept(q)
                 : "accCount="
@@ -761,6 +801,18 @@ public final class Operations {
           // max=" + (point-1));
 
           b.addTransition(r, q, lastPoint, point - 1);
+          if (progressCallback != null) {
+            long builderTransitionsArrayRamBytes = b.getTransitionsArrayRamBytes();
+            if (builderTransitionsArrayRamBytes > lastBuilderTransitionsArrayRamBytes) {
+              pendingEstimatedBytes +=
+                  builderTransitionsArrayRamBytes - lastBuilderTransitionsArrayRamBytes;
+              lastBuilderTransitionsArrayRamBytes = builderTransitionsArrayRamBytes;
+              if (pendingEstimatedBytes >= DETERMINIZE_PROGRESS_REPORT_BYTES) {
+                progressCallback.accept(pendingEstimatedBytes);
+                pendingEstimatedBytes = 0;
+              }
+            }
+          }
         }
 
         // process transitions that end on this point
@@ -790,9 +842,48 @@ public final class Operations {
       assert statesSet.size() == 0 : "size=" + statesSet.size();
     }
 
+    if (progressCallback != null && pendingEstimatedBytes > 0) {
+      progressCallback.accept(pendingEstimatedBytes);
+    }
+
     Automaton result = b.finish();
     assert result.isDeterministic();
     return result;
+  }
+
+  /**
+   * Returns a best-effort, per-state RAM estimate used only for progress reporting.
+   *
+   * <p>This estimate is intentionally coarse and should not be interpreted as exact JVM heap
+   * accounting.
+   */
+  private static long estimateDeterminizeStateRamBytes(FrozenIntSet frozenState) {
+    // FrozenIntSet shallow: header + int[] ref + long hashCode + int state
+    long frozenIntSetShallow =
+        RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
+            + RamUsageEstimator.NUM_BYTES_OBJECT_REF
+            + Long.BYTES
+            + Integer.BYTES;
+
+    // int[] backing the frozen set
+    long intArrayBytes =
+        RamUsageEstimator.alignObjectSize(
+            (long) Integer.BYTES * frozenState.values.length
+                + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER);
+
+    // HashMap.Node: header + int hash + 3 refs (key, value, next)
+    // + boxed Integer: header + int value
+    long mapEntryBytes =
+        RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
+            + Integer.BYTES
+            + 3 * RamUsageEstimator.NUM_BYTES_OBJECT_REF
+            + RamUsageEstimator.NUM_BYTES_OBJECT_HEADER
+            + Integer.BYTES;
+
+    // ArrayDeque slot (one object reference, amortized)
+    long dequeSlotBytes = RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+
+    return frozenIntSetShallow + intArrayBytes + mapEntryBytes + dequeSlotBytes;
   }
 
   /** Returns true if the given automaton accepts no strings. */

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.tests.util.automaton.AutomatonTestUtil;
@@ -1701,6 +1702,98 @@ public class TestAutomaton extends LuceneTestCase {
           a = Operations.reverse(a);
           Operations.determinize(a, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
         });
+  }
+
+  public void testDeterminizeProgressCallback() {
+    Automaton nfa = buildNonDeterministicAutomaton();
+    assertFalse(nfa.isDeterministic());
+
+    AtomicLong totalBytes = new AtomicLong();
+    int[] callCount = new int[1];
+
+    Automaton dfa =
+        Operations.determinize(
+            nfa,
+            DEFAULT_DETERMINIZE_WORK_LIMIT,
+            bytes -> {
+              assertTrue("estimated bytes must be positive", bytes > 0);
+              totalBytes.addAndGet(bytes);
+              callCount[0]++;
+            });
+
+    assertTrue(dfa.isDeterministic());
+    assertTrue("callback should have been invoked at least once", callCount[0] > 0);
+    assertTrue("total estimated bytes should be positive", totalBytes.get() > 0);
+
+    // Verify the result is equivalent: determinizing with and without callback produces same
+    // language
+    Automaton dfaWithout = Operations.determinize(nfa, DEFAULT_DETERMINIZE_WORK_LIMIT);
+    assertTrue(AutomatonTestUtil.sameLanguage(dfa, dfaWithout));
+  }
+
+  public void testDeterminizeProgressCallbackAbort() {
+    Automaton nfa = buildNonDeterministicAutomaton();
+    assertFalse(nfa.isDeterministic());
+
+    RuntimeException abortException =
+        expectThrows(
+            RuntimeException.class,
+            () -> {
+              Operations.determinize(
+                  nfa,
+                  DEFAULT_DETERMINIZE_WORK_LIMIT,
+                  _ -> {
+                    throw new RuntimeException("memory limit exceeded");
+                  });
+            });
+    assertEquals("memory limit exceeded", abortException.getMessage());
+  }
+
+  public void testDeterminizeProgressCallbackNull() {
+    Automaton nfa = buildNonDeterministicAutomaton();
+    Automaton dfaWithNull = Operations.determinize(nfa, DEFAULT_DETERMINIZE_WORK_LIMIT, null);
+    Automaton dfaWithout = Operations.determinize(nfa, DEFAULT_DETERMINIZE_WORK_LIMIT);
+    assertTrue(dfaWithNull.isDeterministic());
+    assertTrue(AutomatonTestUtil.sameLanguage(dfaWithNull, dfaWithout));
+  }
+
+  public void testDeterminizeProgressCallbackNotCalledWhenAlreadyDeterministic() {
+    Automaton dfa = Automata.makeString("hello");
+    assertTrue(dfa.isDeterministic());
+
+    Automaton result =
+        Operations.determinize(
+            dfa,
+            DEFAULT_DETERMINIZE_WORK_LIMIT,
+            _ -> {
+              fail("callback should not be invoked for an already-deterministic automaton");
+            });
+    assertSame(dfa, result);
+
+    // Also test single-state automaton
+    Automaton singleState = Automata.makeChar('x');
+    assertTrue(singleState.getNumStates() <= 2);
+    Automaton singleResult =
+        Operations.determinize(
+            singleState,
+            DEFAULT_DETERMINIZE_WORK_LIMIT,
+            _ -> {
+              fail("callback should not be invoked for a trivial automaton");
+            });
+    assertTrue(singleResult.isDeterministic());
+  }
+
+  private static Automaton buildNonDeterministicAutomaton() {
+    Automaton automaton = new Automaton();
+    int start = automaton.createState();
+    int left = automaton.createState();
+    int right = automaton.createState();
+    automaton.setAccept(left, true);
+    automaton.setAccept(right, true);
+    automaton.addTransition(start, left, 'a');
+    automaton.addTransition(start, right, 'a');
+    automaton.finishState();
+    return automaton;
   }
 
   public void testMakeCharSetEmpty() {


### PR DESCRIPTION
### Problem
Lucene's `Operations.determinize` uses powerset construction to convert an NFA into a DFA. For patterns with combinatorial structure (e.g. *a*b*c*d*e*f*), this can cause exponential blowup in the number of DFA states, each carrying its own FrozenIntSet snapshot, HashMap entry, and backing arrays. The existing `workLimit` parameter bounds `CPU` effort but provides no memory signal,  the JVM can `OOM` long before the work limit is reached. There is currently no way for callers to observe or react to memory growth during determinization. 

### Update
This PR adds a new overload to Lucene's determinization API
```
public static Automaton determinize(Automaton a, int workLimit, LongConsumer progressCallback)
```
When a non-null callback is provided, Lucene periodically invokes it with an accumulated estimate of bytes allocated since the last report. The caller can use this signal to enforce memory policies (e.g. throw a circuit-breaker exception to abort determinization)

The estimate is built from the allocations directly attributable to each newly discovered DFA state during powerset construction. Rather than invoking the callback on every new state (which would add overhead proportional to state count), estimates are accumulated and reported in chunks once a configurable byte threshold is crossed. Any remainder is flushed once at the end

