### PR TITLE
Fix(15831): Resolve race condition in ReferenceManager.doMaybeRefresh

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -640,6 +640,8 @@ Bug Fixes
 * GITHUB#16250: Fix NullPointerException in RoaringDocIdSet#intoBitSet when the iterator is already
   exhausted. (Venkateshwaran Shanmugham)
 
+* GITHUB#15831: Fixed a race condition in ReferenceManager.maybeRefresh() where refreshes could be missed if a new generation was flushed just before the refresh lock was released. (Vijay)
+
 Other
 ---------------------
 * GITHUB#15586: Document that scoring and ranking may change across major Lucene versions, and that applications requiring stable ranking should explicitly configure Similarity. (Parveen Saini)

--- a/lucene/core/src/java/org/apache/lucene/search/ReferenceManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ReferenceManager.java
@@ -161,26 +161,30 @@ public abstract class ReferenceManager<G> implements Closeable {
     refreshLock.lock();
     boolean refreshed = false;
     try {
-      final G reference = acquire();
-      try {
-        notifyRefreshListenersBefore();
-        G newReference = refreshIfNeeded(reference);
-        if (newReference != null) {
-          assert newReference != reference
-              : "refreshIfNeeded should return null if refresh wasn't needed";
-          try {
-            swapReference(newReference);
-            refreshed = true;
-          } finally {
-            if (!refreshed) {
-              release(newReference);
+      notifyRefreshListenersBefore();
+      while (true) {
+        final G reference = acquire();
+        try {
+          G newReference = refreshIfNeeded(reference);
+          if (newReference != null) {
+            assert newReference != reference
+                : "refreshIfNeeded should return null if refresh wasn't needed";
+            try {
+              swapReference(newReference);
+              refreshed = true;
+            } finally {
+              if (!refreshed) {
+                release(newReference);
+              }
             }
+          } else {
+            break;
           }
+        } finally {
+          release(reference);
         }
-      } finally {
-        release(reference);
-        notifyRefreshListenersRefreshed(refreshed);
       }
+      notifyRefreshListenersRefreshed(refreshed);
       afterMaybeRefresh();
     } finally {
       refreshLock.unlock();

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearcherManager.java
@@ -786,17 +786,11 @@ public class TestSearcherManager extends ThreadedIndexingAndSearchingTestCase {
       w.commit();
     }
 
-    // maybeRefresh only refreshes on the next incremental commit
-    // so it takes us numCommits to get to latest
-    int stepsToCurrent = 0;
-    while (sm.isSearcherCurrent() == false) {
-      long oldGen = sm.getSearcherCommitGeneration();
-      sm.maybeRefreshBlocking();
-      long newGen = sm.getSearcherCommitGeneration();
-      assertTrue(newGen == oldGen + 1);
-      stepsToCurrent++;
-    }
-    assertEquals(numCommits, stepsToCurrent);
+    // maybeRefresh now refreshes to the latest commit in one call
+    long initialGen = sm.getSearcherCommitGeneration();
+    sm.maybeRefreshBlocking();
+    assertTrue(sm.isSearcherCurrent());
+    assertEquals(initialGen + numCommits, sm.getSearcherCommitGeneration());
     sm.close();
     w.close();
     dir.close();

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestSearcherTaxonomyManager.java
@@ -422,18 +422,14 @@ public class TestSearcherTaxonomyManager extends FacetTestCase {
       tw.commit();
     }
 
-    // maybeRefresh only refreshes on the next incremental commit
-    // so it takes us numCommits to get to latest
-    int stepsToCurrent = 0;
-    while (sat.isSearcherCurrent() == false) {
-      long oldGen = sat.getSearcherCommitGeneration();
-      sat.maybeRefreshBlocking();
-      long newGen = sat.getSearcherCommitGeneration();
-      assertEquals(newGen, oldGen + 1);
-      stepsToCurrent++;
-      assertTrue(sat.isTaxonomyCurrent());
-    }
-    assertEquals(numCommits, stepsToCurrent);
+    long initialGen = sat.getSearcherCommitGeneration();
+    sat.maybeRefreshBlocking();
+    assertTrue(sat.isSearcherCurrent());
+    assertEquals(initialGen + numCommits, sat.getSearcherCommitGeneration());
+    assertTrue(sat.isTaxonomyCurrent());
+    int stepsToCurrent = 1;
+    assertEquals(1, stepsToCurrent);
+
     sat.close();
     w.close();
     tw.close();


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
The key behavioral change is that with the loop in doMaybeRefresh(), a single call to maybeRefreshBlocking() will now refresh through multiple generations until the reference is fully up to date. This ensures that pending refreshes are not lost due to timing races.

Resolves #15831 