### PR TITLE
Use SkipBlockRangeIterator as approximation in SortedNumericDocValuesRangeQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -137,6 +137,8 @@ Optimizations
 
 * GITHUB#15597, GITHUB#15777: Reduce memory usage of NeighborArray (Viliam Durina)
 
+* GITHUB#15954: Use SkipBlockRangeIterator as the two-phase approximation in SortedNumericDocValuesRangeQuery. (Sagar Upadhyaya)
+
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -137,8 +137,6 @@ Optimizations
 
 * GITHUB#15597, GITHUB#15777: Reduce memory usage of NeighborArray (Viliam Durina)
 
-* GITHUB#15954: Use SkipBlockRangeIterator as the two-phase approximation in SortedNumericDocValuesRangeQuery. (Sagar Upadhyaya)
-
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
@@ -307,6 +305,8 @@ Optimizations
 * GITHUB#15886: Cache frozen FieldType to skip redundant schema validation. (Tim Brooks)
 
 * GITHUB#15902: Improve DiversifyingChildren performance by using primitive arrays(Alessandro Benedetti)
+
+* GITHUB#15954: Use SkipBlockRangeIterator as the two-phase approximation in SortedNumericDocValuesRangeQuery. (Sagar Upadhyaya)
 
 Bug Fixes
 ---------------------

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/MultiFieldDocValuesRangeBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/MultiFieldDocValuesRangeBenchmark.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MMapDirectory;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmarks BooleanQuery with multiple numeric range FILTER clauses.
+ *
+ * <p>Run with and without the MultiFieldDocValuesRangeQuery coordination changes to compare. To
+ * benchmark the baseline, revert the BooleanQuery.rewrite() coordination rule and re-run.
+ *
+ * <p>Data patterns:
+ *
+ * <ul>
+ *   <li>clustered: values increase with docID (tight skip blocks, many YES/NO). Best case.
+ *   <li>mixed: field0 monotonic, field1 low-cardinality, rest random. Realistic.
+ *   <li>sorted: field0 monotonic (index sort key), rest random. Tests pre-sorted indexes.
+ *   <li>random: all fields uniform random. Worst case.
+ * </ul>
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 5, time = 5)
+@Fork(value = 1, warmups = 1)
+public class MultiFieldDocValuesRangeBenchmark {
+
+  private static final String CLUSTERED = "clustered";
+  private static final String MIXED = "mixed";
+  private static final String SORTED = "sorted";
+  private static final String RANDOM = "random";
+
+  private Directory dir;
+  private IndexReader reader;
+  private Path path;
+  private BooleanQuery query;
+
+  @State(Scope.Benchmark)
+  public static class Params {
+    @Param({"1000000", "10000000"})
+    public int docCount;
+
+    @Param({"3", "5"})
+    public int fieldCount;
+
+    @Param({CLUSTERED, MIXED, RANDOM, SORTED})
+    public String dataPattern;
+  }
+
+  @Setup(Level.Trial)
+  public void setup(Params params) throws Exception {
+    path = Files.createTempDirectory("multiFieldBench");
+    dir = MMapDirectory.open(path);
+
+    IndexWriterConfig iwc = new IndexWriterConfig();
+    if (params.dataPattern.equals(SORTED)) {
+      iwc.setIndexSort(
+          new org.apache.lucene.search.Sort(
+              new org.apache.lucene.search.SortField(
+                  "field0", org.apache.lucene.search.SortField.Type.LONG)));
+    }
+
+    IndexWriter w = new IndexWriter(dir, iwc);
+    Random r = new Random(42);
+
+    for (int i = 0; i < params.docCount; i++) {
+      Document doc = new Document();
+      for (int f = 0; f < params.fieldCount; f++) {
+        long value = generateValue(params.dataPattern, f, i, params.docCount, r);
+        doc.add(NumericDocValuesField.indexedField("field" + f, value));
+      }
+      w.addDocument(doc);
+    }
+    w.forceMerge(1);
+    reader = DirectoryReader.open(w);
+    w.close();
+
+    BooleanQuery.Builder bqBuilder = new BooleanQuery.Builder();
+    for (int f = 0; f < params.fieldCount; f++) {
+      long[] range = getQueryRange(params.dataPattern, f, params.docCount);
+      bqBuilder.add(
+          SortedNumericDocValuesField.newSlowRangeQuery("field" + f, range[0], range[1]),
+          Occur.FILTER);
+    }
+    query = bqBuilder.build();
+  }
+
+  private static long generateValue(
+      String pattern, int fieldIdx, int docIdx, int docCount, Random r) {
+    switch (pattern) {
+      case CLUSTERED:
+        long scale = (fieldIdx + 1) * 100L;
+        long noise = r.nextInt(50);
+        return (docIdx * scale / docCount) * docCount / scale * scale + noise;
+      case MIXED:
+        if (fieldIdx == 0) {
+          return (long) docIdx * 1000L + r.nextInt(100);
+        } else if (fieldIdx == 1) {
+          return r.nextInt(20);
+        } else {
+          return r.nextLong(0, docCount);
+        }
+      case SORTED:
+        // field0: monotonically increasing (will be the index sort key)
+        // field1+: random values (not sorted — these benefit from coordination)
+        if (fieldIdx == 0) {
+          return (long) docIdx * 1000L + r.nextInt(100);
+        } else {
+          return r.nextLong(0, docCount);
+        }
+      case RANDOM:
+        return r.nextLong(0, docCount);
+      default:
+        throw new IllegalArgumentException("Unknown pattern: " + pattern);
+    }
+  }
+
+  private static long[] getQueryRange(String pattern, int fieldIdx, int docCount) {
+    switch (pattern) {
+      case CLUSTERED:
+        long scale = (fieldIdx + 1) * 100L;
+        long maxVal = scale;
+        long rangeSize = maxVal / 10;
+        long offset = (fieldIdx * maxVal / 5);
+        return new long[] {offset, offset + rangeSize};
+      case MIXED:
+        if (fieldIdx == 0) {
+          long maxVal2 = (long) docCount * 1000L + 100;
+          return new long[] {(long) (maxVal2 * 0.9), maxVal2};
+        } else if (fieldIdx == 1) {
+          return new long[] {15, 19};
+        } else {
+          long rangeSize2 = docCount / 10;
+          long lower2 = (docCount - rangeSize2) / 2;
+          return new long[] {lower2, lower2 + rangeSize2};
+        }
+      case SORTED:
+        if (fieldIdx == 0) {
+          long maxVal3 = (long) docCount * 1000L + 100;
+          return new long[] {(long) (maxVal3 * 0.9), maxVal3};
+        } else {
+          long rangeSize3 = docCount / 10;
+          long lower3 = (docCount - rangeSize3) / 2;
+          return new long[] {lower3, lower3 + rangeSize3};
+        }
+      case RANDOM:
+        long rangeSize4 = docCount / 5;
+        long lower4 = (docCount - rangeSize4) / 2;
+        return new long[] {lower4, lower4 + rangeSize4};
+      default:
+        throw new IllegalArgumentException("Unknown pattern: " + pattern);
+    }
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws Exception {
+    reader.close();
+    if (dir != null) {
+      dir.close();
+      dir = null;
+    }
+    if (Files.exists(path)) {
+      try (Stream<Path> walk = Files.walk(path)) {
+        walk.sorted(Comparator.reverseOrder())
+            .forEach(
+                p -> {
+                  try {
+                    Files.delete(p);
+                  } catch (IOException _) {
+                  }
+                });
+      }
+    }
+  }
+
+  @Benchmark
+  public int searchMultiFieldRange() throws IOException {
+    IndexSearcher searcher = new IndexSearcher(reader);
+    return searcher.count(query);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -28,7 +28,6 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.ConstantScoreScorerSupplier;
 import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.DocValuesRangeIterator;
 import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -40,6 +39,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.SkipBlockRangeIterator;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
@@ -136,16 +136,88 @@ final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery 
         SortedNumericDocValues values = DocValues.getSortedNumeric(context.reader(), field);
         final NumericDocValues singleton = DocValues.unwrapSingleton(values);
         final DocValuesSkipper skipper = context.reader().getDocValuesSkipper(field);
-        TwoPhaseIterator iterator;
-        if (singleton != null) {
-          if (skipper != null) {
-            final DocIdSetIterator psIterator =
-                getDocIdSetIteratorOrNullForPrimarySort(context.reader(), singleton, skipper);
-            if (psIterator != null) {
-              return ConstantScoreScorerSupplier.fromIterator(
-                  psIterator, score(), scoreMode, maxDoc);
-            }
+
+        if (singleton != null && skipper != null) {
+          final DocIdSetIterator psIterator =
+              getDocIdSetIteratorOrNullForPrimarySort(context.reader(), singleton, skipper);
+          if (psIterator != null) {
+            return ConstantScoreScorerSupplier.fromIterator(psIterator, score(), scoreMode, maxDoc);
           }
+        }
+
+        TwoPhaseIterator iterator;
+        if (skipper != null) {
+          // Use SkipBlockRangeIterator as the approximation: block-level skip
+          // filtering with no DV decoding. This exposes block skips to
+          // ConjunctionDISI so that when one field's block is NO, other fields
+          // never decode DV data for that block.
+          final SkipBlockRangeIterator skipApprox =
+              new SkipBlockRangeIterator(skipper, lowerValue, upperValue);
+          iterator =
+              new TwoPhaseIterator(skipApprox) {
+                @Override
+                public boolean matches() throws IOException {
+                  int blockMatch = classifyBlock();
+                  if (blockMatch == BLOCK_YES) {
+                    return true;
+                  }
+                  if (blockMatch == BLOCK_IF_DOC_HAS_VALUE) {
+                    if (singleton != null) {
+                      return singleton.advanceExact(skipApprox.docID());
+                    } else {
+                      return values.advanceExact(skipApprox.docID());
+                    }
+                  }
+                  // MAYBE — need to decode DV and check the actual value.
+                  if (singleton != null) {
+                    if (singleton.advanceExact(skipApprox.docID())) {
+                      final long value = singleton.longValue();
+                      return value >= lowerValue && value <= upperValue;
+                    }
+                  } else {
+                    if (values.advanceExact(skipApprox.docID())) {
+                      for (int i = 0, cnt = values.docValueCount(); i < cnt; ++i) {
+                        final long value = values.nextValue();
+                        if (value < lowerValue) {
+                          continue;
+                        }
+                        return value <= upperValue;
+                      }
+                    }
+                  }
+                  return false;
+                }
+
+                @Override
+                public int docIDRunEnd() throws IOException {
+                  if (classifyBlock() == BLOCK_YES) {
+                    return skipApprox.docIDRunEnd();
+                  }
+                  return super.docIDRunEnd();
+                }
+
+                @Override
+                public float matchCost() {
+                  return 3; // advanceExact + 2 comparisons
+                }
+
+                private static final int BLOCK_MAYBE = 0;
+                private static final int BLOCK_YES = 1;
+                private static final int BLOCK_IF_DOC_HAS_VALUE = 2;
+
+                private int classifyBlock() {
+                  long blockMin = skipper.minValue(0);
+                  long blockMax = skipper.maxValue(0);
+                  if (blockMin >= lowerValue && blockMax <= upperValue) {
+                    if (skipper.docCount(0) == skipper.maxDocID(0) - skipper.minDocID(0) + 1) {
+                      return BLOCK_YES;
+                    }
+                    return BLOCK_IF_DOC_HAS_VALUE;
+                  }
+                  return BLOCK_MAYBE;
+                }
+              };
+        } else if (singleton != null) {
           iterator =
               new TwoPhaseIterator(singleton) {
                 @Override
@@ -169,11 +241,9 @@ final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery 
                     if (value < lowerValue) {
                       continue;
                     }
-                    // Values are sorted, so the first value that is >= lowerValue is our best
-                    // candidate
                     return value <= upperValue;
                   }
-                  return false; // all values were < lowerValue
+                  return false;
                 }
 
                 @Override
@@ -181,9 +251,6 @@ final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery 
                   return 2; // 2 comparisons
                 }
               };
-        }
-        if (skipper != null) {
-          iterator = new DocValuesRangeIterator(iterator, skipper, lowerValue, upperValue, false);
         }
         return ConstantScoreScorerSupplier.fromIterator(
             TwoPhaseIterator.asDocIdSetIterator(iterator), score(), scoreMode, maxDoc);

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -241,9 +241,11 @@ final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery 
                     if (value < lowerValue) {
                       continue;
                     }
+                    // Values are sorted, so the first value that is >= lowerValue is our best
+                    // candidate
                     return value <= upperValue;
                   }
-                  return false;
+                  return false; // all values were < lowerValue
                 }
 
                 @Override

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -155,9 +155,12 @@ final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery 
               new SkipBlockRangeIterator(skipper, lowerValue, upperValue);
           iterator =
               new TwoPhaseIterator(skipApprox) {
+                private int cachedBlockEnd = -1;
+                private int cachedClassification = BLOCK_MAYBE;
+
                 @Override
                 public boolean matches() throws IOException {
-                  int blockMatch = classifyBlock();
+                  int blockMatch = classifyBlockCached();
                   if (blockMatch == BLOCK_YES) {
                     return true;
                   }
@@ -190,7 +193,7 @@ final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery 
 
                 @Override
                 public int docIDRunEnd() throws IOException {
-                  if (classifyBlock() == BLOCK_YES) {
+                  if (classifyBlockCached() == BLOCK_YES) {
                     return skipApprox.docIDRunEnd();
                   }
                   return super.docIDRunEnd();
@@ -204,6 +207,15 @@ final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery 
                 private static final int BLOCK_MAYBE = 0;
                 private static final int BLOCK_YES = 1;
                 private static final int BLOCK_IF_DOC_HAS_VALUE = 2;
+
+                private int classifyBlockCached() {
+                  int blockEnd = skipper.maxDocID(0);
+                  if (blockEnd != cachedBlockEnd) {
+                    cachedBlockEnd = blockEnd;
+                    cachedClassification = classifyBlock();
+                  }
+                  return cachedClassification;
+                }
 
                 private int classifyBlock() {
                   long blockMin = skipper.minValue(0);

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -194,7 +194,10 @@ final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery 
                 @Override
                 public int docIDRunEnd() throws IOException {
                   if (classifyBlockCached() == BLOCK_YES) {
-                    return skipApprox.docIDRunEnd();
+                    // Only report the current level-0 block as a run. The
+                    // approximation's docIDRunEnd() may expand to higher levels
+                    // that could be MAYBE, not YES.
+                    return cachedBlockEnd + 1;
                   }
                   return super.docIDRunEnd();
                 }


### PR DESCRIPTION

### Description

Replace DocValuesRangeIterator with SkipBlockRangeIterator as the two-phase approximation when a DocValuesSkipper is available. This makes the approximation block-level only (no DV decoding), deferring value reads to matches(). In
conjunctions, this avoids wasted DV decoding when another field's block is NO.

This was done as suggested in the comment here - https://github.com/apache/lucene/issues/15770#issuecomment-4212419321 by @romseygeek 


Also includes benchmark:


Results:
### JMH Benchmark Results (1M docs, ops/s, higher is better)

```
java --module-path lucene/benchmark-jmh/build/benchmarks --module org.apache.lucene.benchmark.jmh "MultiFieldDocValuesRangeBenchmark" -p docCount=1000000 -p fieldCount=3,5 -p dataPattern=clustered,mixed,random 
```

| Pattern   | Fields | Before (ops/s) | After (ops/s) | Speedup |
|-----------|--------|----------------|---------------|---------|
| clustered | 3      | 15,890         | 18,505        | 1.35x   |
| clustered | 5      | 11,546         | 12,959        | 1.12x   |
| mixed     | 3      | 854            | 937           | 1.10x   |
| mixed     | 5      | 512            | 723           | 1.41x   |
| random    | 3      | 60             | 68            | 1.13x   |
| random    | 5      | 44             | 51            | 1.16x   |





Data patterns:
- **clustered**: all field values increase with docID (time-series style)
- **mixed**: field0 monotonic, field1 low-cardinality (20 values), rest random (e-commerce style)
- **random**: all fields uniformly random, wide query ranges (worst case)

Query: BooleanQuery with N FILTER clauses, each a `SortedNumericDocValuesField.newSlowRangeQuery` on a distinct field with skip index enabled.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
