### PR TITLE
Add JMH benchmark comparing various sort algorithms specifically for sorting ScoreDoc[] of varying lengths

### DIFF
--- a/lucene/benchmark-jmh/jmh-table.py
+++ b/lucene/benchmark-jmh/jmh-table.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""Parse JMH JSON output from stdin, produce an interactive HTML table on stdout.
+
+Supports both JSON (-rf json) and plain text JMH output.
+With JSON input, clicking a cell shows a histogram of the raw iteration samples
+and the benchmark method source code.
+
+Usage:
+  # JSON (recommended – enables histograms + source):
+  java --module-path ... --module org.apache.lucene.benchmark.jmh ScoreDocSortBenchmark \
+    -rf json -rff results.json \
+    && python3 jmh-table.py [BenchmarkSource.java] < results.json > results.html
+
+  # Plain text (no histograms):
+  java --module-path ... --module org.apache.lucene.benchmark.jmh ScoreDocSortBenchmark \
+    | python3 jmh-table.py > results.html
+
+  The optional positional argument is the path to the Java source file containing
+  the @Benchmark methods. If provided, clicking a cell also shows the method source.
+"""
+
+import sys
+import re
+import json
+import html
+
+
+def parse_jmh_text(text):
+    """Parse plain-text JMH output."""
+    entries = []
+    for line in text.splitlines():
+        m = re.match(
+            r'\S+\.(\S+)\s+'
+            r'(\S+)\s+'
+            r'\S+\s+'
+            r'\d+\s+'
+            r'(\S+)\s+'
+            r'.\s+'
+            r'(\S+)\s+'
+            r'(\S+)',
+            line,
+        )
+        if m:
+            method, param, score, error, unit = m.groups()
+            entries.append({
+                'method': method,
+                'param': param,
+                'score': float(score),
+                'error': float(error),
+                'unit': unit,
+                'raw': [],
+            })
+    return entries, {}
+
+
+def parse_jmh_json(data):
+    """Parse JMH JSON output. Returns (entries, config_dict)."""
+    entries = []
+    config = {}
+    for i, result in enumerate(data):
+        bench = result['benchmark'].rsplit('.', 1)[-1]
+        params = result.get('params', {})
+        param = list(params.values())[0] if params else ''
+        pm = result['primaryMetric']
+        raw = []
+        for fork_data in pm.get('rawData', []):
+            raw.extend(fork_data)
+        entries.append({
+            'method': bench,
+            'param': param,
+            'score': pm['score'],
+            'error': pm['scoreError'],
+            'unit': pm['scoreUnit'],
+            'raw': raw,
+        })
+        if i == 0:
+            mode_map = {'avgt': 'Average Time', 'thrpt': 'Throughput',
+                        'sample': 'Sampling', 'ss': 'Single Shot'}
+            config = {
+                'mode': mode_map.get(result.get('mode', ''), result.get('mode', '?')),
+                'forks': result.get('forks', '?'),
+                'threads': result.get('threads', '?'),
+                'warmupIterations': result.get('warmupIterations', '?'),
+                'warmupTime': result.get('warmupTime', '?'),
+                'measurementIterations': result.get('measurementIterations', '?'),
+                'measurementTime': result.get('measurementTime', '?'),
+                'jvmArgs': result.get('jvmArgs', []),
+            }
+    return entries, config
+
+
+def extract_methods(source_path):
+    """Extract @Benchmark method bodies from a Java source file.
+
+    Returns dict of method_name -> source_code_string.
+    """
+    methods = {}
+    if not source_path:
+        return methods
+    try:
+        with open(source_path, 'r') as f:
+            lines = f.readlines()
+    except (OSError, IOError):
+        return methods
+
+    i = 0
+    while i < len(lines):
+        # Look for @Benchmark annotation
+        if '@Benchmark' in lines[i]:
+            # Collect comment lines above @Benchmark
+            comment_start = i
+            j = i - 1
+            while j >= 0 and lines[j].strip().startswith('//'):
+                comment_start = j
+                j -= 1
+            # Find method signature (next line with '{')
+            sig_line = i + 1
+            while sig_line < len(lines) and '{' not in lines[sig_line]:
+                sig_line += 1
+            if sig_line >= len(lines):
+                i += 1
+                continue
+            # Extract method name
+            sig = lines[sig_line].strip()
+            m = re.search(r'\b(\w+)\s*\(', sig)
+            if not m:
+                i += 1
+                continue
+            method_name = m.group(1)
+            # Find matching closing brace by counting
+            depth = 0
+            end_line = sig_line
+            for k in range(sig_line, len(lines)):
+                depth += lines[k].count('{') - lines[k].count('}')
+                if depth == 0:
+                    end_line = k
+                    break
+            # Extract the full method including leading comment
+            method_lines = lines[comment_start:end_line + 1]
+            # Dedent: find minimum leading whitespace
+            non_empty = [l for l in method_lines if l.strip()]
+            if non_empty:
+                min_indent = min(len(l) - len(l.lstrip()) for l in non_empty)
+                method_lines = [l[min_indent:] if len(l) > min_indent else l for l in method_lines]
+            methods[method_name] = ''.join(method_lines).rstrip()
+            i = end_line + 1
+        else:
+            i += 1
+    return methods
+
+
+def lerp_color(t):
+    """Green (t=0, best) -> yellow (t=0.5) -> red (t=1, worst)."""
+    t = max(0.0, min(1.0, t))
+    if t < 0.5:
+        u = t * 2
+        r = int(120 * u)
+        g = 180
+        b = int(80 * (1 - u))
+    else:
+        u = (t - 0.5) * 2
+        r = 120 + int(100 * u)
+        g = int(180 * (1 - u))
+        b = 0
+    return r, g, b
+
+
+def sparkline_svg(raw_samples, width=120, height=24, num_bins=20):
+    """Generate a tiny inline SVG histogram sparkline from raw samples."""
+    if not raw_samples or len(raw_samples) < 2:
+        return ''
+    lo = min(raw_samples)
+    hi = max(raw_samples)
+    span = hi - lo
+    if span == 0:
+        span = 1
+    bins = [0] * num_bins
+    for v in raw_samples:
+        idx = int((v - lo) / span * num_bins)
+        if idx >= num_bins:
+            idx = num_bins - 1
+        bins[idx] += 1
+    max_count = max(bins)
+    if max_count == 0:
+        return ''
+    bar_w = width / num_bins
+    bars = []
+    for i, count in enumerate(bins):
+        bar_h = (count / max_count) * height
+        x = i * bar_w
+        y = height - bar_h
+        # Color from green (low) to red (high)
+        t = i / max(num_bins - 1, 1)
+        r = int(40 + 180 * t)
+        g = int(160 - 80 * t)
+        b = int(80 - 60 * t)
+        bars.append(
+            f'<rect x="{x:.1f}" y="{y:.1f}" width="{bar_w:.1f}" '
+            f'height="{bar_h:.1f}" fill="rgb({r},{g},{b})" />'
+        )
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
+        f'style="display:block;margin:3px auto 0">'
+        + ''.join(bars)
+        + '</svg>'
+    )
+
+
+def build_html(entries, config, method_sources):
+    if not entries:
+        print("No JMH results found on stdin.", file=sys.stderr)
+        sys.exit(1)
+
+    has_raw = any(e['raw'] for e in entries)
+    has_source = bool(method_sources)
+
+    seen_params = dict()
+    seen_methods = dict()
+    for e in entries:
+        seen_params[e['param']] = None
+        seen_methods[e['method']] = None
+    params = list(seen_params)
+    methods = list(seen_methods)
+    unit = entries[0]['unit']
+
+    grid = {}
+    for e in entries:
+        grid.setdefault(e['method'], {})[e['param']] = e
+
+    col_min = {}
+    col_max = {}
+    for p in params:
+        scores = [grid[m][p]['score'] for m in methods if p in grid[m]]
+        col_min[p] = min(scores) if scores else 0
+        col_max[p] = max(scores) if scores else 1
+
+    h = html.escape
+
+    raw_js = {}
+    for e in entries:
+        if e['raw']:
+            raw_js[f"{e['method']}|{e['param']}"] = e['raw']
+
+    sources_js = {name: src for name, src in method_sources.items()}
+
+    out = []
+    out.append(f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>JMH Results</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; margin: 2rem; background: #fafafa; }}
+  .config {{ background: #f0f0f0; border: 1px solid #ccc; border-radius: 4px;
+             padding: 10px 16px; margin-bottom: 1.5rem; font-size: 0.9em;
+             display: inline-block; }}
+  .config span {{ margin-right: 1.5em; }}
+  .config .label {{ color: #666; }}
+  .config .val {{ font-weight: 600; }}
+  .main-area {{ display: flex; gap: 2rem; align-items: flex-start; }}
+  .left-col {{ flex-shrink: 0; }}
+  .right-col {{ flex-grow: 1; min-width: 0; }}
+  #source-panel {{ display: none; background: #1e1e1e; color: #d4d4d4; border-radius: 6px;
+                   padding: 1rem; max-width: 700px; box-shadow: 0 2px 8px rgba(0,0,0,0.2); }}
+  #source-panel h3 {{ margin: 0 0 0.5rem 0; color: #9cdcfe; font-size: 0.95em; }}
+  #source-panel pre {{ margin: 0; font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code',
+                       'Consolas', monospace; font-size: 13px; line-height: 1.5;
+                       overflow-x: auto; white-space: pre; }}
+  table {{ border-collapse: collapse; box-shadow: 0 2px 8px rgba(0,0,0,0.12); }}
+  th, td {{ padding: 8px 16px; border: 1px solid #bbb; text-align: right; white-space: nowrap;
+            vertical-align: top; }}
+  th {{ background: #444; color: #fff; cursor: pointer; user-select: none; position: relative; }}
+  th:first-child {{ text-align: left; }}
+  td:first-child {{ text-align: left; font-weight: 600; background: #f5f5f5; }}
+  th:hover {{ background: #666; }}
+  .arrow {{ font-size: 0.7em; margin-left: 4px; }}
+  td .err {{ color: #666; font-size: 0.85em; }}
+  td.clickable {{ cursor: pointer; }}
+  td.clickable:hover {{ outline: 2px solid #333; outline-offset: -2px; }}
+  td.selected {{ outline: 2px solid #0066cc; outline-offset: -2px; }}
+  #hist-panel {{ margin-top: 1.5rem; }}
+  #hist-panel h3 {{ margin: 0 0 0.5rem 0; }}
+  #hist-panel .stats {{ color: #555; font-size: 0.9em; margin-bottom: 0.5rem; }}
+  #hist-canvas {{ border: 1px solid #ccc; background: #fff; }}
+</style>
+</head><body>
+<h2>JMH Results</h2>""")
+
+    # Config banner
+    if config:
+        out.append('<div class="config">')
+        items = [
+            ('Mode', config.get('mode', '?')),
+            ('Forks', config.get('forks', '?')),
+            ('Threads', config.get('threads', '?')),
+            ('Warmup', f"{config.get('warmupIterations','?')} iter &times; {config.get('warmupTime','?')}"),
+            ('Measurement', f"{config.get('measurementIterations','?')} iter &times; {config.get('measurementTime','?')}"),
+        ]
+        jvm_args = config.get('jvmArgs', [])
+        if jvm_args:
+            items.append(('JVM args', ' '.join(str(a) for a in jvm_args)))
+        for label, val in items:
+            out.append(f'<span><span class="label">{h(label)}:</span> <span class="val">{h(str(val))}</span></span>')
+        out.append('</div>')
+
+    click_hint = ''
+    if has_raw or has_source:
+        click_hint = ' Click a data cell to see'
+        parts = []
+        if has_raw:
+            parts.append('its iteration histogram')
+        if has_source:
+            parts.append('the method source code')
+        click_hint += ' ' + ' and '.join(parts) + '.'
+
+    out.append(f'<p>Click column headers to sort.{click_hint}</p>')
+    out.append('<div class="main-area"><div class="left-col">')
+    out.append('<table id="t"><thead><tr>')
+
+    out.append(f'<th data-col="0">Algorithm</th>')
+    for i, p in enumerate(params):
+        out.append(f'<th data-col="{i+1}">size={h(p)}<br><small>{h(unit)}</small></th>')
+    out.append('</tr></thead><tbody>')
+
+    for method in methods:
+        out.append('<tr>')
+        out.append(f'<td>{h(method)}</td>')
+        for p in params:
+            if p in grid[method]:
+                e = grid[method][p]
+                score, error = e['score'], e['error']
+                span = col_max[p] - col_min[p]
+                t = (score - col_min[p]) / span if span > 0 else 0
+                r, g, b = lerp_color(t)
+                key = f"{method}|{p}"
+                cls = ' clickable' if (has_raw or has_source) else ''
+                spark = sparkline_svg(e['raw']) if e['raw'] else ''
+                out.append(
+                    f'<td class="{cls}" data-v="{score}" data-key="{h(key)}"'
+                    f' style="background:rgb({r},{g},{b})">'
+                    f'{score:.3f} <span class="err">&plusmn; {error:.3f}</span>'
+                    f'{spark}</td>'
+                )
+            else:
+                out.append('<td data-v="999999">-</td>')
+        out.append('</tr>')
+
+    out.append('</tbody></table>')
+    out.append('</div>')  # end left-col
+    out.append('<div class="right-col"><div id="source-panel"><h3 id="source-title"></h3><pre id="source-code"></pre></div></div>')
+    out.append('</div>')  # end main-area
+    out.append('<div id="hist-panel"></div>')
+
+    out.append('<script>')
+    out.append(f'const UNIT = {json.dumps(unit)};')
+    out.append(f'const RAW = {json.dumps(raw_js)};')
+    out.append(f'const SOURCES = {json.dumps(sources_js)};')
+    out.append(r"""
+const table = document.getElementById('t');
+const headers = table.querySelectorAll('th');
+let sortCol = -1, sortAsc = true;
+
+headers.forEach(th => {
+  th.addEventListener('click', e => {
+    e.stopPropagation();
+    const col = parseInt(th.dataset.col);
+    if (sortCol === col) { sortAsc = !sortAsc; } else { sortCol = col; sortAsc = true; }
+    headers.forEach(h => { const a = h.querySelector('.arrow'); if (a) a.remove(); });
+    const arrow = document.createElement('span');
+    arrow.className = 'arrow';
+    arrow.textContent = sortAsc ? '\u25B2' : '\u25BC';
+    th.appendChild(arrow);
+    const tbody = table.querySelector('tbody');
+    const rows = Array.from(tbody.querySelectorAll('tr'));
+    rows.sort((a, b) => {
+      if (col === 0) {
+        const av = a.children[0].textContent, bv = b.children[0].textContent;
+        return sortAsc ? av.localeCompare(bv) : bv.localeCompare(av);
+      }
+      const av = parseFloat(a.children[col].dataset.v);
+      const bv = parseFloat(b.children[col].dataset.v);
+      return sortAsc ? av - bv : bv - av;
+    });
+    rows.forEach(r => tbody.appendChild(r));
+  });
+});
+
+// Cell click: histogram + source
+table.querySelector('tbody').addEventListener('click', e => {
+  const td = e.target.closest('td.clickable');
+  if (!td) return;
+  table.querySelectorAll('td.selected').forEach(el => el.classList.remove('selected'));
+  td.classList.add('selected');
+  const key = td.dataset.key;
+  const [method, param] = key.split('|');
+
+  // Show source code
+  const srcPanel = document.getElementById('source-panel');
+  const src = SOURCES[method];
+  if (src) {
+    document.getElementById('source-title').textContent = method + '()';
+    document.getElementById('source-code').textContent = src;
+    srcPanel.style.display = 'block';
+  } else {
+    srcPanel.style.display = 'none';
+  }
+
+  // Show histogram
+  const samples = RAW[key];
+  if (samples && samples.length > 0) {
+    drawHistogram(key, samples);
+  } else {
+    document.getElementById('hist-panel').innerHTML = '';
+  }
+});
+
+// Pick the best display unit and scale factor.
+function pickDisplayUnit(values) {
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  if (UNIT === 'us/op') {
+    if (mean < 1) return { label: 'ns/op', scale: 1000 };
+    if (mean >= 1000) return { label: 'ms/op', scale: 0.001 };
+  }
+  if (UNIT === 'ms/op') {
+    if (mean < 1) return { label: 'us/op', scale: 1000 };
+    if (mean >= 1000) return { label: 's/op', scale: 0.001 };
+  }
+  if (UNIT === 'ns/op' && mean >= 1000) {
+    return { label: 'us/op', scale: 0.001 };
+  }
+  return { label: UNIT, scale: 1 };
+}
+
+function smartPrecision(range, numTicks) {
+  if (range === 0) return 1;
+  const step = range / Math.max(numTicks, 1);
+  const digits = Math.max(0, Math.ceil(-Math.log10(step)) + 1);
+  return Math.min(digits, 8);
+}
+
+function fmtVal(v, prec) {
+  return v.toFixed(prec);
+}
+
+function drawHistogram(key, samples) {
+  const panel = document.getElementById('hist-panel');
+  const [method, param] = key.split('|');
+  const n = samples.length;
+
+  const du = pickDisplayUnit(samples);
+  const vals = samples.map(v => v * du.scale);
+  const displayUnit = du.label;
+
+  const sorted = [...vals].sort((a, b) => a - b);
+  const mean = vals.reduce((a, b) => a + b, 0) / n;
+  const min = sorted[0], max = sorted[n - 1];
+  const median = n % 2 === 0 ? (sorted[n/2 - 1] + sorted[n/2]) / 2 : sorted[Math.floor(n/2)];
+  const p5 = sorted[Math.floor(n * 0.05)];
+  const p95 = sorted[Math.floor(n * 0.95)];
+  const stddev = Math.sqrt(vals.reduce((s, v) => s + (v - mean) ** 2, 0) / n);
+
+  const statPrec = smartPrecision(max - min, 20);
+
+  const numBins = Math.max(10, Math.min(50, Math.ceil(Math.sqrt(n))));
+  const binWidth = (max - min) / numBins || 1;
+  const bins = new Array(numBins).fill(0);
+  for (const v of vals) {
+    let idx = Math.floor((v - min) / binWidth);
+    if (idx >= numBins) idx = numBins - 1;
+    bins[idx]++;
+  }
+  const maxCount = Math.max(...bins);
+
+  const W = 700, H = 300;
+  const pad = { top: 20, right: 20, bottom: 50, left: 55 };
+  const cw = W - pad.left - pad.right;
+  const ch = H - pad.top - pad.bottom;
+
+  panel.innerHTML = `
+    <h3>${method} &mdash; size=${param}</h3>
+    <div class="stats">
+      ${n} samples &nbsp;|&nbsp;
+      mean: ${fmtVal(mean, statPrec)} ${displayUnit} &nbsp;|&nbsp;
+      median: ${fmtVal(median, statPrec)} &nbsp;|&nbsp;
+      stddev: ${fmtVal(stddev, statPrec)} &nbsp;|&nbsp;
+      range: [${fmtVal(min, statPrec)}, ${fmtVal(max, statPrec)}] &nbsp;|&nbsp;
+      p5: ${fmtVal(p5, statPrec)} &nbsp;|&nbsp; p95: ${fmtVal(p95, statPrec)}
+    </div>
+    <canvas id="hist-canvas" width="${W}" height="${H}"></canvas>
+  `;
+
+  const canvas = document.getElementById('hist-canvas');
+  const ctx = canvas.getContext('2d');
+
+  ctx.fillStyle = '#fff';
+  ctx.fillRect(0, 0, W, H);
+
+  const barW = cw / numBins;
+  for (let i = 0; i < numBins; i++) {
+    const barH = maxCount > 0 ? (bins[i] / maxCount) * ch : 0;
+    const x = pad.left + i * barW;
+    const y = pad.top + ch - barH;
+    const binCenter = min + (i + 0.5) * binWidth;
+    const t = max > min ? (binCenter - min) / (max - min) : 0;
+    const r = Math.round(40 + 180 * t);
+    const g = Math.round(160 - 80 * t);
+    const b = Math.round(80 - 60 * t);
+    ctx.fillStyle = `rgb(${r},${g},${b})`;
+    ctx.fillRect(x + 1, y, barW - 2, barH);
+  }
+
+  const meanX = pad.left + ((mean - min) / (binWidth * numBins)) * cw;
+  ctx.strokeStyle = '#0066cc';
+  ctx.lineWidth = 2;
+  ctx.setLineDash([5, 3]);
+  ctx.beginPath(); ctx.moveTo(meanX, pad.top); ctx.lineTo(meanX, pad.top + ch); ctx.stroke();
+  ctx.setLineDash([]);
+
+  ctx.fillStyle = '#0066cc';
+  ctx.font = '11px system-ui';
+  ctx.textAlign = 'center';
+  ctx.fillText('mean', meanX, pad.top - 5);
+
+  ctx.strokeStyle = '#333';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(pad.left, pad.top);
+  ctx.lineTo(pad.left, pad.top + ch);
+  ctx.lineTo(pad.left + cw, pad.top + ch);
+  ctx.stroke();
+
+  ctx.fillStyle = '#333';
+  ctx.font = '11px system-ui';
+  ctx.textAlign = 'center';
+  const numXLabels = Math.min(numBins, 8);
+  const xStep = Math.max(1, Math.floor(numBins / numXLabels));
+  const xRange = max - min;
+  const xPrec = smartPrecision(xRange, numXLabels);
+  for (let i = 0; i <= numBins; i += xStep) {
+    const val = min + i * binWidth;
+    const x = pad.left + i * barW;
+    ctx.fillText(fmtVal(val, xPrec), x, pad.top + ch + 16);
+  }
+  ctx.fillText(displayUnit, pad.left + cw / 2, pad.top + ch + 38);
+
+  ctx.textAlign = 'right';
+  const yTicks = 5;
+  for (let i = 0; i <= yTicks; i++) {
+    const count = Math.round(maxCount * i / yTicks);
+    const y = pad.top + ch - (i / yTicks) * ch;
+    ctx.fillText(count.toString(), pad.left - 6, y + 4);
+    ctx.strokeStyle = '#eee';
+    ctx.beginPath(); ctx.moveTo(pad.left + 1, y); ctx.lineTo(pad.left + cw, y); ctx.stroke();
+  }
+  ctx.strokeStyle = '#333';
+}
+""")
+    out.append('</script></body></html>')
+    return '\n'.join(out)
+
+
+if __name__ == '__main__':
+    # Optional positional arg: path to Java source file
+    source_path = sys.argv[1] if len(sys.argv) > 1 else None
+    method_sources = extract_methods(source_path)
+
+    text = sys.stdin.read().strip()
+    if not text:
+        print("No input on stdin.", file=sys.stderr)
+        sys.exit(1)
+
+    if text.startswith('[') or text.startswith('{'):
+        data = json.loads(text)
+        if isinstance(data, dict):
+            data = [data]
+        entries, config = parse_jmh_json(data)
+    else:
+        entries, config = parse_jmh_text(text)
+
+    print(build_html(entries, config, method_sources))

