### PR TITLE
Use binary search partitioning in ReaderUtil#partitionByLeaf

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -314,6 +314,9 @@ Optimizations
 
 * GITHUB#15954: Use SkipBlockRangeIterator as the two-phase approximation in SortedNumericDocValuesRangeQuery. (Sagar Upadhyaya)
 
+* GITHUB#15938: Optimize ReaderUtil#partitionByLeaf to use binary search on leaf
+  boundaries instead of linear scan. (Greg Miller)
+
 Bug Fixes
 ---------------------
 * GITHUB#15754: Fix HTMLStripCharFilter to prevent tags from incorrectly consuming subsequent
@@ -351,10 +354,6 @@ Bug Fixes
 * GITHUB#15908: Fix MMapDirectory.getSharedArenaMaxPermitsSysprop() to use
   RefCountedSharedArena.DEFAULT_MAX_PERMITS instead of a hardcoded value, so that
   the default change from GITHUB#15078 takes effect. (Huaixinww)
-
-* GITHUB#15899, GITHUB#15900: Improve TruncateTokenFilter to truncate on codepoints not
-  chars and no longer produce half surrogates. There are new factory parameters available
-  to configure legacy prefix chars and new codepoint behaviour.  (Uwe Schindler, Michael Sokolov)
 
 Other
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -382,6 +382,10 @@ Other
 
 * GITHUB#15951: Fix WindowsFS onClose race condition (Szymon Bialkowski)
 
+* GITHUB#xx: Optimize ReaderUtil#partitionByLeaf to use binary search on leaf
+  boundaries instead of linear scan. Add JMH benchmark for partition strategies.
+  (Greg Miller)
+
 ======================= Lucene 10.4.0 =======================
 
 API Changes

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -385,10 +385,6 @@ Other
 
 * GITHUB#15951: Fix WindowsFS onClose race condition (Szymon Bialkowski)
 
-* GITHUB#xx: Optimize ReaderUtil#partitionByLeaf to use binary search on leaf
-  boundaries instead of linear scan. Add JMH benchmark for partition strategies.
-  (Greg Miller)
-
 ======================= Lucene 10.4.0 =======================
 
 API Changes

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -355,6 +355,10 @@ Bug Fixes
   RefCountedSharedArena.DEFAULT_MAX_PERMITS instead of a hardcoded value, so that
   the default change from GITHUB#15078 takes effect. (Huaixinww)
 
