### PR TITLE
Optimize QueryVisitor.EMPTY_VISITOR

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/QueryVisitor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/QueryVisitor.java
@@ -98,5 +98,11 @@ public abstract class QueryVisitor {
   }
 
   /** A QueryVisitor implementation that does nothing */
-  public static final QueryVisitor EMPTY_VISITOR = new QueryVisitor() {};
+  public static final QueryVisitor EMPTY_VISITOR =
+      new QueryVisitor() {
+        @Override
+        public boolean acceptField(String field) {
+          return false;
+        }
+      };
 }


### PR DESCRIPTION
It's a shame the EMPTY_VISITOR was nonetheless still processing various MultiTermQuery implementations.  This fixes that.