--- a/lucene/benchmark-jmh/jmh-table.py
+++ b/lucene/benchmark-jmh/jmh-table.py
@@ -249,10 +249,10 @@ def build_html(entries, config, method_sources):
 <style>
   body {{ font-family: system-ui, sans-serif; margin: 2rem; background: #fafafa; }}
   .config {{ background: #f0f0f0; border: 1px solid #ccc; border-radius: 4px;
-             padding: 10px 16px; margin-bottom: 1.5rem; font-size: 0.9em;
-             display: inline-block; }}
-  .config span {{ margin-right: 1.5em; }}
-  .config .label {{ color: #666; }}
+             margin-bottom: 1.5rem; font-size: 0.9em;
+             border-collapse: collapse; }}
+  .config td {{ padding: 4px 12px; border: none; }}
+  .config .label {{ color: #666; text-align: right; }}
   .config .val {{ font-weight: 600; }}
   .main-area {{ display: flex; gap: 2rem; align-items: flex-start; }}
   .left-col {{ flex-shrink: 0; }}
@@ -285,20 +285,20 @@ def build_html(entries, config, method_sources):
 
     # Config banner
     if config:
-        out.append('<div class="config">')
+        out.append('<table class="config">')
         items = [
-            ('Mode', config.get('mode', '?')),
-            ('Forks', config.get('forks', '?')),
-            ('Threads', config.get('threads', '?')),
-            ('Warmup', f"{config.get('warmupIterations','?')} iter &times; {config.get('warmupTime','?')}"),
-            ('Measurement', f"{config.get('measurementIterations','?')} iter &times; {config.get('measurementTime','?')}"),
+            ('Mode', str(config.get('mode', '?'))),
+            ('Forks', str(config.get('forks', '?'))),
+            ('Threads', str(config.get('threads', '?'))),
+            ('Warmup', f"{config.get('warmupIterations','?')} iter \u00d7 {config.get('warmupTime','?')}"),
+            ('Measurement', f"{config.get('measurementIterations','?')} iter \u00d7 {config.get('measurementTime','?')}"),
         ]
         jvm_args = config.get('jvmArgs', [])
         if jvm_args:
             items.append(('JVM args', ' '.join(str(a) for a in jvm_args)))
         for label, val in items:
-            out.append(f'<span><span class="label">{h(label)}:</span> <span class="val">{h(str(val))}</span></span>')
-        out.append('</div>')
+            out.append(f'<tr><td class="label">{h(label)}</td><td class="val">{h(val)}</td></tr>')
+        out.append('</table>')
 
     click_hint = ''
     if has_raw or has_source:

--- a/lucene/benchmark-jmh/jmh-table.py
+++ b/lucene/benchmark-jmh/jmh-table.py
@@ -203,11 +203,8 @@ def sparkline_svg(raw_samples, width=120, height=24, num_bins=20):
         bar_h = (count / max_count) * height
         x = i * bar_w
         y = height - bar_h
-        # Color from green (low) to red (high)
-        t = i / max(num_bins - 1, 1)
-        r = int(40 + 180 * t)
-        g = int(160 - 80 * t)
-        b = int(80 - 60 * t)
+        # Monochrome sparkline to avoid confusion with heatmap colors
+        r, g, b = 102, 136, 170
         bars.append(
             f'<rect x="{x:.1f}" y="{y:.1f}" width="{bar_w:.1f}" '
             f'height="{bar_h:.1f}" fill="rgb({r},{g},{b})" />'
@@ -345,6 +342,9 @@ def build_html(entries, config, method_sources):
         click_hint += ' ' + ' and '.join(parts) + '.'
 
     out.append(f'<p>Click column headers to sort.{click_hint}</p>')
+    out.append('<p><label style="font-size: 0.9em; user-select: none; cursor: pointer;">'
+               '<input type="checkbox" id="rel-toggle"> Show relative (&times;fastest)'
+               '</label></p>')
     out.append('<div class="main-area"><div class="left-col">')
     out.append('<table id="t"><thead><tr>')
 
@@ -366,10 +366,11 @@ def build_html(entries, config, method_sources):
                 key = f"{method}|{p}"
                 cls = ' clickable' if (has_raw or has_source) else ''
                 spark = sparkline_svg(e['raw']) if e['raw'] else ''
+                rel = score / col_min[p] if col_min[p] > 0 else 1.0
                 out.append(
-                    f'<td class="{cls}" data-v="{score}" data-key="{h(key)}"'
+                    f'<td class="{cls}" data-v="{score}" data-rel="{rel:.2f}&times;" data-key="{h(key)}"'
                     f' style="background:rgb({r},{g},{b})">'
-                    f'{score:.3f} <span class="err">&plusmn; {error:.3f}</span>'
+                    f'<span class="val-text">{score:.3f}</span> <span class="err">&plusmn; {error:.3f}</span>'
                     f'{spark}</td>'
                 )
             else:
@@ -397,8 +398,22 @@ function updateHash() {
   if (sortCol >= 0) {
     hash += ';sort=' + sortCol + ',' + (sortAsc ? 'asc' : 'desc');
   }
+  if (document.getElementById('rel-toggle').checked) {
+    hash += ';rel=1';
+  }
   history.replaceState(null, '', hash ? '#' + hash : location.pathname);
 }
+
+document.getElementById('rel-toggle').addEventListener('change', e => {
+  const showRel = e.target.checked;
+  table.querySelectorAll('td.clickable').forEach(td => {
+    const textSpan = td.querySelector('.val-text');
+    if (textSpan) {
+      textSpan.textContent = showRel ? td.dataset.rel : parseFloat(td.dataset.v).toFixed(3);
+    }
+  });
+  updateHash();
+});
 
 function applySort(col, asc) {
   sortCol = col;
@@ -485,6 +500,11 @@ if (location.hash.length > 1) {
     const m = parts[i].match(/^sort=(\d+),(asc|desc)$/);
     if (m) {
       applySort(parseInt(m[1]), m[2] === 'asc');
+    }
+    if (parts[i] === 'rel=1') {
+      const toggle = document.getElementById('rel-toggle');
+      toggle.checked = true;
+      toggle.dispatchEvent(new Event('change'));
     }
   }
   if (cellKey) {

--- a/lucene/benchmark-jmh/jmh-table.py
+++ b/lucene/benchmark-jmh/jmh-table.py
@@ -382,14 +382,16 @@ headers.forEach(th => {
   });
 });
 
-// Cell click: histogram + source
-table.querySelector('tbody').addEventListener('click', e => {
-  const td = e.target.closest('td.clickable');
+// Activate a cell by its data-key: highlight, show source + histogram, update hash
+function activateCell(key) {
+  const td = table.querySelector(`td[data-key="${CSS.escape(key)}"]`);
   if (!td) return;
   table.querySelectorAll('td.selected').forEach(el => el.classList.remove('selected'));
   td.classList.add('selected');
-  const key = td.dataset.key;
   const [method, param] = key.split('|');
+
+  // Update URL hash (without scrolling)
+  history.replaceState(null, '', '#' + key);
 
   // Show source code
   const srcPanel = document.getElementById('source-panel');
@@ -409,7 +411,22 @@ table.querySelector('tbody').addEventListener('click', e => {
   } else {
     document.getElementById('hist-panel').innerHTML = '';
   }
+
+  // Scroll histogram into view
+  document.getElementById('hist-panel').scrollIntoView({behavior: 'smooth', block: 'nearest'});
+}
+
+// Cell click
+table.querySelector('tbody').addEventListener('click', e => {
+  const td = e.target.closest('td.clickable');
+  if (!td) return;
+  activateCell(td.dataset.key);
 });
+
+// On page load, activate cell from URL hash if present
+if (location.hash.length > 1) {
+  activateCell(decodeURIComponent(location.hash.slice(1)));
+}
 
 // Pick the best display unit and scale factor.
 function pickDisplayUnit(values) {

--- a/lucene/benchmark-jmh/jmh-table.py
+++ b/lucene/benchmark-jmh/jmh-table.py
@@ -79,6 +79,8 @@ def parse_jmh_json(data):
         if i == 0:
             mode_map = {'avgt': 'Average Time', 'thrpt': 'Throughput',
                         'sample': 'Sampling', 'ss': 'Single Shot'}
+            # split jvmArgs into harness args (module-path, module-main)
+            # vs benchmark args (user/annotation provided like -Xmx, -XX:)
             all_jvm_args = result.get('jvmArgs', [])
             harness_prefixes = ('--module-path', '-Djdk.module.main', '-Djmh.')
             harness_args = [a for a in all_jvm_args
@@ -397,7 +399,6 @@ def build_html(entries, config, method_sources):
         out.append(f'<th data-col="{i+1}">size={h(s)}<br><small>{h(unit)}</small></th>')
     out.append('</tr></thead><tbody>')
 
-    default_dist = 'random' if 'random' in dists else dists[0]
     for method in methods:
         out.append('<tr>')
         out.append(f'<td>{h(method)}</td>')
@@ -556,29 +557,6 @@ if (location.hash.length > 1) {
   updateTable();
 }
 
-// Histogram drawing logic (similar to previous version but uses dist/method/size)
-function drawHistogram(dist, method, size, samples) {
-  const panel = document.getElementById('hist-panel');
-  const n = samples.length;
-  const du = pickDisplayUnit(samples);
-  const vals = samples.map(v => v * du.scale);
-  const displayUnit = du.label;
-  const sorted = [...vals].sort((a, b) => a - b);
-  const mean = vals.reduce((a, b) => a + b, 0) / n;
-  const min = sorted[0], max = sorted[n - 1];
-  const statPrec = smartPrecision(max - min, 20);
-
-  panel.innerHTML = `
-    <h3>${method} &mdash; size=${size} (${dist})</h3>
-    <div class="stats">
-      ${n} samples &nbsp;|&nbsp; mean: ${mean.toFixed(statPrec)} ${displayUnit} &nbsp;|&nbsp; 
-      range: [${min.toFixed(statPrec)}, ${max.toFixed(statPrec)}]
-    </div>
-    <canvas id="hist-canvas" width="700" height="300"></canvas>
-  `;
-  // ... (rest of drawHistogram canvas logic omitted for brevity, keeping same implementation)
-}
-""")
 // Pick the best display unit and scale factor.
 function pickDisplayUnit(values) {
   const mean = values.reduce((a, b) => a + b, 0) / values.length;
@@ -607,9 +585,8 @@ function fmtVal(v, prec) {
   return v.toFixed(prec);
 }
 
-function drawHistogram(key, samples) {
+function drawHistogram(dist, method, size, samples) {
   const panel = document.getElementById('hist-panel');
-  const [method, param] = key.split('|');
   const n = samples.length;
 
   const du = pickDisplayUnit(samples);
@@ -642,7 +619,7 @@ function drawHistogram(key, samples) {
   const ch = H - pad.top - pad.bottom;
 
   panel.innerHTML = `
-    <h3>${method} &mdash; size=${param}</h3>
+    <h3>${method} &mdash; size=${size} (${dist})</h3>
     <div class="stats">
       ${n} samples &nbsp;|&nbsp;
       mean: ${fmtVal(mean, statPrec)} ${displayUnit} &nbsp;|&nbsp;

--- a/lucene/benchmark-jmh/jmh-table.py
+++ b/lucene/benchmark-jmh/jmh-table.py
@@ -58,6 +58,7 @@ def parse_jmh_json(data):
     """Parse JMH JSON output. Returns (entries, config_dict)."""
     entries = []
     config = {}
+    total_sec = 0
     for i, result in enumerate(data):
         bench = result['benchmark'].rsplit('.', 1)[-1]
         params = result.get('params', {})
@@ -77,6 +78,26 @@ def parse_jmh_json(data):
             'unit': pm['scoreUnit'],
             'raw': raw,
         })
+        
+        # Estimate total time for this benchmark
+        forks = result.get('forks', 0)
+        wi = result.get('warmupIterations', 0)
+        wt = result.get('warmupTime', '0 s')
+        mi = result.get('measurementIterations', 0)
+        mt = result.get('measurementTime', '0 s')
+        
+        def to_sec(t_str):
+            try:
+                val, unit = t_str.split()
+                val = float(val)
+                if unit == 'ms': return val / 1000
+                if unit == 's': return val
+                if unit == 'min': return val * 60
+                return 0
+            except: return 0
+            
+        total_sec += forks * (wi * to_sec(wt) + mi * to_sec(mt))
+
         if i == 0:
             mode_map = {'avgt': 'Average Time', 'thrpt': 'Throughput',
                         'sample': 'Sampling', 'ss': 'Single Shot'}
@@ -104,6 +125,15 @@ def parse_jmh_json(data):
                 'vmVersion': result.get('vmVersion', ''),
                 'jmhVersion': result.get('jmhVersion', ''),
             }
+            
+    if config:
+        if total_sec > 3600:
+            config['totalTime'] = f"{total_sec/3600:.1f} hours"
+        elif total_sec > 60:
+            config['totalTime'] = f"{total_sec/60:.1f} mins"
+        else:
+            config['totalTime'] = f"{total_sec:.1f} s"
+
     return entries, config
 
 
@@ -366,6 +396,8 @@ def build_html(entries, config, method_sources):
             ('Warmup', f"{config.get('warmupIterations','?')} iter \u00d7 {config.get('warmupTime','?')}"),
             ('Measurement', f"{config.get('measurementIterations','?')} iter \u00d7 {config.get('measurementTime','?')}"),
         ]
+        if config.get('totalTime'):
+            items.append(('Total time (approx)', config.get('totalTime')))
         jvm_desc = ' '.join(s for s in [config.get('vmName', ''), config.get('vmVersion', '')] if s)
         if config.get('jdkVersion'): jvm_desc = f"JDK {config.get('jdkVersion')}, {jvm_desc}"
         if jvm_desc: items.append(('JVM', jvm_desc))

--- a/lucene/benchmark-jmh/jmh-table.py
+++ b/lucene/benchmark-jmh/jmh-table.py
@@ -76,6 +76,14 @@ def parse_jmh_json(data):
         if i == 0:
             mode_map = {'avgt': 'Average Time', 'thrpt': 'Throughput',
                         'sample': 'Sampling', 'ss': 'Single Shot'}
+            # split jvmArgs into harness args (module-path, module-main)
+            # vs benchmark args (user/annotation provided like -Xmx, -XX:)
+            all_jvm_args = result.get('jvmArgs', [])
+            harness_prefixes = ('--module-path', '-Djdk.module.main', '-Djmh.')
+            harness_args = [a for a in all_jvm_args
+                            if any(a.startswith(p) for p in harness_prefixes)]
+            benchmark_args = [a for a in all_jvm_args
+                              if not any(a.startswith(p) for p in harness_prefixes)]
             config = {
                 'mode': mode_map.get(result.get('mode', ''), result.get('mode', '?')),
                 'forks': result.get('forks', '?'),
@@ -84,7 +92,13 @@ def parse_jmh_json(data):
                 'warmupTime': result.get('warmupTime', '?'),
                 'measurementIterations': result.get('measurementIterations', '?'),
                 'measurementTime': result.get('measurementTime', '?'),
-                'jvmArgs': result.get('jvmArgs', []),
+                'harnessJvmArgs': harness_args,
+                'benchmarkJvmArgs': benchmark_args,
+                'jvm': result.get('jvm', ''),
+                'jdkVersion': result.get('jdkVersion', ''),
+                'vmName': result.get('vmName', ''),
+                'vmVersion': result.get('vmVersion', ''),
+                'jmhVersion': result.get('jmhVersion', ''),
             }
     return entries, config
 
@@ -293,9 +307,29 @@ def build_html(entries, config, method_sources):
             ('Warmup', f"{config.get('warmupIterations','?')} iter \u00d7 {config.get('warmupTime','?')}"),
             ('Measurement', f"{config.get('measurementIterations','?')} iter \u00d7 {config.get('measurementTime','?')}"),
         ]
-        jvm_args = config.get('jvmArgs', [])
-        if jvm_args:
-            items.append(('JVM args', ' '.join(str(a) for a in jvm_args)))
+        # JVM identity
+        jvm = config.get('jvm', '')
+        jdk_ver = config.get('jdkVersion', '')
+        vm_name = config.get('vmName', '')
+        vm_ver = config.get('vmVersion', '')
+        jvm_desc = ' '.join(s for s in [vm_name, vm_ver] if s)
+        if jdk_ver:
+            jvm_desc = f"JDK {jdk_ver}, {jvm_desc}" if jvm_desc else f"JDK {jdk_ver}"
+        if jvm:
+            jvm_desc += f" ({jvm})" if jvm_desc else jvm
+        if jvm_desc:
+            items.append(('JVM', jvm_desc))
+        jmh_ver = config.get('jmhVersion', '')
+        if jmh_ver:
+            items.append(('JMH version', jmh_ver))
+        # benchmark JVM args (from @Fork annotation, e.g. -Xmx, -XX:)
+        bench_args = config.get('benchmarkJvmArgs', [])
+        if bench_args:
+            items.append(('Fork JVM args', ' '.join(bench_args)))
+        # harness JVM args (module-path, module-main, etc.)
+        harness_args = config.get('harnessJvmArgs', [])
+        if harness_args:
+            items.append(('Harness JVM args', ' '.join(harness_args)))
         for label, val in items:
             out.append(f'<tr><td class="label">{h(label)}</td><td class="val">{h(val)}</td></tr>')
         out.append('</table>')

--- a/lucene/benchmark-jmh/jmh-table.py
+++ b/lucene/benchmark-jmh/jmh-table.py
@@ -390,29 +390,48 @@ def build_html(entries, config, method_sources):
 const table = document.getElementById('t');
 const headers = table.querySelectorAll('th');
 let sortCol = -1, sortAsc = true;
+let activeKey = '';
+
+function updateHash() {
+  let hash = activeKey || '';
+  if (sortCol >= 0) {
+    hash += ';sort=' + sortCol + ',' + (sortAsc ? 'asc' : 'desc');
+  }
+  history.replaceState(null, '', hash ? '#' + hash : location.pathname);
+}
+
+function applySort(col, asc) {
+  sortCol = col;
+  sortAsc = asc;
+  headers.forEach(h => { const a = h.querySelector('.arrow'); if (a) a.remove(); });
+  const th = table.querySelector(`th[data-col="${col}"]`);
+  if (th) {
+    const arrow = document.createElement('span');
+    arrow.className = 'arrow';
+    arrow.textContent = sortAsc ? '\u25B2' : '\u25BC';
+    th.appendChild(arrow);
+  }
+  const tbody = table.querySelector('tbody');
+  const rows = Array.from(tbody.querySelectorAll('tr'));
+  rows.sort((a, b) => {
+    if (col === 0) {
+      const av = a.children[0].textContent, bv = b.children[0].textContent;
+      return sortAsc ? av.localeCompare(bv) : bv.localeCompare(av);
+    }
+    const av = parseFloat(a.children[col].dataset.v);
+    const bv = parseFloat(b.children[col].dataset.v);
+    return sortAsc ? av - bv : bv - av;
+  });
+  rows.forEach(r => tbody.appendChild(r));
+}
 
 headers.forEach(th => {
   th.addEventListener('click', e => {
     e.stopPropagation();
     const col = parseInt(th.dataset.col);
-    if (sortCol === col) { sortAsc = !sortAsc; } else { sortCol = col; sortAsc = true; }
-    headers.forEach(h => { const a = h.querySelector('.arrow'); if (a) a.remove(); });
-    const arrow = document.createElement('span');
-    arrow.className = 'arrow';
-    arrow.textContent = sortAsc ? '\u25B2' : '\u25BC';
-    th.appendChild(arrow);
-    const tbody = table.querySelector('tbody');
-    const rows = Array.from(tbody.querySelectorAll('tr'));
-    rows.sort((a, b) => {
-      if (col === 0) {
-        const av = a.children[0].textContent, bv = b.children[0].textContent;
-        return sortAsc ? av.localeCompare(bv) : bv.localeCompare(av);
-      }
-      const av = parseFloat(a.children[col].dataset.v);
-      const bv = parseFloat(b.children[col].dataset.v);
-      return sortAsc ? av - bv : bv - av;
-    });
-    rows.forEach(r => tbody.appendChild(r));
+    const asc = (sortCol === col) ? !sortAsc : true;
+    applySort(col, asc);
+    updateHash();
   });
 });
 
@@ -422,10 +441,10 @@ function activateCell(key) {
   if (!td) return;
   table.querySelectorAll('td.selected').forEach(el => el.classList.remove('selected'));
   td.classList.add('selected');
+  activeKey = key;
   const [method, param] = key.split('|');
 
-  // Update URL hash (without scrolling)
-  history.replaceState(null, '', '#' + key);
+  updateHash();
 
   // Show source code
   const srcPanel = document.getElementById('source-panel');
@@ -457,9 +476,20 @@ table.querySelector('tbody').addEventListener('click', e => {
   activateCell(td.dataset.key);
 });
 
-// On page load, activate cell from URL hash if present
+// On page load, restore state from URL hash
 if (location.hash.length > 1) {
-  activateCell(decodeURIComponent(location.hash.slice(1)));
+  const raw = decodeURIComponent(location.hash.slice(1));
+  const parts = raw.split(';');
+  const cellKey = parts[0] || '';
+  for (let i = 1; i < parts.length; i++) {
+    const m = parts[i].match(/^sort=(\d+),(asc|desc)$/);
+    if (m) {
+      applySort(parseInt(m[1]), m[2] === 'asc');
+    }
+  }
+  if (cellKey) {
+    activateCell(cellKey);
+  }
 }
 
 // Pick the best display unit and scale factor.

--- a/lucene/benchmark-jmh/jmh-table.py
+++ b/lucene/benchmark-jmh/jmh-table.py
@@ -60,14 +60,17 @@ def parse_jmh_json(data):
     for i, result in enumerate(data):
         bench = result['benchmark'].rsplit('.', 1)[-1]
         params = result.get('params', {})
-        param = list(params.values())[0] if params else ''
+        # Handle multiple params: ScoreDocSortBenchmark uses 'size' and 'distribution'
+        size = params.get('size', '')
+        dist = params.get('distribution', 'random')
         pm = result['primaryMetric']
         raw = []
         for fork_data in pm.get('rawData', []):
             raw.extend(fork_data)
         entries.append({
             'method': bench,
-            'param': param,
+            'size': size,
+            'dist': dist,
             'score': pm['score'],
             'error': pm['scoreError'],
             'unit': pm['scoreUnit'],
@@ -76,8 +79,6 @@ def parse_jmh_json(data):
         if i == 0:
             mode_map = {'avgt': 'Average Time', 'thrpt': 'Throughput',
                         'sample': 'Sampling', 'ss': 'Single Shot'}
-            # split jvmArgs into harness args (module-path, module-main)
-            # vs benchmark args (user/annotation provided like -Xmx, -XX:)
             all_jvm_args = result.get('jvmArgs', [])
             harness_prefixes = ('--module-path', '-Djdk.module.main', '-Djmh.')
             harness_args = [a for a in all_jvm_args
@@ -104,7 +105,7 @@ def parse_jmh_json(data):
 
 
 def extract_methods(source_path):
-    """Extract @Benchmark method bodies from a Java source file.
+    """Extract @Benchmark method bodies and their runXXX helpers from a Java source file.
 
     Returns dict of method_name -> source_code_string.
     """
@@ -113,53 +114,73 @@ def extract_methods(source_path):
         return methods
     try:
         with open(source_path, 'r') as f:
-            lines = f.readlines()
+            content = f.read()
     except (OSError, IOError):
         return methods
 
-    i = 0
-    while i < len(lines):
-        # Look for @Benchmark annotation
-        if '@Benchmark' in lines[i]:
-            # Collect comment lines above @Benchmark
-            comment_start = i
-            j = i - 1
-            while j >= 0 and lines[j].strip().startswith('//'):
-                comment_start = j
-                j -= 1
-            # Find method signature (next line with '{')
-            sig_line = i + 1
-            while sig_line < len(lines) and '{' not in lines[sig_line]:
-                sig_line += 1
-            if sig_line >= len(lines):
-                i += 1
-                continue
-            # Extract method name
-            sig = lines[sig_line].strip()
-            m = re.search(r'\b(\w+)\s*\(', sig)
-            if not m:
-                i += 1
-                continue
-            method_name = m.group(1)
-            # Find matching closing brace by counting
-            depth = 0
-            end_line = sig_line
-            for k in range(sig_line, len(lines)):
-                depth += lines[k].count('{') - lines[k].count('}')
+    # 1. Find all methods first (crude but effective for this benchmark style)
+    all_methods = {}
+    # Matches: [modifiers] [type] name([args]) { [body] }
+    # Handles nested braces
+    pos = 0
+    while True:
+        m = re.search(r'(?:public|private|protected|static|\s)+\s+[\w<>[\]]+\s+(\w+)\s*\([^)]*\)\s*(?:throws\s+[\w, \t]+)?\s*\{', content[pos:])
+        if not m:
+            break
+        method_name = m.group(1)
+        start_brace = pos + m.end() - 1
+        
+        # Find matching closing brace
+        depth = 0
+        end_brace = -1
+        for i in range(start_brace, len(content)):
+            if content[i] == '{':
+                depth += 1
+            elif content[i] == '}':
+                depth -= 1
                 if depth == 0:
-                    end_line = k
+                    end_brace = i
                     break
-            # Extract the full method including leading comment
-            method_lines = lines[comment_start:end_line + 1]
-            # Dedent: find minimum leading whitespace
-            non_empty = [l for l in method_lines if l.strip()]
+        
+        if end_brace != -1:
+            # Find start of method (including annotations/comments)
+            method_start = pos + m.start()
+            # Look back for comments or annotations
+            lines = content[:method_start].splitlines()
+            actual_start = method_start
+            for i in range(len(lines) - 1, -1, -1):
+                line = lines[i].strip()
+                if line.startswith('@') or line.startswith('//') or line.startswith('*') or line.startswith('/*'):
+                    actual_start = content.rfind(lines[i], 0, actual_start)
+                elif not line:
+                    continue
+                else:
+                    break
+            
+            body = content[actual_start:end_brace + 1]
+            # Dedent
+            lines = body.splitlines()
+            non_empty = [l for l in lines if l.strip()]
             if non_empty:
                 min_indent = min(len(l) - len(l.lstrip()) for l in non_empty)
-                method_lines = [l[min_indent:] if len(l) > min_indent else l for l in method_lines]
-            methods[method_name] = ''.join(method_lines).rstrip()
-            i = end_line + 1
+                body = '\n'.join(l[min_indent:] if len(l) > min_indent else l for l in lines)
+            
+            all_methods[method_name] = body
+            pos = end_brace + 1
         else:
-            i += 1
+            pos += m.end()
+
+    # 2. Filter for @Benchmark methods and attach runXXX helpers
+    for name, body in all_methods.items():
+        if '@Benchmark' in body:
+            # Look for runXXX call: e.g. runJdkSortLambda(work)
+            # Pattern: run followed by capitalized method name
+            run_name = "run" + name[0].upper() + name[1:]
+            if run_name in all_methods:
+                methods[name] = body + "\n\n" + all_methods[run_name]
+            else:
+                methods[name] = body
+    
     return methods
 
 
@@ -225,32 +246,65 @@ def build_html(entries, config, method_sources):
     has_raw = any(e['raw'] for e in entries)
     has_source = bool(method_sources)
 
-    seen_params = dict()
+    seen_sizes = dict()
     seen_methods = dict()
+    seen_dists = dict()
     for e in entries:
-        seen_params[e['param']] = None
+        seen_sizes[e['size']] = None
         seen_methods[e['method']] = None
-    params = list(seen_params)
-    methods = list(seen_methods)
+        seen_dists[e['dist']] = None
+
+    # Sort sizes numerically if possible
+    try:
+        sizes = sorted(seen_sizes.keys(), key=lambda x: int(x))
+    except ValueError:
+        sizes = sorted(seen_sizes.keys())
+
+    methods = sorted(seen_methods.keys())
+    dists = sorted(seen_dists.keys())
     unit = entries[0]['unit']
 
+    # grid[dist][method][size] = entry
     grid = {}
     for e in entries:
-        grid.setdefault(e['method'], {})[e['param']] = e
+        grid.setdefault(e['dist'], {}).setdefault(e['method'], {})[e['size']] = e
 
-    col_min = {}
-    col_max = {}
-    for p in params:
-        scores = [grid[m][p]['score'] for m in methods if p in grid[m]]
-        col_min[p] = min(scores) if scores else 0
-        col_max[p] = max(scores) if scores else 1
+    # Precalculate mins/maxs per (dist, size) for heatmap
+    # stats[dist][size] = {min, max}
+    stats = {}
+    for d in dists:
+        stats[d] = {}
+        for s in sizes:
+            scores = [grid[d][m][s]['score'] for m in methods if s in grid[d].get(m, {})]
+            if scores:
+                stats[d][s] = {'min': min(scores), 'max': max(scores)}
 
     h = html.escape
 
-    raw_js = {}
-    for e in entries:
-        if e['raw']:
-            raw_js[f"{e['method']}|{e['param']}"] = e['raw']
+    # JSON data for JS
+    # data_js[dist][method][size] = {score, error, rel, color, spark}
+    data_js = {}
+    for d in dists:
+        data_js[d] = {}
+        for m in methods:
+            data_js[d][m] = {}
+            for s in sizes:
+                if s in grid[d].get(m, {}):
+                    e = grid[d][m][s]
+                    score = e['score']
+                    lo, hi = stats[d][s]['min'], stats[d][s]['max']
+                    span = hi - lo
+                    t = (score - lo) / span if span > 0 else 0
+                    r, g, b = lerp_color(t)
+                    rel = score / lo if lo > 0 else 1.0
+                    data_js[d][m][s] = {
+                        'score': f"{score:.3f}",
+                        'error': f"{e['error']:.3f}",
+                        'rel': f"{rel:.2f}&times;",
+                        'color': f"rgb({r},{g},{b})",
+                        'spark': sparkline_svg(e['raw']) if e['raw'] else '',
+                        'raw': e['raw']
+                    }
 
     sources_js = {name: src for name, src in method_sources.items()}
 
@@ -269,7 +323,7 @@ def build_html(entries, config, method_sources):
   .left-col {{ flex-shrink: 0; }}
   .right-col {{ flex-grow: 1; min-width: 0; }}
   #source-panel {{ display: none; background: #1e1e1e; color: #d4d4d4; border-radius: 6px;
-                   padding: 1rem; max-width: 700px; box-shadow: 0 2px 8px rgba(0,0,0,0.2); }}
+                   padding: 1rem; max-width: 800px; box-shadow: 0 2px 8px rgba(0,0,0,0.2); }}
   #source-panel h3 {{ margin: 0 0 0.5rem 0; color: #9cdcfe; font-size: 0.95em; }}
   #source-panel pre {{ margin: 0; font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code',
                        'Consolas', monospace; font-size: 13px; line-height: 1.5;
@@ -290,6 +344,8 @@ def build_html(entries, config, method_sources):
   #hist-panel h3 {{ margin: 0 0 0.5rem 0; }}
   #hist-panel .stats {{ color: #555; font-size: 0.9em; margin-bottom: 0.5rem; }}
   #hist-canvas {{ border: 1px solid #ccc; background: #fff; }}
+  .controls {{ display: flex; gap: 2rem; align-items: center; margin-bottom: 1rem; }}
+  select {{ padding: 4px 8px; border-radius: 4px; border: 1px solid #ccc; }}
 </style>
 </head><body>
 <h2>JMH Results</h2>""")
@@ -304,29 +360,11 @@ def build_html(entries, config, method_sources):
             ('Warmup', f"{config.get('warmupIterations','?')} iter \u00d7 {config.get('warmupTime','?')}"),
             ('Measurement', f"{config.get('measurementIterations','?')} iter \u00d7 {config.get('measurementTime','?')}"),
         ]
-        # JVM identity
-        jvm = config.get('jvm', '')
-        jdk_ver = config.get('jdkVersion', '')
-        vm_name = config.get('vmName', '')
-        vm_ver = config.get('vmVersion', '')
-        jvm_desc = ' '.join(s for s in [vm_name, vm_ver] if s)
-        if jdk_ver:
-            jvm_desc = f"JDK {jdk_ver}, {jvm_desc}" if jvm_desc else f"JDK {jdk_ver}"
-        if jvm:
-            jvm_desc += f" ({jvm})" if jvm_desc else jvm
-        if jvm_desc:
-            items.append(('JVM', jvm_desc))
-        jmh_ver = config.get('jmhVersion', '')
-        if jmh_ver:
-            items.append(('JMH version', jmh_ver))
-        # benchmark JVM args (from @Fork annotation, e.g. -Xmx, -XX:)
-        bench_args = config.get('benchmarkJvmArgs', [])
-        if bench_args:
-            items.append(('Fork JVM args', ' '.join(bench_args)))
-        # harness JVM args (module-path, module-main, etc.)
-        harness_args = config.get('harnessJvmArgs', [])
-        if harness_args:
-            items.append(('Harness JVM args', ' '.join(harness_args)))
+        jvm_desc = ' '.join(s for s in [config.get('vmName', ''), config.get('vmVersion', '')] if s)
+        if config.get('jdkVersion'): jvm_desc = f"JDK {config.get('jdkVersion')}, {jvm_desc}"
+        if jvm_desc: items.append(('JVM', jvm_desc))
+        if config.get('jmhVersion'): items.append(('JMH version', config.get('jmhVersion')))
+        if config.get('benchmarkJvmArgs'): items.append(('Fork JVM args', ' '.join(config.get('benchmarkJvmArgs'))))
         for label, val in items:
             out.append(f'<tr><td class="label">{h(label)}</td><td class="val">{h(val)}</td></tr>')
         out.append('</table>')
@@ -335,85 +373,98 @@ def build_html(entries, config, method_sources):
     if has_raw or has_source:
         click_hint = ' Click a data cell to see'
         parts = []
-        if has_raw:
-            parts.append('its iteration histogram')
-        if has_source:
-            parts.append('the method source code')
+        if has_raw: parts.append('its iteration histogram')
+        if has_source: parts.append('the method source code')
         click_hint += ' ' + ' and '.join(parts) + '.'
 
     out.append(f'<p>Click column headers to sort.{click_hint}</p>')
-    out.append('<p><label style="font-size: 0.9em; user-select: none; cursor: pointer;">'
+
+    out.append('<div class="controls">')
+    out.append('<div><label>Distribution: </label><select id="dist-picker">')
+    for d in dists:
+        selected = ' selected' if d == 'random' else ''
+        out.append(f'<option value="{h(d)}"{selected}>{h(d)}</option>')
+    out.append('</select></div>')
+    out.append('<div><label style="font-size: 0.9em; user-select: none; cursor: pointer;">'
                '<input type="checkbox" id="rel-toggle"> Show relative (&times;fastest)'
-               '</label></p>')
+               '</label></div>')
+    out.append('</div>')
+
     out.append('<div class="main-area"><div class="left-col">')
     out.append('<table id="t"><thead><tr>')
-
-    out.append(f'<th data-col="0">Algorithm</th>')
-    for i, p in enumerate(params):
-        out.append(f'<th data-col="{i+1}">size={h(p)}<br><small>{h(unit)}</small></th>')
+    out.append('<th data-col="0">Algorithm</th>')
+    for i, s in enumerate(sizes):
+        out.append(f'<th data-col="{i+1}">size={h(s)}<br><small>{h(unit)}</small></th>')
     out.append('</tr></thead><tbody>')
 
+    default_dist = 'random' if 'random' in dists else dists[0]
     for method in methods:
         out.append('<tr>')
         out.append(f'<td>{h(method)}</td>')
-        for p in params:
-            if p in grid[method]:
-                e = grid[method][p]
-                score, error = e['score'], e['error']
-                span = col_max[p] - col_min[p]
-                t = (score - col_min[p]) / span if span > 0 else 0
-                r, g, b = lerp_color(t)
-                key = f"{method}|{p}"
-                cls = ' clickable' if (has_raw or has_source) else ''
-                spark = sparkline_svg(e['raw']) if e['raw'] else ''
-                rel = score / col_min[p] if col_min[p] > 0 else 1.0
-                out.append(
-                    f'<td class="{cls}" data-v="{score}" data-rel="{rel:.2f}&times;" data-key="{h(key)}"'
-                    f' style="background:rgb({r},{g},{b})">'
-                    f'<span class="val-text">{score:.3f}</span> <span class="err">&plusmn; {error:.3f}</span>'
-                    f'{spark}</td>'
-                )
-            else:
-                out.append('<td data-v="999999">-</td>')
+        for s in sizes:
+            out.append(f'<td data-size="{h(s)}" data-method="{h(method)}"></td>')
         out.append('</tr>')
 
     out.append('</tbody></table>')
-    out.append('</div>')  # end left-col
+    out.append('</div>')
     out.append('<div class="right-col"><div id="source-panel"><h3 id="source-title"></h3><pre id="source-code"></pre></div></div>')
-    out.append('</div>')  # end main-area
+    out.append('</div>')
     out.append('<div id="hist-panel"></div>')
 
     out.append('<script>')
     out.append(f'const UNIT = {json.dumps(unit)};')
-    out.append(f'const RAW = {json.dumps(raw_js)};')
+    out.append(f'const DATA = {json.dumps(data_js)};')
     out.append(f'const SOURCES = {json.dumps(sources_js)};')
     out.append(r"""
 const table = document.getElementById('t');
 const headers = table.querySelectorAll('th');
+const distPicker = document.getElementById('dist-picker');
+const relToggle = document.getElementById('rel-toggle');
 let sortCol = -1, sortAsc = true;
-let activeKey = '';
+let activeKey = ''; // format: dist|method|size
 
 function updateHash() {
   let hash = activeKey || '';
   if (sortCol >= 0) {
     hash += ';sort=' + sortCol + ',' + (sortAsc ? 'asc' : 'desc');
   }
-  if (document.getElementById('rel-toggle').checked) {
+  hash += ';dist=' + distPicker.value;
+  if (relToggle.checked) {
     hash += ';rel=1';
   }
   history.replaceState(null, '', hash ? '#' + hash : location.pathname);
 }
 
-document.getElementById('rel-toggle').addEventListener('change', e => {
-  const showRel = e.target.checked;
-  table.querySelectorAll('td.clickable').forEach(td => {
-    const textSpan = td.querySelector('.val-text');
-    if (textSpan) {
-      textSpan.textContent = showRel ? td.dataset.rel : parseFloat(td.dataset.v).toFixed(3);
+function updateTable() {
+  const dist = distPicker.value;
+  const showRel = relToggle.checked;
+
+  table.querySelectorAll('tbody td[data-size]').forEach(td => {
+    const size = td.dataset.size;
+    const method = td.dataset.method;
+    const d = DATA[dist][method] ? DATA[dist][method][size] : null;
+
+    if (d) {
+      td.style.background = d.color;
+      td.className = 'clickable';
+      if (activeKey === `${dist}|${method}|${size}`) td.classList.add('selected');
+      td.dataset.v = d.score;
+      td.innerHTML = `<span class="val-text">${showRel ? d.rel : d.score}</span> ` +
+                     `<span class="err">&plusmn; ${d.error}</span>${d.spark}`;
+    } else {
+      td.style.background = '';
+      td.className = '';
+      td.innerHTML = '-';
+      td.dataset.v = '999999';
     }
   });
+
+  if (sortCol >= 0) applySort(sortCol, sortAsc);
   updateHash();
-});
+}
+
+distPicker.addEventListener('change', updateTable);
+relToggle.addEventListener('change', updateTable);
 
 function applySort(col, asc) {
   sortCol = col;
@@ -433,8 +484,8 @@ function applySort(col, asc) {
       const av = a.children[0].textContent, bv = b.children[0].textContent;
       return sortAsc ? av.localeCompare(bv) : bv.localeCompare(av);
     }
-    const av = parseFloat(a.children[col].dataset.v);
-    const bv = parseFloat(b.children[col].dataset.v);
+    const av = parseFloat(a.children[col].dataset.v || 999999);
+    const bv = parseFloat(b.children[col].dataset.v || 999999);
     return sortAsc ? av - bv : bv - av;
   });
   rows.forEach(r => tbody.appendChild(r));
@@ -450,18 +501,14 @@ headers.forEach(th => {
   });
 });
 
-// Activate a cell by its data-key: highlight, show source + histogram, update hash
-function activateCell(key) {
-  const td = table.querySelector(`td[data-key="${CSS.escape(key)}"]`);
+function activateCell(dist, method, size) {
+  const td = table.querySelector(`td[data-method="${CSS.escape(method)}"][data-size="${CSS.escape(size)}"]`);
   if (!td) return;
   table.querySelectorAll('td.selected').forEach(el => el.classList.remove('selected'));
   td.classList.add('selected');
-  activeKey = key;
-  const [method, param] = key.split('|');
+  activeKey = `${dist}|${method}|${size}`;
 
-  updateHash();
-
-  // Show source code
+  // Show source
   const srcPanel = document.getElementById('source-panel');
   const src = SOURCES[method];
   if (src) {
@@ -473,45 +520,65 @@ function activateCell(key) {
   }
 
   // Show histogram
-  const samples = RAW[key];
-  if (samples && samples.length > 0) {
-    drawHistogram(key, samples);
+  const d = DATA[dist][method][size];
+  if (d && d.raw && d.raw.length > 0) {
+    drawHistogram(dist, method, size, d.raw);
   } else {
     document.getElementById('hist-panel').innerHTML = '';
   }
-
-  // Scroll histogram into view
-  document.getElementById('hist-panel').scrollIntoView({behavior: 'smooth', block: 'nearest'});
+  updateHash();
 }
 
-// Cell click
 table.querySelector('tbody').addEventListener('click', e => {
   const td = e.target.closest('td.clickable');
   if (!td) return;
-  activateCell(td.dataset.key);
+  activateCell(distPicker.value, td.dataset.method, td.dataset.size);
 });
 
-// On page load, restore state from URL hash
+// Restore from hash
 if (location.hash.length > 1) {
   const raw = decodeURIComponent(location.hash.slice(1));
   const parts = raw.split(';');
   const cellKey = parts[0] || '';
   for (let i = 1; i < parts.length; i++) {
-    const m = parts[i].match(/^sort=(\d+),(asc|desc)$/);
-    if (m) {
-      applySort(parseInt(m[1]), m[2] === 'asc');
-    }
-    if (parts[i] === 'rel=1') {
-      const toggle = document.getElementById('rel-toggle');
-      toggle.checked = true;
-      toggle.dispatchEvent(new Event('change'));
-    }
+    const mSort = parts[i].match(/^sort=(\d+),(asc|desc)$/);
+    if (mSort) { applySort(parseInt(mSort[1]), mSort[2] === 'asc'); }
+    const mDist = parts[i].match(/^dist=(.+)$/);
+    if (mDist) { distPicker.value = mDist[1]; }
+    if (parts[i] === 'rel=1') { relToggle.checked = true; }
   }
+  updateTable();
   if (cellKey) {
-    activateCell(cellKey);
+    const [d, m, s] = cellKey.split('|');
+    if (d && m && s) activateCell(d, m, s);
   }
+} else {
+  updateTable();
 }
 
+// Histogram drawing logic (similar to previous version but uses dist/method/size)
+function drawHistogram(dist, method, size, samples) {
+  const panel = document.getElementById('hist-panel');
+  const n = samples.length;
+  const du = pickDisplayUnit(samples);
+  const vals = samples.map(v => v * du.scale);
+  const displayUnit = du.label;
+  const sorted = [...vals].sort((a, b) => a - b);
+  const mean = vals.reduce((a, b) => a + b, 0) / n;
+  const min = sorted[0], max = sorted[n - 1];
+  const statPrec = smartPrecision(max - min, 20);
+
+  panel.innerHTML = `
+    <h3>${method} &mdash; size=${size} (${dist})</h3>
+    <div class="stats">
+      ${n} samples &nbsp;|&nbsp; mean: ${mean.toFixed(statPrec)} ${displayUnit} &nbsp;|&nbsp; 
+      range: [${min.toFixed(statPrec)}, ${max.toFixed(statPrec)}]
+    </div>
+    <canvas id="hist-canvas" width="700" height="300"></canvas>
+  `;
+  // ... (rest of drawHistogram canvas logic omitted for brevity, keeping same implementation)
+}
+""")
 // Pick the best display unit and scale factor.
 function pickDisplayUnit(values) {
   const mean = values.reduce((a, b) => a + b, 0) / values.length;

--- a/lucene/benchmark-jmh/jmh-table.py
+++ b/lucene/benchmark-jmh/jmh-table.py
@@ -23,6 +23,7 @@ import sys
 import re
 import json
 import html
+import math
 
 
 def parse_jmh_text(text):
@@ -295,8 +296,11 @@ def build_html(entries, config, method_sources):
                     e = grid[d][m][s]
                     score = e['score']
                     lo, hi = stats[d][s]['min'], stats[d][s]['max']
-                    span = hi - lo
-                    t = (score - lo) / span if span > 0 else 0
+                    if lo > 0 and hi > lo:
+                        t = math.log(score / lo) / math.log(hi / lo)
+                    else:
+                        span = hi - lo
+                        t = (score - lo) / span if span > 0 else 0
                     r, g, b = lerp_color(t)
                     rel = score / lo if lo > 0 else 1.0
                     data_js[d][m][s] = {
@@ -702,14 +706,16 @@ function drawHistogram(dist, method, size, samples) {
 
 
 if __name__ == '__main__':
-    if len(sys.argv) < 2:
-        print("Usage: jmh-table.py <BenchmarkSource.java> < results.json > results.html",
-              file=sys.stderr)
-        sys.exit(1)
-    source_path = sys.argv[1]
-    method_sources = extract_methods(source_path)
+    import argparse
+    parser = argparse.ArgumentParser(description='Parse JMH JSON/text output into an interactive HTML table.')
+    parser.add_argument('source', help='Path to Java source file containing @Benchmark methods')
+    parser.add_argument('--skip', nargs='+', default=[], metavar='ALGO',
+                        help='Algorithm names to exclude (substring match, case-insensitive)')
+    args = parser.parse_args()
+
+    method_sources = extract_methods(args.source)
     if not method_sources:
-        print(f"No @Benchmark methods found in {source_path}", file=sys.stderr)
+        print(f"No @Benchmark methods found in {args.source}", file=sys.stderr)
         sys.exit(1)
 
     text = sys.stdin.read().strip()
@@ -724,5 +730,10 @@ if __name__ == '__main__':
         entries, config = parse_jmh_json(data)
     else:
         entries, config = parse_jmh_text(text)
+
+    if args.skip:
+        skip_lower = [s.lower() for s in args.skip]
+        entries = [e for e in entries
+                   if not any(sk in e['method'].lower() for sk in skip_lower)]
 
     print(build_html(entries, config, method_sources))

--- a/lucene/benchmark-jmh/jmh-table.py
+++ b/lucene/benchmark-jmh/jmh-table.py
@@ -638,9 +638,15 @@ function drawHistogram(key, samples) {
 
 
 if __name__ == '__main__':
-    # Optional positional arg: path to Java source file
-    source_path = sys.argv[1] if len(sys.argv) > 1 else None
+    if len(sys.argv) < 2:
+        print("Usage: jmh-table.py <BenchmarkSource.java> < results.json > results.html",
+              file=sys.stderr)
+        sys.exit(1)
+    source_path = sys.argv[1]
     method_sources = extract_methods(source_path)
+    if not method_sources:
+        print(f"No @Benchmark methods found in {source_path}", file=sys.stderr)
+        sys.exit(1)
 
     text = sys.stdin.read().strip()
     if not text:

--- a/lucene/benchmark-jmh/run-benchmark.sh
+++ b/lucene/benchmark-jmh/run-benchmark.sh
@@ -23,4 +23,7 @@ echo "=== Running JMH ===" >&2
 exec "$JAVA_HOME/bin/java" \
   --module-path "$ROOT_DIR/lucene/benchmark-jmh/build/benchmarks" \
   --module org.apache.lucene.benchmark.jmh \
+  --sun-misc-unsafe-memory-access=allow \
+  -rf json -rff results.json \
+  -t 8 \
   "$@"

--- a/lucene/benchmark-jmh/run-benchmark.sh
+++ b/lucene/benchmark-jmh/run-benchmark.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Compiles (if needed) and runs JMH benchmarks, passing all arguments through.
+#
+# Usage:
+#   ./lucene/benchmark-jmh/run-benchmark.sh ScoreDocSortBenchmark -rf json -rff results.json
+#
+# This ensures you never accidentally run stale bytecode.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+: "${JAVA_HOME:=/usr/lib/jvm/java-25-openjdk}"
+export JAVA_HOME
+export JAVA25_HOME="$JAVA_HOME"
+export RUNTIME_JAVA_HOME="$JAVA_HOME"
+
+echo "=== Compiling benchmarks ===" >&2
+JAVA_HOME="$JAVA_HOME" "$ROOT_DIR/gradlew" -p "$ROOT_DIR" :lucene:benchmark-jmh:assemble --quiet
+
+echo "=== Running JMH ===" >&2
+exec "$JAVA_HOME/bin/java" \
+  --module-path "$ROOT_DIR/lucene/benchmark-jmh/build/benchmarks" \
+  --module org.apache.lucene.benchmark.jmh \
+  "$@"

--- a/lucene/benchmark-jmh/run-benchmark.sh
+++ b/lucene/benchmark-jmh/run-benchmark.sh
@@ -25,5 +25,4 @@ exec "$JAVA_HOME/bin/java" \
   --module org.apache.lucene.benchmark.jmh \
   -jvmArgs "--sun-misc-unsafe-memory-access=allow --module-path=/l/trunk/lucene/benchmark-jmh/build/benchmarks -Djdk.module.main=org.apache.lucene.benchmark.jmh" \
   -rf json -rff results.json \
-  -t 8 \
   "$@"

--- a/lucene/benchmark-jmh/run-benchmark.sh
+++ b/lucene/benchmark-jmh/run-benchmark.sh
@@ -23,7 +23,7 @@ echo "=== Running JMH ===" >&2
 exec "$JAVA_HOME/bin/java" \
   --module-path "$ROOT_DIR/lucene/benchmark-jmh/build/benchmarks" \
   --module org.apache.lucene.benchmark.jmh \
-  --sun-misc-unsafe-memory-access=allow \
+  -jvmArgs "--sun-misc-unsafe-memory-access=allow --module-path=/l/trunk/lucene/benchmark-jmh/build/benchmarks -Djdk.module.main=org.apache.lucene.benchmark.jmh" \
   -rf json -rff results.json \
   -t 8 \
   "$@"

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -449,8 +449,10 @@ public class ScoreDocSortBenchmark {
     int len = work.length;
     int docBits = bitsNeeded(MAX_DOC);
     int indexBits = bitsNeeded(len);
-    if (docBits + indexBits <= 32) {
+    if (docBits + indexBits <= 31) {
       // pack into int[]: doc in upper bits, index in lower bits
+      // <= 31 (not 32) because Arrays.sort uses signed comparison,
+      // so bit 31 must stay clear to avoid sign-bit corruption
       int[] packed = new int[len];
       for (int i = 0; i < len; i++) {
         packed[i] = (work[i].doc << indexBits) | i;
@@ -483,8 +485,8 @@ public class ScoreDocSortBenchmark {
      * Documentation of int vs long paths given MAX_DOC = 5,000,000:
      *
      * <ul>
-     *   <li>sizes 10, 50, 100, 500 take the int[] path (23 + 9 <= 32 bits)
-     *   <li>sizes 1,000, 10,000 take the long[] path (23 + 10 > 32 bits)
+     *   <li>sizes 10, 50, 100 take the int[] path (23 + 7 = 30 <= 31 bits)
+     *   <li>sizes 500, 1,000, 10,000 take the long[] path (23 + 9 = 32 > 31 bits)
      * </ul>
      */
     bh.consume(runJdkSortPrimitiveExtractAdaptive(work));

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -171,15 +171,18 @@ public class ScoreDocSortBenchmark {
         "jdkSortPrimitiveExtractAdaptive",
         reference,
         runJdkSortPrimitiveExtractAdaptive(Arrays.copyOf(template, size)));
-    verify(
-        "lsbRadixSortExtract", reference, runLsbRadixSortExtract(Arrays.copyOf(template, size)));
+    verify("lsbRadixSortExtract", reference, runLsbRadixSortExtract(Arrays.copyOf(template, size)));
     verify("radixSort2Pass", reference, runRadixSort2Pass(Arrays.copyOf(template, size)));
   }
 
   private void verify(String name, ScoreDoc[] reference, ScoreDoc[] result) {
     if (result.length != reference.length) {
       throw new IllegalStateException(
-          name + " failed: length mismatch. expected " + reference.length + " but got " + result.length);
+          name
+              + " failed: length mismatch. expected "
+              + reference.length
+              + " but got "
+              + result.length);
     }
     for (int i = 0; i < result.length; i++) {
       if (i > 0 && result[i].doc < result[i - 1].doc) {
@@ -212,7 +215,8 @@ public class ScoreDocSortBenchmark {
     for (ScoreDoc sd : result) {
       Integer c = counts.get(sd);
       if (c == null) {
-        throw new IllegalStateException(name + " failed: result contains unknown ScoreDoc instance");
+        throw new IllegalStateException(
+            name + " failed: result contains unknown ScoreDoc instance");
       }
       if (c == 1) {
         counts.remove(sd);
@@ -523,7 +527,7 @@ public class ScoreDocSortBenchmark {
     bh.consume(runLsbRadixSortExtract(work));
   }
 
-  // ---- 12. Extract doc IDs, manual 2-pass radix sort (16-bit) ----
+  // ---- 12. Extract doc IDs, manual 4-pass radix sort (8-bit) ----
 
   private ScoreDoc[] runRadixSort2Pass(ScoreDoc[] work) {
     int len = work.length;
@@ -535,37 +539,40 @@ public class ScoreDocSortBenchmark {
         packed[i] = (work[i].doc << indexBits) | i;
       }
 
-      // 2-pass 16-bit radix sort
-      int[] bucket = new int[65536];
+      int totalBits = docBits + indexBits;
+      int[] bucket = new int[256];
       int[] workArray = new int[len];
 
-      // pass 1: lower 16 bits
-      for (int i = 0; i < len; i++) {
-        bucket[packed[i] & 0xFFFF]++;
-      }
-      for (int i = 1; i < 65536; i++) {
-        bucket[i] += bucket[i - 1];
-      }
-      for (int i = len - 1; i >= 0; i--) {
-        workArray[--bucket[packed[i] & 0xFFFF]] = packed[i];
+      // up to 4 passes over 8-bit radix, skip unnecessary high passes
+      int passes = (totalBits + 7) >>> 3; // ceil(totalBits / 8)
+      for (int pass = 0; pass < passes; pass++) {
+        int shift = pass * 8;
+        int[] src = (pass % 2 == 0) ? packed : workArray;
+        int[] dst = (pass % 2 == 0) ? workArray : packed;
+
+        // histogram
+        for (int i = 0; i < len; i++) {
+          bucket[(src[i] >>> shift) & 0xFF]++;
+        }
+        // prefix sum
+        for (int i = 1; i < 256; i++) {
+          bucket[i] += bucket[i - 1];
+        }
+        // scatter
+        for (int i = len - 1; i >= 0; i--) {
+          dst[--bucket[(src[i] >>> shift) & 0xFF]] = src[i];
+        }
+
+        Arrays.fill(bucket, 0);
       }
 
-      // pass 2: upper 16 bits
-      Arrays.fill(bucket, 0);
-      for (int i = 0; i < len; i++) {
-        bucket[(workArray[i] >>> 16) & 0xFFFF]++;
-      }
-      for (int i = 1; i < 65536; i++) {
-        bucket[i] += bucket[i - 1];
-      }
-      for (int i = len - 1; i >= 0; i--) {
-        packed[--bucket[(workArray[i] >>> 16) & 0xFFFF]] = workArray[i];
-      }
+      // if odd number of passes, result is in workArray
+      int[] sorted_packed = (passes % 2 == 0) ? packed : workArray;
 
       int indexMask = (1 << indexBits) - 1;
       ScoreDoc[] sorted = new ScoreDoc[len];
       for (int i = 0; i < len; i++) {
-        sorted[i] = work[packed[i] & indexMask];
+        sorted[i] = work[sorted_packed[i] & indexMask];
       }
       return sorted;
     } else {

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -109,7 +109,8 @@ public class ScoreDocSortBenchmark {
   @Param({"10", "50", "100", "500", "1000", "10000"})
   int size;
 
-  @Param({"random", "nearly_sorted", "reversed"})
+  // add "nearly_sorted", "reversed" to test other distributions
+  @Param({"random"})
   String distribution;
 
   /** Template array; copied before each invocation so every sort sees the same random order. */

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -18,6 +18,7 @@ package org.apache.lucene.benchmark.jmh;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.IdentityHashMap;
 import java.util.SplittableRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.lucene.search.ScoreDoc;
@@ -145,6 +146,83 @@ public class ScoreDocSortBenchmark {
         template[size - 1 - i] = tmp;
       }
     }
+
+    // verification - runs once up front per trial (per parameter set)
+    ScoreDoc[] reference = Arrays.copyOf(template, size);
+    Arrays.sort(reference, BY_DOC_ASC);
+
+    verify("jdkSortLambda", reference, runJdkSortLambda(Arrays.copyOf(template, size)));
+    verify("jdkSortComparator", reference, runJdkSortComparator(Arrays.copyOf(template, size)));
+    verify("arrayUtilIntroSort", reference, runArrayUtilIntroSort(Arrays.copyOf(template, size)));
+    verify("arrayUtilTimSort", reference, runArrayUtilTimSort(Arrays.copyOf(template, size)));
+    verify(
+        "introSorterAnonymous", reference, runIntroSorterAnonymous(Arrays.copyOf(template, size)));
+    verify("timSorterAnonymous", reference, runTimSorterAnonymous(Arrays.copyOf(template, size)));
+    verify(
+        "inPlaceMergeSorterAnonymous",
+        reference,
+        runInPlaceMergeSorterAnonymous(Arrays.copyOf(template, size)));
+    verify("jdkParallelSort", reference, runJdkParallelSort(Arrays.copyOf(template, size)));
+    verify(
+        "jdkSortPrimitiveExtractLong",
+        reference,
+        runJdkSortPrimitiveExtractLong(Arrays.copyOf(template, size)));
+    verify(
+        "jdkSortPrimitiveExtractAdaptive",
+        reference,
+        runJdkSortPrimitiveExtractAdaptive(Arrays.copyOf(template, size)));
+    verify(
+        "lsbRadixSortExtract", reference, runLsbRadixSortExtract(Arrays.copyOf(template, size)));
+    verify("radixSort2Pass", reference, runRadixSort2Pass(Arrays.copyOf(template, size)));
+  }
+
+  private void verify(String name, ScoreDoc[] reference, ScoreDoc[] result) {
+    if (result.length != reference.length) {
+      throw new IllegalStateException(
+          name + " failed: length mismatch. expected " + reference.length + " but got " + result.length);
+    }
+    for (int i = 0; i < result.length; i++) {
+      if (i > 0 && result[i].doc < result[i - 1].doc) {
+        throw new IllegalStateException(
+            name
+                + " failed: not sorted at index "
+                + i
+                + ". "
+                + result[i - 1].doc
+                + " > "
+                + result[i].doc);
+      }
+      // check if doc matches reference (handles duplicates correctly since both are doc-sorted)
+      if (result[i].doc != reference[i].doc) {
+        throw new IllegalStateException(
+            name
+                + " failed: doc mismatch at index "
+                + i
+                + ". expected "
+                + reference[i].doc
+                + " but got "
+                + result[i].doc);
+      }
+    }
+    // integrity check: ensure we didn't lose or duplicate objects
+    IdentityHashMap<ScoreDoc, Integer> counts = new IdentityHashMap<>();
+    for (ScoreDoc sd : template) {
+      counts.merge(sd, 1, Integer::sum);
+    }
+    for (ScoreDoc sd : result) {
+      Integer c = counts.get(sd);
+      if (c == null) {
+        throw new IllegalStateException(name + " failed: result contains unknown ScoreDoc instance");
+      }
+      if (c == 1) {
+        counts.remove(sd);
+      } else {
+        counts.put(sd, c - 1);
+      }
+    }
+    if (counts.isEmpty() == false) {
+      throw new IllegalStateException(name + " failed: result missing ScoreDoc instances");
+    }
   }
 
   /**
@@ -163,42 +241,57 @@ public class ScoreDocSortBenchmark {
 
   // ---- 1. JDK Arrays.sort with lambda ----
 
+  private ScoreDoc[] runJdkSortLambda(ScoreDoc[] work) {
+    Arrays.sort(work, (a, b) -> Integer.compare(a.doc, b.doc));
+    return work;
+  }
+
   @Benchmark
   public void jdkSortLambda(Blackhole bh) {
     // intentionally inline — tests whether JIT handles inline lambda differently than static
     // comparator
-    Arrays.sort(work, (a, b) -> Integer.compare(a.doc, b.doc));
-    bh.consume(work);
+    bh.consume(runJdkSortLambda(work));
   }
 
   // ---- 2. JDK Arrays.sort with static comparator ----
 
+  private ScoreDoc[] runJdkSortComparator(ScoreDoc[] work) {
+    Arrays.sort(work, BY_DOC_ASC);
+    return work;
+  }
+
   @Benchmark
   public void jdkSortComparator(Blackhole bh) {
-    Arrays.sort(work, BY_DOC_ASC);
-    bh.consume(work);
+    bh.consume(runJdkSortComparator(work));
   }
 
   // ---- 3. ArrayUtil.introSort (wraps ArrayIntroSorter) ----
 
+  private ScoreDoc[] runArrayUtilIntroSort(ScoreDoc[] work) {
+    ArrayUtil.introSort(work, BY_DOC_ASC);
+    return work;
+  }
+
   @Benchmark
   public void arrayUtilIntroSort(Blackhole bh) {
-    ArrayUtil.introSort(work, BY_DOC_ASC);
-    bh.consume(work);
+    bh.consume(runArrayUtilIntroSort(work));
   }
 
   // ---- 4. ArrayUtil.timSort (wraps ArrayTimSorter) ----
 
+  private ScoreDoc[] runArrayUtilTimSort(ScoreDoc[] work) {
+    ArrayUtil.timSort(work, BY_DOC_ASC);
+    return work;
+  }
+
   @Benchmark
   public void arrayUtilTimSort(Blackhole bh) {
-    ArrayUtil.timSort(work, BY_DOC_ASC);
-    bh.consume(work);
+    bh.consume(runArrayUtilTimSort(work));
   }
 
   // ---- 5. Anonymous IntroSorter ----
 
-  @Benchmark
-  public void introSorterAnonymous(Blackhole bh) {
+  private ScoreDoc[] runIntroSorterAnonymous(ScoreDoc[] work) {
     final ScoreDoc[] arr = work;
     new IntroSorter() {
       ScoreDoc pivot;
@@ -225,13 +318,17 @@ public class ScoreDocSortBenchmark {
         return Integer.compare(arr[i].doc, arr[j].doc);
       }
     }.sort(0, arr.length);
-    bh.consume(work);
+    return arr;
+  }
+
+  @Benchmark
+  public void introSorterAnonymous(Blackhole bh) {
+    bh.consume(runIntroSorterAnonymous(work));
   }
 
   // ---- 6. Anonymous TimSorter ----
 
-  @Benchmark
-  public void timSorterAnonymous(Blackhole bh) {
+  private ScoreDoc[] runTimSorterAnonymous(ScoreDoc[] work) {
     final ScoreDoc[] arr = work;
     final int len = arr.length;
     new TimSorter(len / 2) {
@@ -269,13 +366,17 @@ public class ScoreDocSortBenchmark {
         return Integer.compare(tmp[i].doc, arr[j].doc);
       }
     }.sort(0, len);
-    bh.consume(work);
+    return arr;
+  }
+
+  @Benchmark
+  public void timSorterAnonymous(Blackhole bh) {
+    bh.consume(runTimSorterAnonymous(work));
   }
 
   // ---- 7. Anonymous InPlaceMergeSorter ----
 
-  @Benchmark
-  public void inPlaceMergeSorterAnonymous(Blackhole bh) {
+  private ScoreDoc[] runInPlaceMergeSorterAnonymous(ScoreDoc[] work) {
     final ScoreDoc[] arr = work;
     new InPlaceMergeSorter() {
       @Override
@@ -290,21 +391,29 @@ public class ScoreDocSortBenchmark {
         return Integer.compare(arr[i].doc, arr[j].doc);
       }
     }.sort(0, arr.length);
-    bh.consume(work);
+    return arr;
+  }
+
+  @Benchmark
+  public void inPlaceMergeSorterAnonymous(Blackhole bh) {
+    bh.consume(runInPlaceMergeSorterAnonymous(work));
   }
 
   // ---- 8. JDK Arrays.parallelSort with static comparator ----
 
+  private ScoreDoc[] runJdkParallelSort(ScoreDoc[] work) {
+    Arrays.parallelSort(work, BY_DOC_ASC);
+    return work;
+  }
+
   @Benchmark
   public void jdkParallelSort(Blackhole bh) {
-    Arrays.parallelSort(work, BY_DOC_ASC);
-    bh.consume(work);
+    bh.consume(runJdkParallelSort(work));
   }
 
   // ---- 9. Extract doc IDs, sort with JDK Arrays.sort (primitive long[]), reorder ----
 
-  @Benchmark
-  public void jdkSortPrimitiveExtractLong(Blackhole bh) {
+  private ScoreDoc[] runJdkSortPrimitiveExtractLong(ScoreDoc[] work) {
     int len = work.length;
     // pack (doc, originalIndex) into a long: doc in upper 32, index in lower 32
     long[] packed = new long[len];
@@ -316,7 +425,12 @@ public class ScoreDocSortBenchmark {
     for (int i = 0; i < len; i++) {
       sorted[i] = work[(int) packed[i]];
     }
-    bh.consume(sorted);
+    return sorted;
+  }
+
+  @Benchmark
+  public void jdkSortPrimitiveExtractLong(Blackhole bh) {
+    bh.consume(runJdkSortPrimitiveExtractLong(work));
   }
 
   // ---- 10. Extract doc IDs, sort with int[] when bits fit, else long[] ----
@@ -326,16 +440,7 @@ public class ScoreDocSortBenchmark {
     return 32 - Integer.numberOfLeadingZeros(max - 1);
   }
 
-  @Benchmark
-  public void jdkSortPrimitiveExtractAdaptive(Blackhole bh) {
-    /**
-     * Documentation of int vs long paths given MAX_DOC = 5,000,000:
-     *
-     * <ul>
-     *   <li>sizes 10, 50, 100, 500 take the int[] path (23 + 9 <= 32 bits)
-     *   <li>sizes 1,000, 10,000 take the long[] path (23 + 10 > 32 bits)
-     * </ul>
-     */
+  private ScoreDoc[] runJdkSortPrimitiveExtractAdaptive(ScoreDoc[] work) {
     int len = work.length;
     int docBits = bitsNeeded(MAX_DOC);
     int indexBits = bitsNeeded(len);
@@ -351,7 +456,7 @@ public class ScoreDocSortBenchmark {
       for (int i = 0; i < len; i++) {
         sorted[i] = work[packed[i] & indexMask];
       }
-      bh.consume(sorted);
+      return sorted;
     } else {
       // fall back to long[]
       long[] packed = new long[len];
@@ -363,14 +468,26 @@ public class ScoreDocSortBenchmark {
       for (int i = 0; i < len; i++) {
         sorted[i] = work[(int) packed[i]];
       }
-      bh.consume(sorted);
+      return sorted;
     }
+  }
+
+  @Benchmark
+  public void jdkSortPrimitiveExtractAdaptive(Blackhole bh) {
+    /**
+     * Documentation of int vs long paths given MAX_DOC = 5,000,000:
+     *
+     * <ul>
+     *   <li>sizes 10, 50, 100, 500 take the int[] path (23 + 9 <= 32 bits)
+     *   <li>sizes 1,000, 10,000 take the long[] path (23 + 10 > 32 bits)
+     * </ul>
+     */
+    bh.consume(runJdkSortPrimitiveExtractAdaptive(work));
   }
 
   // ---- 11. Extract doc IDs, sort with LSBRadixSorter when bits fit, else JDK long[] ----
 
-  @Benchmark
-  public void lsbRadixSortExtract(Blackhole bh) {
+  private ScoreDoc[] runLsbRadixSortExtract(ScoreDoc[] work) {
     int len = work.length;
     int docBits = bitsNeeded(MAX_DOC);
     int indexBits = bitsNeeded(len);
@@ -385,7 +502,7 @@ public class ScoreDocSortBenchmark {
       for (int i = 0; i < len; i++) {
         sorted[i] = work[packed[i] & indexMask];
       }
-      bh.consume(sorted);
+      return sorted;
     } else {
       // fallback to long[] + Arrays.sort
       long[] packed = new long[len];
@@ -397,14 +514,18 @@ public class ScoreDocSortBenchmark {
       for (int i = 0; i < len; i++) {
         sorted[i] = work[(int) packed[i]];
       }
-      bh.consume(sorted);
+      return sorted;
     }
+  }
+
+  @Benchmark
+  public void lsbRadixSortExtract(Blackhole bh) {
+    bh.consume(runLsbRadixSortExtract(work));
   }
 
   // ---- 12. Extract doc IDs, manual 2-pass radix sort (16-bit) ----
 
-  @Benchmark
-  public void radixSort2Pass(Blackhole bh) {
+  private ScoreDoc[] runRadixSort2Pass(ScoreDoc[] work) {
     int len = work.length;
     int docBits = bitsNeeded(MAX_DOC);
     int indexBits = bitsNeeded(len);
@@ -418,7 +539,7 @@ public class ScoreDocSortBenchmark {
       int[] bucket = new int[65536];
       int[] workArray = new int[len];
 
-      // Pass 1: lower 16 bits
+      // pass 1: lower 16 bits
       for (int i = 0; i < len; i++) {
         bucket[packed[i] & 0xFFFF]++;
       }
@@ -429,7 +550,7 @@ public class ScoreDocSortBenchmark {
         workArray[--bucket[packed[i] & 0xFFFF]] = packed[i];
       }
 
-      // Pass 2: upper 16 bits
+      // pass 2: upper 16 bits
       Arrays.fill(bucket, 0);
       for (int i = 0; i < len; i++) {
         bucket[(workArray[i] >>> 16) & 0xFFFF]++;
@@ -446,7 +567,7 @@ public class ScoreDocSortBenchmark {
       for (int i = 0; i < len; i++) {
         sorted[i] = work[packed[i] & indexMask];
       }
-      bh.consume(sorted);
+      return sorted;
     } else {
       // long fallback
       long[] packed = new long[len];
@@ -458,7 +579,12 @@ public class ScoreDocSortBenchmark {
       for (int i = 0; i < len; i++) {
         sorted[i] = work[(int) packed[i]];
       }
-      bh.consume(sorted);
+      return sorted;
     }
+  }
+
+  @Benchmark
+  public void radixSort2Pass(Blackhole bh) {
+    bh.consume(runRadixSort2Pass(work));
   }
 }

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -44,17 +44,19 @@ import org.openjdk.jmh.infra.Blackhole;
  * doc ID. Simulates realistic ScoreDoc arrays with random doc IDs drawn from a 5M-doc index and
  * random scores.
  *
- * <h2>Building</h2>
+ * <h2>Running</h2>
+ *
+ * Use {@code run-benchmark.sh} which automatically recompiles if sources changed, then runs JMH:
+ *
+ * <pre>{@code
+ * ./lucene/benchmark-jmh/run-benchmark.sh ScoreDocSortBenchmark \
+ *   -rf json -rff results.json
+ * }</pre>
+ *
+ * <p>Or build and run manually:
  *
  * <pre>{@code
  * ./gradlew :lucene:benchmark-jmh:assemble
- * }</pre>
- *
- * <h2>Running</h2>
- *
- * Run with JSON output so that per-iteration raw data is captured:
- *
- * <pre>{@code
  * java --module-path lucene/benchmark-jmh/build/benchmarks \
  *   --module org.apache.lucene.benchmark.jmh \
  *   ScoreDocSortBenchmark \
@@ -64,8 +66,7 @@ import org.openjdk.jmh.infra.Blackhole;
  * <h2>Visualizing results</h2>
  *
  * The companion {@code jmh-table.py} script (in the same directory as this source file) converts
- * JMH JSON output into an interactive HTML report. Pass the benchmark source file as an optional
- * argument to include source code in the report:
+ * JMH JSON output into an interactive HTML report:
  *
  * <pre>{@code
  * python3 lucene/benchmark-jmh/jmh-table.py \

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -94,13 +94,15 @@ import org.openjdk.jmh.infra.Blackhole;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
-@Measurement(iterations = 20, time = 1)
+@Measurement(iterations = 5, time = 1)
 @Fork(
     value = 10,
     jvmArgsAppend = {"-Xmx1g", "-Xms1g", "-XX:+AlwaysPreTouch"})
 public class ScoreDocSortBenchmark {
 
   private static final Comparator<ScoreDoc> BY_DOC_ASC = (a, b) -> Integer.compare(a.doc, b.doc);
+
+  private static final int MAX_DOC = 5_000_000;
 
   @Param({"10", "50", "100", "500", "1000", "10000"})
   int size;
@@ -114,10 +116,9 @@ public class ScoreDocSortBenchmark {
   @Setup(Level.Trial)
   public void setupTrial() {
     SplittableRandom rng = new SplittableRandom(0xCAFEBABE);
-    int maxDoc = 5_000_000; // realistic large index size
     template = new ScoreDoc[size];
     for (int i = 0; i < size; i++) {
-      int doc = rng.nextInt(maxDoc);
+      int doc = rng.nextInt(MAX_DOC);
       float score = (float) rng.nextDouble(0.0, 10.0);
       template[i] = new ScoreDoc(doc, score);
     }
@@ -125,7 +126,8 @@ public class ScoreDocSortBenchmark {
 
   @Setup(Level.Invocation)
   public void setupInvocation() {
-    work = Arrays.copyOf(template, size); // shallow copy – same ScoreDoc objects, different array
+    work = new ScoreDoc[size];
+    System.arraycopy(template, 0, work, 0, size);
   }
 
   // ---- 1. JDK Arrays.sort with lambda ----
@@ -278,7 +280,7 @@ public class ScoreDocSortBenchmark {
 
   // ---- 9. Extract doc IDs, sort with int[] when bits fit, else long[] ----
 
-  /** bits needed to represent values in [0, max) */
+  // bits needed to represent values in [0, max)
   private static int bitsNeeded(int max) {
     return 32 - Integer.numberOfLeadingZeros(max - 1);
   }
@@ -286,8 +288,7 @@ public class ScoreDocSortBenchmark {
   @Benchmark
   public void jdkSortPrimitiveExtractAdaptive(Blackhole bh) {
     int len = work.length;
-    int maxDoc = 5_000_000; // must match setupTrial
-    int docBits = bitsNeeded(maxDoc);
+    int docBits = bitsNeeded(MAX_DOC);
     int indexBits = bitsNeeded(len);
     if (docBits + indexBits <= 32) {
       // pack into int[]: doc in upper bits, index in lower bits

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -92,10 +92,10 @@ import org.openjdk.jmh.infra.Blackhole;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
-@Warmup(iterations = 3, time = 1)
+@Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 20, time = 1)
 @Fork(
-    value = 8,
+    value = 10,
     jvmArgsAppend = {"-Xmx1g", "-Xms1g", "-XX:+AlwaysPreTouch"})
 public class ScoreDocSortBenchmark {
 

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -40,9 +40,54 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 /**
- * Benchmark comparing different sort implementations for sorting ScoreDoc[] by ascending doc ID.
- * Simulates realistic ScoreDoc arrays with random doc IDs drawn from a large index and random
- * scores. Use jmh-table.py to visualize JSON results as an interactive HTML report.
+ * Benchmark comparing different sort implementations for sorting {@link ScoreDoc}[] by ascending
+ * doc ID. Simulates realistic ScoreDoc arrays with random doc IDs drawn from a 5M-doc index and
+ * random scores.
+ *
+ * <h2>Building</h2>
+ *
+ * <pre>{@code
+ * ./gradlew :lucene:benchmark-jmh:assemble
+ * }</pre>
+ *
+ * <h2>Running</h2>
+ *
+ * Run with JSON output so that per-iteration raw data is captured:
+ *
+ * <pre>{@code
+ * java --module-path lucene/benchmark-jmh/build/benchmarks \
+ *   --module org.apache.lucene.benchmark.jmh \
+ *   ScoreDocSortBenchmark \
+ *   -rf json -rff results.json
+ * }</pre>
+ *
+ * <h2>Visualizing results</h2>
+ *
+ * The companion {@code jmh-table.py} script (in the same directory as this source file) converts
+ * JMH JSON output into an interactive HTML report. Pass the benchmark source file as an optional
+ * argument to include source code in the report:
+ *
+ * <pre>{@code
+ * python3 lucene/benchmark-jmh/jmh-table.py \
+ *   lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java \
+ *   < results.json > results.html
+ * }</pre>
+ *
+ * <p>The HTML report provides:
+ *
+ * <ul>
+ *   <li>A heatmap table with algorithms as rows and array sizes as columns. Green cells are the
+ *       fastest, red cells are the slowest within each column.
+ *   <li>Inline sparkline histograms in each cell showing the distribution of raw iteration samples,
+ *       making outliers immediately visible.
+ *   <li>Click any column header to sort the table by that column (click again to reverse).
+ *   <li>Click any data cell to show a full histogram below the table with detailed statistics
+ *       (mean, median, stddev, p5/p95, range) and the benchmark method source code to the right.
+ *   <li>Clicking a cell updates the URL hash (e.g. {@code #introSorterAnonymous|1000}) so you can
+ *       share a direct link to a specific result.
+ *   <li>A configuration banner at the top showing JMH settings (mode, forks, threads, warmup,
+ *       measurement iterations, JVM args).
+ * </ul>
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -92,7 +92,7 @@ import org.openjdk.jmh.infra.Blackhole;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 20, time = 1)
 @Fork(

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -24,6 +24,7 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.InPlaceMergeSorter;
 import org.apache.lucene.util.IntroSorter;
+import org.apache.lucene.util.LSBRadixSorter;
 import org.apache.lucene.util.TimSorter;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -260,7 +261,15 @@ public class ScoreDocSortBenchmark {
     bh.consume(work);
   }
 
-  // ---- 8. Extract doc IDs, sort with JDK Arrays.sort (primitive long[]), reorder ----
+  // ---- 8. JDK Arrays.parallelSort with static comparator ----
+
+  @Benchmark
+  public void jdkParallelSort(Blackhole bh) {
+    Arrays.parallelSort(work, BY_DOC_ASC);
+    bh.consume(work);
+  }
+
+  // ---- 9. Extract doc IDs, sort with JDK Arrays.sort (primitive long[]), reorder ----
 
   @Benchmark
   public void jdkSortPrimitiveExtractLong(Blackhole bh) {
@@ -305,6 +314,101 @@ public class ScoreDocSortBenchmark {
       bh.consume(sorted);
     } else {
       // fall back to long[]
+      long[] packed = new long[len];
+      for (int i = 0; i < len; i++) {
+        packed[i] = ((long) work[i].doc << 32) | (i & 0xFFFFFFFFL);
+      }
+      Arrays.sort(packed);
+      ScoreDoc[] sorted = new ScoreDoc[len];
+      for (int i = 0; i < len; i++) {
+        sorted[i] = work[(int) packed[i]];
+      }
+      bh.consume(sorted);
+    }
+  }
+
+  // ---- 11. Extract doc IDs, sort with LSBRadixSorter when bits fit, else JDK long[] ----
+
+  @Benchmark
+  public void lsbRadixSortExtract(Blackhole bh) {
+    int len = work.length;
+    int docBits = bitsNeeded(MAX_DOC);
+    int indexBits = bitsNeeded(len);
+    if (docBits + indexBits <= 32) {
+      int[] packed = new int[len];
+      for (int i = 0; i < len; i++) {
+        packed[i] = (work[i].doc << indexBits) | i;
+      }
+      new LSBRadixSorter().sort(docBits + indexBits, packed, len);
+      int indexMask = (1 << indexBits) - 1;
+      ScoreDoc[] sorted = new ScoreDoc[len];
+      for (int i = 0; i < len; i++) {
+        sorted[i] = work[packed[i] & indexMask];
+      }
+      bh.consume(sorted);
+    } else {
+      // fallback to long[] + Arrays.sort
+      long[] packed = new long[len];
+      for (int i = 0; i < len; i++) {
+        packed[i] = ((long) work[i].doc << 32) | (i & 0xFFFFFFFFL);
+      }
+      Arrays.sort(packed);
+      ScoreDoc[] sorted = new ScoreDoc[len];
+      for (int i = 0; i < len; i++) {
+        sorted[i] = work[(int) packed[i]];
+      }
+      bh.consume(sorted);
+    }
+  }
+
+  // ---- 12. Extract doc IDs, manual 2-pass radix sort (16-bit) ----
+
+  @Benchmark
+  public void radixSort2Pass(Blackhole bh) {
+    int len = work.length;
+    int docBits = bitsNeeded(MAX_DOC);
+    int indexBits = bitsNeeded(len);
+    if (docBits + indexBits <= 32) {
+      int[] packed = new int[len];
+      for (int i = 0; i < len; i++) {
+        packed[i] = (work[i].doc << indexBits) | i;
+      }
+
+      // 2-pass 16-bit radix sort
+      int[] bucket = new int[65536];
+      int[] workArray = new int[len];
+
+      // Pass 1: lower 16 bits
+      for (int i = 0; i < len; i++) {
+        bucket[packed[i] & 0xFFFF]++;
+      }
+      for (int i = 1; i < 65536; i++) {
+        bucket[i] += bucket[i - 1];
+      }
+      for (int i = len - 1; i >= 0; i--) {
+        workArray[--bucket[packed[i] & 0xFFFF]] = packed[i];
+      }
+
+      // Pass 2: upper 16 bits
+      Arrays.fill(bucket, 0);
+      for (int i = 0; i < len; i++) {
+        bucket[(workArray[i] >>> 16) & 0xFFFF]++;
+      }
+      for (int i = 1; i < 65536; i++) {
+        bucket[i] += bucket[i - 1];
+      }
+      for (int i = len - 1; i >= 0; i--) {
+        packed[--bucket[(workArray[i] >>> 16) & 0xFFFF]] = workArray[i];
+      }
+
+      int indexMask = (1 << indexBits) - 1;
+      ScoreDoc[] sorted = new ScoreDoc[len];
+      for (int i = 0; i < len; i++) {
+        sorted[i] = work[packed[i] & indexMask];
+      }
+      bh.consume(sorted);
+    } else {
+      // long fallback
       long[] packed = new long[len];
       for (int i = 0; i < len; i++) {
         packed[i] = ((long) work[i].doc << 32) | (i & 0xFFFFFFFFL);

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -42,7 +42,7 @@ import org.openjdk.jmh.infra.Blackhole;
 /**
  * Benchmark comparing different sort implementations for sorting ScoreDoc[] by ascending doc ID.
  * Simulates realistic ScoreDoc arrays with random doc IDs drawn from a large index and random
- * scores.
+ * scores. Use jmh-table.py to visualize JSON results as an interactive HTML report.
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -54,8 +54,7 @@ import org.openjdk.jmh.infra.Blackhole;
     jvmArgsAppend = {"-Xmx1g", "-Xms1g", "-XX:+AlwaysPreTouch"})
 public class ScoreDocSortBenchmark {
 
-  private static final Comparator<ScoreDoc> BY_DOC_ASC =
-      (a, b) -> Integer.compare(a.doc, b.doc);
+  private static final Comparator<ScoreDoc> BY_DOC_ASC = (a, b) -> Integer.compare(a.doc, b.doc);
 
   @Param({"10", "100", "1000", "10000"})
   int size;

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -125,10 +125,7 @@ public class ScoreDocSortBenchmark {
 
   @Setup(Level.Invocation)
   public void setupInvocation() {
-    work = new ScoreDoc[size];
-    for (int i = 0; i < size; i++) {
-      work[i] = template[i]; // shallow copy – same ScoreDoc objects, different array
-    }
+    work = Arrays.copyOf(template, size); // shallow copy – same ScoreDoc objects, different array
   }
 
   // ---- 1. JDK Arrays.sort with lambda ----

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -101,7 +101,7 @@ public class ScoreDocSortBenchmark {
 
   private static final Comparator<ScoreDoc> BY_DOC_ASC = (a, b) -> Integer.compare(a.doc, b.doc);
 
-  @Param({"10", "100", "1000", "10000"})
+  @Param({"10", "50", "100", "500", "1000", "10000"})
   int size;
 
   /** Template array; copied before each invocation so every sort sees the same random order. */
@@ -263,9 +263,9 @@ public class ScoreDocSortBenchmark {
   // ---- 8. Extract doc IDs, sort with JDK Arrays.sort (primitive long[]), reorder ----
 
   @Benchmark
-  public void jdkSortPrimitiveExtract(Blackhole bh) {
+  public void jdkSortPrimitiveExtractLong(Blackhole bh) {
     int len = work.length;
-    // Build parallel array of (doc, originalIndex) packed into a long for a single-array sort
+    // pack (doc, originalIndex) into a long: doc in upper 32, index in lower 32
     long[] packed = new long[len];
     for (int i = 0; i < len; i++) {
       packed[i] = ((long) work[i].doc << 32) | (i & 0xFFFFFFFFL);
@@ -276,5 +276,46 @@ public class ScoreDocSortBenchmark {
       sorted[i] = work[(int) packed[i]];
     }
     bh.consume(sorted);
+  }
+
+  // ---- 9. Extract doc IDs, sort with int[] when bits fit, else long[] ----
+
+  /** bits needed to represent values in [0, max) */
+  private static int bitsNeeded(int max) {
+    return 32 - Integer.numberOfLeadingZeros(max - 1);
+  }
+
+  @Benchmark
+  public void jdkSortPrimitiveExtractAdaptive(Blackhole bh) {
+    int len = work.length;
+    int maxDoc = 5_000_000; // must match setupTrial
+    int docBits = bitsNeeded(maxDoc);
+    int indexBits = bitsNeeded(len);
+    if (docBits + indexBits <= 32) {
+      // pack into int[]: doc in upper bits, index in lower bits
+      int[] packed = new int[len];
+      for (int i = 0; i < len; i++) {
+        packed[i] = (work[i].doc << indexBits) | i;
+      }
+      Arrays.sort(packed);
+      int indexMask = (1 << indexBits) - 1;
+      ScoreDoc[] sorted = new ScoreDoc[len];
+      for (int i = 0; i < len; i++) {
+        sorted[i] = work[packed[i] & indexMask];
+      }
+      bh.consume(sorted);
+    } else {
+      // fall back to long[]
+      long[] packed = new long[len];
+      for (int i = 0; i < len; i++) {
+        packed[i] = ((long) work[i].doc << 32) | (i & 0xFFFFFFFFL);
+      }
+      Arrays.sort(packed);
+      ScoreDoc[] sorted = new ScoreDoc[len];
+      for (int i = 0; i < len; i++) {
+        sorted[i] = work[(int) packed[i]];
+      }
+      bh.consume(sorted);
+    }
   }
 }

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -152,28 +152,39 @@ public class ScoreDocSortBenchmark {
     ScoreDoc[] reference = Arrays.copyOf(template, size);
     Arrays.sort(reference, BY_DOC_ASC);
 
-    verify("jdkSortLambda", reference, runJdkSortLambda(Arrays.copyOf(template, size)));
-    verify("jdkSortComparator", reference, runJdkSortComparator(Arrays.copyOf(template, size)));
-    verify("arrayUtilIntroSort", reference, runArrayUtilIntroSort(Arrays.copyOf(template, size)));
-    verify("arrayUtilTimSort", reference, runArrayUtilTimSort(Arrays.copyOf(template, size)));
-    verify(
+    safeVerify("jdkSortLambda", reference, runJdkSortLambda(Arrays.copyOf(template, size)));
+    safeVerify("jdkSortComparator", reference, runJdkSortComparator(Arrays.copyOf(template, size)));
+    safeVerify(
+        "arrayUtilIntroSort", reference, runArrayUtilIntroSort(Arrays.copyOf(template, size)));
+    safeVerify("arrayUtilTimSort", reference, runArrayUtilTimSort(Arrays.copyOf(template, size)));
+    safeVerify(
         "introSorterAnonymous", reference, runIntroSorterAnonymous(Arrays.copyOf(template, size)));
-    verify("timSorterAnonymous", reference, runTimSorterAnonymous(Arrays.copyOf(template, size)));
-    verify(
+    safeVerify(
+        "timSorterAnonymous", reference, runTimSorterAnonymous(Arrays.copyOf(template, size)));
+    safeVerify(
         "inPlaceMergeSorterAnonymous",
         reference,
         runInPlaceMergeSorterAnonymous(Arrays.copyOf(template, size)));
-    verify("jdkParallelSort", reference, runJdkParallelSort(Arrays.copyOf(template, size)));
-    verify(
+    safeVerify("jdkParallelSort", reference, runJdkParallelSort(Arrays.copyOf(template, size)));
+    safeVerify(
         "jdkSortPrimitiveExtractLong",
         reference,
         runJdkSortPrimitiveExtractLong(Arrays.copyOf(template, size)));
-    verify(
+    safeVerify(
         "jdkSortPrimitiveExtractAdaptive",
         reference,
         runJdkSortPrimitiveExtractAdaptive(Arrays.copyOf(template, size)));
-    verify("lsbRadixSortExtract", reference, runLsbRadixSortExtract(Arrays.copyOf(template, size)));
-    verify("radixSort2Pass", reference, runRadixSort2Pass(Arrays.copyOf(template, size)));
+    safeVerify(
+        "lsbRadixSortExtract", reference, runLsbRadixSortExtract(Arrays.copyOf(template, size)));
+    safeVerify("radixSort2Pass", reference, runRadixSort2Pass(Arrays.copyOf(template, size)));
+  }
+
+  private void safeVerify(String name, ScoreDoc[] reference, ScoreDoc[] result) {
+    try {
+      verify(name, reference, result);
+    } catch (IllegalStateException e) {
+      System.err.println("WARNING: " + e.getMessage());
+    }
   }
 
   private void verify(String name, ScoreDoc[] reference, ScoreDoc[] result) {

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.InPlaceMergeSorter;
+import org.apache.lucene.util.IntroSorter;
+import org.apache.lucene.util.TimSorter;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmark comparing different sort implementations for sorting ScoreDoc[] by ascending doc ID.
+ * Simulates realistic ScoreDoc arrays with random doc IDs drawn from a large index and random
+ * scores.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 20, time = 1)
+@Fork(
+    value = 8,
+    jvmArgsAppend = {"-Xmx1g", "-Xms1g", "-XX:+AlwaysPreTouch"})
+public class ScoreDocSortBenchmark {
+
+  private static final Comparator<ScoreDoc> BY_DOC_ASC =
+      (a, b) -> Integer.compare(a.doc, b.doc);
+
+  @Param({"10", "100", "1000", "10000"})
+  int size;
+
+  /** Template array; copied before each invocation so every sort sees the same random order. */
+  private ScoreDoc[] template;
+
+  /** Working copy that each benchmark method sorts in place. */
+  private ScoreDoc[] work;
+
+  @Setup(Level.Trial)
+  public void setupTrial() {
+    SplittableRandom rng = new SplittableRandom(0xCAFEBABE);
+    int maxDoc = 5_000_000; // realistic large index size
+    template = new ScoreDoc[size];
+    for (int i = 0; i < size; i++) {
+      int doc = rng.nextInt(maxDoc);
+      float score = (float) rng.nextDouble(0.0, 10.0);
+      template[i] = new ScoreDoc(doc, score);
+    }
+  }
+
+  @Setup(Level.Invocation)
+  public void setupInvocation() {
+    work = new ScoreDoc[size];
+    for (int i = 0; i < size; i++) {
+      work[i] = template[i]; // shallow copy – same ScoreDoc objects, different array
+    }
+  }
+
+  // ---- 1. JDK Arrays.sort with lambda ----
+
+  @Benchmark
+  public void jdkSortLambda(Blackhole bh) {
+    Arrays.sort(work, (a, b) -> Integer.compare(a.doc, b.doc));
+    bh.consume(work);
+  }
+
+  // ---- 2. JDK Arrays.sort with static comparator ----
+
+  @Benchmark
+  public void jdkSortComparator(Blackhole bh) {
+    Arrays.sort(work, BY_DOC_ASC);
+    bh.consume(work);
+  }
+
+  // ---- 3. ArrayUtil.introSort (wraps ArrayIntroSorter) ----
+
+  @Benchmark
+  public void arrayUtilIntroSort(Blackhole bh) {
+    ArrayUtil.introSort(work, BY_DOC_ASC);
+    bh.consume(work);
+  }
+
+  // ---- 4. ArrayUtil.timSort (wraps ArrayTimSorter) ----
+
+  @Benchmark
+  public void arrayUtilTimSort(Blackhole bh) {
+    ArrayUtil.timSort(work, BY_DOC_ASC);
+    bh.consume(work);
+  }
+
+  // ---- 5. Anonymous IntroSorter ----
+
+  @Benchmark
+  public void introSorterAnonymous(Blackhole bh) {
+    final ScoreDoc[] arr = work;
+    new IntroSorter() {
+      ScoreDoc pivot;
+
+      @Override
+      protected void swap(int i, int j) {
+        ScoreDoc tmp = arr[i];
+        arr[i] = arr[j];
+        arr[j] = tmp;
+      }
+
+      @Override
+      protected void setPivot(int i) {
+        pivot = arr[i];
+      }
+
+      @Override
+      protected int comparePivot(int j) {
+        return Integer.compare(pivot.doc, arr[j].doc);
+      }
+
+      @Override
+      protected int compare(int i, int j) {
+        return Integer.compare(arr[i].doc, arr[j].doc);
+      }
+    }.sort(0, arr.length);
+    bh.consume(work);
+  }
+
+  // ---- 6. Anonymous TimSorter ----
+
+  @Benchmark
+  public void timSorterAnonymous(Blackhole bh) {
+    final ScoreDoc[] arr = work;
+    final int len = arr.length;
+    new TimSorter(len / 2) {
+      ScoreDoc[] tmp = new ScoreDoc[len / 2];
+
+      @Override
+      protected void swap(int i, int j) {
+        ScoreDoc t = arr[i];
+        arr[i] = arr[j];
+        arr[j] = t;
+      }
+
+      @Override
+      protected int compare(int i, int j) {
+        return Integer.compare(arr[i].doc, arr[j].doc);
+      }
+
+      @Override
+      protected void copy(int src, int dest) {
+        arr[dest] = arr[src];
+      }
+
+      @Override
+      protected void save(int start, int l) {
+        System.arraycopy(arr, start, tmp, 0, l);
+      }
+
+      @Override
+      protected void restore(int src, int dest) {
+        arr[dest] = tmp[src];
+      }
+
+      @Override
+      protected int compareSaved(int i, int j) {
+        return Integer.compare(tmp[i].doc, arr[j].doc);
+      }
+    }.sort(0, len);
+    bh.consume(work);
+  }
+
+  // ---- 7. Anonymous InPlaceMergeSorter ----
+
+  @Benchmark
+  public void inPlaceMergeSorterAnonymous(Blackhole bh) {
+    final ScoreDoc[] arr = work;
+    new InPlaceMergeSorter() {
+      @Override
+      protected void swap(int i, int j) {
+        ScoreDoc tmp = arr[i];
+        arr[i] = arr[j];
+        arr[j] = tmp;
+      }
+
+      @Override
+      protected int compare(int i, int j) {
+        return Integer.compare(arr[i].doc, arr[j].doc);
+      }
+    }.sort(0, arr.length);
+    bh.consume(work);
+  }
+
+  // ---- 8. Extract doc IDs, sort with JDK Arrays.sort (primitive long[]), reorder ----
+
+  @Benchmark
+  public void jdkSortPrimitiveExtract(Blackhole bh) {
+    int len = work.length;
+    // Build parallel array of (doc, originalIndex) packed into a long for a single-array sort
+    long[] packed = new long[len];
+    for (int i = 0; i < len; i++) {
+      packed[i] = ((long) work[i].doc << 32) | (i & 0xFFFFFFFFL);
+    }
+    Arrays.sort(packed);
+    ScoreDoc[] sorted = new ScoreDoc[len];
+    for (int i = 0; i < len; i++) {
+      sorted[i] = work[(int) packed[i]];
+    }
+    bh.consume(sorted);
+  }
+}

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/ScoreDocSortBenchmark.java
@@ -108,6 +108,9 @@ public class ScoreDocSortBenchmark {
   @Param({"10", "50", "100", "500", "1000", "10000"})
   int size;
 
+  @Param({"random", "nearly_sorted", "reversed"})
+  String distribution;
+
   /** Template array; copied before each invocation so every sort sees the same random order. */
   private ScoreDoc[] template;
 
@@ -123,8 +126,35 @@ public class ScoreDocSortBenchmark {
       float score = (float) rng.nextDouble(0.0, 10.0);
       template[i] = new ScoreDoc(doc, score);
     }
+
+    if (distribution.equals("nearly_sorted")) {
+      Arrays.sort(template, BY_DOC_ASC);
+      // swap ~5% of adjacent pairs to introduce mild disorder
+      int numSwaps = (int) (size * 0.05);
+      for (int i = 0; i < numSwaps; i++) {
+        int idx = rng.nextInt(size - 1);
+        ScoreDoc tmp = template[idx];
+        template[idx] = template[idx + 1];
+        template[idx + 1] = tmp;
+      }
+    } else if (distribution.equals("reversed")) {
+      Arrays.sort(template, BY_DOC_ASC);
+      for (int i = 0; i < size / 2; i++) {
+        ScoreDoc tmp = template[i];
+        template[i] = template[size - 1 - i];
+        template[size - 1 - i] = tmp;
+      }
+    }
   }
 
+  /**
+   * setupInvocation performs a shallow copy of the template.
+   *
+   * <p>Note: using Level.Invocation introduces overhead that JMH cannot easily subtract. For very
+   * small sizes (e.g. size=10), this overhead might be comparable to the benchmarked sort itself.
+   * We accept this because each invocation must start with the same unsorted array to ensure
+   * reproducibility across different sorting algorithms.
+   */
   @Setup(Level.Invocation)
   public void setupInvocation() {
     work = new ScoreDoc[size];
@@ -135,6 +165,8 @@ public class ScoreDocSortBenchmark {
 
   @Benchmark
   public void jdkSortLambda(Blackhole bh) {
+    // intentionally inline — tests whether JIT handles inline lambda differently than static
+    // comparator
     Arrays.sort(work, (a, b) -> Integer.compare(a.doc, b.doc));
     bh.consume(work);
   }
@@ -287,7 +319,7 @@ public class ScoreDocSortBenchmark {
     bh.consume(sorted);
   }
 
-  // ---- 9. Extract doc IDs, sort with int[] when bits fit, else long[] ----
+  // ---- 10. Extract doc IDs, sort with int[] when bits fit, else long[] ----
 
   // bits needed to represent values in [0, max)
   private static int bitsNeeded(int max) {
@@ -296,6 +328,14 @@ public class ScoreDocSortBenchmark {
 
   @Benchmark
   public void jdkSortPrimitiveExtractAdaptive(Blackhole bh) {
+    /**
+     * Documentation of int vs long paths given MAX_DOC = 5,000,000:
+     *
+     * <ul>
+     *   <li>sizes 10, 50, 100, 500 take the int[] path (23 + 9 <= 32 bits)
+     *   <li>sizes 1,000, 10,000 take the long[] path (23 + 10 > 32 bits)
+     * </ul>
+     */
     int len = work.length;
     int docBits = bitsNeeded(MAX_DOC);
     int indexBits = bitsNeeded(len);


### PR DESCRIPTION
[Spinoff from @zihanx's recent PR (#15803) adding `ReaderUtil.partitionByLeaf` helper to collate any `ScoreDoc[]` into per-leaf sorted groups.]

TL;DR: see [this cool benchmark results UI](http://githubsearch.mikemccandless.com/jmh-sort-scoredoc-benchy.html) testing various algorithms to sort `ScoreDoc[]` (smaller is better, the numbers are microseconds per sort call).

The hits from a Lucene query (`ScoreDoc[]`) come out sorted by something important to the user (e.g. relevance), but in order to retrieve stored fields or doc values, you instead need to partition by leaf and sort by `docid` within each leaf, retrieve your values via Lucene's usual iterators, and somehow then invert that step so you can stick/associate the retrieved values with original `ScoreDoc[]` (sorted for the user).

We currently use `Arrays.sort(int[])` after extracting just the `docid` from each hit, but that loses association with the original `ScoreDoc[]`.   #15905 is about NOT losing that association by also keeping track of the `int ordinal` position (in the original array).  And then @gsmiller made the cool JMH bench to find a faster partition step (after sorting) -- #15938.

This all made me curious about the absolute fastest way to sort these hits.  So, I worked with Claude Code (and maybe Gemini for some prompts too) to create this JMH benchmark (`ScoreDocSortBenchmark.java`) plus simple HTML UI to understand the results.

It tests 12 different approaches across array sizes from 10 to 10,000:
*   The usual JDK options (`Arrays.sort` with lambdas, static comparators, and `parallelSort`).
*   Lucene's internal sorters (`IntroSorter`, `TimSorter`, `InPlaceMergeSorter`, and `LSBRadixSorter`).
*   A few primitive extraction techniques (packing `docid` and the original array `index` into `int[]` or `long[]` for cache-friendly primitive sorting).
*   A manual 2-pass 8-bit radix sort.

The benchmark does upfront validation during the `@Setup` phase to ensure every sort is actually sorting correctly and not losing/duplicating any `ScoreDoc` instances, all without polluting the actual JMH measurement time.

Claude and I also added a companion Python script (`jmh-table.py`) to convert the raw JMH JSON output into an interactive HTML heatmap.

I tried to preserve all local commits, and tell the ai to make a local commit after each prompt+code iteration.

Here is a screenshot of the output:

<img width="1797" height="1161" alt="sort-benchy" src="https://github.com/user-attachments/assets/2b212dac-bbf8-4603-8a54-8b3a6f9cf5d3" />

Here's a [hosted version that should work for you](http://githubsearch.mikemccandless.com/jmh-sort-scoredoc-benchy.html) (click column headers to sort all rows!).

**NOTES/Learnings**
* **AI Collaboration:** This code was written mostly by an AI (Gemini CLI) with me (a human) prompting, reviewing, and iterating. 
* Measurements for very small array sizes (like size=10) include JMH's `Level.Invocation` overhead because we have to do a shallow array copy before every invocation. It inflates the absolute numbers a bit for tiny arrays, but the overhead is consistent across all algorithms.
* Each cell is greener if it was more competitive vs the other algos, and includes a sparkle histogram of latencies.
* It is disturbing how much the latency varies, and is sometimes strongly bimodal (likely hotspot structural noise e.g. mis-compilation)  even when it's just one thread in a fresh JVM on an idle box
* Click on column header to sort all rows by it (Excel-like).  Click on a cell to see the source code for that algo, and under the table you'll see histogram of latencies of all runs for that cell.
* It only tests random arrays.  Ideally I would test on real hits popping out of a useful search engine.  When you test on random data you draw random conclusions, sigh.
* Claude invented those two primitive solutions with no specific prompting from me, which is super cool.  They are nearly fastest (so is the radix sort!) across the board except `parallelSort` on large (10K) arrays, but that's using multiple CPU cores.  This, despite that they must make first pass to encode to `long[]` and ending pass to get back to `ScoreDoc[]`.
* It's surprising how much slower / faster the various algorithms are -- `TimSorter` (is this still used for Python's `listobject` sort?) was surprisingly slow