+* GITHUB#15899, GITHUB#15900: Improve TruncateTokenFilter to truncate on codepoints not
+  chars and no longer produce half surrogates. There are new factory parameters available
+  to configure legacy prefix chars and new codepoint behaviour.  (Uwe Schindler, Michael Sokolov)
+
 Other
 ---------------------
 * GITHUB#15586: Document that scoring and ranking may change across major Lucene versions, and that applications requiring stable ranking should explicitly configure Similarity. (Parveen Saini)

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/PartitionByLeafBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/PartitionByLeafBenchmark.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.lucene.util.ArrayUtil;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmark comparing partition strategies for ReaderUtil#partitionByLeaf. Both benchmarks operate
+ * on pre-sorted doc IDs to isolate the partition step from sorting overhead.
+ *
+ * <ul>
+ *   <li>linearPartition: linear-scan partition (previous implementation)
+ *   <li>binarySearchPartition: binary-search partition using leaf boundaries (current
+ *       implementation)
+ * </ul>
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(
+    value = 3,
+    jvmArgsAppend = {"-Xmx1g", "-Xms1g", "-XX:+AlwaysPreTouch"})
+public class PartitionByLeafBenchmark {
+
+  private static final int[] EMPTY_INT_ARRAY = new int[0];
+
+  /** Number of doc IDs we'll be partitioning. */
+  @Param({"100", "1000", "10000", "100000"})
+  int numDocIds;
+
+  /** Number of leaves in the test index. */
+  @Param({"5", "10", "20", "50", "200"})
+  int numLeaves;
+
+  /** Pre-sorted doc IDs to partition. */
+  private int[] sortedDocIds;
+
+  /** Leaf boundaries: leafDocBase[i] is the docBase for leaf i. */
+  private int[] leafDocBase;
+
+  /** Max doc per leaf (uniform for simplicity). */
+  private int docsPerLeaf;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    Random r = new Random();
+
+    docsPerLeaf = Math.max(numDocIds / numLeaves, 1) * 10;
+    int totalDocs = numLeaves * docsPerLeaf;
+
+    leafDocBase = new int[numLeaves];
+    for (int i = 0; i < numLeaves; i++) {
+      leafDocBase[i] = i * docsPerLeaf;
+    }
+
+    // Generate unique doc IDs via shuffle
+    int[] pool = new int[totalDocs];
+    for (int i = 0; i < totalDocs; i++) {
+      pool[i] = i;
+    }
+    for (int i = totalDocs - 1; i > 0; i--) {
+      int j = r.nextInt(i + 1);
+      int tmp = pool[i];
+      pool[i] = pool[j];
+      pool[j] = tmp;
+    }
+    sortedDocIds = ArrayUtil.copyOfSubArray(pool, 0, numDocIds);
+    Arrays.sort(sortedDocIds);
+  }
+
+  @Benchmark
+  public void linearPartition(Blackhole bh) {
+    bh.consume(partitionSortedLinear(sortedDocIds));
+  }
+
+  @Benchmark
+  public void binarySearchPartition(Blackhole bh) {
+    bh.consume(partitionSortedBinarySearch(sortedDocIds));
+  }
+
+  /**
+   * Partition sorted doc IDs across leaves using a linear scan. This mirrors the previous
+   * implementation in ReaderUtil#partitionByLeaf.
+   */
+  private int[][] partitionSortedLinear(int[] sortedDocIds) {
+    int[][] result = new int[numLeaves][];
+    if (sortedDocIds.length == 0) {
+      Arrays.fill(result, EMPTY_INT_ARRAY);
+      return result;
+    }
+    int leafStart = 0;
+    int leafIdx = 0;
+    int leafEnd = leafDocBase[0] + docsPerLeaf;
+    for (int i = 0; i < sortedDocIds.length; i++) {
+      int docId = sortedDocIds[i];
+      while (docId >= leafEnd) {
+        int count = i - leafStart;
+        if (count == 0) {
+          result[leafIdx] = EMPTY_INT_ARRAY;
+        } else {
+          result[leafIdx] = new int[count];
+          System.arraycopy(sortedDocIds, leafStart, result[leafIdx], 0, count);
+        }
+        leafStart = i;
+        leafIdx++;
+        leafEnd = leafDocBase[leafIdx] + docsPerLeaf;
+      }
+    }
+    int count = sortedDocIds.length - leafStart;
+    result[leafIdx] = new int[count];
+    System.arraycopy(sortedDocIds, leafStart, result[leafIdx], 0, count);
+    Arrays.fill(result, leafIdx + 1, numLeaves, EMPTY_INT_ARRAY);
+    return result;
+  }
+
+  /**
+   * Partition sorted doc IDs across leaves using binary search on leaf boundaries. For each leaf,
+   * binary search for its end boundary in the sorted doc IDs to find the slice belonging to that
+   * leaf. Each successive search is bounded by the previous result. Includes an O(1) peek to skip
+   * empty leaves and early termination when all docs are placed.
+   */
+  private int[][] partitionSortedBinarySearch(int[] sortedDocIds) {
+    int[][] result = new int[numLeaves][];
+    if (sortedDocIds.length == 0) {
+      Arrays.fill(result, EMPTY_INT_ARRAY);
+      return result;
+    }
+    int from = 0;
+    int leafIdx = 0;
+    for (; leafIdx < numLeaves && from < sortedDocIds.length; leafIdx++) {
+      int leafEnd = leafDocBase[leafIdx] + docsPerLeaf;
+      if (sortedDocIds[from] >= leafEnd) {
+        result[leafIdx] = EMPTY_INT_ARRAY;
+        continue;
+      }
+      int to = Arrays.binarySearch(sortedDocIds, from, sortedDocIds.length, leafEnd);
+      if (to < 0) {
+        to = -to - 1;
+      }
+      int count = to - from;
+      result[leafIdx] = new int[count];
+      System.arraycopy(sortedDocIds, from, result[leafIdx], 0, count);
+      from = to;
+    }
+    Arrays.fill(result, leafIdx, numLeaves, EMPTY_INT_ARRAY);
+    return result;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/index/ReaderUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReaderUtil.java
@@ -114,33 +114,25 @@ public final class ReaderUtil {
       sortedDocIds[i] = hits[i].doc;
     }
     Arrays.sort(sortedDocIds);
-    int leafStart = 0;
+    int from = 0;
     int leafIdx = 0;
-    LeafReaderContext leaf = leaves.getFirst();
-    int leafEnd = leaf.docBase + leaf.reader().maxDoc();
-    for (int i = 0; i < sortedDocIds.length; i++) {
-      int docId = sortedDocIds[i];
-      while (docId >= leafEnd) {
-        int count = i - leafStart;
-        if (count == 0) {
-          result[leafIdx] = EMPTY_INT_ARRAY;
-        } else {
-          result[leafIdx] = new int[count];
-          System.arraycopy(sortedDocIds, leafStart, result[leafIdx], 0, count);
-        }
-        leafStart = i;
-        leafIdx++;
-        leaf = leaves.get(leafIdx);
-        leafEnd = leaf.docBase + leaf.reader().maxDoc();
+    for (; leafIdx < numLeaves && from < sortedDocIds.length; leafIdx++) {
+      LeafReaderContext leaf = leaves.get(leafIdx);
+      int leafEnd = leaf.docBase + leaf.reader().maxDoc();
+      if (sortedDocIds[from] >= leafEnd) {
+        result[leafIdx] = EMPTY_INT_ARRAY;
+        continue;
       }
+      int to = Arrays.binarySearch(sortedDocIds, from, sortedDocIds.length, leafEnd);
+      if (to < 0) {
+        to = -to - 1;
+      }
+      int count = to - from;
+      result[leafIdx] = new int[count];
+      System.arraycopy(sortedDocIds, from, result[leafIdx], 0, count);
+      from = to;
     }
-    // Handle remaining docIDs
-    int count = sortedDocIds.length - leafStart;
-    assert count > 0;
-    result[leafIdx] = new int[count];
-    System.arraycopy(sortedDocIds, leafStart, result[leafIdx], 0, count);
-    // Fill remaining empty leaves
-    Arrays.fill(result, leafIdx + 1, numLeaves, EMPTY_INT_ARRAY);
+    Arrays.fill(result, leafIdx, numLeaves, EMPTY_INT_ARRAY);
     return result;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/ReaderUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReaderUtil.java
@@ -128,6 +128,7 @@ public final class ReaderUtil {
         to = -to - 1;
       }
       int count = to - from;
+      assert count > 0;
       result[leafIdx] = new int[count];
       System.arraycopy(sortedDocIds, from, result[leafIdx], 0, count);
       from = to;


### PR DESCRIPTION
### Description

This change modifies the "partition" step of `ReaderUtil#partitionByLeaf` to leverage binary search instead of a linear scan.

* Current Implementation: Iterates a sorted list of docIDs, checking each against leaf/segment boundaries to partition the sorted docs into their corresponding segments.
* Proposed Implementation: Iterate the leaves/segments and binary search the sorted docIDs to determine the partitions.

I've included a jmh benchmark with this change that I used to test the two approaches. Benchmark results are below. At a high level, the binary search approach outperforms except when there's a very large number of index segments relative to docs being partitioned. My sense is that the cases where the linear scan approach performs best are uncommon cases "in the wild," so I think the binary search approach generally makes sense. But open to feedback/thoughts of course!

### Benchmarks
Some iterations and more details are in #15934 where I initially experimented with this, but the most concise benchmarks are detailed here.

#### Benchmark Hardware
I ran benchmarks on two AWS ec2 Amazon Linux hosts—one with x86 (m5.12xlarge) and one with ARM (m6g.4xlarge):
|                | x86 Linux                    | ARM Linux                |
|----------------|------------------------------|--------------------------|
| CPU            | Intel Xeon Platinum 8175M    | Neoverse-N1 (Graviton2)  |
| Clock          | 2.5 GHz (base), 3.1 GHz (turbo) | ~2.5 GHz            |
| L1d cache      | 32 KB                        | 64 KB                    |
| L2 cache       | 1 MB                         | 1 MB                     |
| Cores          | 48                           | 16                       |

#### Summary Results
Ran benchmarks as: `java -jar lucene/benchmark-jmh/build/benchmarks/lucene-benchmark-jmh-*.jar PartitionByLeafBenchmark`

Fed the results to an AI tool to build summary tables, but including raw output below.

**x86 Results**
| numDocIds | numLeaves | Linear (ops/ms) | BS (ops/ms) | Difference |
|-----------|-----------|------------------|-------------|------------|
| 100       | 5         | 4,352            | 8,429       | BS +94% ✅ |
| 100       | 10        | 3,501            | 4,880       | BS +39% ✅ |
| 100       | 20        | 2,682            | 2,589       | ~tie |
| 100       | 50        | 1,470            | 1,180       | Linear +25% ❌ |
| 100       | 200       | 625              | 461         | Linear +36% ❌ |
| 1,000     | 5         | 484              | 1,911       | BS +295% ✅ |
| 1,000     | 10        | 479              | 1,922       | BS +301% ✅ |
| 1,000     | 20        | 463              | 1,470       | BS +217% ✅ |
| 1,000     | 50        | 416              | 735         | BS +77% ✅ |
| 1,000     | 200       | 264              | 195         | Linear +35% ❌ |
| 10,000    | 5         | 45               | 182         | BS +304% ✅ |
| 10,000    | 10        | 46               | 175         | BS +283% ✅ |
| 10,000    | 20        | 44               | 155         | BS +252% ✅ |
| 10,000    | 50        | 47               | 193         | BS +311% ✅ |
| 10,000    | 200       | 43               | 119         | BS +176% ✅ |
| 100,000   | 5         | 6.1              | 10.9        | BS +80% ✅ |
| 100,000   | 10        | 7.5              | 15.8        | BS +111% ✅ |
| 100,000   | 20        | 8.0              | 17.2        | BS +115% ✅ |
| 100,000   | 50        | 8.2              | 17.7        | BS +116% ✅ |
| 100,000   | 200       | 8.0              | 14.1        | BS +76% ✅ |

**ARM Results**
| numDocIds | numLeaves | Linear (ops/ms) | BS (ops/ms) | Difference |
|-----------|-----------|------------------|-------------|------------|
| 100       | 5         | 5,285            | 6,608       | BS +25% ✅ |
| 100       | 10        | 3,967            | 3,920       | ~tie |
| 100       | 20        | 2,331            | 1,948       | Linear +20% ❌ |
| 100       | 50        | 1,470            | 840         | Linear +75% ❌ |
| 100       | 200       | 580              | 363         | Linear +60% ❌ |
| 1,000     | 5         | 703              | 1,798       | BS +156% ✅ |
| 1,000     | 10        | 648              | 1,402       | BS +116% ✅ |
| 1,000     | 20        | 615              | 1,068       | BS +74% ✅ |
| 1,000     | 50        | 486              | 550         | BS +13% ✅ |
| 1,000     | 200       | 265              | 140         | Linear +89% ❌ |
| 10,000    | 5         | 69               | 273         | BS +295% ✅ |
| 10,000    | 10        | 68               | 205         | BS +201% ✅ |
| 10,000    | 20        | 67               | 196         | BS +193% ✅ |
| 10,000    | 50        | 65               | 169         | BS +160% ✅ |
| 10,000    | 200       | 58               | 74          | BS +27% ✅ |
| 100,000   | 5         | 7.9              | 38.9        | BS +392% ✅ |
| 100,000   | 10        | 7.5              | 36.6        | BS +388% ✅ |
| 100,000   | 20        | 7.6              | 31.6        | BS +316% ✅ |
| 100,000   | 50        | 7.2              | 23.9        | BS +232% ✅ |
| 100,000   | 200       | 6.6              | 16.2        | BS +145% ✅ |

#### Raw Benchmark Output

**x86**
Benchmark                                       (numDocIds)  (numLeaves)   Mode  Cnt     Score     Error   Units
PartitionByLeafBenchmark.binarySearchPartition          100            5  thrpt   15  8429.348 ± 440.448  ops/ms
PartitionByLeafBenchmark.binarySearchPartition          100           10  thrpt   15  4880.362 ±  54.478  ops/ms
PartitionByLeafBenchmark.binarySearchPartition          100           20  thrpt   15  2589.496 ±  65.347  ops/ms
PartitionByLeafBenchmark.binarySearchPartition          100           50  thrpt   15  1180.417 ±  93.940  ops/ms
PartitionByLeafBenchmark.binarySearchPartition          100          200  thrpt   15   460.616 ±  22.819  ops/ms
PartitionByLeafBenchmark.binarySearchPartition         1000            5  thrpt   15  1911.034 ±  23.741  ops/ms
PartitionByLeafBenchmark.binarySearchPartition         1000           10  thrpt   15  1922.153 ±  77.887  ops/ms
PartitionByLeafBenchmark.binarySearchPartition         1000           20  thrpt   15  1470.400 ±  32.570  ops/ms
PartitionByLeafBenchmark.binarySearchPartition         1000           50  thrpt   15   734.610 ±   3.304  ops/ms
PartitionByLeafBenchmark.binarySearchPartition         1000          200  thrpt   15   195.314 ±   1.438  ops/ms
PartitionByLeafBenchmark.binarySearchPartition        10000            5  thrpt   15   182.224 ±   2.416  ops/ms
PartitionByLeafBenchmark.binarySearchPartition        10000           10  thrpt   15   174.868 ±   1.510  ops/ms
PartitionByLeafBenchmark.binarySearchPartition        10000           20  thrpt   15   155.064 ±   2.676  ops/ms
PartitionByLeafBenchmark.binarySearchPartition        10000           50  thrpt   15   193.320 ±   1.270  ops/ms
PartitionByLeafBenchmark.binarySearchPartition        10000          200  thrpt   15   119.443 ±   2.780  ops/ms
PartitionByLeafBenchmark.binarySearchPartition       100000            5  thrpt   15    10.909 ±   0.058  ops/ms
PartitionByLeafBenchmark.binarySearchPartition       100000           10  thrpt   15    15.837 ±   0.137  ops/ms
PartitionByLeafBenchmark.binarySearchPartition       100000           20  thrpt   15    17.244 ±   0.160  ops/ms
PartitionByLeafBenchmark.binarySearchPartition       100000           50  thrpt   15    17.748 ±   0.121  ops/ms
PartitionByLeafBenchmark.binarySearchPartition       100000          200  thrpt   15    14.092 ±   0.460  ops/ms
PartitionByLeafBenchmark.linearPartition                100            5  thrpt   15  4351.953 ±  32.738  ops/ms
PartitionByLeafBenchmark.linearPartition                100           10  thrpt   15  3500.875 ± 134.317  ops/ms
PartitionByLeafBenchmark.linearPartition                100           20  thrpt   15  2681.611 ±  14.056  ops/ms
PartitionByLeafBenchmark.linearPartition                100           50  thrpt   15  1469.889 ± 283.971  ops/ms
PartitionByLeafBenchmark.linearPartition                100          200  thrpt   15   624.940 ±  33.866  ops/ms
PartitionByLeafBenchmark.linearPartition               1000            5  thrpt   15   484.472 ±   1.494  ops/ms
PartitionByLeafBenchmark.linearPartition               1000           10  thrpt   15   478.512 ±   5.470  ops/ms
PartitionByLeafBenchmark.linearPartition               1000           20  thrpt   15   463.223 ±   7.010  ops/ms
PartitionByLeafBenchmark.linearPartition               1000           50  thrpt   15   416.226 ±   9.632  ops/ms
PartitionByLeafBenchmark.linearPartition               1000          200  thrpt   15   264.385 ±   2.228  ops/ms
PartitionByLeafBenchmark.linearPartition              10000            5  thrpt   15    44.861 ±   0.470  ops/ms
PartitionByLeafBenchmark.linearPartition              10000           10  thrpt   15    45.709 ±   0.101  ops/ms
PartitionByLeafBenchmark.linearPartition              10000           20  thrpt   15    44.448 ±   0.156  ops/ms
PartitionByLeafBenchmark.linearPartition              10000           50  thrpt   15    47.107 ±   0.505  ops/ms
PartitionByLeafBenchmark.linearPartition              10000          200  thrpt   15    43.276 ±   0.152  ops/ms
PartitionByLeafBenchmark.linearPartition             100000            5  thrpt   15     6.059 ±   0.015  ops/ms
PartitionByLeafBenchmark.linearPartition             100000           10  thrpt   15     7.519 ±   0.169  ops/ms
PartitionByLeafBenchmark.linearPartition             100000           20  thrpt   15     8.019 ±   0.033  ops/ms
PartitionByLeafBenchmark.linearPartition             100000           50  thrpt   15     8.233 ±   0.045  ops/ms
PartitionByLeafBenchmark.linearPartition             100000          200  thrpt   15     8.048 ±   0.034  ops/ms

**ARM**
Benchmark                                       (numDocIds)  (numLeaves)   Mode  Cnt     Score     Error   Units
PartitionByLeafBenchmark.binarySearchPartition          100            5  thrpt   15  6607.852 ± 248.856  ops/ms
PartitionByLeafBenchmark.binarySearchPartition          100           10  thrpt   15  3920.374 ± 147.577  ops/ms
PartitionByLeafBenchmark.binarySearchPartition          100           20  thrpt   15  1948.412 ±   3.964  ops/ms
PartitionByLeafBenchmark.binarySearchPartition          100           50  thrpt   15   840.036 ±  24.553  ops/ms
PartitionByLeafBenchmark.binarySearchPartition          100          200  thrpt   15   362.670 ±   5.729  ops/ms
PartitionByLeafBenchmark.binarySearchPartition         1000            5  thrpt   15  1798.015 ±  26.241  ops/ms
PartitionByLeafBenchmark.binarySearchPartition         1000           10  thrpt   15  1401.657 ±  25.145  ops/ms
PartitionByLeafBenchmark.binarySearchPartition         1000           20  thrpt   15  1067.532 ±  38.887  ops/ms
PartitionByLeafBenchmark.binarySearchPartition         1000           50  thrpt   15   550.367 ±   5.071  ops/ms
PartitionByLeafBenchmark.binarySearchPartition         1000          200  thrpt   15   139.719 ±   1.729  ops/ms
PartitionByLeafBenchmark.binarySearchPartition        10000            5  thrpt   15   273.486 ±  17.731  ops/ms
PartitionByLeafBenchmark.binarySearchPartition        10000           10  thrpt   15   204.891 ±   1.491  ops/ms
PartitionByLeafBenchmark.binarySearchPartition        10000           20  thrpt   15   195.903 ±   1.537  ops/ms
PartitionByLeafBenchmark.binarySearchPartition        10000           50  thrpt   15   168.672 ±   8.833  ops/ms
PartitionByLeafBenchmark.binarySearchPartition        10000          200  thrpt   15    74.241 ±   3.183  ops/ms
PartitionByLeafBenchmark.binarySearchPartition       100000            5  thrpt   15    38.910 ±   0.332  ops/ms
PartitionByLeafBenchmark.binarySearchPartition       100000           10  thrpt   15    36.608 ±   0.374  ops/ms
PartitionByLeafBenchmark.binarySearchPartition       100000           20  thrpt   15    31.596 ±   0.274  ops/ms
PartitionByLeafBenchmark.binarySearchPartition       100000           50  thrpt   15    23.895 ±   0.305  ops/ms
PartitionByLeafBenchmark.binarySearchPartition       100000          200  thrpt   15    16.244 ±   0.143  ops/ms
PartitionByLeafBenchmark.linearPartition                100            5  thrpt   15  5284.656 ±  31.317  ops/ms
PartitionByLeafBenchmark.linearPartition                100           10  thrpt   15  3966.757 ±  32.919  ops/ms
PartitionByLeafBenchmark.linearPartition                100           20  thrpt   15  2330.805 ±  15.104  ops/ms
PartitionByLeafBenchmark.linearPartition                100           50  thrpt   15  1469.664 ±  49.736  ops/ms
PartitionByLeafBenchmark.linearPartition                100          200  thrpt   15   579.968 ±   8.910  ops/ms
PartitionByLeafBenchmark.linearPartition               1000            5  thrpt   15   703.493 ±   4.639  ops/ms
PartitionByLeafBenchmark.linearPartition               1000           10  thrpt   15   648.284 ±   6.565  ops/ms
PartitionByLeafBenchmark.linearPartition               1000           20  thrpt   15   614.930 ±   6.369  ops/ms
PartitionByLeafBenchmark.linearPartition               1000           50  thrpt   15   485.980 ±  12.309  ops/ms
PartitionByLeafBenchmark.linearPartition               1000          200  thrpt   15   264.950 ±  10.029  ops/ms
PartitionByLeafBenchmark.linearPartition              10000            5  thrpt   15    69.465 ±   4.038  ops/ms
PartitionByLeafBenchmark.linearPartition              10000           10  thrpt   15    68.010 ±   0.186  ops/ms
PartitionByLeafBenchmark.linearPartition              10000           20  thrpt   15    67.008 ±   0.213  ops/ms
PartitionByLeafBenchmark.linearPartition              10000           50  thrpt   15    65.174 ±   3.478  ops/ms
PartitionByLeafBenchmark.linearPartition              10000          200  thrpt   15    58.380 ±   3.943  ops/ms
PartitionByLeafBenchmark.linearPartition             100000            5  thrpt   15     7.858 ±   0.032  ops/ms
PartitionByLeafBenchmark.linearPartition             100000           10  thrpt   15     7.525 ±   0.506  ops/ms
PartitionByLeafBenchmark.linearPartition             100000           20  thrpt   15     7.645 ±   0.029  ops/ms
PartitionByLeafBenchmark.linearPartition             100000           50  thrpt   15     7.245 ±   0.033  ops/ms
PartitionByLeafBenchmark.linearPartition             100000          200  thrpt   15     6.632 ±   0.005  ops/ms

