### PR TITLE
Do not modify filePointer in MemorySegmentIndexInput absolute reads at segment boundary

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -181,6 +181,10 @@ Bug Fixes
 
 * GITHUB#15939: Fix thread-safety issues with NFARunAutomaton. (Dimitris Rempapis)
 
+* GITHUB#15730: Fix MemorySegmentIndexInput absolute read methods (readShort(pos), readInt(pos),
+  readLong(pos)) to not modify the file pointer when the read crosses a memory segment boundary.
+  (Barry)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14187: The query cache is now disabled by default. (Adrien Grand)

--- a/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -502,9 +502,19 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
     try {
       return segments[si].get(LAYOUT_LE_SHORT, pos & chunkSizeMask);
     } catch (IndexOutOfBoundsException _) {
-      // either it's a boundary, or read past EOF, fall back:
-      setPos(pos, si);
-      return readShort();
+      // either it's a boundary, or read past EOF, fall back. Absolute reads must not modify
+      // the file pointer (see RandomAccessInput), so save and restore curSegment state.
+      final int savedSegmentIndex = curSegmentIndex;
+      final MemorySegment savedSegment = curSegment;
+      final long savedPosition = curPosition;
+      try {
+        setPos(pos, si);
+        return readShort();
+      } finally {
+        this.curSegmentIndex = savedSegmentIndex;
+        this.curSegment = savedSegment;
+        this.curPosition = savedPosition;
+      }
     } catch (NullPointerException | IllegalStateException e) {
       throw alreadyClosed(e);
     }
@@ -516,9 +526,19 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
     try {
       return segments[si].get(LAYOUT_LE_INT, pos & chunkSizeMask);
     } catch (IndexOutOfBoundsException _) {
-      // either it's a boundary, or read past EOF, fall back:
-      setPos(pos, si);
-      return readInt();
+      // either it's a boundary, or read past EOF, fall back. Absolute reads must not modify
+      // the file pointer (see RandomAccessInput), so save and restore curSegment state.
+      final int savedSegmentIndex = curSegmentIndex;
+      final MemorySegment savedSegment = curSegment;
+      final long savedPosition = curPosition;
+      try {
+        setPos(pos, si);
+        return readInt();
+      } finally {
+        this.curSegmentIndex = savedSegmentIndex;
+        this.curSegment = savedSegment;
+        this.curPosition = savedPosition;
+      }
     } catch (NullPointerException | IllegalStateException e) {
       throw alreadyClosed(e);
     }
@@ -530,9 +550,19 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
     try {
       return segments[si].get(LAYOUT_LE_LONG, pos & chunkSizeMask);
     } catch (IndexOutOfBoundsException _) {
-      // either it's a boundary, or read past EOF, fall back:
-      setPos(pos, si);
-      return readLong();
+      // either it's a boundary, or read past EOF, fall back. Absolute reads must not modify
+      // the file pointer (see RandomAccessInput), so save and restore curSegment state.
+      final int savedSegmentIndex = curSegmentIndex;
+      final MemorySegment savedSegment = curSegment;
+      final long savedPosition = curPosition;
+      try {
+        setPos(pos, si);
+        return readLong();
+      } finally {
+        this.curSegmentIndex = savedSegmentIndex;
+        this.curSegment = savedSegment;
+        this.curPosition = savedPosition;
+      }
     } catch (NullPointerException | IllegalStateException e) {
       throw alreadyClosed(e);
     }

--- a/lucene/core/src/test/org/apache/lucene/store/TestMultiMMap.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMultiMMap.java
@@ -204,4 +204,57 @@ public class TestMultiMMap extends BaseChunkedDirectoryTestCase {
           "Require a multi impl, got " + clazz, clazz.getSimpleName().matches("Multi\\w+Impl"));
     }
   }
+
+  // GITHUB#15730: MemorySegmentIndexInput's absolute read methods must not modify the input's
+  // file pointer, even when the read crosses a memory-segment boundary and the implementation
+  // has to fall back to seek + relative read.
+  public void testAbsoluteReadDoesNotModifyPositionAcrossBoundary() throws IOException {
+    final int chunkSize = 16;
+    try (Directory dir =
+        getDirectory(createTempDir("testAbsoluteReadDoesNotModifyPosition"), chunkSize)) {
+      try (IndexOutput out = dir.createOutput("file", IOContext.DEFAULT)) {
+        for (int i = 0; i < chunkSize * 2; i++) {
+          out.writeByte((byte) i);
+        }
+      }
+      try (IndexInput input = dir.openInput("file", IOContext.DEFAULT)) {
+        // ensure we really are exercising the multi-segment impl
+        assertCorrectImpl(false, input);
+        RandomAccessInput rai = (RandomAccessInput) input;
+
+        assertEquals(0L, input.getFilePointer());
+
+        // read fits inside the first chunk: position must not change
+        rai.readInt(4);
+        assertEquals(0L, input.getFilePointer());
+
+        // read crosses the chunk boundary: position must still not change
+        rai.readInt(14);
+        assertEquals(0L, input.getFilePointer());
+
+        // same for readShort and readLong at boundaries
+        rai.readShort(15);
+        assertEquals(0L, input.getFilePointer());
+
+        rai.readLong(12);
+        assertEquals(0L, input.getFilePointer());
+
+        // absolute reads must not disturb a non-zero existing file pointer either
+        input.seek(7L);
+        rai.readInt(14);
+        assertEquals(7L, input.getFilePointer());
+        rai.readLong(10);
+        assertEquals(7L, input.getFilePointer());
+        rai.readShort(15);
+        assertEquals(7L, input.getFilePointer());
+
+        // value returned by the boundary-crossing fallback must still be correct
+        input.seek(14L);
+        int expectedIntAtBoundary = input.readInt();
+        input.seek(0L);
+        assertEquals(expectedIntAtBoundary, rai.readInt(14));
+        assertEquals(0L, input.getFilePointer());
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Description

Fixes #15730.

`RandomAccessInput` specifies that absolute reads "have no concept of file position" — the input's file pointer must not change. `MemorySegmentIndexInput.readShort(long)`, `readInt(long)` and `readLong(long)` violate this when the read crosses a memory-segment boundary: they fall back to `setPos(pos, si)` followed by a relative `readShort/readInt/readLong`, which mutate `curSegmentIndex`, `curSegment` and `curPosition`. From the reporter's repro, `input.readInt(14)` on two adjacent 16-byte segments leaves `getFilePointer()` at 18 instead of the original 0.

This PR saves the three fields before entering the boundary fallback and restores them in a `finally` block. The fast in-segment path is unchanged, so there is no performance impact on the common case, and the fallback only ever runs at chunk boundaries or past-EOF — both rare.

### Tests

Added `TestMultiMMap.testAbsoluteReadDoesNotModifyPositionAcrossBoundary` exercising `readInt/readShort/readLong` at and across the chunk boundary (including starting from a non-zero file pointer), and also verifying that the fallback still returns the correct value.

Verified the test fails without the fix (`expected:<0> but was:<18>`) and passes with it. `:lucene:core:test --tests "org.apache.lucene.store.TestMultiMMap"` (75 tests), `:lucene:core:check -x test` (forbiddenApis, ecjLint), and `./gradlew tidy` all pass locally.

CHANGES.txt entry added under 11.0.0 Bug Fixes.