### PR TITLE
Use explicit version check in Lucene90BlockTreeTermsWriter

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene90/blocktree/Lucene90BlockTreeTermsWriter.java
@@ -533,8 +533,8 @@ public final class Lucene90BlockTreeTermsWriter extends FieldsConsumer {
 
       final ByteSequenceOutputs outputs = ByteSequenceOutputs.getSingleton();
       final int fstVersion;
-      if (version >= Lucene90BlockTreeTermsReader.VERSION_CURRENT) {
-        fstVersion = FST.VERSION_CURRENT;
+      if (version >= Lucene90BlockTreeTermsReader.VERSION_FST_CONTINUOUS_ARCS) {
+        fstVersion = FST.VERSION_CONTINUOUS_ARCS;
       } else {
         fstVersion = FST.VERSION_90;
       }


### PR DESCRIPTION
We were checking against VERSION_CURRENT to determine how to load FSTs, which works fine now but could cause problems if VERSION_CURRENT was updated at any point for a different reason.