### PR TITLE
Add forceMerge to TestIndexOptions#testFrozenFieldTypeCacheRestabilizes

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexOptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexOptions.java
@@ -291,6 +291,7 @@ public class TestIndexOptions extends LuceneTestCase {
     for (int i = 20; i < 30; i++) {
       w.addDocument(Collections.singleton(new Field("foo", "val" + i, ftA)));
     }
+    w.forceMerge(1); // just in case we had a random flush
     try (LeafReader r = getOnlyLeafReader(DirectoryReader.open(w))) {
       assertEquals(30, r.maxDoc());
     }


### PR DESCRIPTION
The test assumes we have a single segment, but randomization can sometimes give us more than that.  Adding a forceMerge call ensures the segment geometry is what we expect it to be.

Fixes #15943