### PR TITLE
Fix JFR profile summary skip check

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/CodeProfilingPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/CodeProfilingPlugin.java
@@ -204,7 +204,7 @@ public class CodeProfilingPlugin extends LuceneGradlePlugin {
                               .getProviders()
                               .provider(
                                   () -> {
-                                    return task.getState().getDidWork();
+                                    return task.getState().getFailure() == null;
                                   }));
                 });
           });

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/CodeProfilingPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/CodeProfilingPlugin.java
@@ -204,10 +204,19 @@ public class CodeProfilingPlugin extends LuceneGradlePlugin {
                               .getProviders()
                               .provider(
                                   () -> {
-                                    return task.getState().getFailure() == null;
+                                    return taskDidNotFail(task);
                                   }));
                 });
           });
+    }
+  }
+
+  private static boolean taskDidNotFail(Test task) {
+    try {
+      task.getState().rethrowFailure();
+      return true;
+    } catch (RuntimeException _) {
+      return false;
     }
   }
 


### PR DESCRIPTION
### Description

fixes https://github.com/apache/lucene/pull/15983#issuecomment-4345868221

`showJfrProfileSummary` used `Test.getState().getDidWork()` to decide whether any test task failed. This can be false for skipped/up-to-date/not-selected tasks even when nothing failed, causing the profile summary to be skipped incorrectly.

Used `Test.getState().getFailure() == null` instead so the profile summary is skipped only when a test task actually failed.