### PR TITLE
Optimize IndexSearcher.count() to rewrite the query once

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -351,6 +351,8 @@ Optimizations
 * GITHUB#15732: Prevent writing vectors twice during merging HNSW graphs by allowing doing deferred work after calling
   merge for vectors is finshed. (Ignacio Vera)
 
+* GITHUB#16001: IndexSearcher.count() was calling query.rewrite twice, a regression since v9.10 (David Smiley)
+
 Bug Fixes
 ---------------------
 * GITHUB#15754: Fix HTMLStripCharFilter to prevent tags from incorrectly consuming subsequent

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -493,14 +493,16 @@ public class IndexSearcher {
    * possible.
    */
   public int count(Query query) throws IOException {
-    // Rewrite query before optimization check
     query = rewrite(new ConstantScoreQuery(query));
-    if (query instanceof ConstantScoreQuery csq) {
-      query = csq.getQuery();
+
+    // Unwrap CSQ to check for optimizations on the inner query
+    Query innerQuery = query;
+    if (innerQuery instanceof ConstantScoreQuery csq) {
+      innerQuery = csq.getQuery();
     }
 
     // Check if two clause disjunction optimization applies
-    if (query instanceof BooleanQuery booleanQuery
+    if (innerQuery instanceof BooleanQuery booleanQuery
         && this.reader.hasDeletions() == false
         && booleanQuery.isTwoClausePureDisjunctionWithTerms()) {
       Query[] queries = booleanQuery.rewriteTwoClauseDisjunctionWithTermsForCount(this);
@@ -514,7 +516,12 @@ public class IndexSearcher {
         return countTerm1 + countTerm2 - count(queries[2]);
       }
     }
-    return search(new ConstantScoreQuery(query), new TotalHitCountCollectorManager(getSlices()));
+
+    // Use the already-rewritten query directly, avoiding a redundant rewrite in search(query, collector)
+    var collectorManager = new TotalHitCountCollectorManager(getSlices());
+    var firstCollector = collectorManager.newCollector();
+    final Weight weight = createWeight(query, firstCollector.scoreMode(), 1);
+    return search(weight, collectorManager, firstCollector);
   }
 
   /**
@@ -958,7 +965,7 @@ public class IndexSearcher {
 
   /**
    * Creates a {@link Weight} for the given query, potentially adding caching if possible and
-   * configured.
+   * configured. The query is assumed to have been {@link #rewrite(Query)}-en already.
    *
    * @lucene.experimental
    */

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -493,31 +493,35 @@ public class IndexSearcher {
    * possible.
    */
   public int count(Query query) throws IOException {
+    // CSQ.rewrite may simplify the query -- don't need scores
     query = rewrite(new ConstantScoreQuery(query));
 
-    // Unwrap CSQ to check for optimizations on the inner query
-    Query innerQuery = query;
-    if (innerQuery instanceof ConstantScoreQuery csq) {
-      innerQuery = csq.getQuery();
-    }
+    {
+      // Unwrap CSQ to check for optimizations on the inner query
+      Query innerQuery = query;
+      if (innerQuery instanceof ConstantScoreQuery csq) {
+        innerQuery = csq.getQuery();
+      }
 
-    // Check if two clause disjunction optimization applies
-    if (innerQuery instanceof BooleanQuery booleanQuery
-        && this.reader.hasDeletions() == false
-        && booleanQuery.isTwoClausePureDisjunctionWithTerms()) {
-      Query[] queries = booleanQuery.rewriteTwoClauseDisjunctionWithTermsForCount(this);
-      int countTerm1 = count(queries[0]);
-      int countTerm2 = count(queries[1]);
-      if (countTerm1 == 0 || countTerm2 == 0) {
-        return Math.max(countTerm1, countTerm2);
-        // Only apply optimization if the intersection is significantly smaller than the union
-      } else if ((double) Math.min(countTerm1, countTerm2) / Math.max(countTerm1, countTerm2)
-          < 0.1) {
-        return countTerm1 + countTerm2 - count(queries[2]);
+      // Check if two clause disjunction optimization applies
+      if (innerQuery instanceof BooleanQuery booleanQuery
+          && this.reader.hasDeletions() == false
+          && booleanQuery.isTwoClausePureDisjunctionWithTerms()) {
+        Query[] queries = booleanQuery.rewriteTwoClauseDisjunctionWithTermsForCount(this);
+        int countTerm1 = count(queries[0]);
+        int countTerm2 = count(queries[1]);
+        if (countTerm1 == 0 || countTerm2 == 0) {
+          return Math.max(countTerm1, countTerm2);
+          // Only apply optimization if the intersection is significantly smaller than the union
+        } else if ((double) Math.min(countTerm1, countTerm2) / Math.max(countTerm1, countTerm2)
+            < 0.1) {
+          return countTerm1 + countTerm2 - count(queries[2]);
+        }
       }
     }
 
-    // Use the already-rewritten query directly, avoiding a redundant rewrite in search(query, collector)
+    // Use the already-rewritten query directly, avoiding a redundant rewrite in search(query,
+    // collector)
     var collectorManager = new TotalHitCountCollectorManager(getSlices());
     var firstCollector = collectorManager.newCollector();
     final Weight weight = createWeight(query, firstCollector.scoreMode(), 1);


### PR DESCRIPTION
IndexSearcher.count was invoking Query.rewrite and then calling search() which would rewrite the query again.  Rewriting the query can be expensive.

Credit to my colleague Niyant for noticing this when doing some JFR analysis.