### PR TITLE
Use maven central in addition to google proxy, not as a replacement.

### DIFF
--- a/build-tools/build-infra/declare-repositories.gradle
+++ b/build-tools/build-infra/declare-repositories.gradle
@@ -26,9 +26,8 @@ repositories {
     maven {
       url "https://maven-central.storage-download.googleapis.com/maven2/"
     }
-  } else {
-    mavenCentral()
   }
 
+  mavenCentral()
   gradlePluginPortal()
 }


### PR DESCRIPTION
This returns 404 for me -

https://maven-central.storage-download.googleapis.com/maven2/com/google/errorprone/error_prone_core/2.49.0/error_prone_core-2.49.0.pom

even though it's clearly on central and has been for a while -

https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/2.49.0/error_prone_core-2.49.0.pom

I've made the change to make google central a first-try check on the CI, but fallback to maven central.