### PR TITLE
Support jdk.CPUTimeSample event in ProfileResults for Java 25+ (JEP 509)

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/CodeProfilingPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/CodeProfilingPlugin.java
@@ -92,8 +92,6 @@ public class CodeProfilingPlugin extends LuceneGradlePlugin {
             getCount().get(),
             getLineNumbers().get(),
             getFrametypes().get());
-      } catch (IllegalStateException e) {
-        throw new GradleException(e.getMessage(), e);
       } catch (IOException e) {
         throw new GradleException("Error when generating jfr profile summaries.", e);
       }

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/CodeProfilingPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/CodeProfilingPlugin.java
@@ -20,6 +20,7 @@ import com.carrotsearch.gradle.buildinfra.buildoptions.BuildOptionsExtension;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import org.apache.lucene.gradle.plugins.LuceneGradlePlugin;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -91,6 +92,8 @@ public class CodeProfilingPlugin extends LuceneGradlePlugin {
             getCount().get(),
             getLineNumbers().get(),
             getFrametypes().get());
+      } catch (IllegalStateException e) {
+        throw new GradleException(e.getMessage(), e);
       } catch (IOException e) {
         throw new GradleException("Error when generating jfr profile summaries.", e);
       }
@@ -189,7 +192,7 @@ public class CodeProfilingPlugin extends LuceneGradlePlugin {
             task.jvmArgs(
                 List.of(
                     "-XX:StartFlightRecording=dumponexit=true,maxsize=250M,settings="
-                        + gradlePluginResource(project, "testing/profiling.jfc"),
+                        + gradlePluginResource(project, profilingSettingsPath()),
                     "-XX:+UnlockDiagnosticVMOptions",
                     "-XX:+DebugNonSafepoints"));
             task.dependsOn(cleanPreviousProfiles);
@@ -254,4 +257,14 @@ public class CodeProfilingPlugin extends LuceneGradlePlugin {
       Provider<Integer> countOption,
       Provider<Boolean> lineNumbersOption,
       Provider<Boolean> frametypesOption) {}
+
+  /**
+   * JEP 509 CPU-time sampling ({@code jdk.CPUTimeSample}) is implemented on Linux. Use a Linux-only
+   * JFR template with CPU-time sampling only; other hosts keep wall-clock execution sampling for
+   * short tests.
+   */
+  private static String profilingSettingsPath() {
+    String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+    return os.contains("linux") ? "testing/profiling.linux.jfc" : "testing/profiling.jfc";
+  }
 }

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/CodeProfilingPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/CodeProfilingPlugin.java
@@ -257,12 +257,13 @@ public class CodeProfilingPlugin extends LuceneGradlePlugin {
       Provider<Boolean> frametypesOption) {}
 
   /**
-   * JEP 509 CPU-time sampling ({@code jdk.CPUTimeSample}) is implemented on Linux. Use a Linux-only
-   * JFR template with CPU-time sampling only; other hosts keep wall-clock execution sampling for
-   * short tests.
+   * Java 25+ JEP 509 ({@code jdk.CPUTimeSample}) is currently implemented only on Linux in the JDK.
+   * When the Gradle host is Linux, use {@code testing/profiling.cputime.jfc} (CPU-time sampling
+   * only). Otherwise use {@code testing/profiling.jfc} (legacy wall-clock execution sampling). Host
+   * selection may broaden if CPU-time sampling is supported on other OS releases later.
    */
   private static String profilingSettingsPath() {
     String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
-    return os.contains("linux") ? "testing/profiling.linux.jfc" : "testing/profiling.jfc";
+    return os.contains("linux") ? "testing/profiling.cputime.jfc" : "testing/profiling.jfc";
   }
 }

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ProfileResults.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ProfileResults.java
@@ -101,19 +101,20 @@ public class ProfileResults {
   }
 
   /** true if we care about this event */
-  static boolean isInteresting(String mode, RecordedEvent event, boolean hasCPUTimeSamples) {
+  static boolean isInteresting(String mode, RecordedEvent event) {
     String name = event.getEventType().getName();
     switch (mode) {
       case "cpu":
-        if (hasCPUTimeSamples) {
-          // Prefer jdk.CPUTimeSample (Java 25+, JEP 509): samples by CPU time, not wall-clock
-          // time, so idle threads (like gradle epoll) are inherently excluded; no filtering
-          // needed. When present, we ignore jdk.ExecutionSample and jdk.NativeMethodSample
-          // (wall-clock / JNI execution sampling) so the same hot code is not double-counted.
-          return name.equals("jdk.CPUTimeSample");
+        // jdk.CPUTimeSample: JEP 509 (e.g. gradle/testing/profiling.linux.jfc). Legacy samples:
+        // jdk.ExecutionSample / jdk.NativeMethodSample (e.g. profiling.jfc). Stock Lucene configs
+        // enable one family; filter gradle poll thread for legacy samples only.
+        if (name.equals("jdk.CPUTimeSample")) {
+          return true;
         }
-        return (name.equals("jdk.ExecutionSample") || name.equals("jdk.NativeMethodSample"))
-            && !isGradlePollThread(event.getThread("sampledThread"));
+        if (name.equals("jdk.ExecutionSample") || name.equals("jdk.NativeMethodSample")) {
+          return !isGradlePollThread(event.getThread("sampledThread"));
+        }
+        return false;
       case "heap":
         return (name.equals("jdk.ObjectAllocationInNewTLAB")
                 || name.equals("jdk.ObjectAllocationOutsideTLAB"))
@@ -126,37 +127,6 @@ public class ProfileResults {
   /** true if the thread is gradle epoll thread (which we don't care about) */
   static boolean isGradlePollThread(RecordedThread thread) {
     return (thread != null && thread.getJavaName().startsWith("/127.0.0.1"));
-  }
-
-  /**
-   * Pre-scan recording files for CPU sampling strategy. Returns whether any {@code
-   * jdk.CPUTimeSample} events appear in the inputs. Throws if recordings mix those with legacy
-   * wall-clock samples ({@code jdk.ExecutionSample} / {@code jdk.NativeMethodSample}); only one
-   * CPU sampler should be enabled in JFR settings.
-   */
-  static boolean resolveCpuTimeSampling(List<String> files) throws IOException {
-    boolean hasCpuTime = false;
-    boolean hasLegacy = false;
-    for (String file : files) {
-      try (RecordingFile recording = new RecordingFile(Paths.get(file))) {
-        while (recording.hasMoreEvents()) {
-          RecordedEvent event = recording.readEvent();
-          String n = event.getEventType().getName();
-          if (n.equals("jdk.CPUTimeSample")) {
-            hasCpuTime = true;
-          } else if (n.equals("jdk.ExecutionSample") || n.equals("jdk.NativeMethodSample")) {
-            hasLegacy = true;
-          }
-          if (hasCpuTime && hasLegacy) {
-            throw new IllegalStateException(
-                "Mixed CPU profiling events: found both jdk.CPUTimeSample and legacy wall-clock "
-                    + "samples (jdk.ExecutionSample / jdk.NativeMethodSample). Use a single sampler "
-                    + "in JFR settings (see gradle/testing/profiling*.jfc).");
-          }
-        }
-      }
-    }
-    return hasCpuTime;
   }
 
   /** value we accumulate for this event */
@@ -214,9 +184,6 @@ public class ProfileResults {
       throw new IllegalArgumentException("tests.profile.count must be positive");
     }
 
-    // Pre-scan recordings: decide CPU-time vs legacy sampling and reject mixed configurations.
-    boolean hasCPUTimeSamples = "cpu".equals(mode) && resolveCpuTimeSampling(files);
-
     Map<String, SimpleEntry<String, Long>> histogram = new HashMap<>();
     int totalEvents = 0;
     long sumValues = 0;
@@ -225,7 +192,7 @@ public class ProfileResults {
       try (RecordingFile recording = new RecordingFile(Paths.get(file))) {
         while (recording.hasMoreEvents()) {
           RecordedEvent event = recording.readEvent();
-          if (!isInteresting(mode, event, hasCPUTimeSamples)) {
+          if (!isInteresting(mode, event)) {
             continue;
           }
           RecordedStackTrace trace = event.getStackTrace();

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ProfileResults.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ProfileResults.java
@@ -101,10 +101,16 @@ public class ProfileResults {
   }
 
   /** true if we care about this event */
-  static boolean isInteresting(String mode, RecordedEvent event) {
+  static boolean isInteresting(String mode, RecordedEvent event, boolean hasCPUTimeSamples) {
     String name = event.getEventType().getName();
     switch (mode) {
       case "cpu":
+        if (hasCPUTimeSamples) {
+          // Prefer jdk.CPUTimeSample (Java 25+, JEP 509): samples by CPU time, not wall-clock
+          // time, so idle threads (like gradle epoll) are inherently excluded — no filtering
+          // needed. When available, we skip legacy execution samples to avoid double-counting.
+          return name.equals("jdk.CPUTimeSample");
+        }
         return (name.equals("jdk.ExecutionSample") || name.equals("jdk.NativeMethodSample"))
             && !isGradlePollThread(event.getThread("sampledThread"));
       case "heap":
@@ -121,6 +127,24 @@ public class ProfileResults {
     return (thread != null && thread.getJavaName().startsWith("/127.0.0.1"));
   }
 
+  /**
+   * Pre-scan recording files to detect if any jdk.CPUTimeSample events are present. When they are,
+   * we prefer them over legacy jdk.ExecutionSample/jdk.NativeMethodSample to avoid double-counting.
+   */
+  static boolean detectCPUTimeSamples(List<String> files) throws IOException {
+    for (String file : files) {
+      try (RecordingFile recording = new RecordingFile(Paths.get(file))) {
+        while (recording.hasMoreEvents()) {
+          RecordedEvent event = recording.readEvent();
+          if (event.getEventType().getName().equals("jdk.CPUTimeSample")) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
   /** value we accumulate for this event */
   static long getValue(RecordedEvent event) {
     switch (event.getEventType().getName()) {
@@ -131,6 +155,8 @@ public class ProfileResults {
       case "jdk.ExecutionSample":
         return 1L;
       case "jdk.NativeMethodSample":
+        return 1L;
+      case "jdk.CPUTimeSample":
         return 1L;
       default:
         throw new UnsupportedOperationException(event.toString());
@@ -173,6 +199,11 @@ public class ProfileResults {
     if (count < 1) {
       throw new IllegalArgumentException("tests.profile.count must be positive");
     }
+
+    // Pre-scan to detect if CPU-time samples (Java 25+, JEP 509) are available.
+    // If so, prefer them over legacy execution samples to avoid double-counting.
+    boolean hasCPUTimeSamples = "cpu".equals(mode) && detectCPUTimeSamples(files);
+
     Map<String, SimpleEntry<String, Long>> histogram = new HashMap<>();
     int totalEvents = 0;
     long sumValues = 0;
@@ -181,7 +212,7 @@ public class ProfileResults {
       try (RecordingFile recording = new RecordingFile(Paths.get(file))) {
         while (recording.hasMoreEvents()) {
           RecordedEvent event = recording.readEvent();
-          if (!isInteresting(mode, event)) {
+          if (!isInteresting(mode, event, hasCPUTimeSamples)) {
             continue;
           }
           RecordedStackTrace trace = event.getStackTrace();

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ProfileResults.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ProfileResults.java
@@ -105,7 +105,7 @@ public class ProfileResults {
     String name = event.getEventType().getName();
     switch (mode) {
       case "cpu":
-        // jdk.CPUTimeSample: JEP 509 (e.g. gradle/testing/profiling.linux.jfc). Legacy samples:
+        // jdk.CPUTimeSample: JEP 509 (e.g. gradle/testing/profiling.cputime.jfc). Legacy samples:
         // jdk.ExecutionSample / jdk.NativeMethodSample (e.g. profiling.jfc). Stock Lucene configs
         // enable one family; filter gradle poll thread for legacy samples only.
         if (name.equals("jdk.CPUTimeSample")) {

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ProfileResults.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/ProfileResults.java
@@ -107,8 +107,9 @@ public class ProfileResults {
       case "cpu":
         if (hasCPUTimeSamples) {
           // Prefer jdk.CPUTimeSample (Java 25+, JEP 509): samples by CPU time, not wall-clock
-          // time, so idle threads (like gradle epoll) are inherently excluded — no filtering
-          // needed. When available, we skip legacy execution samples to avoid double-counting.
+          // time, so idle threads (like gradle epoll) are inherently excluded; no filtering
+          // needed. When present, we ignore jdk.ExecutionSample and jdk.NativeMethodSample
+          // (wall-clock / JNI execution sampling) so the same hot code is not double-counted.
           return name.equals("jdk.CPUTimeSample");
         }
         return (name.equals("jdk.ExecutionSample") || name.equals("jdk.NativeMethodSample"))
@@ -128,21 +129,34 @@ public class ProfileResults {
   }
 
   /**
-   * Pre-scan recording files to detect if any jdk.CPUTimeSample events are present. When they are,
-   * we prefer them over legacy jdk.ExecutionSample/jdk.NativeMethodSample to avoid double-counting.
+   * Pre-scan recording files for CPU sampling strategy. Returns whether any {@code
+   * jdk.CPUTimeSample} events appear in the inputs. Throws if recordings mix those with legacy
+   * wall-clock samples ({@code jdk.ExecutionSample} / {@code jdk.NativeMethodSample}); only one
+   * CPU sampler should be enabled in JFR settings.
    */
-  static boolean detectCPUTimeSamples(List<String> files) throws IOException {
+  static boolean resolveCpuTimeSampling(List<String> files) throws IOException {
+    boolean hasCpuTime = false;
+    boolean hasLegacy = false;
     for (String file : files) {
       try (RecordingFile recording = new RecordingFile(Paths.get(file))) {
         while (recording.hasMoreEvents()) {
           RecordedEvent event = recording.readEvent();
-          if (event.getEventType().getName().equals("jdk.CPUTimeSample")) {
-            return true;
+          String n = event.getEventType().getName();
+          if (n.equals("jdk.CPUTimeSample")) {
+            hasCpuTime = true;
+          } else if (n.equals("jdk.ExecutionSample") || n.equals("jdk.NativeMethodSample")) {
+            hasLegacy = true;
+          }
+          if (hasCpuTime && hasLegacy) {
+            throw new IllegalStateException(
+                "Mixed CPU profiling events: found both jdk.CPUTimeSample and legacy wall-clock "
+                    + "samples (jdk.ExecutionSample / jdk.NativeMethodSample). Use a single sampler "
+                    + "in JFR settings (see gradle/testing/profiling*.jfc).");
           }
         }
       }
     }
-    return false;
+    return hasCpuTime;
   }
 
   /** value we accumulate for this event */
@@ -200,9 +214,8 @@ public class ProfileResults {
       throw new IllegalArgumentException("tests.profile.count must be positive");
     }
 
-    // Pre-scan to detect if CPU-time samples (Java 25+, JEP 509) are available.
-    // If so, prefer them over legacy execution samples to avoid double-counting.
-    boolean hasCPUTimeSamples = "cpu".equals(mode) && detectCPUTimeSamples(files);
+    // Pre-scan recordings: decide CPU-time vs legacy sampling and reject mixed configurations.
+    boolean hasCPUTimeSamples = "cpu".equals(mode) && resolveCpuTimeSampling(files);
 
     Map<String, SimpleEntry<String, Long>> histogram = new HashMap<>();
     int totalEvents = 0;

--- a/gradle/testing/profiling.cputime.jfc
+++ b/gradle/testing/profiling.cputime.jfc
@@ -19,21 +19,9 @@
   CPU-time method sampling (Java 25+, JEP 509, jdk.CPUTimeSample). Used when CPU-time profiling
   is available for the test JVM (currently only on Linux for this JDK).
 
-  jdk.ExecutionSample and jdk.NativeMethodSample are listed with enabled=false so wall-clock
-  sampling stays off: defaults vary by JDK/template, and we want an explicit single CPU sampler
-  without stacking overhead from legacy execution sampling.
-
   Object allocation events match profiling.jfc for heap profiling mode.
 -->
 <configuration version="2.0" label="TestProfilingCpuTime" description="CPU-time sampling for tests (JEP 509)" provider="Apache">
-  <event name="jdk.ExecutionSample">
-    <setting name="enabled">false</setting>
-  </event>
-
-  <event name="jdk.NativeMethodSample">
-    <setting name="enabled">false</setting>
-  </event>
-
   <event name="jdk.CPUTimeSample">
     <setting name="enabled">true</setting>
     <setting name="throttle">1 ms</setting>

--- a/gradle/testing/profiling.cputime.jfc
+++ b/gradle/testing/profiling.cputime.jfc
@@ -16,11 +16,16 @@
     limitations under the License.
 -->
 <!--
-  Linux: JEP 509 jdk.CPUTimeSample only (no jdk.ExecutionSample / jdk.NativeMethodSample).
-  Wall-clock sampling at 1 ms added measurable overhead in long runs; CPU-time sampling keeps
-  short tests useful via a 1 ms throttle while avoiding duplicate wall-clock + CPU samplers.
+  CPU-time method sampling (Java 25+, JEP 509, jdk.CPUTimeSample). Used when CPU-time profiling
+  is available for the test JVM (currently only on Linux for this JDK).
+
+  jdk.ExecutionSample and jdk.NativeMethodSample are listed with enabled=false so wall-clock
+  sampling stays off: defaults vary by JDK/template, and we want an explicit single CPU sampler
+  without stacking overhead from legacy execution sampling.
+
+  Object allocation events match profiling.jfc for heap profiling mode.
 -->
-<configuration version="2.0" label="TestProfilingLinux" description="CPU-time sampling for unit tests (Linux)" provider="Apache">
+<configuration version="2.0" label="TestProfilingCpuTime" description="CPU-time sampling for tests (JEP 509)" provider="Apache">
   <event name="jdk.ExecutionSample">
     <setting name="enabled">false</setting>
   </event>

--- a/gradle/testing/profiling.jfc
+++ b/gradle/testing/profiling.jfc
@@ -16,7 +16,9 @@
     limitations under the License.
 -->
 <!--
-Collects only execution and method samples at a low interval
+  Wall-clock execution samples for CPU profiling on platforms where JEP 509 CPU-time sampling
+  is unavailable (non-Linux). On Linux, CodeProfilingPlugin uses profiling.linux.jfc instead.
+  Heap allocation events are enabled on all platforms.
 -->
 <configuration version="2.0" label="TestProfiling" description="Sampling for unit tests" provider="Apache">
   <event name="jdk.ExecutionSample">
@@ -27,11 +29,6 @@ Collects only execution and method samples at a low interval
   <event name="jdk.NativeMethodSample">
     <setting name="enabled">true</setting>
     <setting name="period">1 ms</setting>
-  </event>
-
-  <event name="jdk.CPUTimeSample">
-    <setting name="enabled">true</setting>
-    <setting name="throttle">10 ms</setting>
   </event>
 
   <event name="jdk.ObjectAllocationInNewTLAB">

--- a/gradle/testing/profiling.jfc
+++ b/gradle/testing/profiling.jfc
@@ -16,8 +16,8 @@
     limitations under the License.
 -->
 <!--
-  Wall-clock execution samples for CPU profiling on platforms where JEP 509 CPU-time sampling
-  is unavailable (non-Linux). On Linux, CodeProfilingPlugin uses profiling.linux.jfc instead.
+  Wall-clock execution samples for CPU profiling when JEP 509 CPU-time sampling is not used for
+  tests (see profiling.cputime.jfc on hosts where CodeProfilingPlugin selects it).
   Heap allocation events are enabled on all platforms.
 -->
 <configuration version="2.0" label="TestProfiling" description="Sampling for unit tests" provider="Apache">

--- a/gradle/testing/profiling.jfc
+++ b/gradle/testing/profiling.jfc
@@ -29,6 +29,11 @@ Collects only execution and method samples at a low interval
     <setting name="period">1 ms</setting>
   </event>
 
+  <event name="jdk.CPUTimeSample">
+    <setting name="enabled">true</setting>
+    <setting name="throttle">10 ms</setting>
+  </event>
+
   <event name="jdk.ObjectAllocationInNewTLAB">
     <setting name="enabled">true</setting>
     <setting name="stackTrace">true</setting>

--- a/gradle/testing/profiling.linux.jfc
+++ b/gradle/testing/profiling.linux.jfc
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!--
+  Linux: JEP 509 jdk.CPUTimeSample only (no jdk.ExecutionSample / jdk.NativeMethodSample).
+  Wall-clock sampling at 1 ms added measurable overhead in long runs; CPU-time sampling keeps
+  short tests useful via a 1 ms throttle while avoiding duplicate wall-clock + CPU samplers.
+-->
+<configuration version="2.0" label="TestProfilingLinux" description="CPU-time sampling for unit tests (Linux)" provider="Apache">
+  <event name="jdk.ExecutionSample">
+    <setting name="enabled">false</setting>
+  </event>
+
+  <event name="jdk.NativeMethodSample">
+    <setting name="enabled">false</setting>
+  </event>
+
+  <event name="jdk.CPUTimeSample">
+    <setting name="enabled">true</setting>
+    <setting name="throttle">1 ms</setting>
+  </event>
+
+  <event name="jdk.ObjectAllocationInNewTLAB">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ObjectAllocationOutsideTLAB">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+</configuration>

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -188,7 +188,7 @@ Build
 * GITHUB#15926: Support jdk.CPUTimeSample event (Java 25+, JEP 509) in ProfileResults.
   CPU-time profiling produces more accurate profiles by sampling CPU instructions instead
   of wall-clock time. When CPUTimeSample events are present, they are preferred over legacy
-  ExecutionSample events to avoid double-counting. (Prithvi)
+  ExecutionSample events to avoid double-counting. (Prithvi S)
 
 * GITHUB#15327: New low-level build options to detect abuse of LuceneTestCase.random():
   tests.random.maxacquires and tests.random.maxcalls (Robert Muir, Dawid Weiss)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -187,6 +187,11 @@ Changes in Runtime Behavior
 
 Build
 ---------------------
+* GITHUB#15926: Support jdk.CPUTimeSample event (Java 25+, JEP 509) in ProfileResults.
+  CPU-time profiling produces more accurate profiles by sampling CPU instructions instead
+  of wall-clock time. When CPUTimeSample events are present, they are preferred over legacy
+  ExecutionSample events to avoid double-counting. (Prithvi)
+
 * GITHUB#15327: New low-level build options to detect abuse of LuceneTestCase.random():
   tests.random.maxacquires and tests.random.maxcalls (Robert Muir, Dawid Weiss)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -185,10 +185,10 @@ Changes in Runtime Behavior
 
 Build
 ---------------------
-* GITHUB#15926: Support jdk.CPUTimeSample event (Java 25+, JEP 509) in ProfileResults.
-  Linux test JVMs use gradle/testing/profiling.linux.jfc (CPU-time sampling only); other hosts
-  keep wall-clock jdk.ExecutionSample/jdk.NativeMethodSample. CodeProfilingPlugin selects the
-  JFR settings file by host OS. (Prithvi S)
+* GITHUB#15926: Use the Java 25+ (JEP 509) CPU-time sampling profiler when available (currently
+  only on Linux), and fall back to legacy wall-clock execution sampling elsewhere. ProfileResults
+  recognizes jdk.CPUTimeSample; CodeProfilingPlugin picks gradle/testing/profiling.cputime.jfc or
+  profiling.jfc by host OS. (Prithvi S)
 
 * GITHUB#15327: New low-level build options to detect abuse of LuceneTestCase.random():
   tests.random.maxacquires and tests.random.maxcalls (Robert Muir, Dawid Weiss)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -187,8 +187,8 @@ Build
 ---------------------
 * GITHUB#15926: Support jdk.CPUTimeSample event (Java 25+, JEP 509) in ProfileResults.
   Linux test JVMs use gradle/testing/profiling.linux.jfc (CPU-time sampling only); other hosts
-  keep wall-clock jdk.ExecutionSample/jdk.NativeMethodSample. ProfileResults rejects recordings
-  that mix CPU-time and legacy execution samples. (Prithvi S)
+  keep wall-clock jdk.ExecutionSample/jdk.NativeMethodSample. CodeProfilingPlugin selects the
+  JFR settings file by host OS. (Prithvi S)
 
 * GITHUB#15327: New low-level build options to detect abuse of LuceneTestCase.random():
   tests.random.maxacquires and tests.random.maxcalls (Robert Muir, Dawid Weiss)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -186,9 +186,9 @@ Changes in Runtime Behavior
 Build
 ---------------------
 * GITHUB#15926: Support jdk.CPUTimeSample event (Java 25+, JEP 509) in ProfileResults.
-  CPU-time profiling produces more accurate profiles by sampling CPU instructions instead
-  of wall-clock time. When CPUTimeSample events are present, they are preferred over legacy
-  ExecutionSample events to avoid double-counting. (Prithvi S)
+  Linux test JVMs use gradle/testing/profiling.linux.jfc (CPU-time sampling only); other hosts
+  keep wall-clock jdk.ExecutionSample/jdk.NativeMethodSample. ProfileResults rejects recordings
+  that mix CPU-time and legacy execution samples. (Prithvi S)
 
 * GITHUB#15327: New low-level build options to detect abuse of LuceneTestCase.random():
   tests.random.maxacquires and tests.random.maxcalls (Robert Muir, Dawid Weiss)


### PR DESCRIPTION
### Description

Java 25 added CPU-time profiling (JEP 509) which emits jdk.CPUTimeSample
events. ProfileResults did not recognize this event type, causing empty
profiling reports when the CPU-time profiler is active.

Resolves #15926 