### PR TITLE
Misc junit4 test cleanups

### DIFF
--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestDictionary.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestDictionary.java
@@ -37,7 +37,6 @@ import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.IntsRef;
-import org.junit.Test;
 
 public class TestDictionary extends LuceneTestCase {
 
@@ -325,7 +324,6 @@ public class TestDictionary extends LuceneTestCase {
     assertNotNull(Dictionary.getFlagParsingStrategy("FLAG    UTF-8", UTF_8));
   }
 
-  @Test
   public void testUtf8Flag() {
     Dictionary.FlagParsingStrategy strategy =
         Dictionary.getFlagParsingStrategy("FLAG\tUTF-8", Dictionary.DEFAULT_CHARSET);
@@ -336,7 +334,6 @@ public class TestDictionary extends LuceneTestCase {
     assertEquals(src, new String(strategy.parseFlags(asAscii)));
   }
 
-  @Test
   public void testCustomMorphologicalData() throws IOException, ParseException {
     Dictionary dic = loadDictionary("morphdata.aff", "morphdata.dic");
     assertNull(dic.lookupEntries("nonexistent"));

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestHunspell.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestHunspell.java
@@ -37,7 +37,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestHunspell extends LuceneTestCase {
   public void testCheckCanceled() throws Exception {
@@ -108,14 +107,12 @@ public class TestHunspell extends LuceneTestCase {
     assertEquals(Collections.emptyList(), noLimit.suggest(word.substring(0, 5), timeLimitMs));
   }
 
-  @Test
   public void testStemmingApi() throws Exception {
     Hunspell hunspell = loadNoTimeout("simple");
     assertEquals(Collections.singletonList("apach"), hunspell.getRoots("apache"));
     assertEquals(Collections.singletonList("foo"), hunspell.getRoots("foo"));
   }
 
-  @Test
   public void testAnalysisApi() throws Exception {
     Hunspell hunspell = loadNoTimeout("base");
     assertEquals(hunspell.analyzeSimpleWord("nonexistent"), List.of());
@@ -123,26 +120,22 @@ public class TestHunspell extends LuceneTestCase {
     checkAffixedWord(word, "create", List.of("A"), List.of("D"));
   }
 
-  @Test
   public void testAnalysisSeveralSuffixes() throws Exception {
     Hunspell hunspell = loadNoTimeout("needaffix5");
     AffixedWord word = hunspell.analyzeSimpleWord("pseudoprefoopseudosufbar").get(0);
     checkAffixedWord(word, "foo", List.of("C"), List.of("B", "A"));
   }
 
-  @Test
   public void testAnalysisFlagLong() throws Exception {
     AffixedWord word = loadNoTimeout("flaglong").analyzeSimpleWord("foos").get(0);
     checkAffixedWord(word, "foo", List.of(), List.of("Y1"));
   }
 
-  @Test
   public void testAnalysisFlagNum() throws Exception {
     AffixedWord word = loadNoTimeout("flagnum").analyzeSimpleWord("foos").get(0);
     checkAffixedWord(word, "foo", List.of(), List.of("65000"));
   }
 
-  @Test
   public void testAnalysisMorphData() throws Exception {
     List<AffixedWord> words = loadNoTimeout("morphdata").analyzeSimpleWord("works");
     assertEquals(2, words.size());
@@ -175,7 +168,6 @@ public class TestHunspell extends LuceneTestCase {
     return new Hunspell(dictionary, TimeoutPolicy.NO_TIMEOUT, () -> {});
   }
 
-  @Test
   public void testExpandRootApi() throws Exception {
     Hunspell h = loadNoTimeout("base");
     String[] createFormsBase = {
@@ -208,7 +200,6 @@ public class TestHunspell extends LuceneTestCase {
         nonExistentRoot.stream().map(w -> w.getWord()).collect(Collectors.toSet()));
   }
 
-  @Test
   public void testCompressingApi() throws Exception {
     Hunspell h = loadNoTimeout("base");
     String[] createQuery = {"create", "created", "creates", "creating", "creation"};
@@ -222,7 +213,6 @@ public class TestHunspell extends LuceneTestCase {
         loadNoTimeout("compress"), "toEdit=[], toAdd=[form/X], extra=[forms]", "form", "formx");
   }
 
-  @Test
   public void testCompressingIsMinimal() throws Exception {
     Hunspell h = loadNoTimeout("compress");
     checkCompression(
@@ -236,14 +226,12 @@ public class TestHunspell extends LuceneTestCase {
     assertEquals("toEdit=[], toAdd=[f/abc], extra=[]", fAbc.internalsToString());
   }
 
-  @Test
   public void testCompressingIsFastOnLargeUnrelatedWordSets() throws Exception {
     Hunspell h = loadNoTimeout("compress");
     String[] letters = {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"};
     checkCompression(h, "toEdit=[], toAdd=[a, b, c, d, e, f, g, h, i, j, k, l], extra=[]", letters);
   }
 
-  @Test
   public void testCompressingWithProhibition() throws Exception {
     WordFormGenerator gen = new WordFormGenerator(loadNoTimeout("compress").dictionary);
     assertEquals(
@@ -258,7 +246,6 @@ public class TestHunspell extends LuceneTestCase {
     assertEquals(expected, h.compress(List.of(words)).internalsToString());
   }
 
-  @Test
   public void testSuggestionOrderStabilityOnDictionaryEditing() throws IOException, ParseException {
     String original = "some_word";
 

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestHunspellRepositoryTestCases.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestHunspellRepositoryTestCases.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import org.junit.Assert;
 import org.junit.AssumptionViolatedException;
-import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -74,7 +73,6 @@ public class TestHunspellRepositoryTestCases {
     return names.stream().map(s -> new Object[] {s, tests.resolve(s)}).toList();
   }
 
-  @Test
   public void test() throws Throwable {
     ThrowingRunnable test = () -> TestSpellChecking.checkSpellCheckerExpectations(pathPrefix);
     if (EXPECTED_FAILURES.contains(testName)) {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/minhash/TestMinHashFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/minhash/TestMinHashFilter.java
@@ -33,12 +33,10 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
-import org.junit.Test;
 
 /** Tests for {@link MinHashFilter} */
 public class TestMinHashFilter extends BaseTokenStreamTestCase {
 
-  @Test
   public void testIntHash() {
     LongPair hash = new LongPair();
     MinHashFilter.murmurhash3_x64_128(MinHashFilter.getBytes(0), 0, 4, 0, hash);
@@ -46,7 +44,6 @@ public class TestMinHashFilter extends BaseTokenStreamTestCase {
     assertEquals(6383328099726337777L, hash.val2);
   }
 
-  @Test
   public void testStringHash() {
     LongPair hash = new LongPair();
     byte[] bytes = "woof woof woof woof woof".getBytes(StandardCharsets.UTF_16LE);
@@ -55,7 +52,6 @@ public class TestMinHashFilter extends BaseTokenStreamTestCase {
     assertEquals(4378804943379391304L, hash.val2);
   }
 
-  @Test
   public void testSimpleOrder() {
     LongPair hash1 = new LongPair();
     hash1.val1 = 1;
@@ -66,7 +62,6 @@ public class TestMinHashFilter extends BaseTokenStreamTestCase {
     assert (hash1.compareTo(hash2) > 0);
   }
 
-  @Test
   public void testHashOrder() {
     assertTrue(!MinHashFilter.isLessThanUnsigned(0L, 0L));
     assertTrue(MinHashFilter.isLessThanUnsigned(0L, -1L));
@@ -137,7 +132,6 @@ public class TestMinHashFilter extends BaseTokenStreamTestCase {
     }
   }
 
-  @Test
   public void testHashNotRepeated() {
     FixedSizeTreeSet<LongPair> minSet = new FixedSizeTreeSet<>(500);
     HashSet<LongPair> unadded = new HashSet<>();
@@ -170,7 +164,6 @@ public class TestMinHashFilter extends BaseTokenStreamTestCase {
     }
   }
 
-  @Test
   public void testMockShingleTokenizer() throws IOException {
     Tokenizer mockShingleTokenizer =
         createMockShingleTokenizer(
@@ -180,7 +173,6 @@ public class TestMinHashFilter extends BaseTokenStreamTestCase {
         new String[] {"woof woof woof woof woof", "woof woof woof woof puff"});
   }
 
-  @Test
   public void testTokenStreamSingleInput() throws IOException {
     String[] hashes = new String[] {"℁팽徭聙↝ꇁ홱杯"};
     TokenStream ts = createTokenStream(5, "woof woof woof woof woof", 1, 1, 100, false);
@@ -217,7 +209,6 @@ public class TestMinHashFilter extends BaseTokenStreamTestCase {
         null);
   }
 
-  @Test
   public void testTokenStream1() throws IOException {
     String[] hashes =
         new String[] {
@@ -258,7 +249,6 @@ public class TestMinHashFilter extends BaseTokenStreamTestCase {
     return tokens;
   }
 
-  @Test
   public void testTokenStream2() throws IOException {
     TokenStream ts =
         createTokenStream(
@@ -269,7 +259,6 @@ public class TestMinHashFilter extends BaseTokenStreamTestCase {
     assertEquals(100, tokens.size());
   }
 
-  @Test
   public void testTokenStream3() throws IOException {
     TokenStream ts =
         createTokenStream(
@@ -280,7 +269,6 @@ public class TestMinHashFilter extends BaseTokenStreamTestCase {
     assertEquals(20, tokens.size());
   }
 
-  @Test
   public void testTokenStream4() throws IOException {
     TokenStream ts =
         createTokenStream(
@@ -299,7 +287,6 @@ public class TestMinHashFilter extends BaseTokenStreamTestCase {
     assertEquals(100, tokens.size());
   }
 
-  @Test
   public void testTokenStream5() throws IOException {
     TokenStream ts =
         createTokenStream(

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestCapitalizationFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestCapitalizationFilter.java
@@ -31,7 +31,6 @@ import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.tests.analysis.MockTokenizer;
-import org.junit.Test;
 
 /** Tests {@link CapitalizationFilter} */
 public class TestCapitalizationFilter extends BaseTokenStreamTestCase {
@@ -295,7 +294,6 @@ public class TestCapitalizationFilter extends BaseTokenStreamTestCase {
   }
 
   /** checking the validity of constructor arguments */
-  @Test
   public void testIllegalArguments() throws Exception {
     expectThrows(
         IllegalArgumentException.class,
@@ -312,7 +310,6 @@ public class TestCapitalizationFilter extends BaseTokenStreamTestCase {
         });
   }
 
-  @Test
   public void testIllegalArguments1() throws Exception {
     expectThrows(
         IllegalArgumentException.class,
@@ -329,7 +326,6 @@ public class TestCapitalizationFilter extends BaseTokenStreamTestCase {
         });
   }
 
-  @Test
   public void testIllegalArguments2() throws Exception {
     expectThrows(
         IllegalArgumentException.class,

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestCapitalizationFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestCapitalizationFilter.java
@@ -295,42 +295,54 @@ public class TestCapitalizationFilter extends BaseTokenStreamTestCase {
   }
 
   /** checking the validity of constructor arguments */
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalArguments() throws Exception {
-    new CapitalizationFilter(
-        whitespaceMockTokenizer("accept only valid arguments"),
-        true,
-        null,
-        true,
-        null,
-        -1,
-        DEFAULT_MAX_WORD_COUNT,
-        DEFAULT_MAX_TOKEN_LENGTH);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new CapitalizationFilter(
+              whitespaceMockTokenizer("accept only valid arguments"),
+              true,
+              null,
+              true,
+              null,
+              -1,
+              DEFAULT_MAX_WORD_COUNT,
+              DEFAULT_MAX_TOKEN_LENGTH);
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalArguments1() throws Exception {
-    new CapitalizationFilter(
-        whitespaceMockTokenizer("accept only valid arguments"),
-        true,
-        null,
-        true,
-        null,
-        0,
-        -10,
-        DEFAULT_MAX_TOKEN_LENGTH);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new CapitalizationFilter(
+              whitespaceMockTokenizer("accept only valid arguments"),
+              true,
+              null,
+              true,
+              null,
+              0,
+              -10,
+              DEFAULT_MAX_TOKEN_LENGTH);
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalArguments2() throws Exception {
-    new CapitalizationFilter(
-        whitespaceMockTokenizer("accept only valid arguments"),
-        true,
-        null,
-        true,
-        null,
-        0,
-        DEFAULT_MAX_WORD_COUNT,
-        -50);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new CapitalizationFilter(
+              whitespaceMockTokenizer("accept only valid arguments"),
+              true,
+              null,
+              true,
+              null,
+              0,
+              DEFAULT_MAX_WORD_COUNT,
+              -50);
+        });
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestCodepointCountFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestCodepointCountFilter.java
@@ -70,8 +70,12 @@ public class TestCodepointCountFilter extends BaseTokenStreamTestCase {
   }
 
   /** checking the validity of constructor arguments */
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalArguments() throws Exception {
-    new CodepointCountFilter(whitespaceMockTokenizer("accept only valid arguments"), 4, 1);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new CodepointCountFilter(whitespaceMockTokenizer("accept only valid arguments"), 4, 1);
+        });
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestCodepointCountFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestCodepointCountFilter.java
@@ -24,7 +24,6 @@ import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.tests.util.TestUtil;
-import org.junit.Test;
 
 public class TestCodepointCountFilter extends BaseTokenStreamTestCase {
   public void testFilterWithPosIncr() throws Exception {
@@ -70,7 +69,6 @@ public class TestCodepointCountFilter extends BaseTokenStreamTestCase {
   }
 
   /** checking the validity of constructor arguments */
-  @Test
   public void testIllegalArguments() throws Exception {
     expectThrows(
         IllegalArgumentException.class,

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestConcatenateGraphFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestConcatenateGraphFilter.java
@@ -29,13 +29,11 @@ import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.util.CharsRef;
 import org.apache.lucene.util.CharsRefBuilder;
-import org.junit.Test;
 
 public class TestConcatenateGraphFilter extends BaseTokenStreamTestCase {
 
   private static final char SEP_LABEL = (char) ConcatenateGraphFilter.SEP_LABEL;
 
-  @Test
   public void testBasic() throws Exception {
     Tokenizer tokenStream = new MockTokenizer(MockTokenizer.WHITESPACE, true);
     String input = "mykeyword";
@@ -44,7 +42,6 @@ public class TestConcatenateGraphFilter extends BaseTokenStreamTestCase {
     assertTokenStreamContents(stream, new String[] {input}, null, null, new int[] {1});
   }
 
-  @Test
   public void testWithNoPreserveSep() throws Exception {
     Tokenizer tokenStream = new MockTokenizer(MockTokenizer.WHITESPACE, true);
     String input = "mykeyword another keyword";
@@ -54,7 +51,6 @@ public class TestConcatenateGraphFilter extends BaseTokenStreamTestCase {
         stream, new String[] {"mykeywordanotherkeyword"}, null, null, new int[] {1});
   }
 
-  @Test
   public void testWithMultipleTokens() throws Exception {
     Tokenizer tokenStream = new MockTokenizer(MockTokenizer.WHITESPACE, true);
     String input = "mykeyword another keyword";
@@ -70,7 +66,6 @@ public class TestConcatenateGraphFilter extends BaseTokenStreamTestCase {
         stream, new String[] {builder.toCharsRef().toString()}, null, null, new int[] {1});
   }
 
-  @Test
   public void testWithSynonym() throws Exception {
     SynonymMap.Builder builder = new SynonymMap.Builder(true);
     builder.add(new CharsRef("mykeyword"), new CharsRef("mysynonym"), true);
@@ -83,7 +78,6 @@ public class TestConcatenateGraphFilter extends BaseTokenStreamTestCase {
         stream, new String[] {"mykeyword", "mysynonym"}, null, null, new int[] {1, 0});
   }
 
-  @Test
   public void testWithSynonyms() throws Exception {
     SynonymMap.Builder builder = new SynonymMap.Builder(true);
     builder.add(new CharsRef("mykeyword"), new CharsRef("mysynonym"), true);
@@ -111,7 +105,6 @@ public class TestConcatenateGraphFilter extends BaseTokenStreamTestCase {
     assertTokenStreamContents(stream, expectedOutputs, null, null, new int[] {1, 0});
   }
 
-  @Test
   public void testWithStopword() throws Exception {
     for (boolean preservePosInc : new boolean[] {true, false}) {
       Tokenizer tokenStream = new MockTokenizer(MockTokenizer.WHITESPACE, true);
@@ -137,7 +130,6 @@ public class TestConcatenateGraphFilter extends BaseTokenStreamTestCase {
     }
   }
 
-  @Test
   public void testValidNumberOfExpansions() throws IOException {
     SynonymMap.Builder builder = new SynonymMap.Builder(true);
     for (int i = 0; i < 256; i++) {
@@ -174,7 +166,6 @@ public class TestConcatenateGraphFilter extends BaseTokenStreamTestCase {
     assertTokenStreamContents(filter, new String[0]);
   }
 
-  @Test
   public void testSeparator() throws IOException {
     Tokenizer tokenStream = new MockTokenizer(MockTokenizer.SIMPLE, true);
     String input = "...mykeyword.another.keyword.";
@@ -185,7 +176,6 @@ public class TestConcatenateGraphFilter extends BaseTokenStreamTestCase {
         stream, new String[] {"mykeyword another keyword"}, null, null, new int[] {1});
   }
 
-  @Test
   public void testSeparatorWithStopWords() throws IOException {
     Tokenizer tokenStream = new MockTokenizer(MockTokenizer.WHITESPACE, false);
     String input = "A B C D E F J H";
@@ -197,7 +187,6 @@ public class TestConcatenateGraphFilter extends BaseTokenStreamTestCase {
     assertTokenStreamContents(stream, new String[] {"B-C-F-H"}, null, null, new int[] {1});
   }
 
-  @Test
   public void testSeparatorWithStopWordsAndPreservePositionIncrements() throws IOException {
     Tokenizer tokenStream = new MockTokenizer(MockTokenizer.WHITESPACE, false);
     String input = "A B C D E F J H";
@@ -209,7 +198,6 @@ public class TestConcatenateGraphFilter extends BaseTokenStreamTestCase {
     assertTokenStreamContents(stream, new String[] {"-B-C---F--H"}, null, null, new int[] {1});
   }
 
-  @Test
   public void testSeparatorWithSynonyms() throws IOException {
     SynonymMap.Builder builder = new SynonymMap.Builder(true);
     builder.add(new CharsRef("mykeyword"), new CharsRef("mysynonym"), true);

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestKeywordMarkerFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestKeywordMarkerFilter.java
@@ -25,12 +25,10 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.KeywordAttribute;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
-import org.junit.Test;
 
 /** Testcase for {@link KeywordMarkerFilter} */
 public class TestKeywordMarkerFilter extends BaseTokenStreamTestCase {
 
-  @Test
   public void testSetFilterIncrementToken() throws IOException {
     CharArraySet set = new CharArraySet(5, true);
     set.add("lucenefox");
@@ -54,7 +52,6 @@ public class TestKeywordMarkerFilter extends BaseTokenStreamTestCase {
         output);
   }
 
-  @Test
   public void testPatternFilterIncrementToken() throws IOException {
     String[] output = new String[] {"the", "quick", "brown", "LuceneFox", "jumps"};
     assertTokenStreamContents(

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLengthFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLengthFilter.java
@@ -22,7 +22,6 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
-import org.junit.Test;
 
 public class TestLengthFilter extends BaseTokenStreamTestCase {
 
@@ -47,7 +46,6 @@ public class TestLengthFilter extends BaseTokenStreamTestCase {
   }
 
   /** checking the validity of constructor arguments */
-  @Test
   public void testIllegalArguments() throws Exception {
     expectThrows(
         IllegalArgumentException.class,

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLengthFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLengthFilter.java
@@ -47,8 +47,12 @@ public class TestLengthFilter extends BaseTokenStreamTestCase {
   }
 
   /** checking the validity of constructor arguments */
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalArguments() throws Exception {
-    new LengthFilter(whitespaceMockTokenizer("accept only valid arguments"), -4, -1);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new LengthFilter(whitespaceMockTokenizer("accept only valid arguments"), -4, -1);
+        });
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLimitTokenCountFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLimitTokenCountFilter.java
@@ -19,7 +19,6 @@ package org.apache.lucene.analysis.miscellaneous;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.tests.analysis.MockTokenizer;
-import org.junit.Test;
 
 public class TestLimitTokenCountFilter extends BaseTokenStreamTestCase {
 
@@ -32,7 +31,6 @@ public class TestLimitTokenCountFilter extends BaseTokenStreamTestCase {
     }
   }
 
-  @Test
   public void testIllegalArguments() throws Exception {
     expectThrows(
         IllegalArgumentException.class,

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLimitTokenCountFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLimitTokenCountFilter.java
@@ -32,8 +32,12 @@ public class TestLimitTokenCountFilter extends BaseTokenStreamTestCase {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalArguments() throws Exception {
-    new LimitTokenCountFilter(whitespaceMockTokenizer("A1 B2 C3 D4 E5 F6"), -1);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new LimitTokenCountFilter(whitespaceMockTokenizer("A1 B2 C3 D4 E5 F6"), -1);
+        });
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLimitTokenOffsetFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLimitTokenOffsetFilter.java
@@ -33,8 +33,12 @@ public class TestLimitTokenOffsetFilter extends BaseTokenStreamTestCase {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalArguments() throws Exception {
-    new LimitTokenOffsetFilter(whitespaceMockTokenizer("A1 B2 C3 D4 E5 F6"), -1);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new LimitTokenOffsetFilter(whitespaceMockTokenizer("A1 B2 C3 D4 E5 F6"), -1);
+        });
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLimitTokenOffsetFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLimitTokenOffsetFilter.java
@@ -19,7 +19,6 @@ package org.apache.lucene.analysis.miscellaneous;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.tests.analysis.MockTokenizer;
-import org.junit.Test;
 
 public class TestLimitTokenOffsetFilter extends BaseTokenStreamTestCase {
 
@@ -33,7 +32,6 @@ public class TestLimitTokenOffsetFilter extends BaseTokenStreamTestCase {
     }
   }
 
-  @Test
   public void testIllegalArguments() throws Exception {
     expectThrows(
         IllegalArgumentException.class,

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLimitTokenPositionFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLimitTokenPositionFilter.java
@@ -26,7 +26,6 @@ import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.util.CharsRef;
 import org.apache.lucene.util.CharsRefBuilder;
-import org.junit.Test;
 
 public class TestLimitTokenPositionFilter extends BaseTokenStreamTestCase {
 
@@ -120,7 +119,6 @@ public class TestLimitTokenPositionFilter extends BaseTokenStreamTestCase {
     }
   }
 
-  @Test
   public void testIllegalArguments() throws Exception {
     expectThrows(
         IllegalArgumentException.class,

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLimitTokenPositionFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestLimitTokenPositionFilter.java
@@ -120,8 +120,12 @@ public class TestLimitTokenPositionFilter extends BaseTokenStreamTestCase {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testIllegalArguments() throws Exception {
-    new LimitTokenPositionFilter(whitespaceMockTokenizer("one two three four five"), 0);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new LimitTokenPositionFilter(whitespaceMockTokenizer("one two three four five"), 0);
+        });
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestTruncateTokenFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestTruncateTokenFilter.java
@@ -124,15 +124,23 @@ public class TestTruncateTokenFilter extends BaseTokenStreamTestCase {
     checkRandomData(rnd, a, 20 * RANDOM_MULTIPLIER, truncateLength * 2);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testLegacyNonPositiveLength() throws Exception {
-    TruncateTokenFilter.truncateAfterChars(
-        whitespaceMockTokenizer("param must be a positive number"), -48);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          TruncateTokenFilter.truncateAfterChars(
+              whitespaceMockTokenizer("param must be a positive number"), -48);
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNonPositiveLength() throws Exception {
-    TruncateTokenFilter.truncateAfterCodePoints(
-        whitespaceMockTokenizer("param must be a positive number"), -48);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          TruncateTokenFilter.truncateAfterCodePoints(
+              whitespaceMockTokenizer("param must be a positive number"), -48);
+        });
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestTruncateTokenFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestTruncateTokenFilter.java
@@ -23,7 +23,6 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.util.TestUtil;
-import org.junit.Test;
 
 /** Test the truncate token filter. */
 public class TestTruncateTokenFilter extends BaseTokenStreamTestCase {
@@ -124,7 +123,6 @@ public class TestTruncateTokenFilter extends BaseTokenStreamTestCase {
     checkRandomData(rnd, a, 20 * RANDOM_MULTIPLIER, truncateLength * 2);
   }
 
-  @Test
   public void testLegacyNonPositiveLength() throws Exception {
     expectThrows(
         IllegalArgumentException.class,
@@ -134,7 +132,6 @@ public class TestTruncateTokenFilter extends BaseTokenStreamTestCase {
         });
   }
 
-  @Test
   public void testNonPositiveLength() throws Exception {
     expectThrows(
         IllegalArgumentException.class,

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/synonym/word2vec/TestWord2VecSynonymFilterFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/synonym/word2vec/TestWord2VecSynonymFilterFactory.java
@@ -27,7 +27,6 @@ public class TestWord2VecSynonymFilterFactory extends BaseTokenStreamFactoryTest
   public static final String FACTORY_NAME = "Word2VecSynonym";
   private static final String WORD2VEC_MODEL_FILE = "word2vec-model.zip";
 
-  @Test
   public void testInform() throws Exception {
     ResourceLoader loader = new ClasspathResourceLoader(getClass());
     assertTrue("loader is null and it shouldn't be", loader != null);

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/synonym/word2vec/TestWord2VecSynonymProvider.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/synonym/word2vec/TestWord2VecSynonymProvider.java
@@ -107,7 +107,6 @@ public class TestWord2VecSynonymProvider extends LuceneTestCase {
     assertEquals(0, actualSynonymsResults.size());
   }
 
-  @Test
   public void testModel_shouldReturnNormalizedVectors() {
     Word2VecModel model = new Word2VecModel(4, 2);
     model.addTermAndVector(new TermAndVector(new BytesRef("a"), new float[] {10, 10}));

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseCompletionAnalyzer.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseCompletionAnalyzer.java
@@ -20,11 +20,9 @@ import java.io.IOException;
 import java.util.Random;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
-import org.junit.Test;
 
 public class TestJapaneseCompletionAnalyzer extends BaseTokenStreamTestCase {
 
-  @Test
   public void testCompletionDefault() throws IOException {
     // mode=INDEX (default)
     Analyzer analyzer = new JapaneseCompletionAnalyzer();
@@ -38,7 +36,6 @@ public class TestJapaneseCompletionAnalyzer extends BaseTokenStreamTestCase {
     analyzer.close();
   }
 
-  @Test
   public void testCompletionQuery() throws IOException {
     // mode=QUERY
     Analyzer analyzer = new JapaneseCompletionAnalyzer(null, JapaneseCompletionFilter.Mode.QUERY);
@@ -53,7 +50,6 @@ public class TestJapaneseCompletionAnalyzer extends BaseTokenStreamTestCase {
   }
 
   /** blast random strings against the analyzer */
-  @Test
   public void testRandom() throws IOException {
     Random random = random();
     final Analyzer a = new JapaneseCompletionAnalyzer();
@@ -62,7 +58,6 @@ public class TestJapaneseCompletionAnalyzer extends BaseTokenStreamTestCase {
   }
 
   /** blast some random large strings through the analyzer */
-  @Test
   public void testRandomHugeStrings() throws Exception {
     Random random = random();
     final Analyzer a = new JapaneseCompletionAnalyzer();

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseCompletionFilter.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseCompletionFilter.java
@@ -24,7 +24,6 @@ import org.apache.lucene.analysis.cjk.CJKWidthCharFilter;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 public class TestJapaneseCompletionFilter extends BaseTokenStreamTestCase {
   private Analyzer indexAnalyzer;
@@ -82,7 +81,6 @@ public class TestJapaneseCompletionFilter extends BaseTokenStreamTestCase {
     super.tearDown();
   }
 
-  @Test
   public void testCompletionIndex() throws IOException {
     assertAnalyzesTo(
         indexAnalyzer,
@@ -144,7 +142,6 @@ public class TestJapaneseCompletionFilter extends BaseTokenStreamTestCase {
         new int[] {1, 0, 1, 1, 0});
   }
 
-  @Test
   public void testCompletionQuery() throws IOException {
     assertAnalyzesTo(
         queryAnalyzer,

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseCompletionFilterFactory.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseCompletionFilterFactory.java
@@ -24,10 +24,8 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.cjk.CJKWidthFilterFactory;
 import org.apache.lucene.tests.analysis.BaseTokenStreamFactoryTestCase;
-import org.junit.Test;
 
 public class TestJapaneseCompletionFilterFactory extends BaseTokenStreamFactoryTestCase {
-  @Test
   public void testCompletion() throws IOException {
     JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new HashMap<>());
     TokenStream tokenStream = tokenizerFactory.create();
@@ -41,7 +39,6 @@ public class TestJapaneseCompletionFilterFactory extends BaseTokenStreamFactoryT
   }
 
   /** Test that bogus arguments result in exception */
-  @Test
   public void testBogusArguments() throws Exception {
     IllegalArgumentException expected =
         expectThrows(

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseNumberFilter.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseNumberFilter.java
@@ -31,7 +31,6 @@ import org.apache.lucene.analysis.miscellaneous.SetKeywordMarkerFilter;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.junit.Ignore;
-import org.junit.Test;
 
 public class TestJapaneseNumberFilter extends BaseTokenStreamTestCase {
   private Analyzer analyzer;
@@ -57,7 +56,6 @@ public class TestJapaneseNumberFilter extends BaseTokenStreamTestCase {
     super.tearDown();
   }
 
-  @Test
   public void testBasics() throws IOException {
 
     assertAnalyzesTo(
@@ -82,7 +80,6 @@ public class TestJapaneseNumberFilter extends BaseTokenStreamTestCase {
         new int[] {5, 6, 8, 9, 10, 14, 15, 17});
   }
 
-  @Test
   public void testVariants() throws IOException {
     // Test variants of three
     assertAnalyzesTo(analyzer, "3", new String[] {"3"});
@@ -106,7 +103,6 @@ public class TestJapaneseNumberFilter extends BaseTokenStreamTestCase {
     assertAnalyzesTo(analyzer, "１０百", new String[] {"1000"}); // Strange, but supported
   }
 
-  @Test
   public void testLargeVariants() throws IOException {
     // Test large numbers
     assertAnalyzesTo(analyzer, "三五七八九", new String[] {"35789"});
@@ -118,19 +114,16 @@ public class TestJapaneseNumberFilter extends BaseTokenStreamTestCase {
     assertAnalyzesTo(analyzer, "垓京兆億万千百十一", new String[] {"100010001000100011111"});
   }
 
-  @Test
   public void testNegative() throws IOException {
     assertAnalyzesTo(analyzer, "-100万", new String[] {"-", "1000000"});
   }
 
-  @Test
   public void testMixed() throws IOException {
     // Test mixed numbers
     assertAnalyzesTo(analyzer, "三千2百２十三", new String[] {"3223"});
     assertAnalyzesTo(analyzer, "３２二三", new String[] {"3223"});
   }
 
-  @Test
   public void testNininsankyaku() throws IOException {
     // Unstacked tokens
     assertAnalyzesTo(analyzer, "二", new String[] {"2"});
@@ -140,13 +133,11 @@ public class TestJapaneseNumberFilter extends BaseTokenStreamTestCase {
     assertAnalyzesTo(analyzer, "二人三脚", new String[] {"二", "二人三脚", "人", "三", "脚"});
   }
 
-  @Test
   public void testFujiyaichinisanu() throws IOException {
     // Stacked tokens with a numeral partial
     assertAnalyzesTo(analyzer, "不二家一二三", new String[] {"不", "不二家", "二", "家", "123"});
   }
 
-  @Test
   public void testFunny() throws IOException {
     // Test some oddities for inconsistent input
     assertAnalyzesTo(analyzer, "十十", new String[] {"20"}); // 100?
@@ -154,7 +145,6 @@ public class TestJapaneseNumberFilter extends BaseTokenStreamTestCase {
     assertAnalyzesTo(analyzer, "千千千千", new String[] {"4000"}); // 1,000,000,000,000?
   }
 
-  @Test
   public void testKanjiArabic() throws IOException {
     // Test kanji numerals used as Arabic numbers (with head zero)
     assertAnalyzesTo(analyzer, "〇一二三四五六七八九九八七六五四三二一〇", new String[] {"1234567899876543210"});
@@ -163,13 +153,11 @@ public class TestJapaneseNumberFilter extends BaseTokenStreamTestCase {
     assertAnalyzesTo(analyzer, "〇〇七", new String[] {"7"});
   }
 
-  @Test
   public void testDoubleZero() throws IOException {
     assertAnalyzesTo(
         analyzer, "〇〇", new String[] {"0"}, new int[] {0}, new int[] {2}, new int[] {1});
   }
 
-  @Test
   public void testName() throws IOException {
     // Test name that normalises to number
     assertAnalyzesTo(
@@ -206,61 +194,50 @@ public class TestJapaneseNumberFilter extends BaseTokenStreamTestCase {
     keywordMarkingAnalyzer.close();
   }
 
-  @Test
   public void testDecimal() throws IOException {
     // Test Arabic numbers with punctuation, i.e. 3.2 thousands
     assertAnalyzesTo(analyzer, "１．２万３４５．６７", new String[] {"12345.67"});
   }
 
-  @Test
   public void testDecimalPunctuation() throws IOException {
     // Test Arabic numbers with punctuation, i.e. 3.2 thousands yen
     assertAnalyzesTo(analyzer, "３．２千円", new String[] {"3200", "円"});
   }
 
-  @Test
   public void testThousandSeparator() throws IOException {
     assertAnalyzesTo(analyzer, "4,647", new String[] {"4647"});
   }
 
-  @Test
   public void testDecimalThousandSeparator() throws IOException {
     assertAnalyzesTo(analyzer, "4,647.0010", new String[] {"4647.001"});
   }
 
-  @Test
   public void testCommaDecimalSeparator() throws IOException {
     assertAnalyzesTo(analyzer, "15,7", new String[] {"157"});
   }
 
-  @Test
   public void testTrailingZeroStripping() throws IOException {
     assertAnalyzesTo(analyzer, "1000.1000", new String[] {"1000.1"});
     assertAnalyzesTo(analyzer, "1000.0000", new String[] {"1000"});
   }
 
-  @Test
   public void testEmpty() throws IOException {
     assertAnalyzesTo(analyzer, "", new String[] {});
   }
 
-  @Test
   public void testRandomHugeStrings() throws Exception {
     checkRandomData(random(), analyzer, RANDOM_MULTIPLIER, 4096);
   }
 
-  @Test
   @Nightly
   public void testRandomHugeStringsAtNight() throws Exception {
     checkRandomData(random(), analyzer, 3 * RANDOM_MULTIPLIER, 8192);
   }
 
-  @Test
   public void testRandomSmallStrings() throws Exception {
     checkRandomData(random(), analyzer, 100 * RANDOM_MULTIPLIER, 128);
   }
 
-  @Test
   public void testFunnyIssue() throws Exception {
     BaseTokenStreamTestCase.checkAnalysisConsistency(
         random(), analyzer, true, "〇〇\u302f\u3029\u3039\u3023\u3033\u302bB", true);
@@ -268,7 +245,6 @@ public class TestJapaneseNumberFilter extends BaseTokenStreamTestCase {
 
   @Ignore(
       "This test is used during development when analyze normalizations in large amounts of text")
-  @Test
   public void testLargeData() throws IOException {
     Path input = Paths.get("/tmp/test.txt");
     Path tokenizedOutput = Paths.get("/tmp/test.tok.txt");

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/completion/TestKatakanaRomanizer.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/completion/TestKatakanaRomanizer.java
@@ -19,12 +19,10 @@ package org.apache.lucene.analysis.ja.completion;
 import java.util.List;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.CharsRef;
-import org.junit.Test;
 
 public class TestKatakanaRomanizer extends LuceneTestCase {
   private final KatakanaRomanizer romanizer = KatakanaRomanizer.getInstance();
 
-  @Test
   public void testRomanize() {
     assertCharsRefListEqualsUnordered(
         List.of(new CharsRef("hasi"), new CharsRef("hashi")),
@@ -47,7 +45,6 @@ public class TestKatakanaRomanizer extends LuceneTestCase {
         romanizer.romanize(new CharsRef("ヴォルテール")));
   }
 
-  @Test
   public void testRomanizeWithAlphabets() {
     assertCharsRefListEqualsUnordered(
         List.of(new CharsRef("toukyout")), romanizer.romanize(new CharsRef("トウキョウt")));

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestUnknownDictionary.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestUnknownDictionary.java
@@ -18,12 +18,10 @@ package org.apache.lucene.analysis.ja.dict;
 
 import org.apache.lucene.analysis.util.CSVUtil;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestUnknownDictionary extends LuceneTestCase {
   public static final String FILENAME = "unk-tokeninfo-dict.obj";
 
-  @Test
   public void testPutCharacterCategory() {
     UnknownDictionaryWriter unkDic = new UnknownDictionaryWriter(10 * 1024 * 1024);
 
@@ -38,7 +36,6 @@ public class TestUnknownDictionary extends LuceneTestCase {
     unkDic.putCharacterCategory(4, "KANJI");
   }
 
-  @Test
   public void testPut() {
     UnknownDictionaryWriter unkDic = new UnknownDictionaryWriter(10 * 1024 * 1024);
     expectThrows(

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestUserDictionary.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/TestUserDictionary.java
@@ -20,11 +20,9 @@ import java.io.IOException;
 import java.io.StringReader;
 import org.apache.lucene.analysis.ja.TestJapaneseTokenizer;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestUserDictionary extends LuceneTestCase {
 
-  @Test
   public void testLookup() throws IOException {
     UserDictionary dictionary = TestJapaneseTokenizer.readDict();
     String s = "関西国際空港に行った";
@@ -48,7 +46,6 @@ public class TestUserDictionary extends LuceneTestCase {
     assertEquals(6, dictionaryEntryResult2.length);
   }
 
-  @Test
   public void testReadings() throws IOException {
     UserDictionary dictionary = TestJapaneseTokenizer.readDict();
     int[][] result = dictionary.lookup("日本経済新聞".toCharArray(), 0, 6);
@@ -65,7 +62,6 @@ public class TestUserDictionary extends LuceneTestCase {
         dictionary.getMorphAttributes().getReading(wordIdAsashoryu, "朝青龍".toCharArray(), 0, 3));
   }
 
-  @Test
   public void testPartOfSpeech() throws IOException {
     UserDictionary dictionary = TestJapaneseTokenizer.readDict();
     int[][] result = dictionary.lookup("日本経済新聞".toCharArray(), 0, 6);
@@ -74,13 +70,11 @@ public class TestUserDictionary extends LuceneTestCase {
     assertEquals("カスタム名詞", dictionary.getMorphAttributes().getPartOfSpeech(wordIdKeizai));
   }
 
-  @Test
   public void testRead() throws IOException {
     UserDictionary dictionary = TestJapaneseTokenizer.readDict();
     assertNotNull(dictionary);
   }
 
-  @Test
   public void testReadInvalid1() throws IOException {
     // the concatenated segment must be the same as the surface form
     String invalidEntry = "日経新聞,日本 経済 新聞,ニホン ケイザイ シンブン,カスタム名詞";
@@ -92,7 +86,6 @@ public class TestUserDictionary extends LuceneTestCase {
     assertTrue(e.getMessage().contains("does not match the surface form"));
   }
 
-  @Test
   public void testReadInvalid2() throws IOException {
     // the concatenated segment must be the same as the surface form
     String invalidEntry = "日本経済新聞,日経 新聞,ニッケイ シンブン,カスタム名詞";
@@ -104,7 +97,6 @@ public class TestUserDictionary extends LuceneTestCase {
     assertTrue(e.getMessage().contains("does not match the surface form"));
   }
 
-  @Test
   public void testSharp() throws IOException {
     String[] inputs = {"テスト#", "テスト#テスト"};
     UserDictionary dictionary = TestJapaneseTokenizer.readDict();

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanNumberFilter.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/TestKoreanNumberFilter.java
@@ -36,7 +36,6 @@ import org.apache.lucene.analysis.miscellaneous.SetKeywordMarkerFilter;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.junit.Ignore;
-import org.junit.Test;
 
 public class TestKoreanNumberFilter extends BaseTokenStreamTestCase {
   private Analyzer analyzer;
@@ -86,7 +85,6 @@ public class TestKoreanNumberFilter extends BaseTokenStreamTestCase {
     super.tearDown();
   }
 
-  @Test
   public void testBasics() throws IOException {
 
     assertAnalyzesTo(
@@ -113,7 +111,6 @@ public class TestKoreanNumberFilter extends BaseTokenStreamTestCase {
         new int[] {2, 3, 8, 10, 11});
   }
 
-  @Test
   public void testVariants() throws IOException {
     // Test variants of three
     assertAnalyzesTo(analyzer, "3", new String[] {"3"});
@@ -137,7 +134,6 @@ public class TestKoreanNumberFilter extends BaseTokenStreamTestCase {
     assertAnalyzesTo(analyzer, "１０백", new String[] {"1000"}); // Strange, but supported
   }
 
-  @Test
   public void testLargeVariants() throws IOException {
     // Test large numbers
     assertAnalyzesTo(analyzer, "삼오칠팔구", new String[] {"35789"});
@@ -149,19 +145,16 @@ public class TestKoreanNumberFilter extends BaseTokenStreamTestCase {
     assertAnalyzesTo(analyzer, "해경조억만천백십일", new String[] {"100010001000100011111"});
   }
 
-  @Test
   public void testNegative() throws IOException {
     assertAnalyzesTo(analyzer, "-백만", new String[] {"-", "1000000"});
   }
 
-  @Test
   public void testMixed() throws IOException {
     // Test mixed numbers
     assertAnalyzesTo(analyzer, "삼천2백２십삼", new String[] {"3223"});
     assertAnalyzesTo(analyzer, "３２이삼", new String[] {"3223"});
   }
 
-  @Test
   public void testFunny() throws IOException {
     // Test some oddities for inconsistent input
     assertAnalyzesTo(analyzer, "십십", new String[] {"20"}); // 100?
@@ -169,7 +162,6 @@ public class TestKoreanNumberFilter extends BaseTokenStreamTestCase {
     assertAnalyzesTo(analyzer, "천천천천", new String[] {"4000"}); // 1,000,000,000,000?
   }
 
-  @Test
   public void testHangulArabic() throws IOException {
     // Test kanji numerals used as Arabic numbers (with head zero)
     assertAnalyzesTo(analyzer, "영일이삼사오육칠팔구구팔칠육오사삼이일영", new String[] {"1234567899876543210"});
@@ -178,13 +170,11 @@ public class TestKoreanNumberFilter extends BaseTokenStreamTestCase {
     assertAnalyzesTo(analyzer, "영영칠", new String[] {"7"});
   }
 
-  @Test
   public void testDoubleZero() throws IOException {
     assertAnalyzesTo(
         analyzer, "영영", new String[] {"0"}, new int[] {0}, new int[] {2}, new int[] {1});
   }
 
-  @Test
   public void testName() throws IOException {
     // Test name that normalises to number
     assertAnalyzesTo(
@@ -228,61 +218,50 @@ public class TestKoreanNumberFilter extends BaseTokenStreamTestCase {
     keywordMarkingAnalyzer.close();
   }
 
-  @Test
   public void testDecimal() throws IOException {
     // Test Arabic numbers with punctuation, i.e. 3.2 thousands
     assertAnalyzesTo(analyzer, "１．２만３４５．６７", new String[] {"12345.67"});
   }
 
-  @Test
   public void testDecimalPunctuation() throws IOException {
     // Test Arabic numbers with punctuation, i.e. 3.2 thousands won
     assertAnalyzesTo(analyzer, "３．２천 원", new String[] {"3200", "원"});
   }
 
-  @Test
   public void testThousandSeparator() throws IOException {
     assertAnalyzesTo(analyzer, "4,647", new String[] {"4647"});
   }
 
-  @Test
   public void testDecimalThousandSeparator() throws IOException {
     assertAnalyzesTo(analyzer, "4,647.0010", new String[] {"4647.001"});
   }
 
-  @Test
   public void testCommaDecimalSeparator() throws IOException {
     assertAnalyzesTo(analyzer, "15,7", new String[] {"157"});
   }
 
-  @Test
   public void testTrailingZeroStripping() throws IOException {
     assertAnalyzesTo(analyzer, "1000.1000", new String[] {"1000.1"});
     assertAnalyzesTo(analyzer, "1000.0000", new String[] {"1000"});
   }
 
-  @Test
   public void testEmpty() throws IOException {
     assertAnalyzesTo(analyzer, "", new String[] {});
   }
 
-  @Test
   public void testRandomHugeStrings() throws Exception {
     checkRandomData(random(), analyzer, RANDOM_MULTIPLIER, 4096);
   }
 
-  @Test
   @Nightly
   public void testRandomHugeStringsAtNight() throws Exception {
     checkRandomData(random(), analyzer, 5 * RANDOM_MULTIPLIER, 8192);
   }
 
-  @Test
   public void testRandomSmallStrings() throws Exception {
     checkRandomData(random(), analyzer, 100 * RANDOM_MULTIPLIER, 128);
   }
 
-  @Test
   public void testFunnyIssue() throws Exception {
     BaseTokenStreamTestCase.checkAnalysisConsistency(
         random(), analyzer, true, "영영\u302f\u3029\u3039\u3023\u3033\u302bB", true);
@@ -290,7 +269,6 @@ public class TestKoreanNumberFilter extends BaseTokenStreamTestCase {
 
   @Ignore(
       "This test is used during development when analyze normalizations in large amounts of text")
-  @Test
   public void testLargeData() throws IOException {
     Path input = Paths.get("/tmp/test.txt");
     Path tokenizedOutput = Paths.get("/tmp/test.tok.txt");

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestUnknownDictionary.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestUnknownDictionary.java
@@ -18,11 +18,9 @@ package org.apache.lucene.analysis.ko.dict;
 
 import org.apache.lucene.analysis.util.CSVUtil;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestUnknownDictionary extends LuceneTestCase {
 
-  @Test
   public void testPutCharacterCategory() {
     UnknownDictionaryWriter unkDic = new UnknownDictionaryWriter(10 * 1024 * 1024);
 
@@ -37,7 +35,6 @@ public class TestUnknownDictionary extends LuceneTestCase {
     unkDic.putCharacterCategory(4, "KANJI");
   }
 
-  @Test
   public void testPut() {
     UnknownDictionaryWriter unkDic = new UnknownDictionaryWriter(10 * 1024 * 1024);
     expectThrows(

--- a/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestUserDictionary.java
+++ b/lucene/analysis/nori/src/test/org/apache/lucene/analysis/ko/dict/TestUserDictionary.java
@@ -21,10 +21,8 @@ import java.util.List;
 import org.apache.lucene.analysis.ko.POS;
 import org.apache.lucene.analysis.ko.TestKoreanTokenizer;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestUserDictionary extends LuceneTestCase {
-  @Test
   public void testLookup() throws IOException {
     UserDictionary dictionary = TestKoreanTokenizer.readDict();
     String s = "세종";
@@ -55,7 +53,6 @@ public class TestUserDictionary extends LuceneTestCase {
     assertNull(dictionary.getMorphAttributes().getMorphemes(wordIds.get(0), sArray, 0, s.length()));
   }
 
-  @Test
   public void testRead() {
     UserDictionary dictionary = TestKoreanTokenizer.readDict();
     assertNotNull(dictionary);

--- a/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPTokenizerFactory.java
+++ b/lucene/analysis/opennlp/src/test/org/apache/lucene/analysis/opennlp/TestOpenNLPTokenizerFactory.java
@@ -25,7 +25,6 @@ import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.custom.CustomAnalyzer;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.util.ClasspathResourceLoader;
-import org.junit.Test;
 
 /**
  * Tests the Tokenizer as well- the Tokenizer needs the OpenNLP model files, which this can load
@@ -63,7 +62,6 @@ public class TestOpenNLPTokenizerFactory extends BaseTokenStreamTestCase {
     "Sentence", "number", "1", "has", "6", "words", "."
   };
 
-  @Test
   public void testTokenizer() throws IOException {
     CustomAnalyzer analyzer =
         CustomAnalyzer.builder(new ClasspathResourceLoader(getClass()))
@@ -79,7 +77,6 @@ public class TestOpenNLPTokenizerFactory extends BaseTokenStreamTestCase {
     assertAnalyzesTo(analyzer, SENTENCE1, SENTENCE1_punc);
   }
 
-  @Test
   public void testTokenizerNoSentenceDetector() throws IOException {
     IllegalArgumentException expected =
         expectThrows(
@@ -93,7 +90,6 @@ public class TestOpenNLPTokenizerFactory extends BaseTokenStreamTestCase {
         expected.getMessage().contains("Configuration Error: missing parameter 'sentenceModel'"));
   }
 
-  @Test
   public void testTokenizerNoTokenizer() throws IOException {
     IllegalArgumentException expected =
         expectThrows(
@@ -108,7 +104,6 @@ public class TestOpenNLPTokenizerFactory extends BaseTokenStreamTestCase {
   }
 
   // test analyzer caching the tokenizer
-  @Test
   public void testClose() throws IOException {
     Map<String, String> args =
         new HashMap<>() {

--- a/lucene/benchmark/src/test/org/apache/lucene/benchmark/byTask/feeds/TestEnwikiContentSource.java
+++ b/lucene/benchmark/src/test/org/apache/lucene/benchmark/byTask/feeds/TestEnwikiContentSource.java
@@ -24,7 +24,6 @@ import java.text.ParseException;
 import java.util.Properties;
 import org.apache.lucene.benchmark.byTask.utils.Config;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestEnwikiContentSource extends LuceneTestCase {
 
@@ -99,7 +98,6 @@ public class TestEnwikiContentSource extends LuceneTestCase {
           + "    </revision>\r\n"
           + "  </page>\r\n";
 
-  @Test
   public void testOneDocument() throws Exception {
     String docs = "<mediawiki>\r\n" + PAGE1 + "</mediawiki>";
 
@@ -128,7 +126,6 @@ public class TestEnwikiContentSource extends LuceneTestCase {
     return source;
   }
 
-  @Test
   public void testTwoDocuments() throws Exception {
     String docs = "<mediawiki>\r\n" + PAGE1 + PAGE2 + "</mediawiki>";
 
@@ -143,7 +140,6 @@ public class TestEnwikiContentSource extends LuceneTestCase {
     assertNoMoreDataException(source);
   }
 
-  @Test
   public void testForever() throws Exception {
     String docs = "<mediawiki>\r\n" + PAGE1 + PAGE2 + "</mediawiki>";
 

--- a/lucene/benchmark/src/test/org/apache/lucene/benchmark/byTask/utils/TestConfig.java
+++ b/lucene/benchmark/src/test/org/apache/lucene/benchmark/byTask/utils/TestConfig.java
@@ -18,11 +18,9 @@ package org.apache.lucene.benchmark.byTask.utils;
 
 import java.util.Properties;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestConfig extends LuceneTestCase {
 
-  @Test
   public void testAbsolutePathNamesWindows() throws Exception {
     Properties props = new Properties();
     props.setProperty("work.dir1", "c:\\temp");

--- a/lucene/benchmark/src/test/org/apache/lucene/benchmark/byTask/utils/TestStreamUtils.java
+++ b/lucene/benchmark/src/test/org/apache/lucene/benchmark/byTask/utils/TestStreamUtils.java
@@ -29,19 +29,16 @@ import java.nio.file.Path;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.lucene.benchmark.BenchmarkTestCase;
 import org.junit.Before;
-import org.junit.Test;
 
 public class TestStreamUtils extends BenchmarkTestCase {
   private static final String TEXT = "Some-Text...";
   private Path testDir;
 
-  @Test
   public void testGetInputStreamPlainText() throws Exception {
     assertReadText(rawTextFile("txt"));
     assertReadText(rawTextFile("TXT"));
   }
 
-  @Test
   public void testGetInputStreamGzip() throws Exception {
     assertReadText(rawGzipFile("gz"));
     assertReadText(rawGzipFile("gzip"));
@@ -49,7 +46,6 @@ public class TestStreamUtils extends BenchmarkTestCase {
     assertReadText(rawGzipFile("GZIP"));
   }
 
-  @Test
   public void testGetInputStreamBzip2() throws Exception {
     assertReadText(rawBzip2File("bz2"));
     assertReadText(rawBzip2File("bzip"));
@@ -57,7 +53,6 @@ public class TestStreamUtils extends BenchmarkTestCase {
     assertReadText(rawBzip2File("BZIP"));
   }
 
-  @Test
   public void testGetOutputStreamBzip2() throws Exception {
     assertReadText(autoOutFile("bz2"));
     assertReadText(autoOutFile("bzip"));
@@ -65,7 +60,6 @@ public class TestStreamUtils extends BenchmarkTestCase {
     assertReadText(autoOutFile("BZIP"));
   }
 
-  @Test
   public void testGetOutputStreamGzip() throws Exception {
     assertReadText(autoOutFile("gz"));
     assertReadText(autoOutFile("gzip"));
@@ -73,7 +67,6 @@ public class TestStreamUtils extends BenchmarkTestCase {
     assertReadText(autoOutFile("GZIP"));
   }
 
-  @Test
   public void testGetOutputStreamPlain() throws Exception {
     assertReadText(autoOutFile("txt"));
     assertReadText(autoOutFile("text"));

--- a/lucene/classification/src/test/org/apache/lucene/classification/Test20NewsgroupsClassification.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/Test20NewsgroupsClassification.java
@@ -65,7 +65,6 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.NamedThreadFactory;
 import org.apache.lucene.util.SuppressForbidden;
-import org.junit.Test;
 
 @LuceneTestCase.SuppressSysoutChecks(bugUrl = "none")
 @TimeoutSuite(millis = Integer.MAX_VALUE) // hopefully ~24 days is long enough ;)
@@ -81,7 +80,6 @@ public final class Test20NewsgroupsClassification extends LuceneTestCase {
   private boolean split = true;
 
   @SuppressForbidden(reason = "Thread sleep")
-  @Test
   public void test20Newsgroups() throws Exception {
 
     String indexProperty = System.getProperty("index");

--- a/lucene/classification/src/test/org/apache/lucene/classification/TestBM25NBClassifier.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/TestBM25NBClassifier.java
@@ -31,12 +31,10 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 /** Tests for {@link BM25NBClassifier} */
 public class TestBM25NBClassifier extends ClassificationTestBase<BytesRef> {
 
-  @Test
   public void testBasicUsage() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -50,7 +48,6 @@ public class TestBM25NBClassifier extends ClassificationTestBase<BytesRef> {
     }
   }
 
-  @Test
   public void testBasicUsageWithQuery() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -65,7 +62,6 @@ public class TestBM25NBClassifier extends ClassificationTestBase<BytesRef> {
     }
   }
 
-  @Test
   public void testNGramUsage() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -90,7 +86,6 @@ public class TestBM25NBClassifier extends ClassificationTestBase<BytesRef> {
     }
   }
 
-  @Test
   public void testPerformance() throws Exception {
     MockAnalyzer analyzer = new MockAnalyzer(random());
     int numDocs = atLeast(10);

--- a/lucene/classification/src/test/org/apache/lucene/classification/TestBooleanPerceptronClassifier.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/TestBooleanPerceptronClassifier.java
@@ -26,12 +26,10 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 /** Testcase for {@link org.apache.lucene.classification.BooleanPerceptronClassifier} */
 public class TestBooleanPerceptronClassifier extends ClassificationTestBase<Boolean> {
 
-  @Test
   public void testBasicUsage() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -47,7 +45,6 @@ public class TestBooleanPerceptronClassifier extends ClassificationTestBase<Bool
     }
   }
 
-  @Test
   public void testExplicitThreshold() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -63,7 +60,6 @@ public class TestBooleanPerceptronClassifier extends ClassificationTestBase<Bool
     }
   }
 
-  @Test
   public void testBasicUsageWithQuery() throws Exception {
     TermQuery query = new TermQuery(new Term(textFieldName, "of"));
     LeafReader leafReader = null;
@@ -80,7 +76,6 @@ public class TestBooleanPerceptronClassifier extends ClassificationTestBase<Bool
     }
   }
 
-  @Test
   public void testPerformance() throws Exception {
     MockAnalyzer analyzer = new MockAnalyzer(random());
     int numDocs = atLeast(10);

--- a/lucene/classification/src/test/org/apache/lucene/classification/TestCachingNaiveBayesClassifier.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/TestCachingNaiveBayesClassifier.java
@@ -31,12 +31,10 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 /** Testcase for {@link org.apache.lucene.classification.CachingNaiveBayesClassifier} */
 public class TestCachingNaiveBayesClassifier extends ClassificationTestBase<BytesRef> {
 
-  @Test
   public void testBasicUsage() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -57,7 +55,6 @@ public class TestCachingNaiveBayesClassifier extends ClassificationTestBase<Byte
     }
   }
 
-  @Test
   public void testBasicUsageWithQuery() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -74,7 +71,6 @@ public class TestCachingNaiveBayesClassifier extends ClassificationTestBase<Byte
     }
   }
 
-  @Test
   public void testNGramUsage() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -101,7 +97,6 @@ public class TestCachingNaiveBayesClassifier extends ClassificationTestBase<Byte
     }
   }
 
-  @Test
   public void testPerformance() throws Exception {
     MockAnalyzer analyzer = new MockAnalyzer(random());
     int numDocs = atLeast(10);

--- a/lucene/classification/src/test/org/apache/lucene/classification/TestKNearestFuzzyClassifier.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/TestKNearestFuzzyClassifier.java
@@ -26,12 +26,10 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 /** Tests for {@link KNearestFuzzyClassifier} */
 public class TestKNearestFuzzyClassifier extends ClassificationTestBase<BytesRef> {
 
-  @Test
   public void testBasicUsage() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -47,7 +45,6 @@ public class TestKNearestFuzzyClassifier extends ClassificationTestBase<BytesRef
     }
   }
 
-  @Test
   public void testBasicUsageWithQuery() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -63,7 +60,6 @@ public class TestKNearestFuzzyClassifier extends ClassificationTestBase<BytesRef
     }
   }
 
-  @Test
   public void testPerformance() throws Exception {
     MockAnalyzer analyzer = new MockAnalyzer(random());
     int numDocs = atLeast(10);

--- a/lucene/classification/src/test/org/apache/lucene/classification/TestKNearestNeighborClassifier.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/TestKNearestNeighborClassifier.java
@@ -31,12 +31,10 @@ import org.apache.lucene.search.similarities.LMDirichletSimilarity;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 /** Testcase for {@link KNearestNeighborClassifier} */
 public class TestKNearestNeighborClassifier extends ClassificationTestBase<BytesRef> {
 
-  @Test
   public void testBasicUsage() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -102,7 +100,6 @@ public class TestKNearestNeighborClassifier extends ClassificationTestBase<Bytes
    *
    * @throws Exception if any error happens
    */
-  @Test
   public void testRankedClasses() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -128,7 +125,6 @@ public class TestKNearestNeighborClassifier extends ClassificationTestBase<Bytes
    *
    * @throws Exception if any error happens
    */
-  @Test
   public void testUnbalancedClasses() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -146,7 +142,6 @@ public class TestKNearestNeighborClassifier extends ClassificationTestBase<Bytes
     }
   }
 
-  @Test
   public void testBasicUsageWithQuery() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -163,7 +158,6 @@ public class TestKNearestNeighborClassifier extends ClassificationTestBase<Bytes
     }
   }
 
-  @Test
   public void testPerformance() throws Exception {
     MockAnalyzer analyzer = new MockAnalyzer(random());
     int numDocs = atLeast(10);

--- a/lucene/classification/src/test/org/apache/lucene/classification/TestSimpleNaiveBayesClassifier.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/TestSimpleNaiveBayesClassifier.java
@@ -31,12 +31,10 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 /** Testcase for {@link SimpleNaiveBayesClassifier} */
 public class TestSimpleNaiveBayesClassifier extends ClassificationTestBase<BytesRef> {
 
-  @Test
   public void testBasicUsage() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -52,7 +50,6 @@ public class TestSimpleNaiveBayesClassifier extends ClassificationTestBase<Bytes
     }
   }
 
-  @Test
   public void testBasicUsageWithQuery() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -69,7 +66,6 @@ public class TestSimpleNaiveBayesClassifier extends ClassificationTestBase<Bytes
     }
   }
 
-  @Test
   public void testNGramUsage() throws Exception {
     LeafReader leafReader = null;
     try {
@@ -95,7 +91,6 @@ public class TestSimpleNaiveBayesClassifier extends ClassificationTestBase<Bytes
     }
   }
 
-  @Test
   public void testPerformance() throws Exception {
     MockAnalyzer analyzer = new MockAnalyzer(random());
     int numDocs = atLeast(10);

--- a/lucene/classification/src/test/org/apache/lucene/classification/document/TestKNearestNeighborDocumentClassifier.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/document/TestKNearestNeighborDocumentClassifier.java
@@ -21,13 +21,11 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 /** Tests for {@link org.apache.lucene.classification.KNearestNeighborClassifier} */
 public class TestKNearestNeighborDocumentClassifier
     extends DocumentClassificationTestBase<BytesRef> {
 
-  @Test
   public void testBasicDocumentClassification() throws Exception {
     try {
       Document videoGameDocument = getVideoGameDocument();
@@ -79,7 +77,6 @@ public class TestKNearestNeighborDocumentClassifier
     }
   }
 
-  @Test
   public void testBasicDocumentClassificationScore() throws Exception {
     try {
       Document videoGameDocument = getVideoGameDocument();
@@ -137,7 +134,6 @@ public class TestKNearestNeighborDocumentClassifier
     }
   }
 
-  @Test
   public void testBoostedDocumentClassification() throws Exception {
     try {
       checkCorrectDocumentClassification(
@@ -172,7 +168,6 @@ public class TestKNearestNeighborDocumentClassifier
     }
   }
 
-  @Test
   public void testBasicDocumentClassificationWithQuery() throws Exception {
     try {
       TermQuery query = new TermQuery(new Term(authorFieldName, "ign"));

--- a/lucene/classification/src/test/org/apache/lucene/classification/document/TestSimpleNaiveBayesDocumentClassifier.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/document/TestSimpleNaiveBayesDocumentClassifier.java
@@ -18,13 +18,11 @@ package org.apache.lucene.classification.document;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 /** Tests for {@link org.apache.lucene.classification.SimpleNaiveBayesClassifier} */
 public class TestSimpleNaiveBayesDocumentClassifier
     extends DocumentClassificationTestBase<BytesRef> {
 
-  @Test
   public void testBasicDocumentClassification() throws Exception {
     try {
       checkCorrectDocumentClassification(
@@ -61,7 +59,6 @@ public class TestSimpleNaiveBayesDocumentClassifier
     }
   }
 
-  @Test
   public void testBasicDocumentClassificationScore() throws Exception {
     try {
       double score1 =
@@ -114,7 +111,6 @@ public class TestSimpleNaiveBayesDocumentClassifier
     }
   }
 
-  @Test
   public void testBoostedDocumentClassification() throws Exception {
     try {
       checkCorrectDocumentClassification(

--- a/lucene/classification/src/test/org/apache/lucene/classification/utils/TestConfusionMatrixGenerator.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/utils/TestConfusionMatrixGenerator.java
@@ -31,12 +31,10 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 /** Tests for {@link ConfusionMatrixGenerator} */
 public class TestConfusionMatrixGenerator extends ClassificationTestBase<Object> {
 
-  @Test
   public void testGetConfusionMatrix() throws Exception {
     LeafReader reader = null;
     try {
@@ -86,7 +84,6 @@ public class TestConfusionMatrixGenerator extends ClassificationTestBase<Object>
     }
   }
 
-  @Test
   public void testGetConfusionMatrixWithSNB() throws Exception {
     LeafReader reader = null;
     try {
@@ -122,7 +119,6 @@ public class TestConfusionMatrixGenerator extends ClassificationTestBase<Object>
     assertTrue(f1Measure <= 1d);
   }
 
-  @Test
   public void testGetConfusionMatrixWithBM25NB() throws Exception {
     LeafReader reader = null;
     try {
@@ -139,7 +135,6 @@ public class TestConfusionMatrixGenerator extends ClassificationTestBase<Object>
     }
   }
 
-  @Test
   public void testGetConfusionMatrixWithCNB() throws Exception {
     LeafReader reader = null;
     try {
@@ -156,7 +151,6 @@ public class TestConfusionMatrixGenerator extends ClassificationTestBase<Object>
     }
   }
 
-  @Test
   public void testGetConfusionMatrixWithKNN() throws Exception {
     LeafReader reader = null;
     try {
@@ -174,7 +168,6 @@ public class TestConfusionMatrixGenerator extends ClassificationTestBase<Object>
     }
   }
 
-  @Test
   public void testGetConfusionMatrixWithFLTKNN() throws Exception {
     LeafReader reader = null;
     try {
@@ -192,7 +185,6 @@ public class TestConfusionMatrixGenerator extends ClassificationTestBase<Object>
     }
   }
 
-  @Test
   public void testGetConfusionMatrixWithBP() throws Exception {
     LeafReader reader = null;
     try {

--- a/lucene/classification/src/test/org/apache/lucene/classification/utils/TestDataSplitter.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/utils/TestDataSplitter.java
@@ -36,7 +36,6 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 
 /** Testcase for {@link org.apache.lucene.classification.utils.DatasetSplitter} */
 @LuceneTestCase.SuppressCodecs("SimpleText")
@@ -88,12 +87,10 @@ public class TestDataSplitter extends LuceneTestCase {
     super.tearDown();
   }
 
-  @Test
   public void testSplitOnAllFields() throws Exception {
     assertSplit(originalIndex, 0.1, 0.1);
   }
 
-  @Test
   public void testSplitOnSomeFields() throws Exception {
     assertSplit(originalIndex, 0.2, 0.35, idFieldName, textFieldName);
   }

--- a/lucene/classification/src/test/org/apache/lucene/classification/utils/TestDocToDoubleVectorUtils.java
+++ b/lucene/classification/src/test/org/apache/lucene/classification/utils/TestDocToDoubleVectorUtils.java
@@ -33,7 +33,6 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.IOUtils;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 
 /** Testcase for {@link org.apache.lucene.classification.utils.DocToDoubleVectorUtils} */
 public class TestDocToDoubleVectorUtils extends LuceneTestCase {
@@ -79,7 +78,6 @@ public class TestDocToDoubleVectorUtils extends LuceneTestCase {
     super.tearDown();
   }
 
-  @Test
   public void testDenseFreqDoubleArrayConversion() throws Exception {
     IndexSearcher indexSearcher = new IndexSearcher(index);
     TermVectors termVectors = index.termVectors();
@@ -92,7 +90,6 @@ public class TestDocToDoubleVectorUtils extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testSparseFreqDoubleArrayConversion() throws Exception {
     Terms fieldTerms = MultiTerms.getTerms(index, "text");
     if (fieldTerms != null && fieldTerms.size() != -1) {

--- a/lucene/core.tests/src/test/org/apache/lucene/core/tests/TestRuntimeDependenciesSane.java
+++ b/lucene/core.tests/src/test/org/apache/lucene/core/tests/TestRuntimeDependenciesSane.java
@@ -18,28 +18,23 @@ package org.apache.lucene.core.tests;
 
 import org.apache.lucene.core.tests.main.EmptyReference;
 import org.apache.lucene.index.IndexWriter;
-import org.junit.Test;
 
 /** Intentionally not a subclass of {@code LuceneTestCase}. */
 public class TestRuntimeDependenciesSane {
-  @Test
   public void testExternalDependenciesAreModules() {
     isModule(org.junit.Test.class);
   }
 
-  @Test
   public void testInterProjectDependenciesAreModules() {
     // The core Lucene should be a modular dependency.
     isModule(IndexWriter.class);
   }
 
-  @Test
   public void testTestSourceSetIsAModule() {
     // The test source set itself should be loaded as a module.
     isModule(getClass());
   }
 
-  @Test
   public void testMainSourceSetIsAModule() {
     // The test source set itself should be loaded as a module.
     isModule(EmptyReference.class);

--- a/lucene/core/src/test/org/apache/lucene/analysis/TestCharacterUtils.java
+++ b/lucene/core/src/test/org/apache/lucene/analysis/TestCharacterUtils.java
@@ -23,7 +23,6 @@ import org.apache.lucene.analysis.CharacterUtils.CharacterBuffer;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.ArrayUtil;
-import org.junit.Test;
 
 /** TestCase for the {@link CharacterUtils} class. */
 public class TestCharacterUtils extends LuceneTestCase {
@@ -54,7 +53,6 @@ public class TestCharacterUtils extends LuceneTestCase {
         ArrayUtil.copyOfSubArray(restored, o3, o3 + charCount));
   }
 
-  @Test
   public void testNewCharacterBuffer() {
     CharacterBuffer newCharacterBuffer = CharacterUtils.newCharacterBuffer(1024);
     assertEquals(1024, newCharacterBuffer.getBuffer().length);
@@ -74,7 +72,6 @@ public class TestCharacterUtils extends LuceneTestCase {
         });
   }
 
-  @Test
   public void testFillNoHighSurrogate() throws IOException {
     Reader reader = new StringReader("helloworld");
     CharacterBuffer buffer = CharacterUtils.newCharacterBuffer(6);
@@ -90,7 +87,6 @@ public class TestCharacterUtils extends LuceneTestCase {
     assertFalse(CharacterUtils.fill(buffer, reader));
   }
 
-  @Test
   public void testFill() throws IOException {
     String input = "1234\ud801\udc1c789123\ud801\ud801\udc1c\ud801";
     Reader reader = new StringReader(input);

--- a/lucene/core/src/test/org/apache/lucene/codecs/hnsw/TestPrefetchableFlatVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/hnsw/TestPrefetchableFlatVectorScorer.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
-import org.junit.Test;
 
 /**
  * Tests that {@link PrefetchableFlatVectorScorer} overrides all methods from {@link
@@ -28,7 +27,6 @@ import org.junit.Test;
  */
 public class TestPrefetchableFlatVectorScorer extends LuceneTestCase {
 
-  @Test
   public void testDeclaredMethodsOverridden() {
     implTestDeclaredMethodsOverridden(FlatVectorsScorer.class, PrefetchableFlatVectorScorer.class);
     implTestDeclaredMethodsOverridden(

--- a/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldPostingsFormat2.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldPostingsFormat2.java
@@ -56,7 +56,6 @@ import org.apache.lucene.tests.codecs.blockterms.LuceneVarGapFixedInterval;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
-import org.junit.Test;
 
 /** */
 // TODO: would be better in this test to pull termsenums and instanceof or something?
@@ -103,7 +102,6 @@ public class TestPerFieldPostingsFormat2 extends LuceneTestCase {
   /*
    * Test that heterogeneous index segments are merge successfully
    */
-  @Test
   public void testMergeUnusedPerFieldCodec() throws IOException {
     Directory dir = newDirectory();
     IndexWriterConfig iwconf =
@@ -130,7 +128,6 @@ public class TestPerFieldPostingsFormat2 extends LuceneTestCase {
    */
   // TODO: not sure this test is that great, we should probably peek inside PerFieldPostingsFormat
   // or something?!
-  @Test
   public void testChangeCodecAndMerge() throws IOException {
     Directory dir = newDirectory();
     if (VERBOSE) {
@@ -231,7 +228,6 @@ public class TestPerFieldPostingsFormat2 extends LuceneTestCase {
   /*
    * Test per field codec support - adding fields with random codecs
    */
-  @Test
   public void testStressPerFieldCodec() throws IOException {
     Directory dir = newDirectory(random());
     final int docsPerRound = 97;

--- a/lucene/core/src/test/org/apache/lucene/index/TestCheckIndex.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestCheckIndex.java
@@ -42,7 +42,6 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.VectorUtil;
-import org.junit.Test;
 
 public class TestCheckIndex extends BaseTestCheckIndex {
   private Directory directory;
@@ -59,27 +58,22 @@ public class TestCheckIndex extends BaseTestCheckIndex {
     super.tearDown();
   }
 
-  @Test
   public void testDeletedDocs() throws IOException {
     testDeletedDocs(directory);
   }
 
-  @Test
   public void testChecksumsOnly() throws IOException {
     testChecksumsOnly(directory);
   }
 
-  @Test
   public void testChecksumsOnlyVerbose() throws IOException {
     testChecksumsOnlyVerbose(directory);
   }
 
-  @Test
   public void testObtainsLock() throws IOException {
     testObtainsLock(directory);
   }
 
-  @Test
   public void testCheckIndexAllValid() throws Exception {
     try (Directory dir = newDirectory()) {
       int liveDocCount = 1 + random().nextInt(10);

--- a/lucene/core/src/test/org/apache/lucene/index/TestClassloadingDeadlock.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestClassloadingDeadlock.java
@@ -46,7 +46,6 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.NamedThreadFactory;
 import org.apache.lucene.util.SuppressForbidden;
 import org.junit.Assert;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /* WARNING: This test does *not* extend LuceneTestCase to prevent static class
@@ -56,7 +55,6 @@ import org.junit.runner.RunWith;
 public class TestClassloadingDeadlock extends Assert {
   private static final int MAX_TIME_SECONDS = 30;
 
-  @Test
   @SuppressForbidden(reason = "Uses Path.toFile because ProcessBuilder requires it.")
   public void testDeadlock() throws Exception {
     // pick random codec names for stress test in separate process:

--- a/lucene/core/src/test/org/apache/lucene/index/TestConsistentFieldNumbers.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConsistentFieldNumbers.java
@@ -26,11 +26,9 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.util.FailOnNonBulkMergesInfoStream;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestConsistentFieldNumbers extends LuceneTestCase {
 
-  @Test
   public void testSameFieldNumbersAcrossSegments() throws Exception {
     for (int i = 0; i < 2; i++) {
       Directory dir = newDirectory();
@@ -96,7 +94,6 @@ public class TestConsistentFieldNumbers extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testAddIndexes() throws Exception {
     Directory dir1 = newDirectory();
     Directory dir2 = newDirectory();
@@ -256,7 +253,6 @@ public class TestConsistentFieldNumbers extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testManyFields() throws Exception {
     final int NUM_DOCS = atLeast(200);
     final int MAX_FIELDS = atLeast(50);

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocInverterPerFieldErrorInfo.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocInverterPerFieldErrorInfo.java
@@ -31,7 +31,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.PrintStreamInfoStream;
-import org.junit.Test;
 
 /** Test adding to the info stream when there's an exception thrown during field analysis. */
 public class TestDocInverterPerFieldErrorInfo extends LuceneTestCase {
@@ -62,7 +61,6 @@ public class TestDocInverterPerFieldErrorInfo extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testInfoStreamGetsFieldName() throws Exception {
     Directory dir = newDirectory();
     IndexWriter writer;
@@ -83,7 +81,6 @@ public class TestDocInverterPerFieldErrorInfo extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testNoExtraNoise() throws Exception {
     Directory dir = newDirectory();
     IndexWriter writer;

--- a/lucene/core/src/test/org/apache/lucene/index/TestFilterIndexInput.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFilterIndexInput.java
@@ -26,7 +26,6 @@ import org.apache.lucene.store.FilterIndexInput;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
-import org.junit.Test;
 
 public class TestFilterIndexInput extends TestIndexInput {
 
@@ -59,7 +58,6 @@ public class TestFilterIndexInput extends TestIndexInput {
     }
   }
 
-  @Test
   public void testOverrides() {
     for (Method m : FilterIndexInput.class.getMethods()) {
       if (m.getName().contains("clone")) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexCommit.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexCommit.java
@@ -20,11 +20,9 @@ import java.util.Collection;
 import java.util.Map;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestIndexCommit extends LuceneTestCase {
 
-  @Test
   public void testEqualsHashCode() throws Exception {
     // LUCENE-2417: equals and hashCode() impl was inconsistent
     final Directory dir = newDirectory();

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterConfig.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterConfig.java
@@ -32,7 +32,6 @@ import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.InfoStream;
-import org.junit.Test;
 
 public class TestIndexWriterConfig extends LuceneTestCase {
 
@@ -40,7 +39,6 @@ public class TestIndexWriterConfig extends LuceneTestCase {
     // Does not implement anything - used only for type checking on IndexWriterConfig.
   }
 
-  @Test
   public void testDefaults() throws Exception {
     IndexWriterConfig conf = new IndexWriterConfig(new MockAnalyzer(random()));
     assertEquals(MockAnalyzer.class, conf.getAnalyzer().getClass());
@@ -97,7 +95,6 @@ public class TestIndexWriterConfig extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testSettersChaining() throws Exception {
     // Ensures that every setter returns IndexWriterConfig to allow chaining.
     HashSet<String> liveSetters = new HashSet<>();
@@ -126,7 +123,6 @@ public class TestIndexWriterConfig extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testReuse() throws Exception {
     Directory dir = newDirectory();
     // test that IWC cannot be reused across two IWs
@@ -143,7 +139,6 @@ public class TestIndexWriterConfig extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testOverrideGetters() throws Exception {
     // Test that IndexWriterConfig overrides all getters, so that javadocs
     // contain all methods for the users. Also, ensures that IndexWriterConfig
@@ -168,7 +163,6 @@ public class TestIndexWriterConfig extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testConstants() throws Exception {
     // Tests that the values of the constants does not change
     assertEquals(-1, IndexWriterConfig.DISABLE_AUTO_FLUSH);
@@ -180,7 +174,6 @@ public class TestIndexWriterConfig extends LuceneTestCase {
     assertEquals(true, IndexWriterConfig.DEFAULT_USE_COMPOUND_FILE_SYSTEM);
   }
 
-  @Test
   public void testToString() throws Exception {
     String str = new IndexWriterConfig(new MockAnalyzer(random())).toString();
     for (Field f : IndexWriterConfig.class.getDeclaredFields()) {
@@ -200,7 +193,6 @@ public class TestIndexWriterConfig extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testInvalidValues() throws Exception {
     IndexWriterConfig conf = new IndexWriterConfig(new MockAnalyzer(random()));
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
@@ -51,7 +51,6 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.ThreadInterruptedException;
 import org.apache.lucene.util.Version;
-import org.junit.Test;
 
 @SuppressCodecs("SimpleText") // too slow here
 public class TestIndexWriterReader extends LuceneTestCase {
@@ -1106,7 +1105,6 @@ public class TestIndexWriterReader extends LuceneTestCase {
     d.close();
   }
 
-  @Test
   public void testNRTOpenExceptions() throws Exception {
     // LUCENE-5262: test that several failed attempts to obtain an NRT reader
     // don't leak file handles.

--- a/lucene/core/src/test/org/apache/lucene/index/TestIsCurrent.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIsCurrent.java
@@ -22,7 +22,6 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestIsCurrent extends LuceneTestCase {
 
@@ -53,7 +52,6 @@ public class TestIsCurrent extends LuceneTestCase {
   }
 
   /** Failing testcase showing the trouble */
-  @Test
   public void testDeleteByTermIsCurrent() throws IOException {
 
     // get reader
@@ -76,7 +74,6 @@ public class TestIsCurrent extends LuceneTestCase {
   }
 
   /** Testcase for example to show that writer.deleteAll() is working as expected */
-  @Test
   public void testDeleteAllIsCurrent() throws IOException {
 
     // get reader

--- a/lucene/core/src/test/org/apache/lucene/index/TestNoDeletionPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestNoDeletionPolicy.java
@@ -25,18 +25,15 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestNoDeletionPolicy extends LuceneTestCase {
 
-  @Test
   public void testNoDeletionPolicy() throws Exception {
     IndexDeletionPolicy idp = NoDeletionPolicy.INSTANCE;
     idp.onInit(null);
     idp.onCommit(null);
   }
 
-  @Test
   public void testFinalSingleton() throws Exception {
     assertTrue(Modifier.isFinal(NoDeletionPolicy.class.getModifiers()));
     Constructor<?>[] ctors = NoDeletionPolicy.class.getDeclaredConstructors();
@@ -45,7 +42,6 @@ public class TestNoDeletionPolicy extends LuceneTestCase {
         "that 1 should be private: " + ctors[0], Modifier.isPrivate(ctors[0].getModifiers()));
   }
 
-  @Test
   public void testMethodsOverridden() throws Exception {
     // Ensures that all methods of IndexDeletionPolicy are
     // overridden/implemented. That's important to ensure that NoDeletionPolicy
@@ -65,7 +61,6 @@ public class TestNoDeletionPolicy extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testAllCommitsRemain() throws Exception {
     Directory dir = newDirectory();
     IndexWriter writer =

--- a/lucene/core/src/test/org/apache/lucene/index/TestNoMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestNoMergePolicy.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import org.apache.lucene.index.MergePolicy.MergeSpecification;
 import org.apache.lucene.tests.index.BaseMergePolicyTestCase;
-import org.junit.Test;
 
 public class TestNoMergePolicy extends BaseMergePolicyTestCase {
 
@@ -32,7 +31,6 @@ public class TestNoMergePolicy extends BaseMergePolicyTestCase {
     return NoMergePolicy.INSTANCE;
   }
 
-  @Test
   public void testNoMergePolicy() throws Exception {
     MergePolicy mp = mergePolicy();
     assertNull(mp.findMerges(null, (SegmentInfos) null, null));
@@ -40,7 +38,6 @@ public class TestNoMergePolicy extends BaseMergePolicyTestCase {
     assertNull(mp.findForcedDeletesMerges(null, null));
   }
 
-  @Test
   public void testFinalSingleton() throws Exception {
     assertTrue(Modifier.isFinal(NoMergePolicy.class.getModifiers()));
     Constructor<?>[] ctors = NoMergePolicy.class.getDeclaredConstructors();
@@ -49,7 +46,6 @@ public class TestNoMergePolicy extends BaseMergePolicyTestCase {
         "that 1 should be private: " + ctors[0], Modifier.isPrivate(ctors[0].getModifiers()));
   }
 
-  @Test
   public void testMethodsOverridden() throws Exception {
     // Ensures that all methods of MergePolicy are overridden. That's important
     // to ensure that NoMergePolicy overrides everything, so that no unexpected

--- a/lucene/core/src/test/org/apache/lucene/index/TestNoMergeScheduler.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestNoMergeScheduler.java
@@ -22,18 +22,15 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestNoMergeScheduler extends LuceneTestCase {
 
-  @Test
   public void testNoMergeScheduler() throws Exception {
     MergeScheduler ms = NoMergeScheduler.INSTANCE;
     ms.close();
     ms.merge(null, RandomPicks.randomFrom(random(), MergeTrigger.values()));
   }
 
-  @Test
   public void testFinalSingleton() throws Exception {
     assertTrue(Modifier.isFinal(NoMergeScheduler.class.getModifiers()));
     Constructor<?>[] ctors = NoMergeScheduler.class.getDeclaredConstructors();
@@ -42,7 +39,6 @@ public class TestNoMergeScheduler extends LuceneTestCase {
         "that 1 should be private: " + ctors[0], Modifier.isPrivate(ctors[0].getModifiers()));
   }
 
-  @Test
   public void testMethodsOverridden() throws Exception {
     // Ensures that all methods of MergeScheduler are overridden. That's
     // important to ensure that NoMergeScheduler overrides everything, so that

--- a/lucene/core/src/test/org/apache/lucene/index/TestOneMergeWrappingMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestOneMergeWrappingMergePolicy.java
@@ -27,7 +27,6 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.Version;
-import org.junit.Test;
 
 public class TestOneMergeWrappingMergePolicy extends LuceneTestCase {
 
@@ -80,7 +79,6 @@ public class TestOneMergeWrappingMergePolicy extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testSegmentsAreWrapped() throws IOException {
     try (final Directory dir = newDirectory()) {
       // first create random merge specs

--- a/lucene/core/src/test/org/apache/lucene/index/TestPersistentSnapshotDeletionPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestPersistentSnapshotDeletionPolicy.java
@@ -23,7 +23,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.store.MockDirectoryWrapper;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 
 public class TestPersistentSnapshotDeletionPolicy extends TestSnapshotDeletionPolicy {
 
@@ -44,7 +43,6 @@ public class TestPersistentSnapshotDeletionPolicy extends TestSnapshotDeletionPo
         new KeepOnlyLastCommitDeletionPolicy(), dir, OpenMode.CREATE);
   }
 
-  @Test
   public void testExistingSnapshots() throws Exception {
     int numSnapshots = 3;
     MockDirectoryWrapper dir = newMockDirectory();
@@ -92,7 +90,6 @@ public class TestPersistentSnapshotDeletionPolicy extends TestSnapshotDeletionPo
     dir.close();
   }
 
-  @Test
   public void testNoSnapshotInfos() throws Exception {
     Directory dir = newDirectory();
     new PersistentSnapshotDeletionPolicy(
@@ -100,7 +97,6 @@ public class TestPersistentSnapshotDeletionPolicy extends TestSnapshotDeletionPo
     dir.close();
   }
 
-  @Test
   public void testMissingSnapshots() throws Exception {
     Directory dir = newDirectory();
 
@@ -152,7 +148,6 @@ public class TestPersistentSnapshotDeletionPolicy extends TestSnapshotDeletionPo
     dir.close();
   }
 
-  @Test
   public void testSnapshotRelease() throws Exception {
     Directory dir = newDirectory();
     IndexWriter writer = new IndexWriter(dir, getConfig(random(), getDeletionPolicy(dir)));
@@ -170,7 +165,6 @@ public class TestPersistentSnapshotDeletionPolicy extends TestSnapshotDeletionPo
     dir.close();
   }
 
-  @Test
   public void testSnapshotReleaseByGeneration() throws Exception {
     Directory dir = newDirectory();
     IndexWriter writer = new IndexWriter(dir, getConfig(random(), getDeletionPolicy(dir)));

--- a/lucene/core/src/test/org/apache/lucene/index/TestRollingUpdates.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestRollingUpdates.java
@@ -31,14 +31,12 @@ import org.apache.lucene.tests.util.LineFileDocs;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
-import org.junit.Test;
 
 public class TestRollingUpdates extends LuceneTestCase {
 
   // Just updates the same set of N docs over and over, to
   // stress out deletions
 
-  @Test
   public void testRollingUpdates() throws Exception {
     Random random = new Random(random().nextLong());
     final BaseDirectoryWrapper dir = newDirectory();

--- a/lucene/core/src/test/org/apache/lucene/index/TestSnapshotDeletionPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSnapshotDeletionPolicy.java
@@ -32,7 +32,6 @@ import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.SuppressForbidden;
 import org.apache.lucene.util.ThreadInterruptedException;
-import org.junit.Test;
 
 //
 // This was developed for Lucene In Action,
@@ -98,7 +97,6 @@ public class TestSnapshotDeletionPolicy extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testSnapshotDeletionPolicy() throws Exception {
     Directory fsDir = newDirectory();
     runTest(random(), fsDir);
@@ -253,7 +251,6 @@ public class TestSnapshotDeletionPolicy extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testBasicSnapshots() throws Exception {
     int numSnapshots = 3;
 
@@ -281,7 +278,6 @@ public class TestSnapshotDeletionPolicy extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testMultiThreadedSnapshotting() throws Exception {
     Directory dir = newDirectory();
 
@@ -334,7 +330,6 @@ public class TestSnapshotDeletionPolicy extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testRollbackToOldSnapshot() throws Exception {
     int numSnapshots = 2;
     Directory dir = newDirectory();
@@ -361,7 +356,6 @@ public class TestSnapshotDeletionPolicy extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testReleaseSnapshot() throws Exception {
     Directory dir = newDirectory();
     IndexWriter writer = new IndexWriter(dir, getConfig(random(), getDeletionPolicy()));
@@ -385,7 +379,6 @@ public class TestSnapshotDeletionPolicy extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testSnapshotLastCommitTwice() throws Exception {
     Directory dir = newDirectory();
 
@@ -412,7 +405,6 @@ public class TestSnapshotDeletionPolicy extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testMissingCommits() throws Exception {
     // Tests the behavior of SDP when commits that are given at ctor are missing
     // on onInit().

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestCharHashSet.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestCharHashSet.java
@@ -33,7 +33,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.hamcrest.MatcherAssert;
 import org.junit.Before;
-import org.junit.Test;
 
 /**
  * Tests for {@link CharHashSet}.
@@ -64,7 +63,6 @@ public class TestCharHashSet extends LuceneTestCase {
     set = new CharHashSet();
   }
 
-  @Test
   public void testAddAllViaInterface() {
     set.addAll(key1, key2);
 
@@ -74,7 +72,6 @@ public class TestCharHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(set(iface.toArray()), is(equalTo(set(key1, key2))));
   }
 
-  @Test
   public void testIndexMethods() {
     set.add(keyE);
     set.add(key1);
@@ -114,7 +111,6 @@ public class TestCharHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(set.indexOf(key2), is(lessThan(0)));
   }
 
-  @Test
   public void testCursorIndexIsValid() {
     set.add(keyE);
     set.add(key1);
@@ -126,7 +122,6 @@ public class TestCharHashSet extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testEmptyKey() {
     CharHashSet set = new CharHashSet();
 
@@ -166,7 +161,6 @@ public class TestCharHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(set.indexGet(index), is(equalTo(EMPTY_KEY)));
   }
 
-  @Test
   public void testEnsureCapacity() {
     final AtomicInteger expands = new AtomicInteger();
     CharHashSet set =
@@ -193,19 +187,16 @@ public class TestCharHashSet extends LuceneTestCase {
     assertEquals(before, expands.get());
   }
 
-  @Test
   public void testInitiallyEmpty() {
     assertEquals(0, set.size());
   }
 
-  @Test
   public void testAdd() {
     assertTrue(set.add(key1));
     assertFalse(set.add(key1));
     assertEquals(1, set.size());
   }
 
-  @Test
   public void testAdd2() {
     set.addAll(key1, key1);
     assertEquals(1, set.size());
@@ -213,14 +204,12 @@ public class TestCharHashSet extends LuceneTestCase {
     assertEquals(2, set.size());
   }
 
-  @Test
   public void testAddVarArgs() {
     set.addAll(asArray(0, 1, 2, 1, 0));
     assertEquals(3, set.size());
     assertSortedListEquals(set.toArray(), asArray(0, 1, 2));
   }
 
-  @Test
   public void testAddAll() {
     CharHashSet set2 = new CharHashSet();
     set2.addAll(asArray(1, 2));
@@ -233,7 +222,6 @@ public class TestCharHashSet extends LuceneTestCase {
     assertSortedListEquals(set.toArray(), asArray(0, 1, 2));
   }
 
-  @Test
   public void testRemove() {
     set.addAll(asArray(0, 1, 2, 3, 4));
 
@@ -243,7 +231,6 @@ public class TestCharHashSet extends LuceneTestCase {
     assertSortedListEquals(set.toArray(), asArray(0, 1, 3, 4));
   }
 
-  @Test
   public void testInitialCapacityAndGrowth() {
     for (int i = 0; i < 256; i++) {
       CharHashSet set = new CharHashSet(i);
@@ -256,7 +243,6 @@ public class TestCharHashSet extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testBug_HPPC73_FullCapacityGet() {
     final AtomicInteger reallocations = new AtomicInteger();
     final int elements = 0x7F;
@@ -301,7 +287,6 @@ public class TestCharHashSet extends LuceneTestCase {
     assertEquals(reallocationsBefore + 1, reallocations.get());
   }
 
-  @Test
   public void testRemoveAllFromLookupContainer() {
     set.addAll(asArray(0, 1, 2, 3, 4));
 
@@ -313,14 +298,12 @@ public class TestCharHashSet extends LuceneTestCase {
     assertSortedListEquals(set.toArray(), asArray(0, 2, 4));
   }
 
-  @Test
   public void testClear() {
     set.addAll(asArray(1, 2, 3));
     set.clear();
     assertEquals(0, set.size());
   }
 
-  @Test
   public void testRelease() {
     set.addAll(asArray(1, 2, 3));
     set.release();
@@ -329,7 +312,6 @@ public class TestCharHashSet extends LuceneTestCase {
     assertEquals(3, set.size());
   }
 
-  @Test
   public void testIterable() {
     set.addAll(asArray(1, 2, 2, 3, 4));
     set.remove(key2);
@@ -347,7 +329,6 @@ public class TestCharHashSet extends LuceneTestCase {
   }
 
   /** Runs random insertions/deletions/clearing and compares the results against {@link HashSet}. */
-  @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void testAgainstHashSet() {
     final Random rnd = RandomizedTest.getRandom();
@@ -395,7 +376,6 @@ public class TestCharHashSet extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testHashCodeEquals() {
     CharHashSet l0 = new CharHashSet();
     assertEquals(0, l0.hashCode());
@@ -409,7 +389,6 @@ public class TestCharHashSet extends LuceneTestCase {
     assertEquals(l1, l2);
   }
 
-  @Test
   public void testClone() {
     this.set.addAll(asArray(1, 2, 3));
 
@@ -420,7 +399,6 @@ public class TestCharHashSet extends LuceneTestCase {
     assertSortedListEquals(cloned.toArray(), asArray(2, 3));
   }
 
-  @Test
   public void testEqualsSameClass() {
     CharHashSet l1 = CharHashSet.from(key1, key2, key3);
     CharHashSet l2 = CharHashSet.from(key1, key2, key3);
@@ -431,7 +409,6 @@ public class TestCharHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(l1, is(not(equalTo(l3))));
   }
 
-  @Test
   public void testEqualsSubClass() {
     class Sub extends CharHashSet {}
     ;

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestCharObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestCharObjectHashMap.java
@@ -29,7 +29,6 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.After;
-import org.junit.Test;
 
 /**
  * Tests for {@link CharObjectHashMap}.
@@ -122,7 +121,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEnsureCapacity() {
     final AtomicInteger expands = new AtomicInteger();
     CharObjectHashMap map =
@@ -149,7 +147,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
     assertEquals(before, expands.get());
   }
 
-  @Test
   public void testCursorIndexIsValid() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -161,7 +158,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testIndexMethods() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -204,7 +200,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testCloningConstructor() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -214,7 +209,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testFromArrays() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -226,7 +220,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
     assertSameMap(map, map2);
   }
 
-  @Test
   public void testGetOrDefault() {
     map.put(key2, value2);
     assertTrue(map.containsKey(key2));
@@ -239,7 +232,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPut() {
     map.put(key1, value1);
 
@@ -248,7 +240,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testNullValue() {
     map.put(key1, null);
 
@@ -256,7 +247,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
     assertNull(map.get(key1));
   }
 
-  @Test
   public void testPutOverExistingKey() {
     map.put(key1, value1);
     assertEquals(value1, map.put(key1, value3));
@@ -271,7 +261,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutWithExpansions() {
     final int COUNT = 10000;
     final Random rnd = new Random(random().nextLong());
@@ -290,7 +279,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutAll() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -312,7 +300,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutIfAbsent() {
     assertTrue(map.putIfAbsent(key1, value1));
     assertFalse(map.putIfAbsent(key1, value2));
@@ -320,7 +307,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testRemove() {
     map.put(key1, value1);
     assertEquals(value1, map.remove(key1));
@@ -332,7 +318,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEmptyKey() {
     final char empty = 0;
 
@@ -369,7 +354,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySet() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -379,7 +363,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySetIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -394,7 +377,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testClear() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -414,7 +396,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testRelease() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -429,7 +410,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testIterable() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -452,7 +432,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testBug_HPPC73_FullCapacityGet() {
     final AtomicInteger reallocations = new AtomicInteger();
     final int elements = 0x7F;
@@ -497,7 +476,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
     assertEquals(reallocationsBefore + 1, reallocations.get());
   }
 
-  @Test
   public void testHashCodeEquals() {
     CharObjectHashMap l0 = newInstance();
     assertEquals(0, l0.hashCode());
@@ -518,7 +496,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
     assertFalse(l2.equals(l3));
   }
 
-  @Test
   public void testBug_HPPC37() {
     CharObjectHashMap l1 = CharObjectHashMap.from(newArray(key1), newvArray(value1));
 
@@ -529,7 +506,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /** Runs random insertions/deletions/clearing and compares the results against {@link HashMap}. */
-  @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void testAgainstHashMap() {
     final Random rnd = RandomizedTest.getRandom();
@@ -583,7 +559,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   /*
    *
    */
-  @Test
   public void testClone() {
     this.map.put(key1, value1);
     this.map.put(key2, value2);
@@ -597,7 +572,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValues() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -614,7 +588,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValuesIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -629,7 +602,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSameClass() {
     CharObjectHashMap l1 = newInstance();
     l1.put(key1, value0);
@@ -649,7 +621,6 @@ public class TestCharObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSubClass() {
     class Sub extends CharObjectHashMap {}
 

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestFloatArrayList.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestFloatArrayList.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Before;
-import org.junit.Test;
 
 /**
  * Tests for {@link FloatArrayList}.
@@ -53,38 +52,32 @@ public class TestFloatArrayList extends LuceneTestCase {
     list = new FloatArrayList();
   }
 
-  @Test
   public void testInitiallyEmpty() {
     assertEquals(0, list.size());
   }
 
-  @Test
   public void testAdd() {
     list.add(key1, key2);
     assertListEquals(list.toArray(), 1, 2);
   }
 
-  @Test
   public void testAddTwoArgs() {
     list.add(key1, key2);
     list.add(key3, key4);
     assertListEquals(list.toArray(), 1, 2, 3, 4);
   }
 
-  @Test
   public void testAddArray() {
     list.add(asArray(0, 1, 2, 3), 1, 2);
     assertListEquals(list.toArray(), 1, 2);
   }
 
-  @Test
   public void testAddVarArg() {
     list.add(asArray(0, 1, 2, 3));
     list.add(key4, key5, key6, key7);
     assertListEquals(list.toArray(), 0, 1, 2, 3, 4, 5, 6, 7);
   }
 
-  @Test
   public void testAddAll() {
     FloatArrayList list2 = new FloatArrayList();
     list2.add(asArray(0, 1, 2));
@@ -95,7 +88,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 0, 1, 2, 0, 1, 2);
   }
 
-  @Test
   public void testInsert() {
     list.insert(0, key1);
     list.insert(0, key2);
@@ -105,7 +97,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 2, 4, 1, 3);
   }
 
-  @Test
   public void testSet() {
     list.add(asArray(0, 1, 2));
 
@@ -116,7 +107,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 3, 4, 5);
   }
 
-  @Test
   public void testRemoveAt() {
     list.add(asArray(0, 1, 2, 3, 4));
 
@@ -127,7 +117,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 1, 4);
   }
 
-  @Test
   public void testRemoveLast() {
     list.add(asArray(0, 1, 2, 3, 4));
 
@@ -143,7 +132,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertTrue(list.isEmpty());
   }
 
-  @Test
   public void testRemoveElement() {
     list.add(asArray(0, 1, 2, 3, 3, 4));
 
@@ -154,7 +142,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 0, 1, 3, 4);
   }
 
-  @Test
   public void testRemoveRange() {
     list.add(asArray(0, 1, 2, 3, 4));
 
@@ -171,7 +158,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 3);
   }
 
-  @Test
   public void testRemoveFirstLast() {
     list.add(asArray(0, 1, 2, 1, 0));
 
@@ -188,7 +174,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertEquals(-1, list.removeLast(key0));
   }
 
-  @Test
   public void testRemoveAll() {
     list.add(asArray(0, 1, 0, 1, 0));
 
@@ -200,7 +185,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertTrue(list.isEmpty());
   }
 
-  @Test
   public void testIndexOf() {
     list.add(asArray(0, 1, 2, 1, 0));
 
@@ -209,7 +193,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertEquals(2, list.indexOf(key2));
   }
 
-  @Test
   public void testLastIndexOf() {
     list.add(asArray(0, 1, 2, 1, 0));
 
@@ -218,7 +201,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertEquals(2, list.lastIndexOf(key2));
   }
 
-  @Test
   public void testEnsureCapacity() {
     FloatArrayList list = new FloatArrayList(0);
     assertEquals(list.size(), list.buffer.length);
@@ -227,7 +209,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertNotSame(buffer1, list.buffer);
   }
 
-  @Test
   public void testResizeAndCleanBuffer() {
     list.ensureCapacity(20);
     Arrays.fill(list.buffer, key1);
@@ -249,14 +230,12 @@ public class TestFloatArrayList extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testTrimToSize() {
     list.add(asArray(1, 2));
     list.trimToSize();
     assertEquals(2, list.buffer.length);
   }
 
-  @Test
   public void testRelease() {
     list.add(asArray(1, 2));
     list.release();
@@ -265,7 +244,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertEquals(2, list.size());
   }
 
-  @Test
   public void testIterable() {
     list.add(asArray(0, 1, 2, 3));
     int count = 0;
@@ -284,7 +262,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertEquals(0, count);
   }
 
-  @Test
   public void testIterator() {
     list.add(asArray(0, 1, 2, 3));
     Iterator<FloatCursor> iterator = list.iterator();
@@ -302,7 +279,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertFalse(list.iterator().hasNext());
   }
 
-  @Test
   public void testClear() {
     list.add(asArray(1, 2, 3));
     list.clear();
@@ -310,7 +286,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertEquals(-1, list.indexOf(cast(1)));
   }
 
-  @Test
   public void testFrom() {
     list = FloatArrayList.from(key1, key2, key3);
     assertEquals(3, list.size());
@@ -318,7 +293,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertEquals(list.size(), list.buffer.length);
   }
 
-  @Test
   public void testCopyList() {
     list.add(asArray(1, 2, 3));
     FloatArrayList copy = new FloatArrayList(list);
@@ -327,7 +301,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertEquals(copy.size(), copy.buffer.length);
   }
 
-  @Test
   public void testHashCodeEquals() {
     FloatArrayList l0 = FloatArrayList.from();
     assertEquals(1, l0.hashCode());
@@ -341,7 +314,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertEquals(l1, l2);
   }
 
-  @Test
   public void testEqualElements() {
     FloatArrayList l1 = FloatArrayList.from(key1, key2, key3);
     FloatArrayList l2 = FloatArrayList.from(key1, key2);
@@ -351,7 +323,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertTrue(l2.equalElements(l1));
   }
 
-  @Test
   public void testToArray() {
     FloatArrayList l1 = FloatArrayList.from(key1, key2, key3);
     l1.ensureCapacity(100);
@@ -359,7 +330,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertArrayEquals(new float[] {key1, key2, key3}, result);
   }
 
-  @Test
   public void testClone() {
     list.add(key1, key2, key3);
 
@@ -370,14 +340,12 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertSortedListEquals(cloned.toArray(), key2, key3);
   }
 
-  @Test
   public void testToString() {
     assertEquals(
         "[" + key1 + ", " + key2 + ", " + key3 + "]",
         FloatArrayList.from(key1, key2, key3).toString());
   }
 
-  @Test
   public void testEqualsSameClass() {
     FloatArrayList l1 = FloatArrayList.from(key1, key2, key3);
     FloatArrayList l2 = FloatArrayList.from(key1, key2, key3);
@@ -388,7 +356,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertNotEquals(l1, l3);
   }
 
-  @Test
   public void testEqualsSubClass() {
     class Sub extends FloatArrayList {}
     ;
@@ -403,7 +370,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertNotEquals(l1, l3);
   }
 
-  @Test
   public void testSort() {
     list.add(key3, key1, key3, key2);
     FloatArrayList list2 = new FloatArrayList();
@@ -413,7 +379,6 @@ public class TestFloatArrayList extends LuceneTestCase {
     assertEquals(FloatArrayList.from(key1, key2, key3, key3), list2);
   }
 
-  @Test
   public void testReverse() {
     for (int i = 0; i < 10; i++) {
       float[] elements = new float[i];

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntArrayList.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntArrayList.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Before;
-import org.junit.Test;
 
 /**
  * Tests for {@link IntArrayList}.
@@ -54,38 +53,32 @@ public class TestIntArrayList extends LuceneTestCase {
     list = new IntArrayList();
   }
 
-  @Test
   public void testInitiallyEmpty() {
     assertEquals(0, list.size());
   }
 
-  @Test
   public void testAdd() {
     list.add(key1, key2);
     assertListEquals(list.toArray(), 1, 2);
   }
 
-  @Test
   public void testAddTwoArgs() {
     list.add(key1, key2);
     list.add(key3, key4);
     assertListEquals(list.toArray(), 1, 2, 3, 4);
   }
 
-  @Test
   public void testAddArray() {
     list.add(asArray(0, 1, 2, 3), 1, 2);
     assertListEquals(list.toArray(), 1, 2);
   }
 
-  @Test
   public void testAddVarArg() {
     list.add(asArray(0, 1, 2, 3));
     list.add(key4, key5, key6, key7);
     assertListEquals(list.toArray(), 0, 1, 2, 3, 4, 5, 6, 7);
   }
 
-  @Test
   public void testAddAll() {
     IntArrayList list2 = new IntArrayList();
     list2.add(asArray(0, 1, 2));
@@ -96,7 +89,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 0, 1, 2, 0, 1, 2);
   }
 
-  @Test
   public void testInsert() {
     list.insert(0, key1);
     list.insert(0, key2);
@@ -106,7 +98,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 2, 4, 1, 3);
   }
 
-  @Test
   public void testSet() {
     list.add(asArray(0, 1, 2));
 
@@ -117,7 +108,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 3, 4, 5);
   }
 
-  @Test
   public void testRemoveAt() {
     list.add(asArray(0, 1, 2, 3, 4));
 
@@ -128,7 +118,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 1, 4);
   }
 
-  @Test
   public void testRemoveLast() {
     list.add(asArray(0, 1, 2, 3, 4));
 
@@ -144,7 +133,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertTrue(list.isEmpty());
   }
 
-  @Test
   public void testRemoveElement() {
     list.add(asArray(0, 1, 2, 3, 3, 4));
 
@@ -155,7 +143,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 0, 1, 3, 4);
   }
 
-  @Test
   public void testRemoveRange() {
     list.add(asArray(0, 1, 2, 3, 4));
 
@@ -172,7 +159,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 3);
   }
 
-  @Test
   public void testRemoveFirstLast() {
     list.add(asArray(0, 1, 2, 1, 0));
 
@@ -189,7 +175,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertEquals(-1, list.removeLast(key0));
   }
 
-  @Test
   public void testRemoveAll() {
     list.add(asArray(0, 1, 0, 1, 0));
 
@@ -201,7 +186,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertTrue(list.isEmpty());
   }
 
-  @Test
   public void testIndexOf() {
     list.add(asArray(0, 1, 2, 1, 0));
 
@@ -210,7 +194,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertEquals(2, list.indexOf(key2));
   }
 
-  @Test
   public void testLastIndexOf() {
     list.add(asArray(0, 1, 2, 1, 0));
 
@@ -219,7 +202,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertEquals(2, list.lastIndexOf(key2));
   }
 
-  @Test
   public void testEnsureCapacity() {
     IntArrayList list = new IntArrayList(0);
     assertEquals(list.size(), list.buffer.length);
@@ -228,7 +210,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertNotSame(buffer1, list.buffer);
   }
 
-  @Test
   public void testResizeAndCleanBuffer() {
     list.ensureCapacity(20);
     Arrays.fill(list.buffer, key1);
@@ -250,14 +231,12 @@ public class TestIntArrayList extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testTrimToSize() {
     list.add(asArray(1, 2));
     list.trimToSize();
     assertEquals(2, list.buffer.length);
   }
 
-  @Test
   public void testRelease() {
     list.add(asArray(1, 2));
     list.release();
@@ -266,7 +245,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertEquals(2, list.size());
   }
 
-  @Test
   public void testIterable() {
     list.add(asArray(0, 1, 2, 3));
     int count = 0;
@@ -285,7 +263,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertEquals(0, count);
   }
 
-  @Test
   public void testIterator() {
     list.add(asArray(0, 1, 2, 3));
     Iterator<IntCursor> iterator = list.iterator();
@@ -303,7 +280,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertFalse(list.iterator().hasNext());
   }
 
-  @Test
   public void testClear() {
     list.add(asArray(1, 2, 3));
     list.clear();
@@ -311,7 +287,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertEquals(-1, list.indexOf(cast(1)));
   }
 
-  @Test
   public void testFrom() {
     list = IntArrayList.from(key1, key2, key3);
     assertEquals(3, list.size());
@@ -319,7 +294,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertEquals(list.size(), list.buffer.length);
   }
 
-  @Test
   public void testCopyList() {
     list.add(asArray(1, 2, 3));
     IntArrayList copy = new IntArrayList(list);
@@ -328,7 +302,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertEquals(copy.size(), copy.buffer.length);
   }
 
-  @Test
   public void testHashCodeEquals() {
     IntArrayList l0 = IntArrayList.from();
     assertEquals(1, l0.hashCode());
@@ -342,7 +315,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertEquals(l1, l2);
   }
 
-  @Test
   public void testEqualElements() {
     IntArrayList l1 = IntArrayList.from(key1, key2, key3);
     IntArrayList l2 = IntArrayList.from(key1, key2);
@@ -352,7 +324,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertTrue(l2.equalElements(l1));
   }
 
-  @Test
   public void testToArray() {
     IntArrayList l1 = IntArrayList.from(key1, key2, key3);
     l1.ensureCapacity(100);
@@ -360,7 +331,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertArrayEquals(new int[] {key1, key2, key3}, result);
   }
 
-  @Test
   public void testClone() {
     list.add(key1, key2, key3);
 
@@ -371,14 +341,12 @@ public class TestIntArrayList extends LuceneTestCase {
     assertSortedListEquals(cloned.toArray(), key2, key3);
   }
 
-  @Test
   public void testToString() {
     assertEquals(
         "[" + key1 + ", " + key2 + ", " + key3 + "]",
         IntArrayList.from(key1, key2, key3).toString());
   }
 
-  @Test
   public void testEqualsSameClass() {
     IntArrayList l1 = IntArrayList.from(key1, key2, key3);
     IntArrayList l2 = IntArrayList.from(key1, key2, key3);
@@ -389,7 +357,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertNotEquals(l1, l3);
   }
 
-  @Test
   public void testEqualsSubClass() {
     class Sub extends IntArrayList {}
     ;
@@ -404,7 +371,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertNotEquals(l1, l3);
   }
 
-  @Test
   public void testStream() {
     assertEquals(key1, IntArrayList.from(key1, key2, key3).stream().min().orElseThrow());
     assertEquals(key3, IntArrayList.from(key2, key1, key3).stream().max().orElseThrow());
@@ -416,7 +382,6 @@ public class TestIntArrayList extends LuceneTestCase {
         });
   }
 
-  @Test
   public void testSort() {
     list.add(key3, key1, key3, key2);
     IntArrayList list2 = new IntArrayList();
@@ -426,7 +391,6 @@ public class TestIntArrayList extends LuceneTestCase {
     assertEquals(IntArrayList.from(key1, key2, key3, key3), list2);
   }
 
-  @Test
   public void testReverse() {
     for (int i = 0; i < 10; i++) {
       int[] elements = new int[i];

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntDoubleHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntDoubleHashMap.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /**
  * Tests for {@link IntDoubleHashMap}.
@@ -118,7 +117,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEnsureCapacity() {
     final AtomicInteger expands = new AtomicInteger();
     IntDoubleHashMap map =
@@ -145,7 +143,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
     assertEquals(before, expands.get());
   }
 
-  @Test
   public void testCursorIndexIsValid() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -157,7 +154,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testIndexMethods() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -200,7 +196,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testCloningConstructor() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -210,7 +205,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testFromArrays() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -222,7 +216,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
     assertSameMap(map, map2);
   }
 
-  @Test
   public void testGetOrDefault() {
     map.put(key2, value2);
     assertTrue(map.containsKey(key2));
@@ -235,7 +228,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPut() {
     map.put(key1, value1);
 
@@ -244,7 +236,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutOverExistingKey() {
     map.put(key1, value1);
     assertEquals2(value1, map.put(key1, value3));
@@ -252,7 +243,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutWithExpansions() {
     final int COUNT = 10000;
     final Random rnd = new Random(random().nextInt());
@@ -271,7 +261,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutAll() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -293,27 +282,23 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutIfAbsent() {
     assertTrue(map.putIfAbsent(key1, value1));
     assertFalse(map.putIfAbsent(key1, value2));
     assertEquals2(value1, map.get(key1));
   }
 
-  @Test
   public void testPutOrAdd() {
     assertEquals2(value1, map.putOrAdd(key1, value1, value2));
     assertEquals2(value3, map.putOrAdd(key1, value1, value2));
   }
 
-  @Test
   public void testAddTo() {
     assertEquals2(value1, map.addTo(key1, value1));
     assertEquals2(value3, map.addTo(key1, value2));
   }
 
   /* */
-  @Test
   public void testRemove() {
     map.put(key1, value1);
     assertEquals2(value1, map.remove(key1));
@@ -325,7 +310,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEmptyKey() {
     final int empty = 0;
 
@@ -352,7 +336,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySet() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -362,7 +345,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySetIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -377,7 +359,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testClear() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -397,7 +378,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testRelease() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -412,7 +392,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testIterable() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -435,7 +414,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testBug_HPPC73_FullCapacityGet() {
     final AtomicInteger reallocations = new AtomicInteger();
     final int elements = 0x7F;
@@ -480,7 +458,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
     assertEquals(reallocationsBefore + 1, reallocations.get());
   }
 
-  @Test
   public void testHashCodeEquals() {
     IntDoubleHashMap l0 = newInstance();
     assertEquals(0, l0.hashCode());
@@ -501,7 +478,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
     assertNotEquals(l2, l3);
   }
 
-  @Test
   public void testBug_HPPC37() {
     IntDoubleHashMap l1 = IntDoubleHashMap.from(newArray(key1), newvArray(value1));
 
@@ -512,7 +488,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /** Runs random insertions/deletions/clearing and compares the results against {@link HashMap}. */
-  @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void testAgainstHashMap() {
     final Random rnd = RandomizedTest.getRandom();
@@ -569,7 +544,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   /*
    *
    */
-  @Test
   public void testClone() {
     this.map.put(key1, value1);
     this.map.put(key2, value2);
@@ -583,7 +557,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValues() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -598,7 +571,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValuesIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -613,7 +585,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSameClass() {
     IntDoubleHashMap l1 = newInstance();
     l1.put(key1, value0);
@@ -633,7 +604,6 @@ public class TestIntDoubleHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSubClass() {
     class Sub extends IntDoubleHashMap {}
 

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntFloatHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntFloatHashMap.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /**
  * Tests for {@link IntFloatHashMap}.
@@ -118,7 +117,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEnsureCapacity() {
     final AtomicInteger expands = new AtomicInteger();
     IntFloatHashMap map =
@@ -145,7 +143,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
     assertEquals(before, expands.get());
   }
 
-  @Test
   public void testCursorIndexIsValid() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -157,7 +154,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testIndexMethods() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -200,7 +196,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testCloningConstructor() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -210,7 +205,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testFromArrays() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -222,7 +216,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
     assertSameMap(map, map2);
   }
 
-  @Test
   public void testGetOrDefault() {
     map.put(key2, value2);
     assertTrue(map.containsKey(key2));
@@ -235,7 +228,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPut() {
     map.put(key1, value1);
 
@@ -244,7 +236,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutOverExistingKey() {
     map.put(key1, value1);
     assertEquals2(value1, map.put(key1, value3));
@@ -252,7 +243,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutWithExpansions() {
     final int COUNT = 10000;
     final Random rnd = new Random(random().nextInt());
@@ -271,7 +261,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutAll() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -293,27 +282,23 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutIfAbsent() {
     assertTrue(map.putIfAbsent(key1, value1));
     assertFalse(map.putIfAbsent(key1, value2));
     assertEquals2(value1, map.get(key1));
   }
 
-  @Test
   public void testPutOrAdd() {
     assertEquals2(value1, map.putOrAdd(key1, value1, value2));
     assertEquals2(value3, map.putOrAdd(key1, value1, value2));
   }
 
-  @Test
   public void testAddTo() {
     assertEquals2(value1, map.addTo(key1, value1));
     assertEquals2(value3, map.addTo(key1, value2));
   }
 
   /* */
-  @Test
   public void testRemove() {
     map.put(key1, value1);
     assertEquals2(value1, map.remove(key1));
@@ -325,7 +310,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEmptyKey() {
     final int empty = 0;
 
@@ -352,7 +336,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySet() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -362,7 +345,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySetIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -377,7 +359,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testClear() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -397,7 +378,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testRelease() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -412,7 +392,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testIterable() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -435,7 +414,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testBug_HPPC73_FullCapacityGet() {
     final AtomicInteger reallocations = new AtomicInteger();
     final int elements = 0x7F;
@@ -480,7 +458,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
     assertEquals(reallocationsBefore + 1, reallocations.get());
   }
 
-  @Test
   public void testHashCodeEquals() {
     IntFloatHashMap l0 = newInstance();
     assertEquals(0, l0.hashCode());
@@ -501,7 +478,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
     assertNotEquals(l2, l3);
   }
 
-  @Test
   public void testBug_HPPC37() {
     IntFloatHashMap l1 = IntFloatHashMap.from(newArray(key1), newvArray(value1));
 
@@ -512,7 +488,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /** Runs random insertions/deletions/clearing and compares the results against {@link HashMap}. */
-  @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void testAgainstHashMap() {
     final Random rnd = RandomizedTest.getRandom();
@@ -569,7 +544,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   /*
    *
    */
-  @Test
   public void testClone() {
     this.map.put(key1, value1);
     this.map.put(key2, value2);
@@ -583,7 +557,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValues() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -598,7 +571,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValuesIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -613,7 +585,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSameClass() {
     IntFloatHashMap l1 = newInstance();
     l1.put(key1, value0);
@@ -633,7 +604,6 @@ public class TestIntFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSubClass() {
     class Sub extends IntFloatHashMap {}
 

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntHashSet.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntHashSet.java
@@ -33,7 +33,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.hamcrest.MatcherAssert;
 import org.junit.Before;
-import org.junit.Test;
 
 /**
  * Tests for {@link IntHashSet}.
@@ -64,7 +63,6 @@ public class TestIntHashSet extends LuceneTestCase {
     set = new IntHashSet();
   }
 
-  @Test
   public void testAddAllViaInterface() {
     set.addAll(key1, key2);
 
@@ -74,7 +72,6 @@ public class TestIntHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(set(iface.toArray()), is(equalTo(set(key1, key2))));
   }
 
-  @Test
   public void testIndexMethods() {
     set.add(keyE);
     set.add(key1);
@@ -114,7 +111,6 @@ public class TestIntHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(set.indexOf(key2), is(lessThan(0)));
   }
 
-  @Test
   public void testCursorIndexIsValid() {
     set.add(keyE);
     set.add(key1);
@@ -126,7 +122,6 @@ public class TestIntHashSet extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testEmptyKey() {
     IntHashSet set = new IntHashSet();
 
@@ -166,7 +161,6 @@ public class TestIntHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(set.indexGet(index), is(equalTo(EMPTY_KEY)));
   }
 
-  @Test
   public void testEnsureCapacity() {
     final AtomicInteger expands = new AtomicInteger();
     IntHashSet set =
@@ -193,19 +187,16 @@ public class TestIntHashSet extends LuceneTestCase {
     assertEquals(before, expands.get());
   }
 
-  @Test
   public void testInitiallyEmpty() {
     assertEquals(0, set.size());
   }
 
-  @Test
   public void testAdd() {
     assertTrue(set.add(key1));
     assertFalse(set.add(key1));
     assertEquals(1, set.size());
   }
 
-  @Test
   public void testAdd2() {
     set.addAll(key1, key1);
     assertEquals(1, set.size());
@@ -213,14 +204,12 @@ public class TestIntHashSet extends LuceneTestCase {
     assertEquals(2, set.size());
   }
 
-  @Test
   public void testAddVarArgs() {
     set.addAll(asArray(0, 1, 2, 1, 0));
     assertEquals(3, set.size());
     assertSortedListEquals(set.toArray(), asArray(0, 1, 2));
   }
 
-  @Test
   public void testAddAll() {
     IntHashSet set2 = new IntHashSet();
     set2.addAll(asArray(1, 2));
@@ -233,7 +222,6 @@ public class TestIntHashSet extends LuceneTestCase {
     assertSortedListEquals(set.toArray(), asArray(0, 1, 2));
   }
 
-  @Test
   public void testRemove() {
     set.addAll(asArray(0, 1, 2, 3, 4));
 
@@ -243,7 +231,6 @@ public class TestIntHashSet extends LuceneTestCase {
     assertSortedListEquals(set.toArray(), asArray(0, 1, 3, 4));
   }
 
-  @Test
   public void testInitialCapacityAndGrowth() {
     for (int i = 0; i < 256; i++) {
       IntHashSet set = new IntHashSet(i);
@@ -256,7 +243,6 @@ public class TestIntHashSet extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testBug_HPPC73_FullCapacityGet() {
     final AtomicInteger reallocations = new AtomicInteger();
     final int elements = 0x7F;
@@ -301,7 +287,6 @@ public class TestIntHashSet extends LuceneTestCase {
     assertEquals(reallocationsBefore + 1, reallocations.get());
   }
 
-  @Test
   public void testRemoveAllFromLookupContainer() {
     set.addAll(asArray(0, 1, 2, 3, 4));
 
@@ -313,14 +298,12 @@ public class TestIntHashSet extends LuceneTestCase {
     assertSortedListEquals(set.toArray(), asArray(0, 2, 4));
   }
 
-  @Test
   public void testClear() {
     set.addAll(asArray(1, 2, 3));
     set.clear();
     assertEquals(0, set.size());
   }
 
-  @Test
   public void testRelease() {
     set.addAll(asArray(1, 2, 3));
     set.release();
@@ -329,7 +312,6 @@ public class TestIntHashSet extends LuceneTestCase {
     assertEquals(3, set.size());
   }
 
-  @Test
   public void testIterable() {
     set.addAll(asArray(1, 2, 2, 3, 4));
     set.remove(key2);
@@ -347,7 +329,6 @@ public class TestIntHashSet extends LuceneTestCase {
   }
 
   /** Runs random insertions/deletions/clearing and compares the results against {@link HashSet}. */
-  @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void testAgainstHashSet() {
     final Random rnd = RandomizedTest.getRandom();
@@ -395,7 +376,6 @@ public class TestIntHashSet extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testHashCodeEquals() {
     IntHashSet l0 = new IntHashSet();
     assertEquals(0, l0.hashCode());
@@ -409,7 +389,6 @@ public class TestIntHashSet extends LuceneTestCase {
     assertEquals(l1, l2);
   }
 
-  @Test
   public void testClone() {
     this.set.addAll(asArray(1, 2, 3));
 
@@ -420,7 +399,6 @@ public class TestIntHashSet extends LuceneTestCase {
     assertSortedListEquals(cloned.toArray(), asArray(2, 3));
   }
 
-  @Test
   public void testEqualsSameClass() {
     IntHashSet l1 = IntHashSet.from(key1, key2, key3);
     IntHashSet l2 = IntHashSet.from(key1, key2, key3);
@@ -431,7 +409,6 @@ public class TestIntHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(l1, is(not(equalTo(l3))));
   }
 
-  @Test
   public void testEqualsSubClass() {
     class Sub extends IntHashSet {}
     ;

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntIntHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntIntHashMap.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /**
  * Tests for {@link IntIntHashMap}.
@@ -97,7 +96,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEnsureCapacity() {
     final AtomicInteger expands = new AtomicInteger();
     IntIntHashMap map =
@@ -124,7 +122,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
     assertEquals(before, expands.get());
   }
 
-  @Test
   public void testCursorIndexIsValid() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -136,7 +133,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testIndexMethods() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -179,7 +175,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testCloningConstructor() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -189,7 +184,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testFromArrays() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -201,7 +195,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
     assertSameMap(map, map2);
   }
 
-  @Test
   public void testGetOrDefault() {
     map.put(key2, value2);
     assertTrue(map.containsKey(key2));
@@ -214,7 +207,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPut() {
     map.put(key1, value1);
 
@@ -223,7 +215,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutOverExistingKey() {
     map.put(key1, value1);
     assertEquals(value1, map.put(key1, value3));
@@ -231,7 +222,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutWithExpansions() {
     final int COUNT = 10000;
     final Random rnd = new Random(random().nextLong());
@@ -250,7 +240,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutAll() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -272,27 +261,23 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutIfAbsent() {
     assertTrue(map.putIfAbsent(key1, value1));
     assertFalse(map.putIfAbsent(key1, value2));
     assertEquals(value1, map.get(key1));
   }
 
-  @Test
   public void testPutOrAdd() {
     assertEquals(value1, map.putOrAdd(key1, value1, value2));
     assertEquals(value3, map.putOrAdd(key1, value1, value2));
   }
 
-  @Test
   public void testAddTo() {
     assertEquals(value1, map.addTo(key1, value1));
     assertEquals(value3, map.addTo(key1, value2));
   }
 
   /* */
-  @Test
   public void testRemove() {
     map.put(key1, value1);
     assertEquals(value1, map.remove(key1));
@@ -304,7 +289,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEmptyKey() {
     final int empty = 0;
 
@@ -331,7 +315,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySet() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -341,7 +324,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySetIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -356,7 +338,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testClear() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -376,7 +357,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testRelease() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -391,7 +371,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testIterable() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -414,7 +393,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testBug_HPPC73_FullCapacityGet() {
     final AtomicInteger reallocations = new AtomicInteger();
     final int elements = 0x7F;
@@ -459,7 +437,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
     assertEquals(reallocationsBefore + 1, reallocations.get());
   }
 
-  @Test
   public void testHashCodeEquals() {
     IntIntHashMap l0 = newInstance();
     assertEquals(0, l0.hashCode());
@@ -480,7 +457,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
     assertNotEquals(l2, l3);
   }
 
-  @Test
   public void testBug_HPPC37() {
     IntIntHashMap l1 = IntIntHashMap.from(newArray(key1), newvArray(value1));
 
@@ -491,7 +467,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /** Runs random insertions/deletions/clearing and compares the results against {@link HashMap}. */
-  @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void testAgainstHashMap() {
     final Random rnd = RandomizedTest.getRandom();
@@ -548,7 +523,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   /*
    *
    */
-  @Test
   public void testClone() {
     this.map.put(key1, value1);
     this.map.put(key2, value2);
@@ -562,7 +536,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValues() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -577,7 +550,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValuesIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -592,7 +564,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSameClass() {
     IntIntHashMap l1 = newInstance();
     l1.put(key1, value0);
@@ -612,7 +583,6 @@ public class TestIntIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSubClass() {
     class Sub extends IntIntHashMap {}
 

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntLongHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntLongHashMap.java
@@ -25,7 +25,6 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.After;
-import org.junit.Test;
 
 /**
  * Tests for {@link IntLongHashMap}.
@@ -129,7 +128,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEnsureCapacity() {
     final AtomicInteger expands = new AtomicInteger();
     IntLongHashMap map =
@@ -156,7 +154,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
     assertEquals(before, expands.get());
   }
 
-  @Test
   public void testCursorIndexIsValid() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -168,7 +165,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testIndexMethods() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -211,7 +207,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testCloningConstructor() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -221,7 +216,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testFromArrays() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -233,7 +227,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
     assertSameMap(map, map2);
   }
 
-  @Test
   public void testGetOrDefault() {
     map.put(key2, value2);
     assertTrue(map.containsKey(key2));
@@ -246,7 +239,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPut() {
     map.put(key1, value1);
 
@@ -261,7 +253,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutOverExistingKey() {
     map.put(key1, value1);
     assertEquals(value1, map.put(key1, value3));
@@ -278,7 +269,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutWithExpansions() {
     final int COUNT = 10000;
     final Random rnd = new Random(random().nextLong());
@@ -297,7 +287,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutAll() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -319,27 +308,23 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutIfAbsent() {
     assertTrue(map.putIfAbsent(key1, value1));
     assertFalse(map.putIfAbsent(key1, value2));
     assertEquals(value1, map.get(key1));
   }
 
-  @Test
   public void testPutOrAdd() {
     assertEquals(value1, map.putOrAdd(key1, value1, value2));
     assertEquals(value3, map.putOrAdd(key1, value1, value2));
   }
 
-  @Test
   public void testAddTo() {
     assertEquals(value1, map.addTo(key1, value1));
     assertEquals(value3, map.addTo(key1, value2));
   }
 
   /* */
-  @Test
   public void testRemove() {
     map.put(key1, value1);
     assertEquals(value1, map.remove(key1));
@@ -351,7 +336,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEmptyKey() {
     final int empty = 0;
 
@@ -387,7 +371,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySet() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -397,7 +380,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySetIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -412,7 +394,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testClear() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -432,7 +413,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testRelease() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -447,7 +427,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testIterable() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -470,7 +449,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testBug_HPPC73_FullCapacityGet() {
     final AtomicInteger reallocations = new AtomicInteger();
     final int elements = 0x7F;
@@ -515,7 +493,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
     assertEquals(reallocationsBefore + 1, reallocations.get());
   }
 
-  @Test
   public void testHashCodeEquals() {
     IntLongHashMap l0 = newInstance();
     assertEquals(0, l0.hashCode());
@@ -536,7 +513,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
     assertFalse(l2.equals(l3));
   }
 
-  @Test
   public void testBug_HPPC37() {
     IntLongHashMap l1 = IntLongHashMap.from(newArray(key1), newvArray(value1));
 
@@ -546,7 +522,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
     assertFalse(l2.equals(l1));
   }
 
-  @Test
   public void testEmptyValue() {
     assertEquals(0L, map.put(key1, 0L));
     assertEquals(0L, map.get(key1));
@@ -557,7 +532,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /** Runs random insertions/deletions/clearing and compares the results against {@link HashMap}. */
-  @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void testAgainstHashMap() {
     final Random rnd = RandomizedTest.getRandom();
@@ -613,7 +587,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   /*
    *
    */
-  @Test
   public void testClone() {
     this.map.put(key1, value1);
     this.map.put(key2, value2);
@@ -627,7 +600,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValues() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -642,7 +614,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValuesIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -657,7 +628,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSameClass() {
     IntLongHashMap l1 = newInstance();
     l1.put(k1, value0);
@@ -677,7 +647,6 @@ public class TestIntLongHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSubClass() {
     class Sub extends IntLongHashMap {}
     ;

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestIntObjectHashMap.java
@@ -27,7 +27,6 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Assert;
-import org.junit.Test;
 
 /**
  * Tests for {@link IntObjectHashMap}.
@@ -107,7 +106,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEnsureCapacity() {
     final AtomicInteger expands = new AtomicInteger();
     IntObjectHashMap map =
@@ -134,7 +132,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     assertEquals(before, expands.get());
   }
 
-  @Test
   public void testCursorIndexIsValid() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -146,7 +143,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testIndexMethods() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -189,7 +185,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testCloningConstructor() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -199,7 +194,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testFromArrays() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -211,7 +205,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     assertSameMap(map, map2);
   }
 
-  @Test
   public void testGetOrDefault() {
     map.put(key2, value2);
     assertTrue(map.containsKey(key2));
@@ -224,7 +217,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPut() {
     map.put(key1, value1);
 
@@ -233,7 +225,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testNullValue() {
     map.put(key1, null);
 
@@ -241,7 +232,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     assertNull(map.get(key1));
   }
 
-  @Test
   public void testPutOverExistingKey() {
     map.put(key1, value1);
     assertEquals(value1, map.put(key1, value3));
@@ -256,7 +246,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutWithExpansions() {
     final int COUNT = 10000;
     final Random rnd = new Random(random().nextLong());
@@ -275,7 +264,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutAll() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -297,7 +285,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutIfAbsent() {
     assertTrue(map.putIfAbsent(key1, value1));
     assertFalse(map.putIfAbsent(key1, value2));
@@ -305,7 +292,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testRemove() {
     map.put(key1, value1);
     assertEquals(value1, map.remove(key1));
@@ -317,7 +303,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEmptyKey() {
     final int empty = 0;
 
@@ -354,7 +339,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySet() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -364,7 +348,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySetIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -379,7 +362,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testClear() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -399,7 +381,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testRelease() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -414,7 +395,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testIterable() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -437,7 +417,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testBug_HPPC73_FullCapacityGet() {
     final AtomicInteger reallocations = new AtomicInteger();
     final int elements = 0x7F;
@@ -482,7 +461,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     assertEquals(reallocationsBefore + 1, reallocations.get());
   }
 
-  @Test
   public void testHashCodeEquals() {
     IntObjectHashMap l0 = newInstance();
     assertEquals(0, l0.hashCode());
@@ -503,7 +481,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
     assertNotEquals(l2, l3);
   }
 
-  @Test
   public void testBug_HPPC37() {
     IntObjectHashMap l1 = IntObjectHashMap.from(newArray(key1), newvArray(value1));
 
@@ -514,7 +491,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /** Runs random insertions/deletions/clearing and compares the results against {@link HashMap}. */
-  @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void testAgainstHashMap() {
     final Random rnd = RandomizedTest.getRandom();
@@ -568,7 +544,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   /*
    *
    */
-  @Test
   public void testClone() {
     this.map.put(key1, value1);
     this.map.put(key2, value2);
@@ -582,7 +557,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValues() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -605,7 +579,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValuesIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -620,7 +593,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSameClass() {
     IntObjectHashMap l1 = newInstance();
     l1.put(key1, value0);
@@ -640,7 +612,6 @@ public class TestIntObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSubClass() {
     class Sub extends IntObjectHashMap {}
 

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongArrayList.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongArrayList.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Before;
-import org.junit.Test;
 
 /**
  * Tests for {@link LongArrayList}.
@@ -54,38 +53,32 @@ public class TestLongArrayList extends LuceneTestCase {
     list = new LongArrayList();
   }
 
-  @Test
   public void testInitiallyEmpty() {
     assertEquals(0, list.size());
   }
 
-  @Test
   public void testAdd() {
     list.add(key1, key2);
     assertListEquals(list.toArray(), 1, 2);
   }
 
-  @Test
   public void testAddTwoArgs() {
     list.add(key1, key2);
     list.add(key3, key4);
     assertListEquals(list.toArray(), 1, 2, 3, 4);
   }
 
-  @Test
   public void testAddArray() {
     list.add(asArray(0, 1, 2, 3), 1, 2);
     assertListEquals(list.toArray(), 1, 2);
   }
 
-  @Test
   public void testAddVarArg() {
     list.add(asArray(0, 1, 2, 3));
     list.add(key4, key5, key6, key7);
     assertListEquals(list.toArray(), 0, 1, 2, 3, 4, 5, 6, 7);
   }
 
-  @Test
   public void testAddAll() {
     LongArrayList list2 = new LongArrayList();
     list2.add(asArray(0, 1, 2));
@@ -96,7 +89,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 0, 1, 2, 0, 1, 2);
   }
 
-  @Test
   public void testInsert() {
     list.insert(0, key1);
     list.insert(0, key2);
@@ -106,7 +98,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 2, 4, 1, 3);
   }
 
-  @Test
   public void testSet() {
     list.add(asArray(0, 1, 2));
 
@@ -117,7 +108,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 3, 4, 5);
   }
 
-  @Test
   public void testRemoveAt() {
     list.add(asArray(0, 1, 2, 3, 4));
 
@@ -128,7 +118,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 1, 4);
   }
 
-  @Test
   public void testRemoveLast() {
     list.add(asArray(0, 1, 2, 3, 4));
 
@@ -144,7 +133,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertTrue(list.isEmpty());
   }
 
-  @Test
   public void testRemoveElement() {
     list.add(asArray(0, 1, 2, 3, 3, 4));
 
@@ -155,7 +143,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 0, 1, 3, 4);
   }
 
-  @Test
   public void testRemoveRange() {
     list.add(asArray(0, 1, 2, 3, 4));
 
@@ -172,7 +159,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertListEquals(list.toArray(), 3);
   }
 
-  @Test
   public void testRemoveFirstLast() {
     list.add(asArray(0, 1, 2, 1, 0));
 
@@ -189,7 +175,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertEquals(-1, list.removeLast(key0));
   }
 
-  @Test
   public void testRemoveAll() {
     list.add(asArray(0, 1, 0, 1, 0));
 
@@ -201,7 +186,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertTrue(list.isEmpty());
   }
 
-  @Test
   public void testIndexOf() {
     list.add(asArray(0, 1, 2, 1, 0));
 
@@ -210,7 +194,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertEquals(2, list.indexOf(key2));
   }
 
-  @Test
   public void testLastIndexOf() {
     list.add(asArray(0, 1, 2, 1, 0));
 
@@ -219,7 +202,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertEquals(2, list.lastIndexOf(key2));
   }
 
-  @Test
   public void testEnsureCapacity() {
     LongArrayList list = new LongArrayList(0);
     assertEquals(list.size(), list.buffer.length);
@@ -228,7 +210,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertNotSame(buffer1, list.buffer);
   }
 
-  @Test
   public void testResizeAndCleanBuffer() {
     list.ensureCapacity(20);
     Arrays.fill(list.buffer, key1);
@@ -250,14 +231,12 @@ public class TestLongArrayList extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testTrimToSize() {
     list.add(asArray(1, 2));
     list.trimToSize();
     assertEquals(2, list.buffer.length);
   }
 
-  @Test
   public void testRelease() {
     list.add(asArray(1, 2));
     list.release();
@@ -266,7 +245,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertEquals(2, list.size());
   }
 
-  @Test
   public void testIterable() {
     list.add(asArray(0, 1, 2, 3));
     int count = 0;
@@ -285,7 +263,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertEquals(0, count);
   }
 
-  @Test
   public void testIterator() {
     list.add(asArray(0, 1, 2, 3));
     Iterator<LongCursor> iterator = list.iterator();
@@ -303,7 +280,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertFalse(list.iterator().hasNext());
   }
 
-  @Test
   public void testClear() {
     list.add(asArray(1, 2, 3));
     list.clear();
@@ -311,7 +287,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertEquals(-1, list.indexOf(cast(1)));
   }
 
-  @Test
   public void testFrom() {
     list = LongArrayList.from(key1, key2, key3);
     assertEquals(3, list.size());
@@ -319,7 +294,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertEquals(list.size(), list.buffer.length);
   }
 
-  @Test
   public void testCopyList() {
     list.add(asArray(1, 2, 3));
     LongArrayList copy = new LongArrayList(list);
@@ -328,7 +302,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertEquals(copy.size(), copy.buffer.length);
   }
 
-  @Test
   public void testHashCodeEquals() {
     LongArrayList l0 = LongArrayList.from();
     assertEquals(1, l0.hashCode());
@@ -342,7 +315,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertEquals(l1, l2);
   }
 
-  @Test
   public void testEqualElements() {
     LongArrayList l1 = LongArrayList.from(key1, key2, key3);
     LongArrayList l2 = LongArrayList.from(key1, key2);
@@ -352,7 +324,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertTrue(l2.equalElements(l1));
   }
 
-  @Test
   public void testToArray() {
     LongArrayList l1 = LongArrayList.from(key1, key2, key3);
     l1.ensureCapacity(100);
@@ -360,7 +331,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertArrayEquals(new long[] {key1, key2, key3}, result);
   }
 
-  @Test
   public void testClone() {
     list.add(key1, key2, key3);
 
@@ -371,14 +341,12 @@ public class TestLongArrayList extends LuceneTestCase {
     assertSortedListEquals(cloned.toArray(), key2, key3);
   }
 
-  @Test
   public void testToString() {
     assertEquals(
         "[" + key1 + ", " + key2 + ", " + key3 + "]",
         LongArrayList.from(key1, key2, key3).toString());
   }
 
-  @Test
   public void testEqualsSameClass() {
     LongArrayList l1 = LongArrayList.from(key1, key2, key3);
     LongArrayList l2 = LongArrayList.from(key1, key2, key3);
@@ -389,7 +357,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertNotEquals(l1, l3);
   }
 
-  @Test
   public void testEqualsSubClass() {
     class Sub extends LongArrayList {}
     ;
@@ -404,7 +371,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertNotEquals(l1, l3);
   }
 
-  @Test
   public void testStream() {
     assertEquals(key1, LongArrayList.from(key1, key2, key3).stream().min().orElseThrow());
     assertEquals(key3, LongArrayList.from(key2, key1, key3).stream().max().orElseThrow());
@@ -416,7 +382,6 @@ public class TestLongArrayList extends LuceneTestCase {
         });
   }
 
-  @Test
   public void testSort() {
     list.add(key3, key1, key3, key2);
     LongArrayList list2 = new LongArrayList();
@@ -426,7 +391,6 @@ public class TestLongArrayList extends LuceneTestCase {
     assertEquals(LongArrayList.from(key1, key2, key3, key3), list2);
   }
 
-  @Test
   public void testReverse() {
     for (int i = 0; i < 10; i++) {
       long[] elements = new long[i];

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongFloatHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongFloatHashMap.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /**
  * Tests for {@link LongFloatHashMap}.
@@ -118,7 +117,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEnsureCapacity() {
     final AtomicInteger expands = new AtomicInteger();
     LongFloatHashMap map =
@@ -145,7 +143,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
     assertEquals(before, expands.get());
   }
 
-  @Test
   public void testCursorIndexIsValid() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -157,7 +154,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testIndexMethods() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -200,7 +196,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testCloningConstructor() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -210,7 +205,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testFromArrays() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -222,7 +216,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
     assertSameMap(map, map2);
   }
 
-  @Test
   public void testGetOrDefault() {
     map.put(key2, value2);
     assertTrue(map.containsKey(key2));
@@ -235,7 +228,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPut() {
     map.put(key1, value1);
 
@@ -244,7 +236,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutOverExistingKey() {
     map.put(key1, value1);
     assertEquals2(value1, map.put(key1, value3));
@@ -252,7 +243,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutWithExpansions() {
     final int COUNT = 10000;
     final Random rnd = new Random(random().nextLong());
@@ -271,7 +261,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutAll() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -293,27 +282,23 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutIfAbsent() {
     assertTrue(map.putIfAbsent(key1, value1));
     assertFalse(map.putIfAbsent(key1, value2));
     assertEquals2(value1, map.get(key1));
   }
 
-  @Test
   public void testPutOrAdd() {
     assertEquals2(value1, map.putOrAdd(key1, value1, value2));
     assertEquals2(value3, map.putOrAdd(key1, value1, value2));
   }
 
-  @Test
   public void testAddTo() {
     assertEquals2(value1, map.addTo(key1, value1));
     assertEquals2(value3, map.addTo(key1, value2));
   }
 
   /* */
-  @Test
   public void testRemove() {
     map.put(key1, value1);
     assertEquals2(value1, map.remove(key1));
@@ -325,7 +310,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEmptyKey() {
     final int empty = 0;
 
@@ -352,7 +336,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySet() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -362,7 +345,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySetIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -377,7 +359,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testClear() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -397,7 +378,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testRelease() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -412,7 +392,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testIterable() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -435,7 +414,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testBug_HPPC73_FullCapacityGet() {
     final AtomicInteger reallocations = new AtomicInteger();
     final int elements = 0x7F;
@@ -480,7 +458,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
     assertEquals(reallocationsBefore + 1, reallocations.get());
   }
 
-  @Test
   public void testHashCodeEquals() {
     LongFloatHashMap l0 = newInstance();
     assertEquals(0, l0.hashCode());
@@ -501,7 +478,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
     assertNotEquals(l2, l3);
   }
 
-  @Test
   public void testBug_HPPC37() {
     LongFloatHashMap l1 = LongFloatHashMap.from(newArray(key1), newvArray(value1));
 
@@ -512,7 +488,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /** Runs random insertions/deletions/clearing and compares the results against {@link HashMap}. */
-  @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void testAgainstHashMap() {
     final Random rnd = RandomizedTest.getRandom();
@@ -569,7 +544,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   /*
    *
    */
-  @Test
   public void testClone() {
     this.map.put(key1, value1);
     this.map.put(key2, value2);
@@ -583,7 +557,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValues() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -598,7 +571,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValuesIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -613,7 +585,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSameClass() {
     LongFloatHashMap l1 = newInstance();
     l1.put(key1, value0);
@@ -633,7 +604,6 @@ public class TestLongFloatHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSubClass() {
     class Sub extends LongFloatHashMap {}
 

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongHashSet.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongHashSet.java
@@ -33,7 +33,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.hamcrest.MatcherAssert;
 import org.junit.Before;
-import org.junit.Test;
 
 /**
  * Tests for {@link LongHashSet}.
@@ -64,7 +63,6 @@ public class TestLongHashSet extends LuceneTestCase {
     set = new LongHashSet();
   }
 
-  @Test
   public void testAddAllViaInterface() {
     set.addAll(key1, key2);
 
@@ -74,7 +72,6 @@ public class TestLongHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(set(iface.toArray()), is(equalTo(set(key1, key2))));
   }
 
-  @Test
   public void testIndexMethods() {
     set.add(keyE);
     set.add(key1);
@@ -114,7 +111,6 @@ public class TestLongHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(set.indexOf(key2), is(lessThan(0)));
   }
 
-  @Test
   public void testCursorIndexIsValid() {
     set.add(keyE);
     set.add(key1);
@@ -126,7 +122,6 @@ public class TestLongHashSet extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testEmptyKey() {
     LongHashSet set = new LongHashSet();
 
@@ -166,7 +161,6 @@ public class TestLongHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(set.indexGet(index), is(equalTo(EMPTY_KEY)));
   }
 
-  @Test
   public void testEnsureCapacity() {
     final AtomicInteger expands = new AtomicInteger();
     LongHashSet set =
@@ -193,19 +187,16 @@ public class TestLongHashSet extends LuceneTestCase {
     assertEquals(before, expands.get());
   }
 
-  @Test
   public void testInitiallyEmpty() {
     assertEquals(0, set.size());
   }
 
-  @Test
   public void testAdd() {
     assertTrue(set.add(key1));
     assertFalse(set.add(key1));
     assertEquals(1, set.size());
   }
 
-  @Test
   public void testAdd2() {
     set.addAll(key1, key1);
     assertEquals(1, set.size());
@@ -213,14 +204,12 @@ public class TestLongHashSet extends LuceneTestCase {
     assertEquals(2, set.size());
   }
 
-  @Test
   public void testAddVarArgs() {
     set.addAll(asArray(0, 1, 2, 1, 0));
     assertEquals(3, set.size());
     assertSortedListEquals(set.toArray(), asArray(0, 1, 2));
   }
 
-  @Test
   public void testAddAll() {
     LongHashSet set2 = new LongHashSet();
     set2.addAll(asArray(1, 2));
@@ -233,7 +222,6 @@ public class TestLongHashSet extends LuceneTestCase {
     assertSortedListEquals(set.toArray(), asArray(0, 1, 2));
   }
 
-  @Test
   public void testRemove() {
     set.addAll(asArray(0, 1, 2, 3, 4));
 
@@ -243,7 +231,6 @@ public class TestLongHashSet extends LuceneTestCase {
     assertSortedListEquals(set.toArray(), asArray(0, 1, 3, 4));
   }
 
-  @Test
   public void testInitialCapacityAndGrowth() {
     for (int i = 0; i < 256; i++) {
       LongHashSet set = new LongHashSet(i);
@@ -256,7 +243,6 @@ public class TestLongHashSet extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testBug_HPPC73_FullCapacityGet() {
     final AtomicInteger reallocations = new AtomicInteger();
     final int elements = 0x7F;
@@ -301,7 +287,6 @@ public class TestLongHashSet extends LuceneTestCase {
     assertEquals(reallocationsBefore + 1, reallocations.get());
   }
 
-  @Test
   public void testRemoveAllFromLookupContainer() {
     set.addAll(asArray(0, 1, 2, 3, 4));
 
@@ -313,14 +298,12 @@ public class TestLongHashSet extends LuceneTestCase {
     assertSortedListEquals(set.toArray(), asArray(0, 2, 4));
   }
 
-  @Test
   public void testClear() {
     set.addAll(asArray(1, 2, 3));
     set.clear();
     assertEquals(0, set.size());
   }
 
-  @Test
   public void testRelease() {
     set.addAll(asArray(1, 2, 3));
     set.release();
@@ -329,7 +312,6 @@ public class TestLongHashSet extends LuceneTestCase {
     assertEquals(3, set.size());
   }
 
-  @Test
   public void testIterable() {
     set.addAll(asArray(1, 2, 2, 3, 4));
     set.remove(key2);
@@ -347,7 +329,6 @@ public class TestLongHashSet extends LuceneTestCase {
   }
 
   /** Runs random insertions/deletions/clearing and compares the results against {@link HashSet}. */
-  @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void testAgainstHashSet() {
     final Random rnd = RandomizedTest.getRandom();
@@ -395,7 +376,6 @@ public class TestLongHashSet extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testHashCodeEquals() {
     LongHashSet l0 = new LongHashSet();
     assertEquals(0, l0.hashCode());
@@ -409,7 +389,6 @@ public class TestLongHashSet extends LuceneTestCase {
     assertEquals(l1, l2);
   }
 
-  @Test
   public void testClone() {
     this.set.addAll(asArray(1, 2, 3));
 
@@ -420,7 +399,6 @@ public class TestLongHashSet extends LuceneTestCase {
     assertSortedListEquals(cloned.toArray(), asArray(2, 3));
   }
 
-  @Test
   public void testEqualsSameClass() {
     LongHashSet l1 = LongHashSet.from(key1, key2, key3);
     LongHashSet l2 = LongHashSet.from(key1, key2, key3);
@@ -431,7 +409,6 @@ public class TestLongHashSet extends LuceneTestCase {
     MatcherAssert.assertThat(l1, is(not(equalTo(l3))));
   }
 
-  @Test
   public void testEqualsSubClass() {
     class Sub extends LongHashSet {}
     ;

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongIntHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongIntHashMap.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /**
  * Tests for {@link LongIntHashMap}.
@@ -106,7 +105,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEnsureCapacity() {
     final AtomicInteger expands = new AtomicInteger();
     LongIntHashMap map =
@@ -133,7 +131,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
     assertEquals(before, expands.get());
   }
 
-  @Test
   public void testCursorIndexIsValid() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -145,7 +142,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testIndexMethods() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -188,7 +184,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testCloningConstructor() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -198,7 +193,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testFromArrays() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -210,7 +204,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
     assertSameMap(map, map2);
   }
 
-  @Test
   public void testGetOrDefault() {
     map.put(key2, value2);
     assertTrue(map.containsKey(key2));
@@ -223,7 +216,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPut() {
     map.put(key1, value1);
 
@@ -232,7 +224,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutOverExistingKey() {
     map.put(key1, value1);
     assertEquals(value1, map.put(key1, value3));
@@ -240,7 +231,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutWithExpansions() {
     final int COUNT = 10000;
     final Random rnd = new Random(random().nextLong());
@@ -259,7 +249,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutAll() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -281,27 +270,23 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutIfAbsent() {
     assertTrue(map.putIfAbsent(key1, value1));
     assertFalse(map.putIfAbsent(key1, value2));
     assertEquals(value1, map.get(key1));
   }
 
-  @Test
   public void testPutOrAdd() {
     assertEquals(value1, map.putOrAdd(key1, value1, value2));
     assertEquals(value3, map.putOrAdd(key1, value1, value2));
   }
 
-  @Test
   public void testAddTo() {
     assertEquals(value1, map.addTo(key1, value1));
     assertEquals(value3, map.addTo(key1, value2));
   }
 
   /* */
-  @Test
   public void testRemove() {
     map.put(key1, value1);
     assertEquals(value1, map.remove(key1));
@@ -313,7 +298,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEmptyKey() {
     final long empty = 0;
 
@@ -340,7 +324,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySet() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -350,7 +333,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySetIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -365,7 +347,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testClear() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -385,7 +366,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testRelease() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -400,7 +380,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testIterable() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -423,7 +402,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testBug_HPPC73_FullCapacityGet() {
     final AtomicInteger reallocations = new AtomicInteger();
     final int elements = 0x7F;
@@ -468,7 +446,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
     assertEquals(reallocationsBefore + 1, reallocations.get());
   }
 
-  @Test
   public void testHashCodeEquals() {
     LongIntHashMap l0 = newInstance();
     assertEquals(0, l0.hashCode());
@@ -489,7 +466,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
     assertNotEquals(l2, l3);
   }
 
-  @Test
   public void testBug_HPPC37() {
     LongIntHashMap l1 = LongIntHashMap.from(newArray(key1), newvArray(value1));
 
@@ -500,7 +476,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /** Runs random insertions/deletions/clearing and compares the results against {@link HashMap}. */
-  @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void testAgainstHashMap() {
     final Random rnd = RandomizedTest.getRandom();
@@ -557,7 +532,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   /*
    *
    */
-  @Test
   public void testClone() {
     this.map.put(key1, value1);
     this.map.put(key2, value2);
@@ -571,7 +545,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValues() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -586,7 +559,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValuesIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -601,7 +573,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSameClass() {
     LongIntHashMap l1 = newInstance();
     l1.put(key1, value0);
@@ -621,7 +592,6 @@ public class TestLongIntHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSubClass() {
     class Sub extends LongIntHashMap {}
 

--- a/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongObjectHashMap.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/hppc/TestLongObjectHashMap.java
@@ -28,7 +28,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Test;
 
 /**
  * Tests for {@link LongObjectHashMap}.
@@ -104,7 +103,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEnsureCapacity() {
     final AtomicInteger expands = new AtomicInteger();
     LongObjectHashMap map =
@@ -131,7 +129,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
     assertEquals(before, expands.get());
   }
 
-  @Test
   public void testCursorIndexIsValid() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -143,7 +140,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testIndexMethods() {
     map.put(keyE, value1);
     map.put(key1, value2);
@@ -186,7 +182,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testCloningConstructor() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -196,7 +191,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testFromArrays() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -208,7 +202,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
     assertSameMap(map, map2);
   }
 
-  @Test
   public void testGetOrDefault() {
     map.put(key2, value2);
     assertTrue(map.containsKey(key2));
@@ -221,7 +214,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPut() {
     map.put(key1, value1);
 
@@ -230,7 +222,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testNullValue() {
     map.put(key1, null);
 
@@ -238,7 +229,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
     assertNull(map.get(key1));
   }
 
-  @Test
   public void testPutOverExistingKey() {
     map.put(key1, value1);
     assertEquals(value1, map.put(key1, value3));
@@ -253,7 +243,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutWithExpansions() {
     final int COUNT = 10000;
     final Random rnd = new Random(random().nextLong());
@@ -272,7 +261,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutAll() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -294,7 +282,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testPutIfAbsent() {
     assertTrue(map.putIfAbsent(key1, value1));
     assertFalse(map.putIfAbsent(key1, value2));
@@ -302,7 +289,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testRemove() {
     map.put(key1, value1);
     assertEquals(value1, map.remove(key1));
@@ -314,7 +300,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEmptyKey() {
     final long empty = 0;
 
@@ -351,7 +336,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySet() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -361,7 +345,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapKeySetIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -376,7 +359,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testClear() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -396,7 +378,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testRelease() {
     map.put(key1, value1);
     map.put(key2, value1);
@@ -411,7 +392,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testIterable() {
     map.put(key1, value1);
     map.put(key2, value2);
@@ -434,7 +414,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testBug_HPPC73_FullCapacityGet() {
     final AtomicInteger reallocations = new AtomicInteger();
     final int elements = 0x7F;
@@ -479,7 +458,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
     assertEquals(reallocationsBefore + 1, reallocations.get());
   }
 
-  @Test
   public void testHashCodeEquals() {
     LongObjectHashMap l0 = newInstance();
     assertEquals(0, l0.hashCode());
@@ -500,7 +478,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
     assertNotEquals(l2, l3);
   }
 
-  @Test
   public void testBug_HPPC37() {
     LongObjectHashMap l1 = LongObjectHashMap.from(newArray(key1), newvArray(value1));
 
@@ -511,7 +488,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /** Runs random insertions/deletions/clearing and compares the results against {@link HashMap}. */
-  @Test
   @SuppressWarnings({"rawtypes", "unchecked"})
   public void testAgainstHashMap() {
     final Random rnd = RandomizedTest.getRandom();
@@ -565,7 +541,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   /*
    *
    */
-  @Test
   public void testClone() {
     this.map.put(key1, value1);
     this.map.put(key2, value2);
@@ -579,7 +554,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValues() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -596,7 +570,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testMapValuesIterator() {
     map.put(key1, value3);
     map.put(key2, value2);
@@ -611,7 +584,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSameClass() {
     LongObjectHashMap l1 = newInstance();
     l1.put(key1, value0);
@@ -631,7 +603,6 @@ public class TestLongObjectHashMap extends LuceneTestCase {
   }
 
   /* */
-  @Test
   public void testEqualsSubClass() {
     class Sub extends LongObjectHashMap {}
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestBaseRangeFilter.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBaseRangeFilter.java
@@ -36,7 +36,6 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestBaseRangeFilter extends LuceneTestCase {
 
@@ -209,7 +208,6 @@ public class TestBaseRangeFilter extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testPad() {
 
     int[] tests = new int[] {-9999999, -99560, -100, -3, -1, 0, 3, 9, 10, 1000, 999999999};

--- a/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
@@ -40,7 +40,6 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.ArrayUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 /**
  * Test BooleanQuery2 against BooleanQuery by overriding the standard query parser. This also tests
@@ -268,7 +267,6 @@ public class TestBoolean2 extends LuceneTestCase {
     CheckHits.checkEqual(query, hits1, hits2);
   }
 
-  @Test
   public void testQueries01() throws Exception {
     BooleanQuery.Builder query = new BooleanQuery.Builder();
     query.add(new TermQuery(new Term(field, "w3")), BooleanClause.Occur.MUST);
@@ -277,7 +275,6 @@ public class TestBoolean2 extends LuceneTestCase {
     queriesTest(query.build(), expDocNrs);
   }
 
-  @Test
   public void testQueries02() throws Exception {
     BooleanQuery.Builder query = new BooleanQuery.Builder();
     query.add(new TermQuery(new Term(field, "w3")), BooleanClause.Occur.MUST);
@@ -286,7 +283,6 @@ public class TestBoolean2 extends LuceneTestCase {
     queriesTest(query.build(), expDocNrs);
   }
 
-  @Test
   public void testQueries03() throws Exception {
     BooleanQuery.Builder query = new BooleanQuery.Builder();
     query.add(new TermQuery(new Term(field, "w3")), BooleanClause.Occur.SHOULD);
@@ -295,7 +291,6 @@ public class TestBoolean2 extends LuceneTestCase {
     queriesTest(query.build(), expDocNrs);
   }
 
-  @Test
   public void testQueries04() throws Exception {
     BooleanQuery.Builder query = new BooleanQuery.Builder();
     query.add(new TermQuery(new Term(field, "w3")), BooleanClause.Occur.SHOULD);
@@ -304,7 +299,6 @@ public class TestBoolean2 extends LuceneTestCase {
     queriesTest(query.build(), expDocNrs);
   }
 
-  @Test
   public void testQueries05() throws Exception {
     BooleanQuery.Builder query = new BooleanQuery.Builder();
     query.add(new TermQuery(new Term(field, "w3")), BooleanClause.Occur.MUST);
@@ -313,7 +307,6 @@ public class TestBoolean2 extends LuceneTestCase {
     queriesTest(query.build(), expDocNrs);
   }
 
-  @Test
   public void testQueries06() throws Exception {
     BooleanQuery.Builder query = new BooleanQuery.Builder();
     query.add(new TermQuery(new Term(field, "w3")), BooleanClause.Occur.MUST);
@@ -323,7 +316,6 @@ public class TestBoolean2 extends LuceneTestCase {
     queriesTest(query.build(), expDocNrs);
   }
 
-  @Test
   public void testQueries07() throws Exception {
     BooleanQuery.Builder query = new BooleanQuery.Builder();
     query.add(new TermQuery(new Term(field, "w3")), BooleanClause.Occur.MUST_NOT);
@@ -333,7 +325,6 @@ public class TestBoolean2 extends LuceneTestCase {
     queriesTest(query.build(), expDocNrs);
   }
 
-  @Test
   public void testQueries08() throws Exception {
     BooleanQuery.Builder query = new BooleanQuery.Builder();
     query.add(new TermQuery(new Term(field, "w3")), BooleanClause.Occur.MUST);
@@ -343,7 +334,6 @@ public class TestBoolean2 extends LuceneTestCase {
     queriesTest(query.build(), expDocNrs);
   }
 
-  @Test
   public void testQueries09() throws Exception {
     BooleanQuery.Builder query = new BooleanQuery.Builder();
     query.add(new TermQuery(new Term(field, "w3")), BooleanClause.Occur.MUST);
@@ -354,7 +344,6 @@ public class TestBoolean2 extends LuceneTestCase {
     queriesTest(query.build(), expDocNrs);
   }
 
-  @Test
   public void testRandomQueries() throws Exception {
     String[] vals = {"w1", "w2", "w3", "w4", "w5", "xx", "yy", "zzz"};
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestFilterWeight.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFilterWeight.java
@@ -19,11 +19,9 @@ package org.apache.lucene.search;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestFilterWeight extends LuceneTestCase {
 
-  @Test
   public void testDeclaredMethodsOverridden() throws Exception {
     final Class<?> subClass = FilterWeight.class;
     implTestDeclaredMethodsOverridden(subClass.getSuperclass(), subClass);

--- a/lucene/core/src/test/org/apache/lucene/search/TestFullPrecisionFloatVectorSimilarityValuesSource.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFullPrecisionFloatVectorSimilarityValuesSource.java
@@ -40,7 +40,6 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.TestVectorUtil;
 import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 import org.junit.Before;
-import org.junit.Test;
 
 public class TestFullPrecisionFloatVectorSimilarityValuesSource extends LuceneTestCase {
 
@@ -84,7 +83,6 @@ public class TestFullPrecisionFloatVectorSimilarityValuesSource extends LuceneTe
 
   // TODO: incredibly slow
   @Nightly
-  @Test
   public void testFullPrecisionVectorSimilarityDVS() throws Exception {
     List<float[]> vectors = new ArrayList<>();
     int numVectors = atLeast(NUM_VECTORS);

--- a/lucene/core/src/test/org/apache/lucene/search/TestFuzzyTermOnShortTerms.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFuzzyTermOnShortTerms.java
@@ -29,12 +29,10 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
-import org.junit.Test;
 
 public class TestFuzzyTermOnShortTerms extends LuceneTestCase {
   private static final String FIELD = "field";
 
-  @Test
   public void test() throws Exception {
     // proves rule that edit distance between the two terms
     // must be > smaller term for there to be a match

--- a/lucene/core/src/test/org/apache/lucene/search/TestHnswQueueSaturationCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestHnswQueueSaturationCollector.java
@@ -18,12 +18,10 @@ package org.apache.lucene.search;
 
 import java.util.Random;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /** Tests for {@link HnswQueueSaturationCollector} */
 public class TestHnswQueueSaturationCollector extends LuceneTestCase {
 
-  @Test
   public void testDelegate() {
     Random random = random();
     int numDocs = 100;
@@ -43,7 +41,6 @@ public class TestHnswQueueSaturationCollector extends LuceneTestCase {
         1e-3);
   }
 
-  @Test
   public void testEarlyExpectedExit() {
     int numDocs = 1000;
     int k = 10;
@@ -62,7 +59,6 @@ public class TestHnswQueueSaturationCollector extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testDelegateVsSaturateEarlyExit() {
     Random random = random();
     int numDocs = 10000;
@@ -81,7 +77,6 @@ public class TestHnswQueueSaturationCollector extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testEarlyExitRelation() {
     Random random = random();
     int numDocs = 10000;

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiCollector.java
@@ -35,7 +35,6 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.search.DummyTotalHitCountCollector;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
-import org.junit.Test;
 
 public class TestMultiCollector extends LuceneTestCase {
 
@@ -317,7 +316,6 @@ public class TestMultiCollector extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testNullCollectors() throws Exception {
     // Tests that the collector rejects all null collectors.
     expectThrows(
@@ -336,7 +334,6 @@ public class TestMultiCollector extends LuceneTestCase {
     c.getLeafCollector(null).setScorer(new SimpleScorable());
   }
 
-  @Test
   public void testSingleCollector() throws Exception {
     // Tests that if a single Collector is input, it is returned (and not MultiCollector).
     DummyCollector dc = new DummyCollector();
@@ -344,7 +341,6 @@ public class TestMultiCollector extends LuceneTestCase {
     assertSame(dc, MultiCollector.wrap(dc, null));
   }
 
-  @Test
   public void testCollector() throws Exception {
     // Tests that the collector delegates calls to input collectors properly.
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestMultiTermConstantScore.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMultiTermConstantScore.java
@@ -33,7 +33,6 @@ import org.apache.lucene.util.automaton.Operations;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestMultiTermConstantScore extends TestBaseRangeFilter {
 
@@ -117,7 +116,6 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
     return new WildcardQuery(wild, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, method);
   }
 
-  @Test
   public void testBasics() throws IOException {
     for (MultiTermQuery.RewriteMethod rw : CONSTANT_SCORE_REWRITES) {
       QueryUtils.check(csrq("data", "1", "6", T, T, rw));
@@ -134,7 +132,6 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
     }
   }
 
-  @Test
   public void testEqualScores() throws IOException {
     // NOTE: uses index build in *this* setUp
 
@@ -178,7 +175,6 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
     }
   }
 
-  @Test // Test for LUCENE-5245: Empty MTQ rewrites should have a consistent norm, so always need to
   // return a CSQ!
   public void testEqualScoresWhenNoHits() throws IOException {
     // NOTE: uses index build in *this* setUp
@@ -230,7 +226,6 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
     }
   }
 
-  @Test
   public void testBooleanOrderUnAffected() throws IOException {
     // NOTE: uses index build in *this* setUp
 
@@ -262,7 +257,6 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
     }
   }
 
-  @Test
   public void testRangeQueryId() throws IOException {
     // NOTE: uses index build in *super* setUp
 
@@ -355,7 +349,6 @@ public class TestMultiTermConstantScore extends TestBaseRangeFilter {
     }
   }
 
-  @Test
   public void testRangeQueryRand() throws IOException {
     // NOTE: uses index build in *super* setUp
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestSimpleExplanations.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSimpleExplanations.java
@@ -19,7 +19,6 @@ package org.apache.lucene.search;
 import java.util.Arrays;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.tests.search.BaseExplanationTestCase;
-import org.junit.Test;
 
 /** TestExplanations subclass focusing on basic query types */
 public class TestSimpleExplanations extends BaseExplanationTestCase {
@@ -747,7 +746,6 @@ public class TestSimpleExplanations extends BaseExplanationTestCase {
     qtest(query, new int[] {0, 1, 2, 3});
   }
 
-  @Test
   public void testEquality() {
 
     Explanation e1 = Explanation.match(1f, "an explanation");

--- a/lucene/core/src/test/org/apache/lucene/store/BaseDataOutputTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/store/BaseDataOutputTestCase.java
@@ -30,7 +30,6 @@ import java.util.Random;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.IOConsumer;
-import org.junit.Test;
 
 public abstract class BaseDataOutputTestCase<T extends DataOutput> extends LuceneTestCase {
   protected abstract T newInstance();
@@ -42,7 +41,6 @@ public abstract class BaseDataOutputTestCase<T extends DataOutput> extends Lucen
     R apply(T t, U u) throws IOException;
   }
 
-  @Test
   public void testRandomizedWrites() throws IOException {
     T dst = newInstance();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDataInput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDataInput.java
@@ -30,10 +30,8 @@ import java.util.List;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.IOConsumer;
-import org.junit.Test;
 
 public final class TestByteBuffersDataInput extends LuceneTestCase {
-  @Test
   public void testSanity() throws IOException {
     ByteBuffersDataOutput out = new ByteBuffersDataOutput();
     ByteBuffersDataInput o1 = out.toDataInput();
@@ -65,7 +63,6 @@ public final class TestByteBuffersDataInput extends LuceneTestCase {
     assertEquals(1, o2.position());
   }
 
-  @Test
   public void testRandomReads() throws Exception {
     ByteBuffersDataOutput dst = new ByteBuffersDataOutput();
 
@@ -85,7 +82,6 @@ public final class TestByteBuffersDataInput extends LuceneTestCase {
         });
   }
 
-  @Test
   public void testRandomReadsOnSlices() throws Exception {
     for (int reps = randomIntBetween(1, 20); --reps > 0; ) {
       ByteBuffersDataOutput dst = new ByteBuffersDataOutput();
@@ -117,7 +113,6 @@ public final class TestByteBuffersDataInput extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testSeekEmpty() throws Exception {
     ByteBuffersDataOutput dst = new ByteBuffersDataOutput();
     ByteBuffersDataInput in = dst.toDataInput();
@@ -137,7 +132,6 @@ public final class TestByteBuffersDataInput extends LuceneTestCase {
         });
   }
 
-  @Test
   public void testSeekAndSkip() throws Exception {
     for (int reps = randomIntBetween(1, 200); --reps > 0; ) {
       ByteBuffersDataOutput dst = new ByteBuffersDataOutput();
@@ -197,7 +191,6 @@ public final class TestByteBuffersDataInput extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testSlicingWindow() throws Exception {
     ByteBuffersDataOutput dst = new ByteBuffersDataOutput();
     assertEquals(0, dst.toDataInput().slice(0, 0).length());
@@ -214,7 +207,6 @@ public final class TestByteBuffersDataInput extends LuceneTestCase {
     assertEquals(0, in.slice((int) dst.size(), 0).length());
   }
 
-  @Test
   @Timeout(millis = 5000)
   public void testEofOnArrayReadPastBufferSize() throws Exception {
     ByteBuffersDataOutput dst = new ByteBuffersDataOutput();
@@ -236,7 +228,6 @@ public final class TestByteBuffersDataInput extends LuceneTestCase {
   }
 
   // https://issues.apache.org/jira/browse/LUCENE-8625
-  @Test
   public void testSlicingLargeBuffers() throws IOException {
     // Simulate a "large" (> 4GB) input by duplicating
     // buffers with the same content.

--- a/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDataOutput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDataOutput.java
@@ -26,7 +26,6 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.junit.Assert;
-import org.junit.Test;
 
 public final class TestByteBuffersDataOutput extends BaseDataOutputTestCase<ByteBuffersDataOutput> {
   @Override
@@ -39,7 +38,6 @@ public final class TestByteBuffersDataOutput extends BaseDataOutputTestCase<Byte
     return instance.toArrayCopy();
   }
 
-  @Test
   public void testReuse() throws IOException {
     AtomicInteger allocations = new AtomicInteger(0);
     ByteBuffersDataOutput.ByteBufferRecycler reuser =
@@ -71,7 +69,6 @@ public final class TestByteBuffersDataOutput extends BaseDataOutputTestCase<Byte
     assertArrayEquals(data, o.toArrayCopy());
   }
 
-  @Test
   public void testConstructorWithExpectedSize() {
     {
       ByteBuffersDataOutput o = new ByteBuffersDataOutput(0);
@@ -152,7 +149,6 @@ public final class TestByteBuffersDataOutput extends BaseDataOutputTestCase<Byte
         });
   }
 
-  @Test
   public void testSanity() {
     ByteBuffersDataOutput o = newInstance();
     assertEquals(0, o.size());
@@ -169,7 +165,6 @@ public final class TestByteBuffersDataOutput extends BaseDataOutputTestCase<Byte
     assertArrayEquals(new byte[] {1, 2, 3, 4}, o.toArrayCopy());
   }
 
-  @Test
   public void testWriteByteBuffer() {
     ByteBuffersDataOutput o = new ByteBuffersDataOutput();
     byte[] bytes = new byte[1024 * 8 + 10];
@@ -185,7 +180,6 @@ public final class TestByteBuffersDataOutput extends BaseDataOutputTestCase<Byte
         ArrayUtil.copyOfSubArray(bytes, offset, offset + len), o.toArrayCopy());
   }
 
-  @Test
   public void testLargeArrayAdd() {
     ByteBuffersDataOutput o = new ByteBuffersDataOutput();
     int MB = 1024 * 1024;
@@ -204,7 +198,6 @@ public final class TestByteBuffersDataOutput extends BaseDataOutputTestCase<Byte
         ArrayUtil.copyOfSubArray(bytes, offset, offset + len), o.toArrayCopy());
   }
 
-  @Test
   public void testCopyBytesOnHeap() throws IOException {
     byte[] bytes = new byte[1024 * 8 + 10];
     random().nextBytes(bytes);
@@ -222,7 +215,6 @@ public final class TestByteBuffersDataOutput extends BaseDataOutputTestCase<Byte
         o.toArrayCopy(), ArrayUtil.copyOfSubArray(bytes, offset, offset + len));
   }
 
-  @Test
   public void testCopyBytesOnDirectByteBuffer() throws IOException {
     byte[] bytes = new byte[1024 * 8 + 10];
     random().nextBytes(bytes);
@@ -240,7 +232,6 @@ public final class TestByteBuffersDataOutput extends BaseDataOutputTestCase<Byte
         o.toArrayCopy(), ArrayUtil.copyOfSubArray(bytes, offset, offset + len));
   }
 
-  @Test
   public void testToBufferListReturnsReadOnlyBuffers() throws Exception {
     ByteBuffersDataOutput dst = new ByteBuffersDataOutput();
     dst.writeBytes(new byte[100]);
@@ -249,7 +240,6 @@ public final class TestByteBuffersDataOutput extends BaseDataOutputTestCase<Byte
     }
   }
 
-  @Test
   public void testToWriteableBufferListReturnsOriginalBuffers() throws Exception {
     ByteBuffersDataOutput dst = new ByteBuffersDataOutput();
     for (ByteBuffer bb : dst.toWriteableBufferList()) {
@@ -264,7 +254,6 @@ public final class TestByteBuffersDataOutput extends BaseDataOutputTestCase<Byte
     }
   }
 
-  @Test
   public void testRamBytesUsed() {
     ByteBuffersDataOutput out = new ByteBuffersDataOutput();
     // Empty output requires no RAM

--- a/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDirectory.java
@@ -30,7 +30,6 @@ import org.apache.lucene.index.IndexWriterConfig.OpenMode;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.store.BaseDirectoryTestCase;
 import org.apache.lucene.tests.util.English;
-import org.junit.Test;
 
 public class TestByteBuffersDirectory extends BaseDirectoryTestCase {
   private Supplier<ByteBuffersDirectory> implSupplier;
@@ -44,7 +43,6 @@ public class TestByteBuffersDirectory extends BaseDirectoryTestCase {
     return implSupplier.get();
   }
 
-  @Test
   public void testBuildIndex() throws IOException {
     try (Directory dir = getDirectory(null);
         IndexWriter writer =

--- a/lucene/core/src/test/org/apache/lucene/store/TestFilterDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestFilterDirectory.java
@@ -22,7 +22,6 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.lucene.tests.store.BaseDirectoryTestCase;
-import org.junit.Test;
 
 public class TestFilterDirectory extends BaseDirectoryTestCase {
 
@@ -31,7 +30,6 @@ public class TestFilterDirectory extends BaseDirectoryTestCase {
     return new FilterDirectory(new ByteBuffersDirectory()) {};
   }
 
-  @Test
   public void testOverrides() throws Exception {
     // verify that all methods of Directory are overridden by FilterDirectory,
     // except those under the 'exclude' list

--- a/lucene/core/src/test/org/apache/lucene/store/TestFilterIndexOutput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestFilterIndexOutput.java
@@ -19,7 +19,6 @@ package org.apache.lucene.store;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import org.junit.Test;
 
 public class TestFilterIndexOutput extends BaseDataOutputTestCase<FilterIndexOutput> {
 
@@ -36,7 +35,6 @@ public class TestFilterIndexOutput extends BaseDataOutputTestCase<FilterIndexOut
     return ((ByteBuffersIndexOutput) instance.out).toArrayCopy();
   }
 
-  @Test
   public void testOverrides() {
     for (Method m : FilterIndexOutput.class.getMethods()) {
       if (m.getDeclaringClass() == FilterIndexOutput.class) {

--- a/lucene/core/src/test/org/apache/lucene/util/TestBytesRefHash.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestBytesRefHash.java
@@ -32,7 +32,6 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRefHash.MaxBytesLengthExceededException;
 import org.junit.Before;
-import org.junit.Test;
 
 public class TestBytesRefHash extends LuceneTestCase {
 
@@ -332,7 +331,6 @@ public class TestBytesRefHash extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testLargeValue() {
     int[] sizes =
         new int[] {random().nextInt(5), ByteBlockPool.BYTE_BLOCK_SIZE - 33 + random().nextInt(31)};

--- a/lucene/core/src/test/org/apache/lucene/util/TestRecyclingByteBlockAllocator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestRecyclingByteBlockAllocator.java
@@ -21,7 +21,6 @@ import java.util.HashSet;
 import java.util.List;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Before;
-import org.junit.Test;
 
 /** Testcase for {@link RecyclingByteBlockAllocator} */
 public class TestRecyclingByteBlockAllocator extends LuceneTestCase {
@@ -37,7 +36,6 @@ public class TestRecyclingByteBlockAllocator extends LuceneTestCase {
     return new RecyclingByteBlockAllocator(random().nextInt(97), Counter.newCounter());
   }
 
-  @Test
   public void testAllocate() {
     RecyclingByteBlockAllocator allocator = newAllocator();
     HashSet<byte[]> set = new HashSet<>();
@@ -57,7 +55,6 @@ public class TestRecyclingByteBlockAllocator extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testAllocateAndRecycle() {
     RecyclingByteBlockAllocator allocator = newAllocator();
     HashSet<byte[]> allocated = new HashSet<>();
@@ -94,7 +91,6 @@ public class TestRecyclingByteBlockAllocator extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testAllocateAndFree() {
     RecyclingByteBlockAllocator allocator = newAllocator();
     HashSet<byte[]> allocated = new HashSet<>();

--- a/lucene/core/src/test/org/apache/lucene/util/TestRecyclingIntBlockAllocator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestRecyclingIntBlockAllocator.java
@@ -21,7 +21,6 @@ import java.util.HashSet;
 import java.util.List;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Before;
-import org.junit.Test;
 
 /** Testcase for {@link RecyclingIntBlockAllocator} */
 public class TestRecyclingIntBlockAllocator extends LuceneTestCase {
@@ -38,7 +37,6 @@ public class TestRecyclingIntBlockAllocator extends LuceneTestCase {
         1 << (2 + random().nextInt(15)), random().nextInt(97), Counter.newCounter());
   }
 
-  @Test
   public void testAllocate() {
     RecyclingIntBlockAllocator allocator = newAllocator();
     HashSet<int[]> set = new HashSet<>();
@@ -58,7 +56,6 @@ public class TestRecyclingIntBlockAllocator extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testAllocateAndRecycle() {
     RecyclingIntBlockAllocator allocator = newAllocator();
     HashSet<int[]> allocated = new HashSet<>();
@@ -95,7 +92,6 @@ public class TestRecyclingIntBlockAllocator extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testAllocateAndFree() {
     RecyclingIntBlockAllocator allocator = newAllocator();
     HashSet<int[]> allocated = new HashSet<>();

--- a/lucene/core/src/test/org/apache/lucene/util/TestSentinelIntSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestSentinelIntSet.java
@@ -18,12 +18,10 @@ package org.apache.lucene.util;
 
 import java.util.HashSet;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /** */
 public class TestSentinelIntSet extends LuceneTestCase {
 
-  @Test
   public void test() throws Exception {
     SentinelIntSet set = new SentinelIntSet(10, -1);
     assertFalse(set.exists(50));
@@ -43,7 +41,6 @@ public class TestSentinelIntSet extends LuceneTestCase {
     assertEquals(24, set.rehashCount);
   }
 
-  @Test
   public void testRandom() throws Exception {
     for (int i = 0; i < 10000; i++) {
       int initSz = random().nextInt(20);

--- a/lucene/core/src/test/org/apache/lucene/util/TestSetOnce.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestSetOnce.java
@@ -19,7 +19,6 @@ package org.apache.lucene.util;
 import java.util.Random;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.SetOnce.AlreadySetException;
-import org.junit.Test;
 
 public class TestSetOnce extends LuceneTestCase {
 
@@ -49,20 +48,17 @@ public class TestSetOnce extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testEmptyCtor() throws Exception {
     SetOnce<Integer> set = new SetOnce<>();
     assertNull(set.get());
   }
 
-  @Test
   public void testSettingCtor() throws Exception {
     SetOnce<Integer> set = new SetOnce<>(5);
     assertEquals(5, set.get().intValue());
     expectThrows(AlreadySetException.class, () -> set.set(7));
   }
 
-  @Test
   public void testSetOnce() throws Exception {
     SetOnce<Integer> set = new SetOnce<>();
     set.set(5);
@@ -70,7 +66,6 @@ public class TestSetOnce extends LuceneTestCase {
     expectThrows(AlreadySetException.class, () -> set.set(7));
   }
 
-  @Test
   public void testTrySet() {
     SetOnce<Integer> set = new SetOnce<>();
     assertTrue(set.trySet(5));
@@ -79,7 +74,6 @@ public class TestSetOnce extends LuceneTestCase {
     assertEquals(5, set.get().intValue());
   }
 
-  @Test
   public void testSetMultiThreaded() throws Exception {
     final SetOnce<Integer> set = new SetOnce<>();
     SetOnceThread[] threads = new SetOnceThread[10];

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestIntSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestIntSet.java
@@ -20,15 +20,12 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestIntSet extends LuceneTestCase {
-  @Test
   public void testFreezeEqualitySmallSet() {
     testFreezeEquality(10);
   }
 
-  @Test
   public void testFreezeEqualityLargeSet() {
     testFreezeEquality(100);
   }
@@ -51,7 +48,6 @@ public class TestIntSet extends LuceneTestCase {
     assertEquals("Frozen sets were not equal", frozen0, frozen1);
   }
 
-  @Test
   public void testMapCutover() {
     StateSet set = new StateSet(10);
     for (int i = 0; i < 35; i++) {
@@ -69,7 +65,6 @@ public class TestIntSet extends LuceneTestCase {
     assertThat(set.size(), equalTo(0));
   }
 
-  @Test
   public void testModify() {
     StateSet set = new StateSet(2);
     set.incr(1);
@@ -88,7 +83,6 @@ public class TestIntSet extends LuceneTestCase {
     assertNotEquals(set, set2);
   }
 
-  @Test
   public void testHashCode() {
     StateSet set = new StateSet(1000);
     StateSet set2 = new StateSet(100);

--- a/lucene/demo/src/test/org/apache/lucene/demo/facet/TestAssociationsFacetsExample.java
+++ b/lucene/demo/src/test/org/apache/lucene/demo/facet/TestAssociationsFacetsExample.java
@@ -19,11 +19,9 @@ package org.apache.lucene.demo.facet;
 import java.util.List;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestAssociationsFacetsExample extends LuceneTestCase {
 
-  @Test
   public void testExamples() throws Exception {
     List<FacetResult> res = new AssociationsFacetsExample().runSumAssociations();
     assertEquals("Wrong number of results", 2, res.size());
@@ -35,7 +33,6 @@ public class TestAssociationsFacetsExample extends LuceneTestCase {
         res.get(1).toString());
   }
 
-  @Test
   public void testDrillDown() throws Exception {
     FacetResult result = new AssociationsFacetsExample().runDrillDown();
     assertEquals(

--- a/lucene/demo/src/test/org/apache/lucene/demo/facet/TestCustomFacetSetExample.java
+++ b/lucene/demo/src/test/org/apache/lucene/demo/facet/TestCustomFacetSetExample.java
@@ -19,11 +19,9 @@ package org.apache.lucene.demo.facet;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.facet.LabelAndValue;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestCustomFacetSetExample extends LuceneTestCase {
 
-  @Test
   public void testExactMatching() throws Exception {
     FacetResult result = new CustomFacetSetExample().runExactMatching();
 
@@ -36,7 +34,6 @@ public class TestCustomFacetSetExample extends LuceneTestCase {
     assertEquals(new LabelAndValue("July 2022 (120f)", 2), result.labelValues[1]);
   }
 
-  @Test
   public void testExactMatchingWithFastMatchQuery() throws Exception {
     FacetResult result = new CustomFacetSetExample().runExactMatchingWithFastMatchQuery();
 
@@ -49,7 +46,6 @@ public class TestCustomFacetSetExample extends LuceneTestCase {
     assertEquals(new LabelAndValue("July 2022 (120f)", 2), result.labelValues[1]);
   }
 
-  @Test
   public void testRangeMatching() throws Exception {
     FacetResult result = new CustomFacetSetExample().runRangeMatching();
 
@@ -61,7 +57,6 @@ public class TestCustomFacetSetExample extends LuceneTestCase {
     assertEquals(new LabelAndValue("Eighty to Hundred Degrees", 4), result.labelValues[0]);
   }
 
-  @Test
   public void testCustomRangeMatching() throws Exception {
     FacetResult result = new CustomFacetSetExample().runCustomRangeMatching();
 

--- a/lucene/demo/src/test/org/apache/lucene/demo/facet/TestDynamicRangeFacetsExample.java
+++ b/lucene/demo/src/test/org/apache/lucene/demo/facet/TestDynamicRangeFacetsExample.java
@@ -19,10 +19,8 @@ package org.apache.lucene.demo.facet;
 import java.util.List;
 import org.apache.lucene.facet.range.DynamicRangeUtil;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestDynamicRangeFacetsExample extends LuceneTestCase {
-  @Test
   public void testExample() throws Exception {
     List<DynamicRangeUtil.DynamicRangeInfo> res = new DynamicRangeFacetsExample().runSearch();
     assertEquals(

--- a/lucene/demo/src/test/org/apache/lucene/demo/facet/TestExpressionAggregationFacetsExample.java
+++ b/lucene/demo/src/test/org/apache/lucene/demo/facet/TestExpressionAggregationFacetsExample.java
@@ -18,11 +18,9 @@ package org.apache.lucene.demo.facet;
 
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestExpressionAggregationFacetsExample extends LuceneTestCase {
 
-  @Test
   public void testSimple() throws Exception {
     FacetResult result = new ExpressionAggregationFacetsExample().runSearch();
     assertEquals(

--- a/lucene/demo/src/test/org/apache/lucene/demo/facet/TestMultiCategoryListsFacetsExample.java
+++ b/lucene/demo/src/test/org/apache/lucene/demo/facet/TestMultiCategoryListsFacetsExample.java
@@ -19,11 +19,9 @@ package org.apache.lucene.demo.facet;
 import java.util.List;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestMultiCategoryListsFacetsExample extends LuceneTestCase {
 
-  @Test
   public void testExample() throws Exception {
     List<FacetResult> results = new MultiCategoryListsFacetsExample().runSearch();
     assertEquals(2, results.size());

--- a/lucene/demo/src/test/org/apache/lucene/demo/facet/TestRangeFacetsExample.java
+++ b/lucene/demo/src/test/org/apache/lucene/demo/facet/TestRangeFacetsExample.java
@@ -19,11 +19,9 @@ package org.apache.lucene.demo.facet;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestRangeFacetsExample extends LuceneTestCase {
 
-  @Test
   public void testSimple() throws Exception {
     RangeFacetsExample example = new RangeFacetsExample();
     example.index();
@@ -49,7 +47,6 @@ public class TestRangeFacetsExample extends LuceneTestCase {
     example.close();
   }
 
-  @Test
   @SuppressWarnings("unchecked")
   public void testDrillDown() throws Exception {
     RangeFacetsExample example = new RangeFacetsExample();

--- a/lucene/demo/src/test/org/apache/lucene/demo/facet/TestSimpleFacetsExample.java
+++ b/lucene/demo/src/test/org/apache/lucene/demo/facet/TestSimpleFacetsExample.java
@@ -19,11 +19,9 @@ package org.apache.lucene.demo.facet;
 import java.util.List;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestSimpleFacetsExample extends LuceneTestCase {
 
-  @Test
   public void testFacetOnly() throws Exception {
     List<FacetResult> results = new SimpleFacetsExample().runFacetOnly();
     assertEquals(2, results.size());
@@ -35,7 +33,6 @@ public class TestSimpleFacetsExample extends LuceneTestCase {
         results.get(1).toString());
   }
 
-  @Test
   public void testSimple() throws Exception {
     List<FacetResult> results = new SimpleFacetsExample().runSearch();
     assertEquals(2, results.size());
@@ -47,14 +44,12 @@ public class TestSimpleFacetsExample extends LuceneTestCase {
         results.get(1).toString());
   }
 
-  @Test
   public void testDrillDown() throws Exception {
     FacetResult result = new SimpleFacetsExample().runDrillDown();
     assertEquals(
         "dim=Author path=[] value=2 childCount=2\n  Bob (1)\n  Lisa (1)\n", result.toString());
   }
 
-  @Test
   public void testDrillSideways() throws Exception {
     List<FacetResult> result = new SimpleFacetsExample().runDrillSideways();
     assertEquals(

--- a/lucene/demo/src/test/org/apache/lucene/demo/facet/TestSimpleSortedSetFacetsExample.java
+++ b/lucene/demo/src/test/org/apache/lucene/demo/facet/TestSimpleSortedSetFacetsExample.java
@@ -19,12 +19,11 @@ package org.apache.lucene.demo.facet;
 import java.util.List;
 import org.apache.lucene.facet.FacetResult;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 // We require sorted set DVs:
+
 public class TestSimpleSortedSetFacetsExample extends LuceneTestCase {
 
-  @Test
   public void testSimple() throws Exception {
     List<FacetResult> results = new SimpleSortedSetFacetsExample().runSearch();
     assertEquals(2, results.size());
@@ -36,7 +35,6 @@ public class TestSimpleSortedSetFacetsExample extends LuceneTestCase {
         results.get(1).toString());
   }
 
-  @Test
   public void testDrillDown() throws Exception {
     FacetResult result = new SimpleSortedSetFacetsExample().runDrillDown();
     assertEquals(

--- a/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestModularLayer.java
+++ b/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestModularLayer.java
@@ -42,7 +42,6 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Assumptions;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 /**
  * Sanity checks concerning the distribution's binary artifacts (modules).
@@ -112,7 +111,6 @@ public class TestModularLayer extends AbstractLuceneDistributionTest {
   }
 
   /** Make sure all published module names remain constant, even if we reorganize the build. */
-  @Test
   public void testExpectedDistributionModuleNames() {
     Assertions.assertThat(
             allLuceneModules.stream().map(module -> module.descriptor().name()).sorted())
@@ -153,7 +151,6 @@ public class TestModularLayer extends AbstractLuceneDistributionTest {
   }
 
   /** Try to instantiate the demo classes so that we make sure their module layer is complete. */
-  @Test
   public void testDemoClassesCanBeLoaded() {
     ModuleLayer bootLayer = ModuleLayer.boot();
     Assertions.assertThatNoException()
@@ -185,7 +182,6 @@ public class TestModularLayer extends AbstractLuceneDistributionTest {
   }
 
   /** Checks that Lucene Core is a MR-JAR and has Panama foreign classes */
-  @Test
   public void testMultiReleaseJar() {
     ModuleLayer bootLayer = ModuleLayer.boot();
     Assertions.assertThatNoException()
@@ -228,7 +224,6 @@ public class TestModularLayer extends AbstractLuceneDistributionTest {
   }
 
   /** Make sure we don't publish automatic modules. */
-  @Test
   public void testAllCoreModulesAreNamedModules() {
     Assertions.assertThat(allLuceneModules)
         .allSatisfy(
@@ -239,7 +234,6 @@ public class TestModularLayer extends AbstractLuceneDistributionTest {
   }
 
   /** Ensure all modules have the same (expected) version. */
-  @Test
   public void testAllModulesHaveExpectedVersion() {
     String luceneBuildVersion = System.getProperty(VERSION_PROPERTY);
     Assumptions.assumeThat(luceneBuildVersion).isNotNull();
@@ -251,7 +245,6 @@ public class TestModularLayer extends AbstractLuceneDistributionTest {
   }
 
   /** Ensure SPIs are equal for the module and classpath layer. */
-  @Test
   public void testModularAndClasspathProvidersAreConsistent() throws IOException {
     for (var module : allLuceneModules) {
       TreeMap<String, TreeSet<String>> modularProviders = getModularServiceProviders(module);
@@ -326,7 +319,6 @@ public class TestModularLayer extends AbstractLuceneDistributionTest {
    * <p>This test should be progressively tuned so that certain internal packages are hidden in the
    * module layer.
    */
-  @Test
   public void testAllExportedPackagesInSync() throws IOException {
     for (var module : allLuceneModules) {
       Set<String> jarPackages = getJarPackages(module, _ -> true);
@@ -377,7 +369,6 @@ public class TestModularLayer extends AbstractLuceneDistributionTest {
   }
 
   /** This test ensures that all analysis modules open their resources files to core. */
-  @Test
   public void testAllOpenAnalysisPackagesInSync() throws IOException {
     for (var module : allLuceneModules) {
       if (false == module.descriptor().name().startsWith("org.apache.lucene.analysis.")) {

--- a/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestScripts.java
+++ b/lucene/distribution.tests/src/test/org/apache/lucene/distribution/TestScripts.java
@@ -33,11 +33,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowingConsumer;
-import org.junit.Test;
 
 /** Verify that scripts included in the distribution work. */
 public class TestScripts extends AbstractLuceneDistributionTest {
-  @Test
   @RequiresGUI
   public void testLukeCanBeLaunched() throws Exception {
     Path distributionPath;

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestDrillSideways.java
@@ -90,7 +90,6 @@ import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.InPlaceMergeSorter;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.NamedThreadFactory;
-import org.junit.Test;
 
 public class TestDrillSideways extends FacetTestCase {
 
@@ -2231,7 +2230,6 @@ public class TestDrillSideways extends FacetTestCase {
     IOUtils.close(searcher.getIndexReader(), taxoReader, taxoWriter, dir, taxoDir);
   }
 
-  @Test
   public void testDrillSidewaysSearchUseCorrectIterator() throws Exception {
     // This test reproduces an issue (see GitHub #12211) where DrillSidewaysScorer would ultimately
     // cause multiple consecutive calls to TwoPhaseIterator::matches, which results in a failed

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestFacetQuery.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestFacetQuery.java
@@ -32,7 +32,6 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.IOUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestFacetQuery extends FacetTestCase {
 
@@ -92,13 +91,11 @@ public class TestFacetQuery extends FacetTestCase {
     config = null;
   }
 
-  @Test
   public void testSingleValued() throws Exception {
     TopDocs topDocs = searcher.search(new FacetQuery("Author", "Mark Twain"), 10);
     assertEquals(1, topDocs.totalHits.value());
   }
 
-  @Test
   public void testMultiValued() throws Exception {
     TopDocs topDocs =
         searcher.search(

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestMultipleIndexFields.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestMultipleIndexFields.java
@@ -37,7 +37,6 @@ import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 public class TestMultipleIndexFields extends FacetTestCase {
 
@@ -60,7 +59,6 @@ public class TestMultipleIndexFields extends FacetTestCase {
     return config;
   }
 
-  @Test
   public void testDefault() throws Exception {
     Directory indexDir = newDirectory();
     Directory taxoDir = newDirectory();
@@ -97,7 +95,6 @@ public class TestMultipleIndexFields extends FacetTestCase {
     IOUtils.close(tr, ir, tw, indexDir, taxoDir);
   }
 
-  @Test
   public void testCustom() throws Exception {
     Directory indexDir = newDirectory();
     Directory taxoDir = newDirectory();
@@ -140,7 +137,6 @@ public class TestMultipleIndexFields extends FacetTestCase {
     IOUtils.close(tr, ir, tw, indexDir, taxoDir);
   }
 
-  @Test
   public void testTwoCustomsSameField() throws Exception {
     Directory indexDir = newDirectory();
     Directory taxoDir = newDirectory();
@@ -197,7 +193,6 @@ public class TestMultipleIndexFields extends FacetTestCase {
     fail("no ordinals found for " + field);
   }
 
-  @Test
   public void testDifferentFieldsAndText() throws Exception {
     Directory indexDir = newDirectory();
     Directory taxoDir = newDirectory();
@@ -242,7 +237,6 @@ public class TestMultipleIndexFields extends FacetTestCase {
     IOUtils.close(tr, ir, tw, indexDir, taxoDir);
   }
 
-  @Test
   public void testSomeSameSomeDifferent() throws Exception {
     Directory indexDir = newDirectory();
     Directory taxoDir = newDirectory();

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestFacetLabel.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestFacetLabel.java
@@ -21,18 +21,15 @@ import org.apache.lucene.facet.FacetTestCase;
 import org.apache.lucene.facet.sortedset.SortedSetDocValuesFacetField;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
-import org.junit.Test;
 
 public class TestFacetLabel extends FacetTestCase {
 
-  @Test
   public void testBasic() {
     assertEquals(0, new FacetLabel().length);
     assertEquals(1, new FacetLabel("hello").length);
     assertEquals(2, new FacetLabel("hello", "world").length);
   }
 
-  @Test
   public void testToString() {
     // When the category is empty, we expect an empty string
     assertEquals("FacetLabel: []", new FacetLabel().toString());
@@ -42,7 +39,6 @@ public class TestFacetLabel extends FacetTestCase {
     assertEquals("FacetLabel: [hello, world]", new FacetLabel("hello", "world").toString());
   }
 
-  @Test
   public void testGetComponent() {
     String[] components = new String[atLeast(10)];
     for (int i = 0; i < components.length; i++) {
@@ -54,7 +50,6 @@ public class TestFacetLabel extends FacetTestCase {
     }
   }
 
-  @Test
   public void testDefaultConstructor() {
     // test that the default constructor (no parameters) currently
     // defaults to creating an object with a 0 initial capacity.
@@ -65,7 +60,6 @@ public class TestFacetLabel extends FacetTestCase {
     assertEquals("FacetLabel: []", p.toString());
   }
 
-  @Test
   public void testSubPath() {
     final FacetLabel p = new FacetLabel("hi", "there", "man");
     assertEquals(p.length, 3);
@@ -93,7 +87,6 @@ public class TestFacetLabel extends FacetTestCase {
   }
 
   @SuppressWarnings("unlikely-arg-type")
-  @Test
   public void testEquals() {
     assertEquals(new FacetLabel(), new FacetLabel());
     assertFalse(new FacetLabel().equals(new FacetLabel("hi")));
@@ -101,7 +94,6 @@ public class TestFacetLabel extends FacetTestCase {
     assertEquals(new FacetLabel("hello", "world"), new FacetLabel("hello", "world"));
   }
 
-  @Test
   public void testHashCode() {
     assertEquals(new FacetLabel().hashCode(), new FacetLabel().hashCode());
     assertFalse(new FacetLabel().hashCode() == new FacetLabel("hi").hashCode());
@@ -109,7 +101,6 @@ public class TestFacetLabel extends FacetTestCase {
         new FacetLabel("hello", "world").hashCode(), new FacetLabel("hello", "world").hashCode());
   }
 
-  @Test
   public void testLongHashCode() {
     assertEquals(new FacetLabel().longHashCode(), new FacetLabel().longHashCode());
     assertFalse(new FacetLabel().longHashCode() == new FacetLabel("hi").longHashCode());
@@ -118,14 +109,12 @@ public class TestFacetLabel extends FacetTestCase {
         new FacetLabel("hello", "world").longHashCode());
   }
 
-  @Test
   public void testArrayConstructor() {
     FacetLabel p = new FacetLabel("hello", "world", "yo");
     assertEquals(3, p.length);
     assertEquals("FacetLabel: [hello, world, yo]", p.toString());
   }
 
-  @Test
   public void testCompareTo() {
     FacetLabel p = new FacetLabel("a", "b", "c", "d");
     FacetLabel pother = new FacetLabel("a", "b", "c", "d");
@@ -145,7 +134,6 @@ public class TestFacetLabel extends FacetTestCase {
     assertTrue(p.compareTo(pother) < 0);
   }
 
-  @Test
   public void testEmptyNullComponents() throws Exception {
     // LUCENE-4724: CategoryPath should not allow empty or null components
     String[][] components_tests =
@@ -199,7 +187,6 @@ public class TestFacetLabel extends FacetTestCase {
     expectThrows(IllegalArgumentException.class, () -> new SortedSetDocValuesFacetField("dim", ""));
   }
 
-  @Test
   public void testLongPath() throws Exception {
     String bigComp = null;
     while (true) {

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestLRUHashMap.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestLRUHashMap.java
@@ -17,13 +17,11 @@
 package org.apache.lucene.facet.taxonomy;
 
 import org.apache.lucene.facet.FacetTestCase;
-import org.junit.Test;
 
 public class TestLRUHashMap extends FacetTestCase {
   // testLRU() tests that the specified size limit is indeed honored, and
   // the remaining objects in the map are indeed those that have been most
   // recently used
-  @Test
   public void testLRU() throws Exception {
     LRUHashMap<String, String> lru = new LRUHashMap<>(3);
     assertEquals(0, lru.size());

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestOrdinalMappingLeafReader.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestOrdinalMappingLeafReader.java
@@ -42,7 +42,6 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.junit.Before;
-import org.junit.Test;
 
 public class TestOrdinalMappingLeafReader extends FacetTestCase {
 
@@ -57,7 +56,6 @@ public class TestOrdinalMappingLeafReader extends FacetTestCase {
     facetConfig.setIndexFieldName("tag", "$tags"); // add custom index field name
   }
 
-  @Test
   public void testTaxonomyMergeUtils() throws Exception {
     Directory srcIndexDir = newDirectory();
     Directory srcTaxoDir = newDirectory();

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyCombined.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyCombined.java
@@ -30,7 +30,6 @@ import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressCodecs;
 import org.apache.lucene.util.SuppressForbidden;
-import org.junit.Test;
 
 @SuppressCodecs("SimpleText")
 public class TestTaxonomyCombined extends FacetTestCase {
@@ -159,7 +158,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    * do not test here that after writing the index can be read - this will be done in more tests
    * below.
    */
-  @Test
   public void testWriter() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -175,7 +173,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    * testWriterTwice is exactly like testWriter, except that after adding all the categories, we add
    * them again, and see that we get the same old ids again - not new categories.
    */
-  @Test
   public void testWriterTwice() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -197,7 +194,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    * with writing and reading correctly just to the cache, testWriterTwice2 checks also the actual
    * disk read part of the writer:
    */
-  @Test
   public void testWriterTwice2() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -219,7 +215,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    * sessions. This test used to fail because of a bug involving commit(), explained below, and now
    * should succeed.
    */
-  @Test
   public void testWriterTwice3() throws Exception {
     Directory indexDir = newDirectory();
     // First, create and fill the taxonomy
@@ -251,7 +246,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    * cases, and therefore may be more helpful for debugging a problem than testWriter() which is
    * hard to know why or where it failed.
    */
-  @Test
   public void testWriterSimpler() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -295,7 +289,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    * Test writing an empty index, and seeing that a reader finds in it the root category, and only
    * it. We check all the methods on that root category return the expected results.
    */
-  @Test
   public void testRootOnly() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -317,7 +310,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    * before opening the reader. We want to see that the root is visible to the reader not only after
    * the writer is closed, but immediately after it is created.
    */
-  @Test
   public void testRootOnly2() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -337,7 +329,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    * getCategory() and getOrdinal()). We test that after writing the index, it can be read and all
    * the categories and ordinals are there just as we expected them to be.
    */
-  @Test
   public void testReaderBasic() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -405,7 +396,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    * they should not be tested! Until they are removed (*if* they are removed), these tests should
    * remain to see that they still work correctly.
    */
-  @Test
   public void testReaderParent() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -460,7 +450,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    *
    * <p>This test code is virtually identical to that of testReaderParent().
    */
-  @Test
   public void testWriterParent1() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -476,7 +465,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
     indexDir.close();
   }
 
-  @Test
   public void testWriterParent2() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -535,7 +523,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    * Test TaxonomyReader's child browsing method, getChildrenArrays() This only tests for
    * correctness of the data on one example - we have below further tests on data refresh etc.
    */
-  @Test
   public void testChildrenArrays() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -596,7 +583,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    * taxonomies, because we do not need to build the expected list of categories like we did in the
    * above test.
    */
-  @Test
   public void testChildrenArraysInvariants() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -681,7 +667,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
   }
 
   /** Test how getChildrenArrays() deals with the taxonomy's growth: */
-  @Test
   public void testChildrenArraysGrowth() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -720,7 +705,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
   }
 
   // Test that getParentArrays is valid when retrieved during refresh
-  @Test
   public void testTaxonomyReaderRefreshRaces() throws Exception {
     // compute base child arrays - after first chunk, and after the other
     Directory indexDirBase = newDirectory();
@@ -879,7 +863,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    * happens when the two processes do their actual work at exactly the same time. It also doesn't
    * test multi-threading.
    */
-  @Test
   public void testSeparateReaderAndWriter() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -934,7 +917,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
     indexDir.close();
   }
 
-  @Test
   public void testSeparateReaderAndWriter2() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -1038,7 +1020,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    * Basic test for TaxonomyWriter.getParent(). This is similar to testWriter above, except we also
    * check the parents of the added categories, not just the categories themselves.
    */
-  @Test
   public void testWriterCheckPaths() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -1056,7 +1037,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
    * paths. We repeat the path checking yet again after closing and opening the index for writing
    * again - to see that the reading of existing data from disk works as well.
    */
-  @Test
   public void testWriterCheckPaths2() throws Exception {
     Directory indexDir = newDirectory();
     TaxonomyWriter tw = new DirectoryTaxonomyWriter(indexDir);
@@ -1074,7 +1054,6 @@ public class TestTaxonomyCombined extends FacetTestCase {
     indexDir.close();
   }
 
-  @Test
   public void testNRT() throws Exception {
     Directory dir = newDirectory();
     DirectoryTaxonomyWriter writer = new DirectoryTaxonomyWriter(dir);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts2.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts2.java
@@ -50,7 +50,6 @@ import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.util.IOUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestTaxonomyFacetCounts2 extends FacetTestCase {
 
@@ -264,7 +263,6 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     IOUtils.close(taxoWriter);
   }
 
-  @Test
   public void testDifferentNumResults() throws Exception {
     // test the collector w/ FacetRequests and different numResults
     DirectoryReader indexReader = DirectoryReader.open(indexDir);
@@ -288,7 +286,6 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     IOUtils.close(indexReader, taxoReader);
   }
 
-  @Test
   public void testAllCounts() throws Exception {
     DirectoryReader indexReader = DirectoryReader.open(indexDir);
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
@@ -329,7 +326,6 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     IOUtils.close(indexReader, taxoReader);
   }
 
-  @Test
   public void testBigNumResults() throws Exception {
     DirectoryReader indexReader = DirectoryReader.open(indexDir);
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);
@@ -353,7 +349,6 @@ public class TestTaxonomyFacetCounts2 extends FacetTestCase {
     IOUtils.close(indexReader, taxoReader);
   }
 
-  @Test
   public void testNoParents() throws Exception {
     DirectoryReader indexReader = DirectoryReader.open(indexDir);
     TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDir);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyReader.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyReader.java
@@ -45,14 +45,12 @@ import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 public class TestDirectoryTaxonomyReader extends FacetTestCase {
 
   private static final FacetLabel ILLEGAL_PATH =
       new FacetLabel("PATH_THAT_CAUSED_IllegalArgumentException");
 
-  @Test
   public void testCloseAfterIncRef() throws Exception {
     Directory dir = newDirectory();
     DirectoryTaxonomyWriter ltw = new DirectoryTaxonomyWriter(dir);
@@ -70,7 +68,6 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testCloseTwice() throws Exception {
     Directory dir = newDirectory();
     DirectoryTaxonomyWriter ltw = new DirectoryTaxonomyWriter(dir);
@@ -84,7 +81,6 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testOpenIfChangedResult() throws Exception {
     Directory dir = null;
     DirectoryTaxonomyWriter ltw = null;
@@ -112,7 +108,6 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     }
   }
 
-  @Test
   public void testAlreadyClosed() throws Exception {
     Directory dir = newDirectory();
     DirectoryTaxonomyWriter ltw = new DirectoryTaxonomyWriter(dir);
@@ -127,12 +122,10 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
   }
 
   /** recreating a taxonomy should work well with a freshly opened taxonomy reader */
-  @Test
   public void testFreshReadRecreatedTaxonomy() throws Exception {
     doTestReadRecreatedTaxonomy(random(), true);
   }
 
-  @Test
   public void testOpenIfChangedReadRecreatedTaxonomy() throws Exception {
     doTestReadRecreatedTaxonomy(random(), false);
   }
@@ -185,7 +178,6 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     }
   }
 
-  @Test
   public void testOpenIfChangedAndRefCount() throws Exception {
     Directory dir = new ByteBuffersDirectory(); // no need for random directories here
 
@@ -212,7 +204,6 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testOpenIfChangedManySegments() throws Exception {
     // test openIfChanged() when the taxonomy contains many segments
     Directory dir = newDirectory();
@@ -258,7 +249,6 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testOpenIfChangedMergedSegment() throws Exception {
     // test openIfChanged() when all index segments were merged - used to be
     // a bug in ParentArray, caught by testOpenIfChangedManySegments - only
@@ -303,7 +293,6 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testOpenIfChangedNoChangesButSegmentMerges() throws Exception {
     // test openIfChanged() when the taxonomy hasn't really changed, but segments
     // were merged. The NRT reader will be reopened, and ParentArray used to assert
@@ -351,7 +340,6 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testOpenIfChangedReuseAfterRecreate() throws Exception {
     // tests that if the taxonomy is recreated, no data is reused from the previous taxonomy
     Directory dir = newDirectory();
@@ -389,7 +377,6 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testOpenIfChangedReuse() throws Exception {
     // test the reuse of data from the old DTR instance
     for (boolean nrt : new boolean[] {false, true}) {
@@ -426,7 +413,6 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     }
   }
 
-  @Test
   public void testOpenIfChangedReplaceTaxonomy() throws Exception {
     // test openIfChanged when replaceTaxonomy is called, which is equivalent to recreate
     // only can work with NRT as well
@@ -556,7 +542,6 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     assertGettingOrdinals(reader, ords, paths);
   }
 
-  @Test
   public void testGetChildren() throws Exception {
     Directory dir = newDirectory();
     DirectoryTaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(dir);
@@ -623,7 +608,6 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testAccountable() throws Exception {
     Directory dir = newDirectory();
     DirectoryTaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(dir);
@@ -651,7 +635,6 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testGetPathAndOrdinalsRandomMultithreading() throws Exception {
     Directory src = newDirectory();
     DirectoryTaxonomyWriter w = new DirectoryTaxonomyWriter(src);

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyWriter.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyWriter.java
@@ -46,7 +46,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 public class TestDirectoryTaxonomyWriter extends FacetTestCase {
 
@@ -82,7 +81,6 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
         }
       };
 
-  @Test
   public void testCommit() throws Exception {
     // Verifies that nothing is committed to the underlying Directory, if
     // commit() wasn't called.
@@ -101,7 +99,6 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testCommitUserData() throws Exception {
     // Verifies taxonomy commit data
     Directory dir = newDirectory();
@@ -165,7 +162,6 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testRollback() throws Exception {
     // Verifies that if rollback is called, DTW is closed.
     Directory dir = newDirectory();
@@ -183,7 +179,6 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testRecreateRollback() throws Exception {
     // Tests rollback with OpenMode.CREATE
     Directory dir = newDirectory();
@@ -195,7 +190,6 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testEnsureOpen() throws Exception {
     // verifies that an exception is thrown if DTW was closed
     Directory dir = newDirectory();
@@ -222,7 +216,6 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
     taxoWriter.commit();
   }
 
-  @Test
   public void testRecreateAndRefresh() throws Exception {
     // DirTaxoWriter lost the INDEX_EPOCH property if it was opened in
     // CREATE_OR_APPEND (or commit(userData) called twice), which could lead to
@@ -267,7 +260,6 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
     }
   }
 
-  @Test
   public void testBackwardsCompatibility() throws Exception {
     // tests that if the taxonomy index doesn't have the INDEX_EPOCH
     // property (supports pre-3.6 indexes), all still works.
@@ -388,7 +380,6 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
     return Long.parseLong(infos.getUserData().get(DirectoryTaxonomyWriter.INDEX_EPOCH));
   }
 
-  @Test
   public void testReplaceTaxonomy() throws Exception {
     Directory input = newDirectory();
     DirectoryTaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(input);
@@ -429,7 +420,6 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
     input.close();
   }
 
-  @Test
   public void testReaderFreshness() throws Exception {
     // ensures that the internal index reader is always kept fresh. Previously,
     // this simple scenario failed, if the cache just evicted the category that
@@ -444,7 +434,6 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testCommitNoEmptyCommits() throws Exception {
     // LUCENE-4972: DTW used to create empty commits even if no changes were made
     Directory dir = newDirectory();
@@ -461,7 +450,6 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testCloseNoEmptyCommits() throws Exception {
     // LUCENE-4972: DTW used to create empty commits even if no changes were made
     Directory dir = newDirectory();
@@ -478,7 +466,6 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
     dir.close();
   }
 
-  @Test
   public void testPrepareCommitNoEmptyCommits() throws Exception {
     // LUCENE-4972: DTW used to create empty commits even if no changes were made
     Directory dir = newDirectory();
@@ -498,7 +485,6 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
   }
 
   // TODO: this test can hit pathological cases: it adds only a few docs, what is going on?
-  @Test
   @Nightly
   public void testHugeLabel() throws Exception {
     Directory indexDir = newDirectory(), taxoDir = newDirectory();
@@ -545,7 +531,6 @@ public class TestDirectoryTaxonomyWriter extends FacetTestCase {
     IOUtils.close(indexReader, taxoReader, indexDir, taxoDir);
   }
 
-  @Test
   public void testReplaceTaxoWithLargeTaxonomy() throws Exception {
     Directory srcTaxoDir = newDirectory(), targetTaxoDir = newDirectory();
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/writercache/TestLruTaxonomyWriterCache.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/writercache/TestLruTaxonomyWriterCache.java
@@ -19,11 +19,9 @@ package org.apache.lucene.facet.taxonomy.writercache;
 
 import org.apache.lucene.facet.FacetTestCase;
 import org.apache.lucene.facet.taxonomy.FacetLabel;
-import org.junit.Test;
 
 public class TestLruTaxonomyWriterCache extends FacetTestCase {
 
-  @Test
   public void testDefaultLRUTypeIsCollisionSafe() {
     // These labels are clearly different, but have identical longHashCodes.
     // Note that these labels are clearly contrived. We did encounter

--- a/lucene/highlighter/src/test/org/apache/lucene/search/matchhighlight/TestMatchHighlighter.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/matchhighlight/TestMatchHighlighter.java
@@ -63,7 +63,6 @@ import org.apache.lucene.util.CharsRef;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Before;
-import org.junit.Test;
 
 public class TestMatchHighlighter extends LuceneTestCase {
   private static final String FLD_ID = "id";
@@ -126,7 +125,6 @@ public class TestMatchHighlighter extends LuceneTestCase {
     return builder.build();
   }
 
-  @Test
   public void testBasicUsage() throws Exception {
     new IndexBuilder(this::toField)
         .doc(FLD_TEXT1, "foo bar baz")
@@ -236,7 +234,6 @@ public class TestMatchHighlighter extends LuceneTestCase {
             });
   }
 
-  @Test
   public void testSynonymHighlight() throws Exception {
     // There is nothing special needed to highlight or process complex queries, synonyms, etc.
     // Synonyms defined in the constructor of this class.
@@ -267,7 +264,6 @@ public class TestMatchHighlighter extends LuceneTestCase {
             });
   }
 
-  @Test
   public void testAnalyzedTextIntervals() throws Exception {
     SynonymMap synonymMap =
         buildSynonymMap(
@@ -318,7 +314,6 @@ public class TestMatchHighlighter extends LuceneTestCase {
             });
   }
 
-  @Test
   public void testStandardQueryParserIntervalFunctions() throws Exception {
     Analyzer analyzer =
         new Analyzer() {
@@ -534,7 +529,6 @@ public class TestMatchHighlighter extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testCustomFieldHighlightHandling() throws Exception {
     // Match highlighter is a showcase of individual components in this package, suitable
     // to create any kind of field-display designs.
@@ -641,7 +635,6 @@ public class TestMatchHighlighter extends LuceneTestCase {
             });
   }
 
-  @Test
   public void testHighlightMoreQueriesAtOnceShowoff() throws Exception {
     // Match highlighter underlying components are powerful enough to build interesting,
     // if not always super-practical, things. In this case, we would like to highlight

--- a/lucene/highlighter/src/test/org/apache/lucene/search/matchhighlight/TestMatchRegionRetriever.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/matchhighlight/TestMatchRegionRetriever.java
@@ -69,7 +69,6 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Before;
-import org.junit.Test;
 
 public class TestMatchRegionRetriever extends LuceneTestCase {
   private static final String FLD_ID = IndexBuilder.FLD_ID;
@@ -160,12 +159,10 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
         }
       };
 
-  @Test
   public void testTermQueryWithOffsets() throws Exception {
     checkTermQuery(FLD_TEXT_POS_OFFS);
   }
 
-  @Test
   public void testTermQueryWithPositions() throws Exception {
     checkTermQuery(FLD_TEXT_POS);
   }
@@ -188,12 +185,10 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
             });
   }
 
-  @Test
   public void testBooleanMultifieldQueryWithOffsets() throws Exception {
     checkBooleanMultifieldQuery(FLD_TEXT_POS_OFFS);
   }
 
-  @Test
   public void testBooleanMultifieldQueryWithPositions() throws Exception {
     checkBooleanMultifieldQuery(FLD_TEXT_POS);
   }
@@ -221,12 +216,10 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
             });
   }
 
-  @Test
   public void testVariousQueryTypesWithOffsets() throws Exception {
     checkVariousQueryTypes(FLD_TEXT_POS_OFFS);
   }
 
-  @Test
   public void testVariousQueryTypesWithPositions() throws Exception {
     checkVariousQueryTypes(FLD_TEXT_POS);
   }
@@ -313,7 +306,6 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
             });
   }
 
-  @Test
   public void testIntervalQueryHighlightCrossingMultivalueBoundary() throws Exception {
     String field = FLD_TEXT_POS;
     new IndexBuilder(this::toField)
@@ -331,7 +323,6 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
             });
   }
 
-  @Test
   public void testIntervalQueries() throws Exception {
     String field = FLD_TEXT_POS_OFFS;
 
@@ -395,12 +386,10 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
             });
   }
 
-  @Test
   public void testDegenerateIntervalsWithPositions() throws Exception {
     testDegenerateIntervals(FLD_TEXT_POS);
   }
 
-  @Test
   public void testDegenerateIntervalsWithOffsets() throws Exception {
     testDegenerateIntervals(FLD_TEXT_POS_OFFS);
   }
@@ -425,12 +414,10 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
             });
   }
 
-  @Test
   public void testMultivaluedFieldsWithOffsets() throws Exception {
     checkMultivaluedFields(FLD_TEXT_POS_OFFS);
   }
 
-  @Test
   public void testMultivaluedFieldsWithPositions() throws Exception {
     checkMultivaluedFields(FLD_TEXT_POS);
   }
@@ -452,7 +439,6 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
             });
   }
 
-  @Test
   public void testMultiFieldHighlights() throws Exception {
     for (String[] fieldPairs :
         new String[][] {
@@ -490,7 +476,6 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
    * Rewritten Boolean queries may omit matches from {@link
    * org.apache.lucene.search.BooleanClause.Occur#SHOULD} clauses. Check that this isn't the case.
    */
-  @Test
   public void testNoRewrite() throws Exception {
     String field1 = FLD_TEXT_POS_OFFS1;
     String field2 = FLD_TEXT_POS_OFFS2;
@@ -524,12 +509,10 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
             });
   }
 
-  @Test
   public void testNestedQueryHitsWithOffsets() throws Exception {
     checkNestedQueryHits(FLD_TEXT_POS_OFFS);
   }
 
-  @Test
   public void testNestedQueryHitsWithPositions() throws Exception {
     checkNestedQueryHits(FLD_TEXT_POS);
   }
@@ -561,12 +544,10 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
             });
   }
 
-  @Test
   public void testGraphQueryWithOffsets() throws Exception {
     checkGraphQuery(FLD_TEXT_SYNONYMS_POS_OFFS);
   }
 
-  @Test
   public void testGraphQueryWithPositions() throws Exception {
     checkGraphQuery(FLD_TEXT_SYNONYMS_POS);
   }
@@ -604,12 +585,10 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
             });
   }
 
-  @Test
   public void testSpanQueryWithOffsets() throws Exception {
     checkSpanQueries(FLD_TEXT_POS_OFFS);
   }
 
-  @Test
   public void testSpanQueryWithPositions() throws Exception {
     checkSpanQueries(FLD_TEXT_POS);
   }
@@ -673,7 +652,6 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
    * checks the {@link OffsetsFromValues} strategy that returns highlights over entire indexed
    * values.
    */
-  @Test
   public void testTextFieldNoPositionsOffsetFromValues() throws Exception {
     String field = FLD_TEXT_NOPOS;
 
@@ -707,7 +685,6 @@ public class TestMatchRegionRetriever extends LuceneTestCase {
    *
    * <p>Such field structure is often useful for multivalued "keyword-like" fields.
    */
-  @Test
   public void testTextFieldNoPositionsOffsetsFromTokens() throws Exception {
     String field = FLD_TEXT_NOPOS;
 

--- a/lucene/highlighter/src/test/org/apache/lucene/search/matchhighlight/TestPassageSelector.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/matchhighlight/TestPassageSelector.java
@@ -283,7 +283,6 @@ public class TestPassageSelector extends LuceneTestCase {
             new OffsetRange(18, Integer.MAX_VALUE)));
   }
 
-  @Test
   public void testHighlightAcrossAllowedValueRange() {
     checkPassages(
         "012>34<|>56<789",

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterReanalysis.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterReanalysis.java
@@ -26,14 +26,12 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.junit.Test;
 
 public class TestUnifiedHighlighterReanalysis extends UnifiedHighlighterTestBase {
   public TestUnifiedHighlighterReanalysis() {
     super(randomFieldType(random()));
   }
 
-  @Test
   public void testWithoutIndexSearcher() throws IOException {
     String text =
         "This is a test. Just a test highlighting without a searcher. Feel free to ignore.";
@@ -55,7 +53,6 @@ public class TestUnifiedHighlighterReanalysis extends UnifiedHighlighterTestBase
     assertEquals("Hello", highlighter.highlightWithoutSearcher("nonexistent", query, "Hello", 1));
   }
 
-  @Test
   public void testIndexSearcherNullness() throws IOException {
     String text =
         "This is a test. Just a test highlighting without a searcher. Feel free to ignore.";

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermVec.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermVec.java
@@ -43,7 +43,6 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.junit.Test;
 
 /**
  * Tests highlighting for matters *expressly* relating to term vectors.
@@ -205,7 +204,6 @@ public class TestUnifiedHighlighterTermVec extends UnifiedHighlighterTestBase {
     }
   }
 
-  @Test
   public void testUserFailedToIndexOffsets() throws IOException {
     FieldType fieldType = new FieldType(tvType); // note: it's indexed too
     fieldType.setStoreTermVectorPositions(random().nextBoolean());

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/visibility/TestUnifiedHighlighterExtensibility.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/visibility/TestUnifiedHighlighterExtensibility.java
@@ -47,7 +47,6 @@ import org.apache.lucene.search.uhighlight.UnifiedHighlighter;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
-import org.junit.Test;
 
 /** Helps us be aware of visibility/extensibility concerns. */
 public class TestUnifiedHighlighterExtensibility extends LuceneTestCase {
@@ -56,7 +55,6 @@ public class TestUnifiedHighlighterExtensibility extends LuceneTestCase {
    * This test is for maintaining the extensibility of the FieldOffsetStrategy for customizations
    * out of package.
    */
-  @Test
   public void testFieldOffsetStrategyExtensibility() {
     final UnifiedHighlighter.OffsetSource offsetSource =
         UnifiedHighlighter.OffsetSource.NONE_NEEDED;
@@ -95,7 +93,6 @@ public class TestUnifiedHighlighterExtensibility extends LuceneTestCase {
    * This test is for maintaining the extensibility of the UnifiedHighlighter for customizations out
    * of package.
    */
-  @Test
   public void testUnifiedHighlighterExtensibility() {
     final int maxLength = 1000;
     UnifiedHighlighter.Builder uhBuilder =
@@ -230,7 +227,6 @@ public class TestUnifiedHighlighterExtensibility extends LuceneTestCase {
     assertEquals(uh.getMaxLength(), maxLength);
   }
 
-  @Test
   public void testPassageFormatterExtensibility() {
     final Object formattedResponse = new Object();
     PassageFormatter formatter =
@@ -243,7 +239,6 @@ public class TestUnifiedHighlighterExtensibility extends LuceneTestCase {
     assertEquals(formattedResponse, formatter.format(new Passage[0], ""));
   }
 
-  @Test
   public void testFieldHiglighterExtensibility() {
     final String fieldName = "fieldName";
     FieldHighlighter fieldHighlighter =

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestBlockJoinSorting.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestBlockJoinSorting.java
@@ -38,12 +38,10 @@ import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
-import org.junit.Test;
 
 /** */
 public class TestBlockJoinSorting extends LuceneTestCase {
 
-  @Test
   public void testNestedSorting() throws Exception {
     final Directory dir = newDirectory();
     final RandomIndexWriter w =
@@ -327,7 +325,6 @@ public class TestBlockJoinSorting extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testParentMissingValueNestedSorting() throws Exception {
     final Directory dir = newDirectory();
     final RandomIndexWriter w =
@@ -451,7 +448,6 @@ public class TestBlockJoinSorting extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testChildMissingValueNestedSorting() throws Exception {
     final Directory dir = newDirectory();
     final RandomIndexWriter w =

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
@@ -98,7 +98,6 @@ import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.packed.PackedInts;
-import org.junit.Test;
 
 public class TestJoinUtil extends LuceneTestCase {
 
@@ -1466,14 +1465,12 @@ public class TestJoinUtil extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testSingleValueRandomJoin() throws Exception {
     int maxIndexIter = atLeast(1);
     int maxSearchIter = atLeast(1);
     executeRandomJoin(false, maxIndexIter, maxSearchIter, TestUtil.nextInt(random(), 87, 764));
   }
 
-  @Test
   // This test really takes more time, that is why the number of iterations are smaller.
   public void testMultiValueRandomJoin() throws Exception {
     int maxIndexIter = atLeast(1);

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestParentsChildrenBlockJoinQuery.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestParentsChildrenBlockJoinQuery.java
@@ -44,7 +44,6 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestParentsChildrenBlockJoinQuery extends LuceneTestCase {
 
@@ -57,13 +56,11 @@ public class TestParentsChildrenBlockJoinQuery extends LuceneTestCase {
         random(), dir, newIndexWriterConfig().setMergePolicy(newLogMergePolicy()));
   }
 
-  @Test
   public void testEmptyIndex() throws Exception {
     // No documents to index, just test the query execution
     test(new TestDoc[0][0], new int[0], 10);
   }
 
-  @Test
   public void testOnlyParentDocs() throws Exception {
     // Only parent documents, no children
     TestDoc[][] blocks = {
@@ -75,7 +72,6 @@ public class TestParentsChildrenBlockJoinQuery extends LuceneTestCase {
     test(blocks, expectedDocIds, 10);
   }
 
-  @Test
   public void testFirstParentWithoutChild() throws Exception {
     // First parent has no children, but the second parent has two children
     TestDoc[][] blocks = {
@@ -86,7 +82,6 @@ public class TestParentsChildrenBlockJoinQuery extends LuceneTestCase {
     test(blocks, expectedDocIds, 10);
   }
 
-  @Test
   public void testWithRandomizedIndex() throws Exception {
     for (int i = 0; i < 10; i++) {
       // Run multiple iterations to ensure randomness
@@ -146,7 +141,6 @@ public class TestParentsChildrenBlockJoinQuery extends LuceneTestCase {
     test(testDocs, expectedMatchArray, childLimitPerParent);
   }
 
-  @Test
   public void testAdvance() throws Exception {
     // Create test blocks with specific structure to test advance()
     TestDoc[][] blocks = new TestDoc[3][];
@@ -325,7 +319,6 @@ public class TestParentsChildrenBlockJoinQuery extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testInvalidChildLimit() {
     BitSetProducer parentFilter =
         new QueryBitSetProducer(new TermQuery(new Term("type", "parent")));
@@ -339,7 +332,6 @@ public class TestParentsChildrenBlockJoinQuery extends LuceneTestCase {
     assertTrue(e.getMessage().contains("childLimitPerParent must be > 0"));
   }
 
-  @Test
   public void testExplain() throws Exception {
     // Create test blocks with specific structure to test explain()
     TestDoc[][] blocks = new TestDoc[2][];
@@ -411,7 +403,6 @@ public class TestParentsChildrenBlockJoinQuery extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testIntraSegmentConcurrencyNotSupported() throws Exception {
     // Create test blocks with specific structure - using a larger number of documents
     final int numParents = atLeast(1000); // Create at least 1000 parents to ensure large segment

--- a/lucene/luke/src/test/org/apache/lucene/luke/app/desktop/util/TestListUtils.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/app/desktop/util/TestListUtils.java
@@ -21,11 +21,9 @@ import java.util.Arrays;
 import java.util.List;
 import javax.swing.JList;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestListUtils extends LuceneTestCase {
 
-  @Test
   public void testGetAllItems() {
     JList<String> list = new JList<>(new String[] {"Item 1", "Item 2"});
     List<String> items = ListUtils.getAllItems(list);

--- a/lucene/luke/src/test/org/apache/lucene/luke/app/desktop/util/inifile/TestSimpleIniFile.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/app/desktop/util/inifile/TestSimpleIniFile.java
@@ -25,11 +25,9 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestSimpleIniFile extends LuceneTestCase {
 
-  @Test
   public void testStore() throws IOException {
     Path path = saveTestIni();
     assertTrue(Files.exists(path));
@@ -49,7 +47,6 @@ public class TestSimpleIniFile extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testLoad() throws IOException {
     Path path = saveTestIni();
 
@@ -62,7 +59,6 @@ public class TestSimpleIniFile extends LuceneTestCase {
     assertEquals(2, sections.get("section2").size());
   }
 
-  @Test
   public void testPut() {
     SimpleIniFile iniFile = new SimpleIniFile();
     iniFile.put("section1", "s1", "aaa");
@@ -76,7 +72,6 @@ public class TestSimpleIniFile extends LuceneTestCase {
     assertNull(sections.get("section2").get("b2"));
   }
 
-  @Test
   public void testGet() throws IOException {
     Path path = saveTestIni();
     SimpleIniFile iniFile = new SimpleIniFile();

--- a/lucene/luke/src/test/org/apache/lucene/luke/models/analysis/TestAnalysisImpl.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/analysis/TestAnalysisImpl.java
@@ -30,32 +30,27 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.custom.CustomAnalyzer;
 import org.apache.lucene.luke.models.LukeException;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestAnalysisImpl extends LuceneTestCase {
 
-  @Test
   public void testGetAvailableCharFilters() {
     AnalysisImpl analysis = new AnalysisImpl();
     Collection<String> charFilters = analysis.getAvailableCharFilters();
     assertNotNull(charFilters);
   }
 
-  @Test
   public void testGetAvailableTokenizers() {
     AnalysisImpl analysis = new AnalysisImpl();
     Collection<String> tokenizers = analysis.getAvailableTokenizers();
     assertNotNull(tokenizers);
   }
 
-  @Test
   public void testGetAvailableTokenFilters() {
     AnalysisImpl analysis = new AnalysisImpl();
     Collection<String> tokenFilters = analysis.getAvailableTokenFilters();
     assertNotNull(tokenFilters);
   }
 
-  @Test
   public void testAnalyze_preset() {
     AnalysisImpl analysis = new AnalysisImpl();
     String analyzerType = "org.apache.lucene.analysis.standard.StandardAnalyzer";
@@ -68,7 +63,6 @@ public class TestAnalysisImpl extends LuceneTestCase {
     assertNotNull(tokens);
   }
 
-  @Test
   public void testAnalyze_custom() {
     AnalysisImpl analysis = new AnalysisImpl();
     Map<String, String> tkParams = new HashMap<>();
@@ -90,7 +84,6 @@ public class TestAnalysisImpl extends LuceneTestCase {
     assertNotNull(tokens);
   }
 
-  @Test
   public void testAnalyzer_custom_with_confdir() throws Exception {
     Path confDir = createTempDir("conf");
     Path stopFile = Files.createFile(Paths.get(confDir.toString(), "stop.txt"));
@@ -132,7 +125,6 @@ public class TestAnalysisImpl extends LuceneTestCase {
     assertNotNull(tokens);
   }
 
-  @Test
   public void testAnalyzeStepByStep_preset() {
     AnalysisImpl analysis = new AnalysisImpl();
     String analyzerType = "org.apache.lucene.analysis.standard.StandardAnalyzer";
@@ -143,7 +135,6 @@ public class TestAnalysisImpl extends LuceneTestCase {
     expectThrows(LukeException.class, () -> analysis.analyzeStepByStep(text));
   }
 
-  @Test
   public void testAnalyzeStepByStep_custom() {
     AnalysisImpl analysis = new AnalysisImpl();
     Map<String, String> tkParams = new HashMap<>();

--- a/lucene/luke/src/test/org/apache/lucene/luke/models/commits/TestCommitsImpl.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/commits/TestCommitsImpl.java
@@ -35,7 +35,6 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 
 public class TestCommitsImpl extends LuceneTestCase {
 
@@ -94,7 +93,6 @@ public class TestCommitsImpl extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testListCommits() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     List<Commit> commitList = commits.listCommits();
@@ -104,7 +102,6 @@ public class TestCommitsImpl extends LuceneTestCase {
     assertEquals(1, commitList.get(commitList.size() - 1).getGeneration());
   }
 
-  @Test
   public void testGetCommit() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     Optional<Commit> commit = commits.getCommit(1);
@@ -112,13 +109,11 @@ public class TestCommitsImpl extends LuceneTestCase {
     assertEquals(1, commit.get().getGeneration());
   }
 
-  @Test
   public void testGetCommit_generation_notfound() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     assertFalse(commits.getCommit(10).isPresent());
   }
 
-  @Test
   public void testGetFiles() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     List<File> files = commits.getFiles(1);
@@ -126,81 +121,69 @@ public class TestCommitsImpl extends LuceneTestCase {
     assertTrue(files.stream().anyMatch(file -> file.getFileName().equals("segments_1")));
   }
 
-  @Test
   public void testGetFiles_generation_notfound() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     assertTrue(commits.getFiles(10).isEmpty());
   }
 
-  @Test
   public void testGetSegments() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     List<Segment> segments = commits.getSegments(1);
     assertTrue(segments.size() > 0);
   }
 
-  @Test
   public void testGetSegments_generation_notfound() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     assertTrue(commits.getSegments(10).isEmpty());
   }
 
-  @Test
   public void testGetSegmentAttributes() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     Map<String, String> attributes = commits.getSegmentAttributes(1, "_0");
     assertTrue(attributes.size() > 0);
   }
 
-  @Test
   public void testGetSegmentAttributes_generation_notfound() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     Map<String, String> attributes = commits.getSegmentAttributes(3, "_0");
     assertTrue(attributes.isEmpty());
   }
 
-  @Test
   public void testGetSegmentAttributes_invalid_name() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     Map<String, String> attributes = commits.getSegmentAttributes(1, "xxx");
     assertTrue(attributes.isEmpty());
   }
 
-  @Test
   public void testGetSegmentDiagnostics() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     Map<String, String> diagnostics = commits.getSegmentDiagnostics(1, "_0");
     assertTrue(diagnostics.size() > 0);
   }
 
-  @Test
   public void testGetSegmentDiagnostics_generation_notfound() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     assertTrue(commits.getSegmentDiagnostics(10, "_0").isEmpty());
   }
 
-  @Test
   public void testGetSegmentDiagnostics_invalid_name() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     Map<String, String> diagnostics = commits.getSegmentDiagnostics(1, "xxx");
     assertTrue(diagnostics.isEmpty());
   }
 
-  @Test
   public void testSegmentCodec() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     Optional<Codec> codec = commits.getSegmentCodec(1, "_0");
     assertTrue(codec.isPresent());
   }
 
-  @Test
   public void testSegmentCodec_generation_notfound() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     Optional<Codec> codec = commits.getSegmentCodec(10, "_0");
     assertFalse(codec.isPresent());
   }
 
-  @Test
   public void testSegmentCodec_invalid_name() {
     CommitsImpl commits = new CommitsImpl(reader, indexDir.toString());
     Optional<Codec> codec = commits.getSegmentCodec(1, "xxx");

--- a/lucene/luke/src/test/org/apache/lucene/luke/models/documents/TestDocValuesAdapter.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/documents/TestDocValuesAdapter.java
@@ -31,7 +31,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
-import org.junit.Test;
 
 public class TestDocValuesAdapter extends DocumentsTestBase {
 
@@ -58,7 +57,6 @@ public class TestDocValuesAdapter extends DocumentsTestBase {
     dir.close();
   }
 
-  @Test
   public void testGetDocValues_binary() throws Exception {
     DocValuesAdapter adapterImpl = new DocValuesAdapter(reader);
     DocValues values =
@@ -68,7 +66,6 @@ public class TestDocValuesAdapter extends DocumentsTestBase {
     assertEquals(Collections.emptyList(), values.getNumericValues());
   }
 
-  @Test
   public void testGetDocValues_sorted() throws Exception {
     DocValuesAdapter adapterImpl = new DocValuesAdapter(reader);
     DocValues values =
@@ -78,7 +75,6 @@ public class TestDocValuesAdapter extends DocumentsTestBase {
     assertEquals(Collections.emptyList(), values.getNumericValues());
   }
 
-  @Test
   public void testGetDocValues_sorted_set() throws Exception {
     DocValuesAdapter adapterImpl = new DocValuesAdapter(reader);
     DocValues values =
@@ -89,7 +85,6 @@ public class TestDocValuesAdapter extends DocumentsTestBase {
     assertEquals(Collections.emptyList(), values.getNumericValues());
   }
 
-  @Test
   public void testGetDocValues_numeric() throws Exception {
     DocValuesAdapter adapterImpl = new DocValuesAdapter(reader);
     DocValues values =
@@ -99,7 +94,6 @@ public class TestDocValuesAdapter extends DocumentsTestBase {
     assertEquals(42L, values.getNumericValues().get(0).longValue());
   }
 
-  @Test
   public void testGetDocValues_sorted_numeric() throws Exception {
     DocValuesAdapter adapterImpl = new DocValuesAdapter(reader);
     DocValues values =
@@ -110,7 +104,6 @@ public class TestDocValuesAdapter extends DocumentsTestBase {
     assertEquals(22L, values.getNumericValues().get(1).longValue());
   }
 
-  @Test
   public void testGetDocValues_notAvailable() throws Exception {
     DocValuesAdapter adapterImpl = new DocValuesAdapter(reader);
     assertFalse(adapterImpl.getDocValues(0, "no_dv").isPresent());

--- a/lucene/luke/src/test/org/apache/lucene/luke/models/documents/TestDocumentsImpl.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/documents/TestDocumentsImpl.java
@@ -25,9 +25,9 @@ import org.apache.lucene.luke.models.util.IndexUtils;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.NumericUtils;
-import org.junit.Test;
 
 // See: https://github.com/DmitryKey/luke/issues/133
+
 @LuceneTestCase.SuppressCodecs({
   "DummyCompressingStoredFieldsData",
   "HighCompressionCompressingStoredFieldsData",
@@ -36,19 +36,16 @@ import org.junit.Test;
 })
 public class TestDocumentsImpl extends DocumentsTestBase {
 
-  @Test
   public void testGetMaxDoc() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     assertEquals(5, documents.getMaxDoc());
   }
 
-  @Test
   public void testIsLive() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     assertTrue(documents.isLive(0));
   }
 
-  @Test
   public void testGetDocumentFields() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     List<DocumentField> fields = documents.getDocumentFields(0);
@@ -131,7 +128,6 @@ public class TestDocumentsImpl extends DocumentsTestBase {
     assertNull(f5.getNumericValue());
   }
 
-  @Test
   public void testFirstTerm() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     Term term = documents.firstTerm("title").orElseThrow(IllegalStateException::new);
@@ -139,14 +135,12 @@ public class TestDocumentsImpl extends DocumentsTestBase {
     assertEquals("a", term.text());
   }
 
-  @Test
   public void testFirstTerm_notAvailable() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     assertFalse(documents.firstTerm("subject").isPresent());
     assertNull(documents.getCurrentField());
   }
 
-  @Test
   public void testNextTerm() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     documents.firstTerm("title").orElseThrow(IllegalStateException::new);
@@ -158,13 +152,11 @@ public class TestDocumentsImpl extends DocumentsTestBase {
     }
   }
 
-  @Test
   public void testNextTerm_unPositioned() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     assertFalse(documents.nextTerm().isPresent());
   }
 
-  @Test
   public void testSeekTerm() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     documents.firstTerm("title").orElseThrow(IllegalStateException::new);
@@ -174,13 +166,11 @@ public class TestDocumentsImpl extends DocumentsTestBase {
     assertFalse(documents.seekTerm("x").isPresent());
   }
 
-  @Test
   public void testSeekTerm_unPositioned() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     assertFalse(documents.seekTerm("a").isPresent());
   }
 
-  @Test
   public void testFirstTermDoc() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     documents.firstTerm("title").orElseThrow(IllegalStateException::new);
@@ -189,13 +179,11 @@ public class TestDocumentsImpl extends DocumentsTestBase {
     assertTrue(documents.firstTermDoc().isPresent());
   }
 
-  @Test
   public void testFirstTermDoc_unPositioned() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     assertFalse(documents.firstTermDoc().isPresent());
   }
 
-  @Test
   public void testNextTermDoc() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     Term term = documents.firstTerm("title").orElseThrow(IllegalStateException::new);
@@ -208,14 +196,12 @@ public class TestDocumentsImpl extends DocumentsTestBase {
     assertFalse(documents.nextTermDoc().isPresent());
   }
 
-  @Test
   public void testNextTermDoc_unPositioned() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     documents.firstTerm("title").orElseThrow(IllegalStateException::new);
     assertFalse(documents.nextTermDoc().isPresent());
   }
 
-  @Test
   public void testTermPositions() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     documents.firstTerm("author").orElseThrow(IllegalStateException::new);
@@ -228,14 +214,12 @@ public class TestDocumentsImpl extends DocumentsTestBase {
     assertEquals(13, postings.get(0).getEndOffset());
   }
 
-  @Test
   public void testTermPositions_unPositioned() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     documents.firstTerm("author").orElseThrow(IllegalStateException::new);
     assertEquals(0, documents.getTermPositions().size());
   }
 
-  @Test
   public void testTermPositions_noPositions() {
     DocumentsImpl documents = new DocumentsImpl(reader);
     documents.firstTerm("title").orElseThrow(IllegalStateException::new);
@@ -243,7 +227,6 @@ public class TestDocumentsImpl extends DocumentsTestBase {
     assertEquals(0, documents.getTermPositions().size());
   }
 
-  @Test
   public void testClose() throws Exception {
     new DocumentsImpl(reader);
     reader.close();

--- a/lucene/luke/src/test/org/apache/lucene/luke/models/documents/TestTermVectorsAdapter.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/documents/TestTermVectorsAdapter.java
@@ -25,7 +25,6 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.junit.Test;
 
 public class TestTermVectorsAdapter extends DocumentsTestBase {
 
@@ -67,7 +66,6 @@ public class TestTermVectorsAdapter extends DocumentsTestBase {
     dir.close();
   }
 
-  @Test
   public void testGetTermVector() throws Exception {
     TermVectorsAdapter adapterImpl = new TermVectorsAdapter(reader);
     List<TermVectorEntry> tvEntries = adapterImpl.getTermVector(0, "text1");
@@ -129,7 +127,6 @@ public class TestTermVectorsAdapter extends DocumentsTestBase {
     assertEquals(1, tvEntries.get(17).getFreq());
   }
 
-  @Test
   public void testGetTermVector_with_positions() throws Exception {
     TermVectorsAdapter adapterImpl = new TermVectorsAdapter(reader);
     List<TermVectorEntry> tvEntries = adapterImpl.getTermVector(0, "text2");
@@ -143,7 +140,6 @@ public class TestTermVectorsAdapter extends DocumentsTestBase {
     assertFalse(tvEntries.get(1).getPositions().get(0).getEndOffset().isPresent());
   }
 
-  @Test
   public void testGetTermVector_with_positions_offsets() throws Exception {
     TermVectorsAdapter adapterImpl = new TermVectorsAdapter(reader);
     List<TermVectorEntry> tvEntries = adapterImpl.getTermVector(0, "text3");
@@ -157,7 +153,6 @@ public class TestTermVectorsAdapter extends DocumentsTestBase {
     assertEquals(38, tvEntries.get(1).getPositions().get(0).getEndOffset().orElse(-1));
   }
 
-  @Test
   public void testGetTermVectors_notAvailable() throws Exception {
     TermVectorsAdapter adapterImpl = new TermVectorsAdapter(reader);
     assertEquals(0, adapterImpl.getTermVector(0, "title").size());

--- a/lucene/luke/src/test/org/apache/lucene/luke/models/overview/TestOverviewImpl.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/overview/TestOverviewImpl.java
@@ -23,96 +23,80 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import org.apache.lucene.store.AlreadyClosedException;
-import org.junit.Test;
 
 public class TestOverviewImpl extends OverviewTestBase {
 
-  @Test
   public void testGetIndexPath() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     assertEquals(indexDir.toString(), overview.getIndexPath());
   }
 
-  @Test
   public void testGetNumFields() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     assertEquals(2, (long) overview.getNumFields());
   }
 
-  @Test
   public void testGetFieldNames() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     assertEquals(new HashSet<>(Arrays.asList("f1", "f2")), new HashSet<>(overview.getFieldNames()));
   }
 
-  @Test
   public void testGetNumDocuments() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     assertEquals(3, (long) overview.getNumDocuments());
   }
 
-  @Test
   public void testGetNumTerms() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     assertEquals(9, overview.getNumTerms());
   }
 
-  @Test
   public void testHasDeletions() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     assertFalse(overview.hasDeletions());
   }
 
-  @Test
   public void testGetNumDeletedDocs() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     assertEquals(0, (long) overview.getNumDeletedDocs());
   }
 
-  @Test
   public void testIsOptimized() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     assertTrue(overview.isOptimized().isPresent());
   }
 
-  @Test
   public void testGetIndexVersion() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     assertTrue(overview.getIndexVersion().orElseThrow(IllegalStateException::new) > 0);
   }
 
-  @Test
   public void testGetIndexFormat() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     assertEquals("Lucene 8.6 or later", overview.getIndexFormat().get());
   }
 
-  @Test
   public void testGetDirImpl() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     assertEquals(dir.getClass().getName(), overview.getDirImpl().get());
   }
 
-  @Test
   public void testGetCommitDescription() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     assertTrue(overview.getCommitDescription().isPresent());
   }
 
-  @Test
   public void testGetCommitUserData() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     assertTrue(overview.getCommitUserData().isPresent());
   }
 
-  @Test
   public void testGetSortedTermCounts() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     Map<String, Long> countsMap = overview.getSortedTermCounts(TermCountsOrder.COUNT_DESC);
     assertEquals(Arrays.asList("f2", "f1"), new ArrayList<>(countsMap.keySet()));
   }
 
-  @Test
   public void testGetTopTerms() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     List<TermStats> result = overview.getTopTerms("f2", 2);
@@ -121,13 +105,11 @@ public class TestOverviewImpl extends OverviewTestBase {
     assertEquals("f2", result.get(0).getField());
   }
 
-  @Test
   public void testGetTopTerms_illegal_numterms() {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     expectThrows(IllegalArgumentException.class, () -> overview.getTopTerms("f2", -1));
   }
 
-  @Test
   public void testClose() throws Exception {
     OverviewImpl overview = new OverviewImpl(reader, indexDir.toString());
     reader.close();

--- a/lucene/luke/src/test/org/apache/lucene/luke/models/overview/TestTermCounts.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/overview/TestTermCounts.java
@@ -20,17 +20,14 @@ package org.apache.lucene.luke.models.overview;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
-import org.junit.Test;
 
 public class TestTermCounts extends OverviewTestBase {
 
-  @Test
   public void testNumTerms() throws Exception {
     TermCounts termCounts = new TermCounts(reader);
     assertEquals(9, termCounts.numTerms());
   }
 
-  @Test
   @SuppressWarnings("unchecked")
   public void testSortedTermCounts_count_asc() throws Exception {
     TermCounts termCounts = new TermCounts(reader);
@@ -42,7 +39,6 @@ public class TestTermCounts extends OverviewTestBase {
     assertEquals(6, (long) countsMap.get("f2"));
   }
 
-  @Test
   @SuppressWarnings("unchecked")
   public void testSortedTermCounts_count_desc() throws Exception {
     TermCounts termCounts = new TermCounts(reader);
@@ -54,7 +50,6 @@ public class TestTermCounts extends OverviewTestBase {
     assertEquals(6, (long) countsMap.get("f2"));
   }
 
-  @Test
   @SuppressWarnings("unchecked")
   public void testSortedTermCounts_name_asc() throws Exception {
     TermCounts termCounts = new TermCounts(reader);
@@ -66,7 +61,6 @@ public class TestTermCounts extends OverviewTestBase {
     assertEquals(6, (long) countsMap.get("f2"));
   }
 
-  @Test
   @SuppressWarnings("unchecked")
   public void testSortedTermCounts_name_desc() throws Exception {
     TermCounts termCounts = new TermCounts(reader);

--- a/lucene/luke/src/test/org/apache/lucene/luke/models/overview/TestTopTerms.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/overview/TestTopTerms.java
@@ -18,11 +18,9 @@
 package org.apache.lucene.luke.models.overview;
 
 import java.util.List;
-import org.junit.Test;
 
 public class TestTopTerms extends OverviewTestBase {
 
-  @Test
   public void testGetTopTerms() throws Exception {
     TopTerms topTerms = new TopTerms(reader);
     List<TermStats> result = topTerms.getTopTerms("f2", 2);

--- a/lucene/luke/src/test/org/apache/lucene/luke/models/search/TestSearchImpl.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/search/TestSearchImpl.java
@@ -49,7 +49,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
-import org.junit.Test;
 
 public class TestSearchImpl extends LuceneTestCase {
 
@@ -154,7 +153,6 @@ public class TestSearchImpl extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testGetSortableFieldNames() {
     SearchImpl search = new SearchImpl(reader);
     assertArrayEquals(
@@ -162,20 +160,17 @@ public class TestSearchImpl extends LuceneTestCase {
         search.getSortableFieldNames().toArray());
   }
 
-  @Test
   public void testGetSearchableFieldNames() {
     SearchImpl search = new SearchImpl(reader);
     assertArrayEquals(new String[] {"f1"}, search.getSearchableFieldNames().toArray());
   }
 
-  @Test
   public void testGetRangeSearchableFieldNames() {
     SearchImpl search = new SearchImpl(reader);
     assertArrayEquals(
         new String[] {"f8", "f9", "f10", "f11"}, search.getRangeSearchableFieldNames().toArray());
   }
 
-  @Test
   public void testParseClassic() {
     SearchImpl search = new SearchImpl(reader);
     QueryParserConfig config =
@@ -188,7 +183,6 @@ public class TestSearchImpl extends LuceneTestCase {
     assertEquals("+f1:app~1 +f2:*ie", q.toString());
   }
 
-  @Test
   public void testParsePointRange() {
     SearchImpl search = new SearchImpl(reader);
     Map<String, Class<? extends Number>> types = new HashMap<>();
@@ -201,7 +195,6 @@ public class TestSearchImpl extends LuceneTestCase {
     assertTrue(q instanceof PointRangeQuery);
   }
 
-  @Test
   public void testGuessSortTypes() {
     SearchImpl search = new SearchImpl(reader);
 
@@ -254,13 +247,11 @@ public class TestSearchImpl extends LuceneTestCase {
         search.guessSortTypes("f7").toArray());
   }
 
-  @Test
   public void testGuessSortTypesNoSuchField() {
     SearchImpl search = new SearchImpl(reader);
     expectThrows(LukeException.class, () -> search.guessSortTypes("unknown"));
   }
 
-  @Test
   public void testGetSortType() {
     SearchImpl search = new SearchImpl(reader);
 
@@ -295,13 +286,11 @@ public class TestSearchImpl extends LuceneTestCase {
     assertFalse(search.getSortType("f7", "STRING", false).isPresent());
   }
 
-  @Test
   public void testGetSortTypeNoSuchField() {
     SearchImpl search = new SearchImpl(reader);
     expectThrows(LukeException.class, () -> search.getSortType("unknown", "STRING", false));
   }
 
-  @Test
   public void testSearch() throws Exception {
     SearchImpl search = new SearchImpl(reader);
     Query query = new QueryParser("f1", new StandardAnalyzer()).parse("apple");
@@ -313,7 +302,6 @@ public class TestSearchImpl extends LuceneTestCase {
     assertEquals(0, res.getOffset());
   }
 
-  @Test
   public void testSearchWithSort() throws Exception {
     SearchImpl search = new SearchImpl(reader);
     Query query = new QueryParser("f1", new StandardAnalyzer()).parse("apple");
@@ -326,7 +314,6 @@ public class TestSearchImpl extends LuceneTestCase {
     assertEquals(0, res.getOffset());
   }
 
-  @Test
   public void testNextPage() throws Exception {
     SearchImpl search = new SearchImpl(reader);
     Query query = new QueryParser("f1", new StandardAnalyzer()).parse("pie");
@@ -340,13 +327,11 @@ public class TestSearchImpl extends LuceneTestCase {
     assertEquals(10, res.getOffset());
   }
 
-  @Test
   public void testNextPageSearchNotStarted() {
     SearchImpl search = new SearchImpl(reader);
     expectThrows(LukeException.class, () -> search.nextPage());
   }
 
-  @Test
   public void testNextPageNoMoreResults() throws Exception {
     SearchImpl search = new SearchImpl(reader);
     Query query = new QueryParser("f1", new StandardAnalyzer()).parse("pie");
@@ -355,7 +340,6 @@ public class TestSearchImpl extends LuceneTestCase {
     assertFalse(search.nextPage().isPresent());
   }
 
-  @Test
   public void testPrevPage() throws Exception {
     SearchImpl search = new SearchImpl(reader);
     Query query = new QueryParser("f1", new StandardAnalyzer()).parse("pie");
@@ -370,13 +354,11 @@ public class TestSearchImpl extends LuceneTestCase {
     assertEquals(0, res.getOffset());
   }
 
-  @Test
   public void testPrevPageSearchNotStarted() {
     SearchImpl search = new SearchImpl(reader);
     expectThrows(LukeException.class, () -> search.prevPage());
   }
 
-  @Test
   public void testPrevPageNoMoreResults() throws Exception {
     SearchImpl search = new SearchImpl(reader);
     Query query = new QueryParser("f1", new StandardAnalyzer()).parse("pie");

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestDocumentBatch.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestDocumentBatch.java
@@ -25,13 +25,11 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.hamcrest.MatcherAssert;
-import org.junit.Test;
 
 public class TestDocumentBatch extends LuceneTestCase {
 
   public static final Analyzer ANALYZER = new StandardAnalyzer();
 
-  @Test
   public void testDocumentBatchThrowsIllegalArgumentExceptionUponZeroDocument() {
     expectThrows(
         IllegalArgumentException.class,

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestDocumentBatch.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestDocumentBatch.java
@@ -31,9 +31,13 @@ public class TestDocumentBatch extends LuceneTestCase {
 
   public static final Analyzer ANALYZER = new StandardAnalyzer();
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDocumentBatchThrowsIllegalArgumentExceptionUponZeroDocument() {
-    DocumentBatch.of(ANALYZER);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          DocumentBatch.of(ANALYZER);
+        });
   }
 
   public void testSingleDocumentAndArrayOfOneDocumentResultInSameDocumentBatch()

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestMonitorReadonly.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestMonitorReadonly.java
@@ -30,12 +30,10 @@ import org.apache.lucene.index.IndexNotFoundException;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.FSDirectory;
-import org.junit.Test;
 
 public class TestMonitorReadonly extends MonitorTestBase {
   private static final Analyzer ANALYZER = new WhitespaceAnalyzer();
 
-  @Test
   public void testReadonlyMonitorThrowsOnInexistentIndex() {
     Path indexDirectory = createTempDir();
     MonitorConfiguration config =
@@ -51,7 +49,6 @@ public class TestMonitorReadonly extends MonitorTestBase {
         });
   }
 
-  @Test
   public void testReadonlyMonitorThrowsWhenCallingWriteRequests() throws IOException {
     Path indexDirectory = createTempDir();
     MonitorConfiguration writeConfig =
@@ -92,7 +89,6 @@ public class TestMonitorReadonly extends MonitorTestBase {
     }
   }
 
-  @Test
   public void testSettingCustomDirectory() throws IOException {
     Path indexDirectory = createTempDir();
     Document doc = new Document();
@@ -118,7 +114,6 @@ public class TestMonitorReadonly extends MonitorTestBase {
     }
   }
 
-  @Test
   public void testMonitorReadOnlyCouldReadOnTheSameIndex() throws IOException {
     Path indexDirectory = createTempDir();
     Document doc = new Document();
@@ -166,7 +161,6 @@ public class TestMonitorReadonly extends MonitorTestBase {
     }
   }
 
-  @Test
   public void testReadonlyMonitorGetsRefreshed() throws IOException, InterruptedException {
     Path indexDirectory = createTempDir();
     Document doc = new Document();

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/outsidepackage/TestCandidateMatcherVisibility.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/outsidepackage/TestCandidateMatcherVisibility.java
@@ -25,7 +25,6 @@ import org.apache.lucene.monitor.CandidateMatcher;
 import org.apache.lucene.monitor.QueryMatch;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TermQuery;
-import org.junit.Test;
 
 public class TestCandidateMatcherVisibility {
 
@@ -36,7 +35,6 @@ public class TestCandidateMatcherVisibility {
     return QueryMatch.SIMPLE_MATCHER.createMatcher(searcher);
   }
 
-  @Test
   public void testMatchQueryVisibleOutsidePackage() throws IOException {
     CandidateMatcher<QueryMatch> matcher = newCandidateMatcher();
     // This should compile from outside org.apache.lucene.monitor package
@@ -45,7 +43,6 @@ public class TestCandidateMatcherVisibility {
     matcher.matchQuery("test", new TermQuery(new Term("test_field")), Collections.emptyMap());
   }
 
-  @Test
   public void testReportErrorVisibleOutsidePackage() {
     CandidateMatcher<QueryMatch> matcher = newCandidateMatcher();
     // This should compile from outside org.apache.lucene.monitor package
@@ -54,7 +51,6 @@ public class TestCandidateMatcherVisibility {
     matcher.reportError("test", new RuntimeException("test exception"));
   }
 
-  @Test
   public void testFinishVisibleOutsidePackage() {
     CandidateMatcher<QueryMatch> matcher = newCandidateMatcher();
     // This should compile from outside org.apache.lucene.monitor package

--- a/lucene/queries/src/test/org/apache/lucene/queries/TestCommonTermsQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/TestCommonTermsQuery.java
@@ -54,7 +54,6 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.PriorityQueue;
-import org.junit.Test;
 
 public class TestCommonTermsQuery extends LuceneTestCase {
 
@@ -356,7 +355,6 @@ public class TestCommonTermsQuery extends LuceneTestCase {
         });
   }
 
-  @Test
   public void testExtend() throws IOException {
     Directory dir = newDirectory();
     MockAnalyzer analyzer = new MockAnalyzer(random());

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestFieldScoreQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestFieldScoreQuery.java
@@ -24,7 +24,6 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.tests.search.QueryUtils;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 /**
  * Test FieldScoreQuery search.
@@ -44,25 +43,21 @@ public class TestFieldScoreQuery extends FunctionTestSetup {
   }
 
   /** Test that FieldScoreQuery of Type.INT returns docs in expected order. */
-  @Test
   public void testRankInt() throws Exception {
     doTestRank(INT_VALUESOURCE);
   }
 
-  @Test
   public void testRankIntMultiValued() throws Exception {
     doTestRank(INT_MV_MAX_VALUESOURCE);
     doTestRank(INT_MV_MIN_VALUESOURCE);
   }
 
   /** Test that FieldScoreQuery of Type.FLOAT returns docs in expected order. */
-  @Test
   public void testRankFloat() throws Exception {
     // same values, but in flot format
     doTestRank(FLOAT_VALUESOURCE);
   }
 
-  @Test
   public void testRankFloatMultiValued() throws Exception {
     // same values, but in flot format
     doTestRank(FLOAT_MV_MAX_VALUESOURCE);
@@ -91,25 +86,21 @@ public class TestFieldScoreQuery extends FunctionTestSetup {
   }
 
   /** Test that FieldScoreQuery of Type.INT returns the expected scores. */
-  @Test
   public void testExactScoreInt() throws Exception {
     doTestExactScore(INT_VALUESOURCE);
   }
 
-  @Test
   public void testExactScoreIntMultiValued() throws Exception {
     doTestExactScore(INT_MV_MAX_VALUESOURCE);
     doTestExactScore(INT_MV_MIN_VALUESOURCE);
   }
 
   /** Test that FieldScoreQuery of Type.FLOAT returns the expected scores. */
-  @Test
   public void testExactScoreFloat() throws Exception {
     // same values, but in flot format
     doTestExactScore(FLOAT_VALUESOURCE);
   }
 
-  @Test
   public void testExactScoreFloatMultiValued() throws Exception {
     // same values, but in flot format
     doTestExactScore(FLOAT_MV_MAX_VALUESOURCE);

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestFunctionRangeQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestFunctionRangeQuery.java
@@ -31,7 +31,6 @@ import org.apache.lucene.search.TopDocs;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestFunctionRangeQuery extends FunctionTestSetup {
 
@@ -54,23 +53,19 @@ public class TestFunctionRangeQuery extends FunctionTestSetup {
     indexReader.close();
   }
 
-  @Test
   public void testRangeInt() throws IOException {
     doTestRange(INT_VALUESOURCE);
   }
 
-  @Test
   public void testRangeIntMultiValued() throws IOException {
     doTestRange(INT_MV_MAX_VALUESOURCE);
     doTestRange(INT_MV_MIN_VALUESOURCE);
   }
 
-  @Test
   public void testRangeFloat() throws IOException {
     doTestRange(FLOAT_VALUESOURCE);
   }
 
-  @Test
   public void testRangeFloatMultiValued() throws IOException {
     doTestRange(FLOAT_MV_MAX_VALUESOURCE);
     doTestRange(FLOAT_MV_MIN_VALUESOURCE);
@@ -86,12 +81,10 @@ public class TestFunctionRangeQuery extends FunctionTestSetup {
     expectScores(scoreDocs, 4, 3);
   }
 
-  @Test
   public void testDeleted() throws IOException {
     doTestDeleted(INT_VALUESOURCE);
   }
 
-  @Test
   public void testDeletedMultiValued() throws IOException {
     doTestDeleted(INT_MV_MAX_VALUESOURCE);
     doTestDeleted(INT_MV_MIN_VALUESOURCE);
@@ -117,7 +110,6 @@ public class TestFunctionRangeQuery extends FunctionTestSetup {
     }
   }
 
-  @Test
   public void testExplain() throws IOException {
     Query rangeQuery = new FunctionRangeQuery(INT_VALUESOURCE, 2, 2, true, true);
     ScoreDoc[] scoreDocs = indexSearcher.search(rangeQuery, N_DOCS).scoreDocs;
@@ -128,7 +120,6 @@ public class TestFunctionRangeQuery extends FunctionTestSetup {
         explain.toString());
   }
 
-  @Test
   public void testExplainMultiValued() throws IOException {
     Query rangeQuery = new FunctionRangeQuery(INT_MV_MIN_VALUESOURCE, 2, 2, true, true);
     ScoreDoc[] scoreDocs = indexSearcher.search(rangeQuery, N_DOCS).scoreDocs;
@@ -144,7 +135,6 @@ public class TestFunctionRangeQuery extends FunctionTestSetup {
         explain.toString());
   }
 
-  @Test
   public void testTwoRangeQueries() throws IOException {
     Query rq1 = new FunctionRangeQuery(INT_VALUESOURCE, 2, 4, true, true);
     Query rq2 = new FunctionRangeQuery(INT_VALUESOURCE, 8, 10, true, true);

--- a/lucene/queries/src/test/org/apache/lucene/queries/payloads/TestPayloadScoreQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/payloads/TestPayloadScoreQuery.java
@@ -49,7 +49,6 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class TestPayloadScoreQuery extends LuceneTestCase {
 
@@ -94,7 +93,6 @@ public class TestPayloadScoreQuery extends LuceneTestCase {
     QueryUtils.check(random(), psq, searcher);
   }
 
-  @Test
   public void testTermQuery() throws IOException {
 
     SpanTermQuery q = new SpanTermQuery(new Term("field", "eighteen"));
@@ -106,7 +104,6 @@ public class TestPayloadScoreQuery extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testOrQuery() throws IOException {
 
     SpanOrQuery q =
@@ -125,7 +122,6 @@ public class TestPayloadScoreQuery extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testNearQuery() throws IOException {
 
     //   2     4
@@ -152,7 +148,6 @@ public class TestPayloadScoreQuery extends LuceneTestCase {
 
   // TODO: incredibly slow
   @Nightly
-  @Test
   public void testNestedNearQuery() throws Exception {
 
     // (one OR hundred) NEAR (twenty two) ~ 1
@@ -212,7 +207,6 @@ public class TestPayloadScoreQuery extends LuceneTestCase {
 
   // TODO: incredibly slow
   @Nightly
-  @Test
   public void testSpanContainingQuery() throws Exception {
 
     // twenty WITHIN ((one OR hundred) NEAR two)~2
@@ -235,7 +229,6 @@ public class TestPayloadScoreQuery extends LuceneTestCase {
     checkQuery(q, new MinPayloadFunction(), new int[] {222, 122}, new float[] {4.0f, 2.0f});
   }
 
-  @Test
   public void testEquality() {
     SpanQuery sq1 = new SpanTermQuery(new Term("field", "one"));
     SpanQuery sq2 = new SpanTermQuery(new Term("field", "two"));

--- a/lucene/queries/src/test/org/apache/lucene/queries/spans/TestFilterSpans.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/spans/TestFilterSpans.java
@@ -18,11 +18,9 @@ package org.apache.lucene.queries.spans;
 
 import java.lang.reflect.Method;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestFilterSpans extends LuceneTestCase {
 
-  @Test
   public void testOverrides() throws Exception {
     // verify that all methods of Spans are overridden by FilterSpans,
     for (Method m : FilterSpans.class.getMethods()) {

--- a/lucene/queries/src/test/org/apache/lucene/queries/spans/TestSpanCollection.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/spans/TestSpanCollection.java
@@ -32,7 +32,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestSpanCollection extends LuceneTestCase {
 
@@ -104,7 +103,6 @@ public class TestSpanCollection extends LuceneTestCase {
     assertEquals("Unexpected terms found", expectedTerms.length, collector.terms.size());
   }
 
-  @Test
   public void testNestedNearQuery() throws IOException {
 
     // near(w1, near(w2, or(w3, w4)))
@@ -136,7 +134,6 @@ public class TestSpanCollection extends LuceneTestCase {
         spans, collector, new Term(FIELD, "w1"), new Term(FIELD, "w2"), new Term(FIELD, "w3"));
   }
 
-  @Test
   public void testOrQuery() throws IOException {
     SpanTermQuery q2 = new SpanTermQuery(new Term(FIELD, "w2"));
     SpanTermQuery q3 = new SpanTermQuery(new Term(FIELD, "w3"));
@@ -165,7 +162,6 @@ public class TestSpanCollection extends LuceneTestCase {
     checkCollectedTerms(spans, collector, new Term(FIELD, "w3"));
   }
 
-  @Test
   public void testSpanNotQuery() throws IOException {
 
     SpanTermQuery q1 = new SpanTermQuery(new Term(FIELD, "w1"));

--- a/lucene/queries/src/test/org/apache/lucene/queries/spans/TestSpanMultiTermQueryWrapper.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/spans/TestSpanMultiTermQueryWrapper.java
@@ -30,7 +30,6 @@ import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /** Tests for {@link SpanMultiTermQueryWrapper}, wrapping a few MultiTermQueries. */
 public class TestSpanMultiTermQueryWrapper extends LuceneTestCase {
@@ -223,7 +222,6 @@ public class TestSpanMultiTermQueryWrapper extends LuceneTestCase {
     assertEquals(0, searcher.count(spanFirst));
   }
 
-  @Test
   public void testWrappedQueryIsNotModified() {
     final PrefixQuery pq = new PrefixQuery(new Term("field", "test"));
     int pqHash = pq.hashCode();

--- a/lucene/queries/src/test/org/apache/lucene/queries/spans/TestSpanWithinQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/spans/TestSpanWithinQuery.java
@@ -29,7 +29,6 @@ import org.apache.lucene.tests.search.QueryUtils;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 /** Basic tests for SpanWithinQuery */
 public class TestSpanWithinQuery extends LuceneTestCase {
@@ -118,7 +117,6 @@ public class TestSpanWithinQuery extends LuceneTestCase {
     check(query, expectedDocs);
   }
 
-  @Test
   public void testDifferentFieldsThrowsIllegalArgumentException() {
     SpanQuery big = new SpanTermQuery(new Term("field1", "one"));
     SpanQuery little = new SpanTermQuery(new Term("field2", "two"));

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/core/builders/TestQueryTreeBuilder.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/core/builders/TestQueryTreeBuilder.java
@@ -23,11 +23,9 @@ import org.apache.lucene.queryparser.flexible.core.nodes.QueryNodeImpl;
 import org.apache.lucene.queryparser.flexible.core.parser.EscapeQuerySyntax;
 import org.apache.lucene.queryparser.flexible.core.util.UnescapedCharSequence;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestQueryTreeBuilder extends LuceneTestCase {
 
-  @Test
   public void testSetFieldBuilder() throws QueryNodeException {
     QueryTreeBuilder qtb = new QueryTreeBuilder();
     qtb.setBuilder("field", new DummyBuilder());

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/core/util/TestUnescapedCharSequence.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/core/util/TestUnescapedCharSequence.java
@@ -18,12 +18,10 @@ package org.apache.lucene.queryparser.flexible.core.util;
 
 import java.util.Locale;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestUnescapedCharSequence extends LuceneTestCase {
   private static final char[] wildcardChars = {'*', '?'};
 
-  @Test
   public void testToStringEscaped() {
     char[] chars = {'a', 'b', 'c', '\\', 'e'};
     boolean[] wasEscaped = {false, true, true, false, false};
@@ -33,7 +31,6 @@ public class TestUnescapedCharSequence extends LuceneTestCase {
     assertTrue(sequence.wasEscaped(1));
   }
 
-  @Test
   public void testToStringEscapedWithEnabledChars() {
     char[] chars = {'a', 'b', 'c', '?', '*'};
     boolean[] wasEscaped = {true, true, true, true, true};
@@ -41,13 +38,11 @@ public class TestUnescapedCharSequence extends LuceneTestCase {
     assertEquals("abc\\?\\*", sequence.toStringEscaped(wildcardChars));
   }
 
-  @Test
   public void testSubSequence() {
     UnescapedCharSequence sequence = new UnescapedCharSequence("abcdef");
     assertEquals("bc", sequence.subSequence(1, 3).toString());
   }
 
-  @Test
   public void testToLowerCase() {
     UnescapedCharSequence sequence = new UnescapedCharSequence("ABC");
     assertEquals(

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestStandardQPEnhancements.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestStandardQPEnhancements.java
@@ -31,7 +31,6 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Test;
 
 /** Test interval sub-query support in {@link StandardQueryParser}. */
 public class TestStandardQPEnhancements extends LuceneTestCase {
@@ -53,7 +52,6 @@ public class TestStandardQPEnhancements extends LuceneTestCase {
     return qp;
   }
 
-  @Test
   public void testMinShouldMatchOperator() throws Exception {
     Query parsed =
         parsedQuery(
@@ -68,42 +66,34 @@ public class TestStandardQPEnhancements extends LuceneTestCase {
         ((BooleanQuery) parsed).getMinimumNumberShouldMatch(), Matchers.equalTo(2));
   }
 
-  @Test
   public void testAtLeast() throws Exception {
     checkIntervalQueryNode("fn:atleast(3 FOO BAR baz)");
   }
 
-  @Test
   public void testMaxWidth() throws Exception {
     checkIntervalQueryNode("fn:maxwidth(3 fn:atleast(2 foo bar baz))");
   }
 
-  @Test
   public void testQuotedTerm() throws Exception {
     checkIntervalQueryNode("fn:atleast(2 \"foo\" \"BAR baz\")");
   }
 
-  @Test
   public void testMaxGaps() throws Exception {
     checkIntervalQueryNode("fn:maxgaps(2 fn:unordered(foo BAR baz))");
   }
 
-  @Test
   public void testOrdered() throws Exception {
     checkIntervalQueryNode("fn:ordered(foo BAR baz)");
   }
 
-  @Test
   public void testUnordered() throws Exception {
     checkIntervalQueryNode("fn:unordered(foo BAR baz)");
   }
 
-  @Test
   public void testOr() throws Exception {
     checkIntervalQueryNode("fn:or(foo baz)");
   }
 
-  @Test
   public void testWildcard() throws Exception {
     checkIntervalQueryNode("fn:wildcard(foo*)");
 
@@ -111,72 +101,58 @@ public class TestStandardQPEnhancements extends LuceneTestCase {
     checkIntervalQueryNode("fn:wildcard(foo* 128)");
   }
 
-  @Test
   public void testPhrase() throws Exception {
     checkIntervalQueryNode("fn:phrase(abc def fn:or(baz boo))");
   }
 
-  @Test
   public void testBefore() throws Exception {
     checkIntervalQueryNode("fn:before(abc fn:ordered(foo bar))");
   }
 
-  @Test
   public void testAfter() throws Exception {
     checkIntervalQueryNode("fn:after(abc fn:ordered(foo bar))");
   }
 
-  @Test
   public void testContaining() throws Exception {
     checkIntervalQueryNode("fn:containing(big small)");
   }
 
-  @Test
   public void testContainedBy() throws Exception {
     checkIntervalQueryNode("fn:containedBy(small big)");
   }
 
-  @Test
   public void testNotContaining() throws Exception {
     checkIntervalQueryNode("fn:notContaining(minuend subtrahend)");
   }
 
-  @Test
   public void testNotContainedBy() throws Exception {
     checkIntervalQueryNode("fn:notContainedBy(small big)");
   }
 
-  @Test
   public void testWithin() throws Exception {
     checkIntervalQueryNode("fn:within(small 2 fn:ordered(big foo))");
   }
 
-  @Test
   public void testNotWithin() throws Exception {
     checkIntervalQueryNode("fn:notWithin(small 2 fn:ordered(big foo))");
   }
 
-  @Test
   public void testOverlapping() throws Exception {
     checkIntervalQueryNode("fn:overlapping(fn:ordered(big foo) small)");
   }
 
-  @Test
   public void testNonOverlapping() throws Exception {
     checkIntervalQueryNode("fn:nonOverlapping(fn:ordered(big foo) small)");
   }
 
-  @Test
   public void testUnorderedNoOverlaps() throws Exception {
     checkIntervalQueryNode("fn:unorderedNoOverlaps(fn:ordered(big foo) small)");
   }
 
-  @Test
   public void testExtend() throws Exception {
     checkIntervalQueryNode("fn:extend(fn:ordered(big foo) 2 5)");
   }
 
-  @Test
   public void testFuzzy() throws Exception {
     checkIntervalQueryNode("fn:fuzzyTerm(dfe)");
     // Explicit maxEdits

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/surround/query/TestSrndQuery.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/surround/query/TestSrndQuery.java
@@ -20,7 +20,6 @@ import org.apache.lucene.queryparser.surround.parser.QueryParser;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.tests.search.QueryUtils;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /** */
 public class TestSrndQuery extends LuceneTestCase {
@@ -34,7 +33,6 @@ public class TestSrndQuery extends LuceneTestCase {
     QueryUtils.checkEqual(lq1, lq2);
   }
 
-  @Test
   public void testHashEquals() throws Exception {
     // grab some sample queries from Test02Boolean and Test03Distance and
     // check there hashes and equals

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestDistanceStrategy.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestDistanceStrategy.java
@@ -30,7 +30,6 @@ import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.apache.lucene.spatial.serialized.SerializedDVStrategy;
 import org.apache.lucene.spatial.vector.PointVectorStrategy;
 import org.apache.lucene.util.ArrayUtil;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.Shape;
@@ -79,7 +78,6 @@ public class TestDistanceStrategy extends StrategyTestCase {
     this.strategy = strategy;
   }
 
-  @Test
   public void testDistanceOrder() throws IOException {
     ShapeFactory shapeFactory = ctx.getShapeFactory();
     adoc("100", shapeFactory.pointXY(2, 1));
@@ -91,7 +89,6 @@ public class TestDistanceStrategy extends StrategyTestCase {
     checkDistValueSource(shapeFactory.pointXY(0, 4), 3.6043684f, 0.9975641f, 180f);
   }
 
-  @Test
   public void testRecipScore() throws IOException {
     Point p100 = ctx.getShapeFactory().pointXY(2.02, 0.98);
     adoc("100", p100);

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestPortedSolr3.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestPortedSolr3.java
@@ -30,7 +30,6 @@ import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.apache.lucene.spatial.query.SpatialArgs;
 import org.apache.lucene.spatial.query.SpatialOperation;
 import org.apache.lucene.spatial.vector.PointVectorStrategy;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.distance.DistanceUtils;
 import org.locationtech.spatial4j.shape.Point;
@@ -95,7 +94,6 @@ public class TestPortedSolr3 extends StrategyTestCase {
     commit();
   }
 
-  @Test
   public void testIntersections() throws Exception {
     setupDocs();
     // Try some edge cases

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestQueryEqualsHashCode.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestQueryEqualsHashCode.java
@@ -30,7 +30,6 @@ import org.apache.lucene.spatial.query.SpatialOperation;
 import org.apache.lucene.spatial.serialized.SerializedDVStrategy;
 import org.apache.lucene.spatial.vector.PointVectorStrategy;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.shape.Shape;
 
@@ -40,7 +39,6 @@ public class TestQueryEqualsHashCode extends LuceneTestCase {
 
   private SpatialOperation predicate;
 
-  @Test
   public void testEqualsHashCode() {
 
     switch (random().nextInt(4)) { // 0-3

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestTestFramework.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/TestTestFramework.java
@@ -32,7 +32,6 @@ import org.locationtech.spatial4j.shape.Rectangle;
 /** Make sure we are reading the tests as expected */
 public class TestTestFramework extends LuceneTestCase {
 
-  @Test
   public void testQueries() throws IOException {
     String name = StrategyTestCase.QTEST_Cities_Intersects_BBox;
 

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/bbox/TestBBoxStrategy.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/bbox/TestBBoxStrategy.java
@@ -26,7 +26,6 @@ import org.apache.lucene.spatial.query.SpatialArgs;
 import org.apache.lucene.spatial.query.SpatialOperation;
 import org.apache.lucene.spatial.util.ShapeAreaValueSource;
 import org.junit.Ignore;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.context.SpatialContextFactory;
 import org.locationtech.spatial4j.distance.DistanceUtils;
@@ -80,7 +79,6 @@ public class TestBBoxStrategy extends RandomSpatialOpStrategyTestCase {
     return randomIndexedShape();
   }
 
-  @Test
   public void testOperations() throws IOException {
     // setup
     if (random().nextInt(4) > 0) { // 75% of the time choose geo (more interesting to test)
@@ -107,7 +105,6 @@ public class TestBBoxStrategy extends RandomSpatialOpStrategyTestCase {
     }
   }
 
-  @Test
   public void testIntersectsBugDatelineEdge() throws IOException {
     setupGeo();
     testOperation(
@@ -117,7 +114,6 @@ public class TestBBoxStrategy extends RandomSpatialOpStrategyTestCase {
         true);
   }
 
-  @Test
   public void testIntersectsWorldDatelineEdge() throws IOException {
     setupGeo();
     testOperation(
@@ -127,7 +123,6 @@ public class TestBBoxStrategy extends RandomSpatialOpStrategyTestCase {
         true);
   }
 
-  @Test
   public void testWithinBugDatelineEdge() throws IOException {
     setupGeo();
     testOperation(
@@ -137,7 +132,6 @@ public class TestBBoxStrategy extends RandomSpatialOpStrategyTestCase {
         true);
   }
 
-  @Test
   public void testContainsBugDatelineEdge() throws IOException {
     setupGeo();
     testOperation(
@@ -147,7 +141,6 @@ public class TestBBoxStrategy extends RandomSpatialOpStrategyTestCase {
         true);
   }
 
-  @Test
   public void testWorldContainsXDL() throws IOException {
     setupGeo();
     testOperation(
@@ -158,7 +151,6 @@ public class TestBBoxStrategy extends RandomSpatialOpStrategyTestCase {
   }
 
   /** See https://github.com/spatial4j/spatial4j/issues/85 */
-  @Test
   public void testAlongDatelineOppositeSign() throws IOException {
     // Due to Spatial4j bug #85, we can't simply do:
     //    testOperation(indexedShape,
@@ -189,7 +181,6 @@ public class TestBBoxStrategy extends RandomSpatialOpStrategyTestCase {
 
   // OLD STATIC TESTS (worthless?)
 
-  @Test
   @Ignore("Overlaps not supported")
   public void testBasicOperaions() throws IOException {
     setupGeo();
@@ -198,7 +189,6 @@ public class TestBBoxStrategy extends RandomSpatialOpStrategyTestCase {
     executeQueries(SpatialMatchConcern.EXACT, QTEST_Simple_Queries_BBox);
   }
 
-  @Test
   public void testStatesBBox() throws IOException {
     setupGeo();
     getAddAndVerifyIndexedDocuments(DATA_STATES_BBOX);
@@ -207,7 +197,6 @@ public class TestBBoxStrategy extends RandomSpatialOpStrategyTestCase {
     executeQueries(SpatialMatchConcern.FILTER, QTEST_States_Intersects_BBox);
   }
 
-  @Test
   public void testCitiesIntersectsBBox() throws IOException {
     setupGeo();
     getAddAndVerifyIndexedDocuments(DATA_WORLD_CITIES_POINTS);

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/composite/TestCompositeStrategy.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/composite/TestCompositeStrategy.java
@@ -28,7 +28,6 @@ import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.apache.lucene.spatial.query.SpatialOperation;
 import org.apache.lucene.spatial.serialized.SerializedDVStrategy;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.context.SpatialContextFactory;
 import org.locationtech.spatial4j.shape.Point;
@@ -71,7 +70,6 @@ public class TestCompositeStrategy extends RandomSpatialOpStrategyTestCase {
     return rpt;
   }
 
-  @Test
   public void testOperations() throws IOException {
     // setup
     if (randomBoolean()) {

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestDateNRStrategy.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestDateNRStrategy.java
@@ -26,7 +26,6 @@ import org.apache.lucene.spatial.prefix.tree.DateRangePrefixTree;
 import org.apache.lucene.spatial.prefix.tree.NumberRangePrefixTree.UnitNRShape;
 import org.apache.lucene.spatial.query.SpatialOperation;
 import org.junit.Before;
-import org.junit.Test;
 import org.locationtech.spatial4j.shape.Shape;
 
 public class TestDateNRStrategy extends RandomSpatialOpStrategyTestCase {
@@ -50,31 +49,26 @@ public class TestDateNRStrategy extends RandomSpatialOpStrategyTestCase {
     randomCalWindowMs = Math.max(2000L, tmpCal.getTimeInMillis());
   }
 
-  @Test
   @Repeat(iterations = ITERATIONS)
   public void testIntersects() throws IOException {
     testOperationRandomShapes(SpatialOperation.Intersects);
   }
 
-  @Test
   @Repeat(iterations = ITERATIONS)
   public void testWithin() throws IOException {
     testOperationRandomShapes(SpatialOperation.IsWithin);
   }
 
-  @Test
   @Repeat(iterations = ITERATIONS)
   public void testContains() throws IOException {
     testOperationRandomShapes(SpatialOperation.Contains);
   }
 
-  @Test
   public void testWithinSame() throws IOException {
     Shape shape = randomIndexedShape();
     testOperation(shape, SpatialOperation.IsWithin, shape, true); // is within itself
   }
 
-  @Test
   public void testWorld() throws IOException {
     ((NumberRangePrefixTreeStrategy) strategy).setPointsOnly(false);
     testOperation(
@@ -84,7 +78,6 @@ public class TestDateNRStrategy extends RandomSpatialOpStrategyTestCase {
         true);
   }
 
-  @Test
   public void testBugInitIterOptimization() throws Exception {
     ((NumberRangePrefixTreeStrategy) strategy).setPointsOnly(false);
     // bug due to fast path initIter() optimization
@@ -95,7 +88,6 @@ public class TestDateNRStrategy extends RandomSpatialOpStrategyTestCase {
         true);
   }
 
-  @Test
   public void testLastMillionYearPeriod() throws Exception {
     testOperation(
         tree.parseShape(

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestHeatmapFacetCounter.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestHeatmapFacetCounter.java
@@ -30,7 +30,6 @@ import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.apache.lucene.util.Bits;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.context.SpatialContextFactory;
 import org.locationtech.spatial4j.distance.DistanceUtils;
@@ -70,7 +69,6 @@ public class TestHeatmapFacetCounter extends StrategyTestCase {
         "Validated " + cellsValidated + " cells, " + cellValidatedNonZero + " non-zero");
   }
 
-  @Test
   public void testStatic() throws IOException {
     // Some specific tests (static, not random).
     adoc("0", shapeFactory.rect(179.8, -170, -90, -80)); // barely crosses equator
@@ -86,7 +84,6 @@ public class TestHeatmapFacetCounter extends StrategyTestCase {
     // add specific tests if we find a bug.
   }
 
-  @Test
   public void testLucene7291Dateline() throws IOException {
     grid = new QuadPrefixTree(ctx, 2); // only 2, and we wind up with some big leaf cells
     strategy = new RecursivePrefixTreeStrategy(grid, getTestClass().getSimpleName());
@@ -95,7 +92,6 @@ public class TestHeatmapFacetCounter extends StrategyTestCase {
     validateHeatmapResultLoop(shapeFactory.rect(179, -179, 62, 63), 2, 100); // HM crosses dateline
   }
 
-  @Test
   public void testQueryCircle() throws IOException {
     // overwrite setUp; non-geo bounds is more straight-forward; otherwise 88,88 would actually be
     // practically north,
@@ -162,7 +158,6 @@ public class TestHeatmapFacetCounter extends StrategyTestCase {
     }
   }
 
-  @Test
   @Repeat(iterations = 20)
   public void testRandom() throws IOException {
     // Tests using random index shapes & query shapes. This has found all sorts of edge case bugs

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestJtsPolygon.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestJtsPolygon.java
@@ -31,7 +31,6 @@ import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.apache.lucene.spatial.query.SpatialArgs;
 import org.apache.lucene.spatial.query.SpatialOperation;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContextFactory;
 import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.Shape;
@@ -58,7 +57,6 @@ public class TestJtsPolygon extends StrategyTestCase {
         .setDistErrPct(LUCENE_4464_distErrPct); // 1% radius (small!)
   }
 
-  @Test
   /* LUCENE-4464 */
   public void testCloseButNoMatch() throws Exception {
     getAddAndVerifyIndexedDocuments("LUCENE-4464.txt");
@@ -86,7 +84,6 @@ public class TestJtsPolygon extends StrategyTestCase {
    * A PrefixTree pruning optimization gone bad. See <a
    * href="https://issues.apache.org/jira/browse/LUCENE-4770">LUCENE-4770</a>.
    */
-  @Test
   public void testBadPrefixTreePrune() throws Exception {
 
     Shape area =

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestNumberRangeFacets.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestNumberRangeFacets.java
@@ -37,7 +37,6 @@ import org.apache.lucene.tests.search.FixedBitSetCollector;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.junit.Before;
-import org.junit.Test;
 import org.locationtech.spatial4j.shape.Shape;
 
 public class TestNumberRangeFacets extends StrategyTestCase {
@@ -61,7 +60,6 @@ public class TestNumberRangeFacets extends StrategyTestCase {
   }
 
   @Repeat(iterations = 20)
-  @Test
   public void test() throws IOException {
     // generate test data
     List<Shape> indexedShapes = new ArrayList<>();

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestRandomSpatialOpFuzzyPrefixTree.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestRandomSpatialOpFuzzyPrefixTree.java
@@ -50,7 +50,6 @@ import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.apache.lucene.spatial.query.SpatialArgs;
 import org.apache.lucene.spatial.query.SpatialOperation;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.context.SpatialContextFactory;
 import org.locationtech.spatial4j.shape.Point;
@@ -127,28 +126,24 @@ public class TestRandomSpatialOpFuzzyPrefixTree extends StrategyTestCase {
     return new RecursivePrefixTreeStrategy(this.grid, getClass().getSimpleName());
   }
 
-  @Test
   @Repeat(iterations = ITERATIONS)
   public void testIntersects() throws IOException {
     setupGrid(-1);
     doTest(SpatialOperation.Intersects);
   }
 
-  @Test
   @Repeat(iterations = ITERATIONS)
   public void testWithin() throws IOException {
     setupGrid(-1);
     doTest(SpatialOperation.IsWithin);
   }
 
-  @Test
   @Repeat(iterations = ITERATIONS)
   public void testContains() throws IOException {
     setupGrid(-1);
     doTest(SpatialOperation.Contains);
   }
 
-  @Test
   public void testPackedQuadPointsOnlyBug() throws IOException {
     setupQuadGrid(1, true); // packed quad.  maxLevels doesn't matter.
     setupCtx2D(ctx);
@@ -160,7 +155,6 @@ public class TestRandomSpatialOpFuzzyPrefixTree extends StrategyTestCase {
     assertEquals(1, executeQuery(query, 1).numFound);
   }
 
-  @Test
   public void testPointsOnlyOptBug() throws IOException {
     setupQuadGrid(8, false);
     setupCtx2D(ctx);
@@ -175,7 +169,6 @@ public class TestRandomSpatialOpFuzzyPrefixTree extends StrategyTestCase {
   }
 
   /** See LUCENE-5062, {@link ContainsPrefixTreeQuery#multiOverlappingIndexedShapes}. */
-  @Test
   public void testContainsPairOverlap() throws IOException {
     setupQuadGrid(3, randomBoolean());
     adoc(
@@ -190,7 +183,6 @@ public class TestRandomSpatialOpFuzzyPrefixTree extends StrategyTestCase {
     assertEquals(1, searchResults.numFound);
   }
 
-  @Test
   public void testWithinDisjointParts() throws IOException {
     setupQuadGrid(7, randomBoolean());
     // one shape comprised of two parts, quite separated apart
@@ -208,7 +200,6 @@ public class TestRandomSpatialOpFuzzyPrefixTree extends StrategyTestCase {
     assertTrue(searchResults.numFound == 0);
   }
 
-  @Test
   /* LUCENE-4916 */
   public void testWithinLeafApproxRule() throws IOException {
     setupQuadGrid(2, randomBoolean()); // 4x4 grid
@@ -242,7 +233,6 @@ public class TestRandomSpatialOpFuzzyPrefixTree extends StrategyTestCase {
             == 1); // match
   }
 
-  @Test
   public void testShapePair() {
     ctx = SpatialContext.GEO;
     setupCtx2D(ctx);

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestRecursivePrefixTreeStrategy.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestRecursivePrefixTreeStrategy.java
@@ -25,7 +25,6 @@ import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
 import org.apache.lucene.spatial.query.SpatialArgs;
 import org.apache.lucene.spatial.query.SpatialOperation;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.distance.DistanceUtils;
 import org.locationtech.spatial4j.shape.Point;
@@ -44,7 +43,6 @@ public class TestRecursivePrefixTreeStrategy extends StrategyTestCase {
     this.strategy = new RecursivePrefixTreeStrategy(grid, getClass().getSimpleName());
   }
 
-  @Test
   public void testFilterWithVariableScanLevel() throws IOException {
     init(GeohashPrefixTree.getMaxLevelsPossible());
     getAddAndVerifyIndexedDocuments(DATA_WORLD_CITIES_POINTS);
@@ -56,7 +54,6 @@ public class TestRecursivePrefixTreeStrategy extends StrategyTestCase {
     }
   }
 
-  @Test
   public void testOneMeterPrecision() {
     init(GeohashPrefixTree.getMaxLevelsPossible());
     GeohashPrefixTree grid = (GeohashPrefixTree) ((RecursivePrefixTreeStrategy) strategy).getGrid();
@@ -65,7 +62,6 @@ public class TestRecursivePrefixTreeStrategy extends StrategyTestCase {
     assertEquals(11, grid.getLevelForDistance(degrees));
   }
 
-  @Test
   public void testPrecision() throws IOException {
     init(GeohashPrefixTree.getMaxLevelsPossible());
 

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestTermQueryPrefixGridStrategy.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/TestTermQueryPrefixGridStrategy.java
@@ -24,13 +24,11 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.spatial.SpatialTestCase;
 import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.shape.Shape;
 
 public class TestTermQueryPrefixGridStrategy extends SpatialTestCase {
 
-  @Test
   public void testNGramPrefixGridLosAngeles() throws IOException {
     SpatialContext ctx = SpatialContext.GEO;
     TermQueryPrefixTreeStrategy prefixGridStrategy =

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/tree/TestS2PrefixTree.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/tree/TestS2PrefixTree.java
@@ -23,14 +23,12 @@ import com.google.common.geometry.S2Projections;
 import org.apache.lucene.spatial.spatial4j.Geo3dSpatialContextFactory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.shape.Point;
 
 /** Test for S2 Spatial prefix tree. */
 public class TestS2PrefixTree extends LuceneTestCase {
 
-  @Test
   @Repeat(iterations = 10)
   public void testCells() {
     int face = random().nextInt(6);
@@ -69,7 +67,6 @@ public class TestS2PrefixTree extends LuceneTestCase {
     assertEquals(cell, cell2);
   }
 
-  @Test
   @Repeat(iterations = 10)
   public void testDistanceAndLevels() {
     S2PrefixTree tree =
@@ -98,7 +95,6 @@ public class TestS2PrefixTree extends LuceneTestCase {
     assertTrue(randomDist > distanceLevel);
   }
 
-  @Test
   @Repeat(iterations = 10)
   public void testPrecision() {
     int arity = random().nextInt(3) + 1;

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/tree/TestSpatialPrefixTree.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/tree/TestSpatialPrefixTree.java
@@ -30,7 +30,6 @@ import org.apache.lucene.spatial.prefix.TermQueryPrefixTreeStrategy;
 import org.apache.lucene.spatial.query.SpatialArgs;
 import org.apache.lucene.spatial.query.SpatialOperation;
 import org.junit.Before;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.Rectangle;
@@ -49,7 +48,6 @@ public class TestSpatialPrefixTree extends SpatialTestCase {
     ctx = SpatialContext.GEO;
   }
 
-  @Test
   public void testCellTraverse() {
     trie = new GeohashPrefixTree(ctx, 4);
 
@@ -79,7 +77,6 @@ public class TestSpatialPrefixTree extends SpatialTestCase {
    * A PrefixTree pruning optimization gone bad, applicable when optimize=true. See <a
    * href="https://issues.apache.org/jira/browse/LUCENE-4770">LUCENE-4770</a>.
    */
-  @Test
   public void testBadPrefixTreePrune() throws Exception {
 
     trie = new QuadPrefixTree(ctx, 12);

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/query/TestSpatialArgsParser.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/query/TestSpatialArgsParser.java
@@ -18,7 +18,6 @@ package org.apache.lucene.spatial.query;
 
 import java.text.ParseException;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.shape.Rectangle;
 
@@ -30,7 +29,6 @@ public class TestSpatialArgsParser extends LuceneTestCase {
   // The args parser is only dependent on the ctx for IO so I don't care to test
   // with other implementations.
 
-  @Test
   public void testArgsParser() throws Exception {
     SpatialArgsParser parser = new SpatialArgsParser();
 

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/serialized/TestSerializedStrategy.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/serialized/TestSerializedStrategy.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import org.apache.lucene.spatial.SpatialMatchConcern;
 import org.apache.lucene.spatial.StrategyTestCase;
 import org.junit.Before;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 
 public class TestSerializedStrategy extends StrategyTestCase {
@@ -33,14 +32,12 @@ public class TestSerializedStrategy extends StrategyTestCase {
     this.strategy = new SerializedDVStrategy(ctx, "serialized");
   }
 
-  @Test
   public void testBasicOperaions() throws IOException {
     getAddAndVerifyIndexedDocuments(DATA_SIMPLE_BBOX);
 
     executeQueries(SpatialMatchConcern.EXACT, QTEST_Simple_Queries_BBox);
   }
 
-  @Test
   public void testStatesBBox() throws IOException {
     getAddAndVerifyIndexedDocuments(DATA_STATES_BBOX);
 
@@ -48,7 +45,6 @@ public class TestSerializedStrategy extends StrategyTestCase {
     executeQueries(SpatialMatchConcern.FILTER, QTEST_States_Intersects_BBox);
   }
 
-  @Test
   public void testCitiesIntersectsBBox() throws IOException {
     getAddAndVerifyIndexedDocuments(DATA_WORLD_CITIES_POINTS);
 

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/ShapeRectRelationTestCase.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/ShapeRectRelationTestCase.java
@@ -19,7 +19,6 @@ package org.apache.lucene.spatial.spatial4j;
 import static org.locationtech.spatial4j.distance.DistanceUtils.DEGREES_TO_RADIANS;
 
 import org.junit.Rule;
-import org.junit.Test;
 import org.locationtech.spatial4j.TestLog;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.shape.Circle;
@@ -76,7 +75,6 @@ public abstract class ShapeRectRelationTestCase extends RandomizedShapeTestCase 
     }
   }
 
-  @Test
   public void testGeoCircleRect() {
     new AbstractRectIntersectionTestHelper(ctx) {
 
@@ -93,7 +91,6 @@ public abstract class ShapeRectRelationTestCase extends RandomizedShapeTestCase 
     }.testRelateWithRectangle();
   }
 
-  @Test
   public void testGeoBBoxRect() {
     new AbstractRectIntersectionTestHelper(ctx) {
 
@@ -123,7 +120,6 @@ public abstract class ShapeRectRelationTestCase extends RandomizedShapeTestCase 
   }
 
   // very slow, and test sources are not here, so no clue how to fix
-  @Test
   public void testGeoPolygonRect() {
     new AbstractRectIntersectionTestHelper(ctx) {
 
@@ -164,7 +160,6 @@ public abstract class ShapeRectRelationTestCase extends RandomizedShapeTestCase 
     }.testRelateWithRectangle();
   }
 
-  @Test
   public void testGeoPathRect() {
     new AbstractRectIntersectionTestHelper(ctx) {
 

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/TestGeo3d.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/TestGeo3d.java
@@ -18,14 +18,12 @@
 package org.apache.lucene.spatial.spatial4j;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.exception.InvalidShapeException;
 import org.locationtech.spatial4j.shape.Shape;
 
 public class TestGeo3d extends LuceneTestCase {
 
-  @Test
   public void testWKT() throws Exception {
     Geo3dSpatialContextFactory factory = new Geo3dSpatialContextFactory();
     SpatialContext ctx = factory.newSpatialContext();
@@ -65,7 +63,6 @@ public class TestGeo3d extends LuceneTestCase {
     // assertTrue(s instanceof  Geo3dShape<?>);
   }
 
-  @Test
   public void testPolygonWithCoplanarPoints() {
     Geo3dSpatialContextFactory factory = new Geo3dSpatialContextFactory();
     SpatialContext ctx = factory.newSpatialContext();

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/TestGeo3dRpt.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/TestGeo3dRpt.java
@@ -42,7 +42,6 @@ import org.apache.lucene.spatial3d.geom.GeoPoint;
 import org.apache.lucene.spatial3d.geom.GeoPointShape;
 import org.apache.lucene.spatial3d.geom.GeoPolygonFactory;
 import org.apache.lucene.spatial3d.geom.PlanetModel;
-import org.junit.Test;
 import org.locationtech.spatial4j.shape.Rectangle;
 import org.locationtech.spatial4j.shape.Shape;
 
@@ -88,7 +87,6 @@ public class TestGeo3dRpt extends RandomSpatialOpStrategyTestCase {
             "composite_" + getClass().getSimpleName(), rptStrategy, serializedDVStrategy);
   }
 
-  @Test
   public void testFailure1() throws IOException {
     setupStrategy();
     final List<GeoPoint> points = new ArrayList<>();
@@ -103,7 +101,6 @@ public class TestGeo3dRpt extends RandomSpatialOpStrategyTestCase {
     testOperation(rect, SpatialOperation.Intersects, triangle, false);
   }
 
-  @Test
   public void testFailureLucene6535() throws IOException {
     setupStrategy();
 
@@ -126,7 +123,6 @@ public class TestGeo3dRpt extends RandomSpatialOpStrategyTestCase {
     testOperation(rect, SpatialOperation.Intersects, shape, true);
   }
 
-  @Test
   public void testOperations() throws IOException {
     setupStrategy();
 
@@ -152,7 +148,6 @@ public class TestGeo3dRpt extends RandomSpatialOpStrategyTestCase {
 
   // TODO: incredibly slow
   @Nightly
-  @Test
   public void testOperationsFromFile() throws IOException {
     setupStrategy();
     final Iterator<SpatialTestData> indexedSpatialData = getSampleData("states-poly.txt");

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/TestGeo3dShapeSphereModelRectRelation.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/TestGeo3dShapeSphereModelRectRelation.java
@@ -43,7 +43,6 @@ public class TestGeo3dShapeSphereModelRectRelation extends ShapeRectRelationTest
     this.ctx = factory.newSpatialContext();
   }
 
-  @Test
   public void testFailure1() {
     final GeoBBox rect =
         GeoBBoxFactory.makeGeoBBox(
@@ -81,7 +80,6 @@ public class TestGeo3dShapeSphereModelRectRelation extends ShapeRectRelationTest
     assertFalse(rect.isWithin(point));
   }
 
-  @Test
   public void testFailure2_LUCENE6475() {
     GeoCircle geo3dCircle =
         GeoCircleFactory.makeGeoCircle(

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/TestGeo3dShapeWGS84ModelRectRelation.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/TestGeo3dShapeWGS84ModelRectRelation.java
@@ -45,7 +45,6 @@ public class TestGeo3dShapeWGS84ModelRectRelation extends ShapeRectRelationTestC
     ((Geo3dShapeFactory) ctx.getShapeFactory()).setCircleAccuracy(1e-12);
   }
 
-  @Test
   public void testFailure1() {
     final GeoBBox rect =
         GeoBBoxFactory.makeGeoBBox(
@@ -68,7 +67,6 @@ public class TestGeo3dShapeWGS84ModelRectRelation extends ShapeRectRelationTestC
     // assertFalse(GeoArea.DISJOINT == rect.getRelationship(bbox));
   }
 
-  @Test
   public void testFailure2() {
     final GeoBBox rect =
         GeoBBoxFactory.makeGeoBBox(
@@ -90,7 +88,6 @@ public class TestGeo3dShapeWGS84ModelRectRelation extends ShapeRectRelationTestC
     // assertFalse(GeoArea.DISJOINT == rect.getRelationship(bbox));
   }
 
-  @Test
   public void testFailure3() {
     /*
      * [junit4]   1> S-R Rel: {}, Shape {}, Rectangle {}    lap# {} [CONTAINS, Geo3dShape{planetmodel=PlanetModel: {xyScaling=1.0011188180710464, zScaling=0.9977622539852008}, shape=GeoPath: {planetmodel=PlanetModel: {xyScaling=1.0011188180710464, zScaling=0.9977622539852008}, width=1.53588974175501(87.99999999999999),

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/vector/TestPointVectorStrategy.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/vector/TestPointVectorStrategy.java
@@ -27,7 +27,6 @@ import org.apache.lucene.spatial.StrategyTestCase;
 import org.apache.lucene.spatial.query.SpatialArgs;
 import org.apache.lucene.spatial.query.SpatialOperation;
 import org.junit.Before;
-import org.junit.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.shape.Circle;
 import org.locationtech.spatial4j.shape.Point;
@@ -41,7 +40,6 @@ public class TestPointVectorStrategy extends StrategyTestCase {
     this.ctx = SpatialContext.GEO;
   }
 
-  @Test
   public void testCircleShapeSupport() {
     this.strategy = PointVectorStrategy.newInstance(ctx, getClass().getSimpleName());
     Circle circle = ctx.makeCircle(ctx.makePoint(0, 0), 10);
@@ -51,7 +49,6 @@ public class TestPointVectorStrategy extends StrategyTestCase {
     assertNotNull(query);
   }
 
-  @Test
   public void testInvalidQueryShape() {
     this.strategy = PointVectorStrategy.newInstance(ctx, getClass().getSimpleName());
     Point point = ctx.makePoint(0, 0);
@@ -59,7 +56,6 @@ public class TestPointVectorStrategy extends StrategyTestCase {
     expectThrows(UnsupportedOperationException.class, () -> this.strategy.makeQuery(args));
   }
 
-  @Test
   public void testCitiesIntersectsBBox() throws IOException {
     // note: does not require docValues
     this.strategy = PointVectorStrategy.newInstance(ctx, getClass().getSimpleName());
@@ -67,7 +63,6 @@ public class TestPointVectorStrategy extends StrategyTestCase {
     executeQueries(SpatialMatchConcern.FILTER, QTEST_Cities_Intersects_BBox);
   }
 
-  @Test
   public void testFieldOptions() throws IOException, ParseException {
     // It's not stored; test it isn't.
     this.strategy = PointVectorStrategy.newInstance(ctx, getClass().getSimpleName());

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestCompositeGeoPolygonRelationships.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestCompositeGeoPolygonRelationships.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /**
  * Check relationship between polygon and GeoShapes of composite polygons. Normally we construct the
@@ -29,7 +28,6 @@ import org.junit.Test;
  */
 public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
 
-  @Test
   public void testGeoCompositePolygon1() {
 
     // POLYGON ((19.845091 -60.452631, 20.119948 -61.655652, 23.207901 -61.453298, 22.820804
@@ -91,7 +89,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.OVERLAPS, rel);
   }
 
-  @Test
   public void testGeoCompositePolygon2() {
 
     // POLYGON ((19.845091 -60.452631, 20.119948 -61.655652, 23.207901 -61.453298, 22.820804
@@ -154,7 +151,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.OVERLAPS, rel);
   }
 
-  @Test
   public void testGeoCompositePolygon3() {
 
     // POLYGON ((19.845091 -60.452631, 20.119948 -61.655652, 23.207901 -61.453298, 22.820804
@@ -217,7 +213,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.OVERLAPS, rel);
   }
 
-  @Test
   public void testGeoCompositePolygon4() {
 
     // POLYGON ((19.845091 -60.452631, 20.119948 -61.655652, 23.207901 -61.453298, 22.820804
@@ -280,7 +275,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.WITHIN, rel);
   }
 
-  @Test
   public void testGeoCompositePolygon5() {
 
     // POLYGON ((19.845091 -60.452631, 20.119948 -61.655652, 23.207901 -61.453298, 22.820804
@@ -341,7 +335,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.OVERLAPS, rel);
   }
 
-  @Test
   public void testGeoCompositePolygon6() {
 
     // POLYGON ((19.845091 -60.452631, 20.119948 -61.655652, 23.207901 -61.453298, 22.820804
@@ -402,7 +395,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.CONTAINS, rel);
   }
 
-  @Test
   public void testGeoCompositePolygon7() {
 
     // POLYGON ((19.845091 -60.452631, 20.119948 -61.655652, 23.207901 -61.453298, 22.820804
@@ -465,7 +457,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.OVERLAPS, rel);
   }
 
-  @Test
   public void testGeoCompositePolygon8() {
 
     // POLYGON ((19.845091 -60.452631, 20.119948 -61.655652, 23.207901 -61.453298, 22.820804
@@ -489,7 +480,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.WITHIN, rel);
   }
 
-  @Test
   public void testGeoPolygonPole1() {
     // POLYGON((0 80, 45 85 ,90 80,135 85,180 80, -135 85, -90 80, -45 85,0 80))
     GeoPolygon compositePol = getCompositePolygon();
@@ -523,7 +513,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.WITHIN, rel);
   }
 
-  @Test
   public void testGeoPolygonPole2() {
     // POLYGON((0 80, 45 85 ,90 80,135 85,180 80, -135 85, -90 80, -45 85,0 80))
     GeoPolygon compositePol = getCompositePolygon();
@@ -555,7 +544,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.OVERLAPS, rel);
   }
 
-  @Test
   public void testGeoPolygonPole3() {
     // POLYGON((0 80, 45 85 ,90 80,135 85,180 80, -135 85, -90 80, -45 85,0 80))
     GeoPolygon compositePol = getCompositePolygon();
@@ -587,7 +575,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.OVERLAPS, rel);
   }
 
-  @Test
   public void testMultiPolygon1() {
     // MULTIPOLYGON(((-145.790967486 -5.17543698881, -145.790854979 -5.11348060995, -145.853073512
     // -5.11339421216, -145.853192037 -5.17535061936, -145.790967486 -5.17543698881)),
@@ -621,7 +608,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(false, polConcave.intersects(multiPol));
   }
 
-  @Test
   public void testMultiPolygon2() {
     // MULTIPOLYGON(((-145.790967486 -5.17543698881, -145.790854979 -5.11348060995, -145.853073512
     // -5.11339421216, -145.853192037 -5.17535061936, -145.790967486 -5.17543698881)),
@@ -652,7 +638,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(true, polConcave.intersects(multiPol));
   }
 
-  @Test
   public void testMultiPolygon3() {
     // MULTIPOLYGON(((-145.790967486 -5.17543698881, -145.790854979 -5.11348060995, -145.853073512
     // -5.11339421216, -145.853192037 -5.17535061936, -145.790967486 -5.17543698881)),
@@ -683,7 +668,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(false, polConcave.intersects(multiPol));
   }
 
-  @Test
   public void testMultiPolygon4() {
     // MULTIPOLYGON(((-145.790967486 -5.17543698881, -145.790854979 -5.11348060995, -145.853073512
     // -5.11339421216, -145.853192037 -5.17535061936, -145.790967486 -5.17543698881)),
@@ -714,7 +698,6 @@ public class TestCompositeGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(false, polConcave.intersects(multiPol));
   }
 
-  @Test
   public void testMultiPolygon5() {
     // MULTIPOLYGON(((-145.790967486 -5.17543698881, -145.790854979 -5.11348060995, -145.853073512
     // -5.11339421216, -145.853192037 -5.17535061936, -145.790967486 -5.17543698881)),

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoBBox.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoBBox.java
@@ -20,13 +20,11 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.lucene.tests.geo.GeoTestUtil;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestGeoBBox extends LuceneTestCase {
 
   protected static final double DEGREES_TO_RADIANS = Math.PI / 180.0;
 
-  @Test
   public void testBBoxDegenerate() {
     GeoBBox box;
     int relationship;
@@ -58,7 +56,6 @@ public class TestGeoBBox extends LuceneTestCase {
     assertEquals(GeoArea.CONTAINS, relationship);
   }
 
-  @Test
   public void testBBoxPointWithin() {
     GeoBBox box;
     GeoPoint gp;
@@ -123,7 +120,6 @@ public class TestGeoBBox extends LuceneTestCase {
     assertTrue(box.isWithin(gp));
   }
 
-  @Test
   public void testBBoxExpand() {
     GeoBBox box;
     GeoPoint gp;
@@ -148,7 +144,6 @@ public class TestGeoBBox extends LuceneTestCase {
     assertFalse(box.isWithin(gp));
   }
 
-  @Test
   public void testBBoxBounds() {
     GeoBBox c;
     LatLonBounds b;
@@ -427,7 +422,6 @@ public class TestGeoBBox extends LuceneTestCase {
 
   }
 
-  @Test
   public void testFailureCase1() {
     final GeoPoint point =
         new GeoPoint(-0.017413370801260174, -2.132522881412925E-18, 0.9976113450663769);
@@ -449,7 +443,6 @@ public class TestGeoBBox extends LuceneTestCase {
     assertTrue(box.isWithin(point) ? solid.isWithin(point) : true);
   }
 
-  @Test
   public void testFailureCase2() {
     // final GeoPoint point = new GeoPoint(-0.7375647084975573, -2.3309121299774915E-10,
     // 0.6746626163258577);
@@ -482,7 +475,6 @@ public class TestGeoBBox extends LuceneTestCase {
     assertTrue(box.isWithin(point) == solid.isWithin(point));
   }
 
-  @Test
   public void testLUCENE10508() {
     double minX = Geo3DUtil.fromDegrees(GeoTestUtil.nextLongitude());
     double maxX = Geo3DUtil.fromDegrees(GeoTestUtil.nextLongitude());
@@ -491,7 +483,6 @@ public class TestGeoBBox extends LuceneTestCase {
     assertNotNull(GeoAreaFactory.makeGeoArea(PlanetModel.SPHERE, maxY, minY, minX, maxX));
   }
 
-  @Test
   public void testBBoxRandomDegenerate() {
     for (int i = 0; i < 100; i++) {
       double minX = Geo3DUtil.fromDegrees(GeoTestUtil.nextLongitude());
@@ -502,7 +493,6 @@ public class TestGeoBBox extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testBBoxLatDegenerate() {
     double minX = Geo3DUtil.fromDegrees(-180.0);
     double maxX = Geo3DUtil.fromDegrees(-174.37500008381903);
@@ -511,7 +501,6 @@ public class TestGeoBBox extends LuceneTestCase {
     assertNotNull(GeoAreaFactory.makeGeoArea(PlanetModel.SPHERE, maxY, minY, minX, maxX));
   }
 
-  @Test
   public void testBBoxRandomLatDegenerate() {
     for (int i = 0; i < 100; i++) {
       double minX = Geo3DUtil.fromDegrees(GeoTestUtil.nextLongitude());
@@ -522,7 +511,6 @@ public class TestGeoBBox extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testBBoxRandomLonDegenerate() {
     for (int i = 0; i < 100; i++) {
       double minX = Geo3DUtil.fromDegrees(GeoTestUtil.nextLongitude());

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoCircle.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoCircle.java
@@ -17,11 +17,9 @@
 package org.apache.lucene.spatial3d.geom;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestGeoCircle extends LuceneTestCase {
 
-  @Test
   public void testCircleDistance() {
     GeoCircle c;
     GeoPoint gp;
@@ -40,7 +38,6 @@ public class TestGeoCircle extends LuceneTestCase {
     assertEquals(0.049979, c.computeDistance(DistanceStyle.NORMAL, gp), 0.000001);
   }
 
-  @Test
   public void testCircleFullWorld() {
     GeoCircle c;
     GeoPoint gp;
@@ -64,7 +61,6 @@ public class TestGeoCircle extends LuceneTestCase {
     assertTrue(b.checkNoBottomLatitudeBound());
   }
 
-  @Test
   public void testCirclePointWithin() {
     GeoCircle c;
     GeoPoint gp;
@@ -86,7 +82,6 @@ public class TestGeoCircle extends LuceneTestCase {
     assertFalse(c.isWithin(gp));
   }
 
-  @Test
   public void testCircleBounds() {
     GeoCircle c;
     LatLonBounds b;
@@ -510,7 +505,6 @@ public class TestGeoCircle extends LuceneTestCase {
     assertEquals(-0.4, b.getRightLongitude(), 0.00001);
   }
 
-  @Test
   public void testBoundsFailureCase1() {
     // lat=2.7399499693409367E-13, lon=-3.141592653589793([X=-1.0011188539924791,
     // Y=-1.226017000107956E-16, Z=2.743015573303327E-13])], radius=2.1814042682464985
@@ -539,7 +533,6 @@ public class TestGeoCircle extends LuceneTestCase {
     assertTrue(solid.isWithin(gp));
   }
 
-  @Test
   public void testBoundsFailureCase2() {
     final GeoCircle gc =
         GeoCircleFactory.makeGeoCircle(
@@ -562,7 +555,6 @@ public class TestGeoCircle extends LuceneTestCase {
     assert gc.isWithin(gp) ? solid.isWithin(gp) : true;
   }
 
-  @Test
   public void testWholeWorld() {
     final GeoCircle circle1 =
         GeoCircleFactory.makeGeoCircle(PlanetModel.SPHERE, 0.0, 0.0, 3.1415926535897913);

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoConvexPolygon.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoConvexPolygon.java
@@ -17,11 +17,9 @@
 package org.apache.lucene.spatial3d.geom;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestGeoConvexPolygon extends LuceneTestCase {
 
-  @Test
   public void testPolygonPointWithin() {
     GeoConvexPolygon c;
     GeoPoint gp;
@@ -62,7 +60,6 @@ public class TestGeoConvexPolygon extends LuceneTestCase {
     assertFalse(c.isWithin(gp));
   }
 
-  @Test
   public void testPolygonBounds() {
     GeoConvexPolygon c;
     LatLonBounds b;

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoExactCircle.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoExactCircle.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 /** Tests for GeoExactCircle. */
 public class TestGeoExactCircle extends LuceneTestCase {
 
-  @Test
   public void testExactCircle() {
     GeoCircle c;
     GeoPoint gp;
@@ -56,7 +55,6 @@ public class TestGeoExactCircle extends LuceneTestCase {
     assertTrue(c.isWithin(gp));
   }
 
-  @Test
   public void testSurfacePointOnBearingScale() {
     PlanetModel p1 = PlanetModel.WGS84;
     PlanetModel p2 =
@@ -128,7 +126,6 @@ public class TestGeoExactCircle extends LuceneTestCase {
         surfaceDistance - radius < Vector.MINIMUM_ANGULAR_RESOLUTION);
   }
 
-  @Test
   public void testExactCircleBounds() {
 
     GeoPoint center = new GeoPoint(PlanetModel.WGS84, 0, 0);
@@ -161,7 +158,6 @@ public class TestGeoExactCircle extends LuceneTestCase {
         });
   }
 
-  @Test
   public void testExactCircleDoesNotFit() {
     expectThrows(
         IllegalArgumentException.class,
@@ -194,7 +190,6 @@ public class TestGeoExactCircle extends LuceneTestCase {
    * in LUCENE-8054 we have problems with exact circles that have edges that are close together.
    * This test creates those circles with the same center and slightly different radius.
    */
-  @Test
   @Repeat(iterations = 100)
   public void testRandomLUCENE8054() {
     PlanetModel planetModel = randomPlanetModel();
@@ -217,7 +212,6 @@ public class TestGeoExactCircle extends LuceneTestCase {
     assertTrue(b.toString(), circle1.getRelationship(circle2) != GeoArea.DISJOINT);
   }
 
-  @Test
   public void testLUCENE8054() {
     GeoCircle circle1 =
         GeoCircleFactory.makeExactGeoCircle(
@@ -239,7 +233,6 @@ public class TestGeoExactCircle extends LuceneTestCase {
     assertTrue(rel != GeoArea.DISJOINT);
   }
 
-  @Test
   public void testLUCENE8056() {
     GeoCircle circle =
         GeoCircleFactory.makeExactGeoCircle(
@@ -263,7 +256,6 @@ public class TestGeoExactCircle extends LuceneTestCase {
     assertTrue(bBox.getRelationship(circle) == GeoArea.OVERLAPS);
   }
 
-  @Test
   public void testExactCircleLUCENE8054() {
     // [junit4]    > Throwable #1: java.lang.AssertionError: circle1: GeoExactCircle:
     // {planetmodel=PlanetModel.WGS84, center=[lat=-1.2097332228999564,
@@ -286,7 +278,6 @@ public class TestGeoExactCircle extends LuceneTestCase {
     assertTrue("cannot be disjoint", c1.getRelationship(c2) != GeoArea.DISJOINT);
   }
 
-  @Test
   public void testLUCENE8065() {
     // Circle planes are convex
     GeoCircle circle1 =

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoModel.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoModel.java
@@ -17,14 +17,12 @@
 package org.apache.lucene.spatial3d.geom;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /** Test basic plane functionality. */
 public class TestGeoModel extends LuceneTestCase {
 
   protected static final PlanetModel scaledModel = new PlanetModel(1.2, 1.5);
 
-  @Test
   public void testBasicCircle() {
     // The point of this test is just to make sure nothing blows up doing normal things with a quite
     // non-spherical model
@@ -76,7 +74,6 @@ public class TestGeoModel extends LuceneTestCase {
     assertEquals(0.0089, bounds.getRightLongitude(), 0.0001);
   }
 
-  @Test
   public void testBasicRectangle() {
     final GeoBBox bbox = GeoBBoxFactory.makeGeoBBox(scaledModel, 1.0, 0.0, 0.0, 1.0);
     final GeoPoint insidePoint = new GeoPoint(scaledModel, 0.5, 0.5);

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoPath.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoPath.java
@@ -17,11 +17,9 @@
 package org.apache.lucene.spatial3d.geom;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestGeoPath extends LuceneTestCase {
 
-  @Test
   public void testPathDistance() {
     // Start with a really simple case
     GeoStandardPath p;
@@ -74,7 +72,6 @@ public class TestGeoPath extends LuceneTestCase {
     assertEquals(0.0 + 0.05, p.computeDistance(DistanceStyle.ARC, gp), 0.000001);
   }
 
-  @Test
   public void test11956() {
     // Geo3D:GeoStandardPath: {planetmodel=PlanetModel.SPHERE, width=1.1344640137963142(65.0),
     //  points={[[lat=-1.289777264488089, lon=3.0020962766211765([X=-0.2746408902222561,
@@ -124,7 +121,6 @@ public class TestGeoPath extends LuceneTestCase {
     // assertTrue(bounds.isWithin(gp));
   }
 
-  @Test
   public void testPathPointWithin() {
     // Tests whether we can properly detect whether a point is within a path or not
     GeoStandardPath p;
@@ -174,7 +170,6 @@ public class TestGeoPath extends LuceneTestCase {
     assertFalse(p.isWithin(gp));
   }
 
-  @Test
   public void testGetRelationship() {
     GeoArea rect;
     GeoStandardPath p;
@@ -228,7 +223,6 @@ public class TestGeoPath extends LuceneTestCase {
     assertEquals(GeoArea.DISJOINT, rect.getRelationship(p));
   }
 
-  @Test
   public void testPathBounds() {
     GeoStandardPath c;
     LatLonBounds b;
@@ -332,7 +326,6 @@ public class TestGeoPath extends LuceneTestCase {
     assertEquals(0.3999999, b.getMaxLatitude(), 0.000001);
   }
 
-  @Test
   public void testCoLinear() {
     // p1: (12,-90), p2: (11, -55), (129, -90)
     GeoStandardPath p = new GeoStandardPath(PlanetModel.SPHERE, 0.1);
@@ -342,7 +335,6 @@ public class TestGeoPath extends LuceneTestCase {
     p.done(); // at least test this doesn't bomb like it used too -- LUCENE-6520
   }
 
-  @Test
   public void testFailure1() {
     /*
     GeoStandardPath: {planetmodel=PlanetModel.WGS84, width=1.117010721276371(64.0), points={[
@@ -384,7 +376,6 @@ public class TestGeoPath extends LuceneTestCase {
     assertTrue(solid.isWithin(point));
   }
 
-  @Test
   public void testInterpolation() {
     final double lat = 52.51607;
     final double lon = 13.37698;
@@ -435,7 +426,6 @@ public class TestGeoPath extends LuceneTestCase {
 
   }
 
-  @Test
   public void testInterpolation2() {
     final double lat = 52.5665;
     final double lon = 13.3076;
@@ -481,7 +471,6 @@ public class TestGeoPath extends LuceneTestCase {
     assertEquals(oldFormulaDistance, distance, 1e-12);
   }
 
-  @Test
   public void testIdenticalPoints() {
     PlanetModel planetModel = PlanetModel.WGS84;
     GeoPoint point1 = new GeoPoint(planetModel, 1.5707963267948963, -2.4818290647609542E-148);
@@ -504,7 +493,6 @@ public class TestGeoPath extends LuceneTestCase {
     path = GeoPathFactory.makeGeoPath(planetModel, 0.5, new GeoPoint[] {point4, point5, point6});
   }
 
-  @Test
   public void testLUCENE8696() {
     GeoPoint[] points = new GeoPoint[4];
     points[0] = new GeoPoint(PlanetModel.WGS84, 2.4457272005608357E-47, 0.017453291479645996);

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoPoint.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoPoint.java
@@ -118,8 +118,12 @@ public class TestGeoPoint extends LuceneTestCase {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadLatLon() {
-    new GeoPoint(PlanetModel.SPHERE, 50.0, 32.2);
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new GeoPoint(PlanetModel.SPHERE, 50.0, 32.2);
+        });
   }
 }

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoPoint.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoPoint.java
@@ -19,13 +19,11 @@ package org.apache.lucene.spatial3d.geom;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomFloat;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /** Test basic GeoPoint functionality. */
 public class TestGeoPoint extends LuceneTestCase {
   static final double DEGREES_TO_RADIANS = Math.PI / 180;
 
-  @Test
   public void testConversion() {
     testPointRoundTrip(PlanetModel.SPHERE, 90 * DEGREES_TO_RADIANS, 0, 1e-6);
     testPointRoundTrip(PlanetModel.SPHERE, -90 * DEGREES_TO_RADIANS, 0, 1e-6);
@@ -56,7 +54,6 @@ public class TestGeoPoint extends LuceneTestCase {
     assertEquals(0, dist, epsilon);
   }
 
-  @Test
   public void testSurfaceDistance() {
     final int times = atLeast(100);
     for (int i = 0; i < times; i++) {
@@ -99,7 +96,6 @@ public class TestGeoPoint extends LuceneTestCase {
         1e-6);
   }
 
-  @Test
   public void testBisection() {
     final int times = atLeast(100);
     for (int i = 0; i < times; i++) {
@@ -118,7 +114,6 @@ public class TestGeoPoint extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testBadLatLon() {
     expectThrows(
         IllegalArgumentException.class,

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoPolygon.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestGeoPolygon.java
@@ -21,11 +21,9 @@ import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestGeoPolygon extends LuceneTestCase {
 
-  @Test
   public void testH3CellsWrongIntersection() {
     final List<GeoPoint> points1 = new ArrayList<>();
     addToList(points1, PlanetModel.SPHERE, -64.2102198418716, -39.14233318389477);
@@ -52,7 +50,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     points.add(new GeoPoint(planetModel, Geo3DUtil.fromDegrees(lat), Geo3DUtil.fromDegrees(lon)));
   }
 
-  @Test
   public void testPolygonPointFiltering() {
     final GeoPoint point1 = new GeoPoint(PlanetModel.WGS84, 1.0, 2.0);
     final GeoPoint point2 = new GeoPoint(PlanetModel.WGS84, 0.5, 2.5);
@@ -119,7 +116,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testPolygonPointFiltering2() {
     // all coplanar
     GeoPoint point1 = new GeoPoint(PlanetModel.SPHERE, 1.1264101919629863, -0.9108307879480759);
@@ -134,7 +130,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertEquals(null, filteredPoints);
   }
 
-  @Test
   public void testPolygonClockwise() {
     GeoPolygon c;
     GeoPoint gp;
@@ -184,7 +179,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(c.isWithin(gp));
   }
 
-  @Test
   public void testPolygonIntersects() {
     GeoPolygon c;
     List<GeoPoint> points;
@@ -277,7 +271,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertEquals(GeoArea.DISJOINT, xyzSolid.getRelationship(c));
   }
 
-  @Test
   public void testPolygonPointWithin() {
     GeoPolygon c;
     GeoPoint gp;
@@ -437,7 +430,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertFalse(c.isWithin(gp));
   }
 
-  @Test
   public void testPolygonBounds() {
     GeoMembershipShape c;
     LatLonBounds b;
@@ -489,7 +481,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertEquals(0.1, b.getMaxLatitude(), 0.000001);
   }
 
-  @Test
   public void testPolygonBoundsCase1() {
     GeoPolygon c;
     List<GeoPoint> points;
@@ -536,7 +527,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(area.isWithin(point2));
   }
 
-  @Test
   public void testGeoPolygonBoundsCase2() {
     // [junit4]   1> TEST: iter=23 shape=GeoCompositeMembershipShape: {[GeoConvexPolygon:
     // {planetmodel=PlanetModel(xyScaling=0.7563871189161702 zScaling=1.2436128810838298), points=
@@ -593,7 +583,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(area.isWithin(pointQuantized));
   }
 
-  @Test
   public void testGeoConcaveRelationshipCase1() {
     /*
      *  [junit4]   1> doc=906 matched but should not
@@ -647,7 +636,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(xyzSolid.getRelationship(c) == GeoArea.OVERLAPS);
   }
 
-  @Test
   public void testPolygonFactoryCase1() {
     /*
      * [junit4]   1> Initial points:
@@ -693,7 +681,6 @@ public class TestGeoPolygon extends LuceneTestCase {
         });
   }
 
-  @Test
   public void testPolygonFactoryCase2() {
     /*
     [[lat=-0.48522750470337056, lon=-1.7370471071224087([X=-0.14644023172524287, Y=-0.8727091042681705, Z=-0.4665895520487907])],
@@ -724,7 +711,6 @@ public class TestGeoPolygon extends LuceneTestCase {
         });
   }
 
-  @Test
   public void testPolygonFactoryCase3() throws Exception {
     /*
      * This one failed to be detected as convex:
@@ -762,7 +748,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertFalse(mutableBoolean.value);
   }
 
-  @Test
   public void testPolygonFactoryCase4() {
     // [[lat=0.897812132711355, lon=0.0025364171887532795([X=0.6227358672251874,
     // Y=0.0015795213449218714, Z=0.7812318690127594])],
@@ -789,7 +774,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     GeoPolygonFactory.makeLargeGeoPolygon(PlanetModel.WGS84, shapeList);
   }
 
-  @Test
   public void testPolygonFactoryCase5() {
     /*
      * [junit4]   1> points=[[lat=0.0425265613312593, lon=0.0([X=1.0002076326868337, Y=0.0, Z=0.042561051669501374])],
@@ -874,7 +858,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(p.isWithin(point) ? solid.isWithin(point) : true);
   }
 
-  @Test
   public void testLargePolygonFailureCase1() {
     /*
      * [junit4]    >   shape=GeoComplexPolygon: {planetmodel=PlanetModel.WGS84, number of shapes=1, address=65f193fc,
@@ -942,7 +925,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertEquals(referenceBounds.getMaximumZ(), actualBounds.getMaximumZ(), 0.0000001);
   }
 
-  @Test
   public void testLargePolygonFailureCase2() {
     /*
      * [junit4]    > Throwable #1: java.lang.AssertionError: FAIL: id=2 should have matched but did not
@@ -1042,7 +1024,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(solid.isWithin(checkPoint));
   }
 
-  @Test
   public void testPolygonFailureCase1() {
     final List<GeoPoint> poly2List = new ArrayList<>();
     poly2List.add(new GeoPoint(PlanetModel.WGS84, -0.6370451769779303, 2.5318373679431616));
@@ -1059,7 +1040,6 @@ public class TestGeoPolygon extends LuceneTestCase {
         });
   }
 
-  @Test
   public void testPolygonFailureCase2() {
     /*
     [junit4]   1>   shape=GeoCompositeMembershipShape: {[GeoConvexPolygon: {planetmodel=PlanetModel.WGS84, points=[
@@ -1096,7 +1076,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(poly1.isWithin(point) ? solid.isWithin(point) : true);
   }
 
-  @Test
   public void testConcavePolygon() {
     ArrayList<GeoPoint> points = new ArrayList<>();
     points.add(new GeoPoint(PlanetModel.SPHERE, -0.1, -0.5));
@@ -1110,7 +1089,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertEquals(polygon, polygonConcave);
   }
 
-  @Test
   public void testPolygonWithHole() {
     ArrayList<GeoPoint> points = new ArrayList<>();
     points.add(new GeoPoint(PlanetModel.SPHERE, -1.1, -1.5));
@@ -1158,7 +1136,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertEquals(holeSimplePolygon.isWithin(gp), holeComplexPolygon.isWithin(gp));
   }
 
-  @Test
   public void testConvexPolygon() {
     ArrayList<GeoPoint> points = new ArrayList<>();
     points.add(new GeoPoint(PlanetModel.SPHERE, 0, 0));
@@ -1172,7 +1149,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertEquals(polygon, polygon2);
   }
 
-  @Test
   public void testConvexPolygonWithHole() {
     ArrayList<GeoPoint> points = new ArrayList<>();
     points.add(new GeoPoint(PlanetModel.SPHERE, -1, -1));
@@ -1197,7 +1173,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertEquals(polygon, polygon2);
   }
 
-  @Test
   public void testLUCENE8133() {
     GeoPoint point1 =
         new GeoPoint(
@@ -1244,7 +1219,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testLUCENE8140() throws Exception {
     // POINT(15.426026 68.35078) is coplanar
     // "POLYGON((15.426411 68.35069,15.4261 68.35078,15.426026 68.35078,15.425868 68.35078,15.425745
@@ -1270,7 +1244,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(GeoPolygonFactory.makeGeoPolygon(PlanetModel.SPHERE, points) != null);
   }
 
-  @Test
   public void testLUCENE8211() {
     // We need to handle the situation where the check point is parallel to
     // the test point.
@@ -1301,7 +1274,6 @@ public class TestGeoPolygon extends LuceneTestCase {
             PlanetModel.SPHERE.createSurfacePoint(-testPoint.x, -testPoint.y, testPoint.z)));
   }
 
-  @Test
   public void testCoplanarityTileConvex() throws Exception {
     // This test has been disabled because it is possible that the polygon specified actually
     // intersects itself.
@@ -1364,7 +1336,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon != null);
   }
 
-  @Test
   public void testCoplanarityConcave() throws Exception {
     // POLYGON((-52.18851 64.53777,-52.18853 64.53828,-52.18675 64.53829,-52.18676
     // 64.53855,-52.18736 64.53855,-52.18737 64.53881,-52.18677 64.53881,-52.18683
@@ -1412,7 +1383,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     GeoPolygonFactory.makeGeoPolygon(PlanetModel.SPHERE, points);
   }
 
-  @Test
   public void testCoplanarityConvex2() throws Exception {
     // POLYGON((-3.488658 50.45564,-3.4898987 50.455627,-3.489865 50.455585,-3.489833
     // 50.45551,-3.489808 50.455433,-3.489806 50.455406,-3.4898643 50.45525,-3.4892037
@@ -1520,7 +1490,6 @@ public class TestGeoPolygon extends LuceneTestCase {
    * [junit4]   1>       unquantized=[lat=-3.1780051348770987E-74, lon=-3.032608859187692([X=-0.9951793580358298, Y=-0.1088898762907205, Z=-3.181560858610375E-74])]
    * [junit4]   1>       quantized=[X=-0.9951793580415914, Y=-0.10888987641797832, Z=-2.3309121299774915E-10]
    */
-  @Test
   public void testLUCENE8227() throws Exception {
     List<GeoPoint> points = new ArrayList<>();
     points.add(new GeoPoint(PlanetModel.WGS84, -0.63542308910253, 0.9853722928232957));
@@ -1574,7 +1543,6 @@ public class TestGeoPolygon extends LuceneTestCase {
    * [lat=0.0, lon=0.0([X=1.0011188539924791, Y=0.0, Z=0.0])],
    * [lat=0.2839194570254642, lon=-1.2434404554202965([X=0.30893121415043073, Y=-0.9097632721627391, Z=0.2803596238536593])]}}
    */
-  @Test
   public void testLUCENE8227_case2() {
     List<GeoPoint> points = new ArrayList<>();
     points.add(new GeoPoint(PlanetModel.WGS84, -1.5707963267948966, -1.0755217966112058));
@@ -1620,7 +1588,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(standard.isWithin(quantized) ? standardSolid.isWithin(quantized) : true);
   }
 
-  @Test
   public void testLUCENE7642() {
     // Construct XYZ solid
     final XYZSolid solid =
@@ -1755,7 +1722,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(intersection == largeIntersection);
   }
 
-  @Test
   public void testComplexPolygonPlaneOutsideWorld() {
     List<GeoPoint> points = new ArrayList<>();
     points.add(new GeoPoint(PlanetModel.SPHERE, -0.5, -0.5));
@@ -1781,7 +1747,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point1) == largePolygon.isWithin(point1));
   }
 
-  @Test
   public void testComplexPolygonDegeneratedVector() {
     List<GeoPoint> points = new ArrayList<>();
     points.add(new GeoPoint(PlanetModel.SPHERE, -0.5, -0.5));
@@ -1807,7 +1772,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point3) == largePolygon.isWithin(point3));
   }
 
-  @Test
   public void testAboveBelowCrossingDifferentEdges() {
     // POLYGON((130.846821906638 -5.066128831305991,134.5635278421427
     // 21.75703481126756,156.31803093908155 44.5755831677161,0.0
@@ -1848,7 +1812,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point1) == largePolygon.isWithin(point1));
   }
 
-  @Test
   public void testBelowCrossingTwiceEdgePoint() {
     // POLYGON((162.9024012378976 -0.17652184258966092,162.56882659034474
     // -0.009075185910497524,162.52932263918404 1.6235907240799453E-189,162.17731099253956
@@ -1889,7 +1852,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point) == largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8245() {
     // POLYGON((-70.19447784626787 -83.117346007187,0.0 2.8E-322,-139.99870438810106
     // 7.994601469571884,-143.14292702670522 -18.500141088122664,-158.7373186858464
@@ -1933,7 +1895,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point) == largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8245_case2() {
     // POLYGON((5.512285089810178 -26.833721534785912,12.13983320542565
     // -16.085163683089583,4.868755337835201 -9.167423203860656,0.0
@@ -1980,7 +1941,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point) == largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8245_case3() {
     // POLYGON((144.76249846857021 8.828705232593283,166.00162989841027 -8.5E-322,157.03429484830787
     // 64.92565566857392,108.64696979831984 39.10241638996957,102.54234512410089
@@ -2026,7 +1986,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point) == largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8245_case4() {
     // POLYGON((-3.728795716978514 -10.354090605548162,-137.97868338527985
     // 0.05602723926521642,-113.87317441507611 -76.2471400450585,-162.64032677742279
@@ -2073,7 +2032,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point) == largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8251() {
     // POLYGON((135.63207358036593 -51.43541696593334,113.00782694696038 -58.984559858566556,0.0
     // -3.68E-321,-66.33598777585381 -7.382056816201731,135.63207358036593 -51.43541696593334))
@@ -2117,7 +2075,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point) == largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8257() {
     // POLYGON((12.9610296281349 -8.35317290232106,15.448601008878832
     // -3.990004427754539,22.375905319231205 0.2308875600810982,-13.473550791109867
@@ -2175,7 +2132,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point) == largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8258() {
     // POLYGON((0.004541088101890366 2.457524007073783E-4,0.003771467014711204
     // 0.0011493732122651466,0.003975546116981415 0.002208372357731988,0.0010780690991920934
@@ -2232,7 +2188,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point) == largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8266_case1() {
     // POLYGON((-6.35093158794635E-11 -4.965517818537545E-11,0.0 3.113E-321,-60.23538585411111
     // 18.46706692248612, 162.37100340450482 -25.988383239097754,-6.35093158794635E-11
@@ -2273,7 +2228,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertFalse(largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8266_case2() {
     // POLYGON((7.885596306952593 -42.25131029665893,1.5412637897085604
     // -6.829581354691802,34.03338913004999 27.583811665797796,0.0 5.7E-322,-8.854664233194431E-12
@@ -2325,7 +2279,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertFalse(largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8266_case3() {
     // POLYGON((-98.38897266664411 7.286530349760722,-169.07259176302364
     // -7.410435277740526,8E-123,-179.9999999999438 -1.298973436027626E-10,66.2759716901292
@@ -2373,7 +2326,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertFalse(largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8276_case1() {
     // POLYGON((1.0517792672527197E-4 -1.592702733911458E-5,1.0324192726355287E-4
     // 2.5741558803919037E-5,7.879018764391666E-5 7.192932029677136E-5,0.0
@@ -2421,7 +2373,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point) == largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8276_case2() {
     // POLYGON((0.05925400271049228 -0.08922986460239596,0.07309863706879852
     // -0.07813330646578831,0.07411491387725304 -0.07715685640120272,0.0
@@ -2478,7 +2429,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point) == largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8276_case3() {
     // POLYGON((2.693381024483753E-4 -0.001073608118084019,1.5848404608659423E-4
     // -2.6378130512803985E-4,8.981079660799132E-4 -6.4697719116416E-4,-7.934854852157693E-5
@@ -2531,7 +2481,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point) == largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8281() {
     /*
      * [junit4]    > Standard polygon: GeoCompositePolygon: {[GeoConvexPolygon: {planetmodel=PlanetModel.WGS84, points=[[lat=-3.89514302068452E-6, lon=6.597839410815709E-6([X=1.0011188539630433, Y=6.605221429683868E-6, Z=-3.89950111699443E-6])], [lat=-2.8213942160840002E-6, lon=1.608008770581648E-5([X=1.0011188538590383, Y=1.60980789753873E-5, Z=-2.8245509442632E-6])], [lat=3.8977187534179774E-6, lon=1.9713406091526053E-5([X=1.0011188537902969, Y=1.973546251320774E-5, Z=3.902079731596721E-6])], [lat=1.980614928404974E-5, lon=4.069266235973146E-6([X=1.0011188537865057, Y=4.07381914993205E-6, Z=1.982830947192924E-5])], [lat=7.4E-323, lon=0.0([X=1.0011188539924791, Y=0.0, Z=7.4E-323])]], internalEdges={4}}, GeoConvexPolygon: {planetmodel=PlanetModel.WGS84, points=[[lat=-3.89514302068452E-6, lon=6.597839410815709E-6([X=1.0011188539630433, Y=6.605221429683868E-6, Z=-3.89950111699443E-6])], [lat=7.4E-323, lon=0.0([X=1.0011188539924791, Y=0.0, Z=7.4E-323])], [lat=-1.261719663233924E-5, lon=-1.5701544210600105E-5([X=1.001118853788849, Y=-1.5719111944122703E-5, Z=-1.2631313432823314E-5])]], internalEdges={0}}]}
@@ -2597,7 +2546,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point) == largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8280() {
     /*
      * [junit4]   1>       unquantized=[lat=0.16367268756896675, lon=-3.141592653589793([X=-0.9876510422569805, Y=-1.2095236875745584E-16, Z=0.16311061810965483])]
@@ -2644,7 +2592,6 @@ public class TestGeoPolygon extends LuceneTestCase {
 
   }
 
-  @Test
   public void testLUCENE8337() {
     /*
      *  {planetmodel=PlanetModel.WGS84, number of shapes=1, address=c865f21d,
@@ -2681,7 +2628,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(largePolygon.isWithin(thePoint) == smallPolygon.isWithin(thePoint));
   }
 
-  @Test
   public void testLUCENE8444() {
     // POLYGON((0.0 -67.68132244526963,-1.2477695347678826E-95 -88.11137674490907,
     // 1.7059188343238906E-9 7.009654350320916,0.0 -67.68132244526963))
@@ -2718,7 +2664,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(false == largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8445() {
     // POLYGON((32.18017946378854 -17.397683785381247,49.51018758330871
     // -9.870219317504647,58.77903721991479 33.90553510354402,2.640604559432277
@@ -2775,7 +2720,6 @@ public class TestGeoPolygon extends LuceneTestCase {
     assertTrue(polygon.isWithin(point) == largePolygon.isWithin(point));
   }
 
-  @Test
   public void testLUCENE8451() {
     // POLYGON((-2.5185339401969213 -24.093993739745027,0.0
     // 8.828539494442529E-27,5.495998489568957E-11 -8.321407453133E-11,2.7174659198424288E-11

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestPlane.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestPlane.java
@@ -17,12 +17,10 @@
 package org.apache.lucene.spatial3d.geom;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /** Test basic plane functionality. */
 public class TestPlane extends LuceneTestCase {
 
-  @Test
   public void testIdenticalPlanes() {
     final GeoPoint p = new GeoPoint(PlanetModel.SPHERE, 0.123, -0.456);
     final Plane plane1 = new Plane(p, 0.0);
@@ -38,7 +36,6 @@ public class TestPlane extends LuceneTestCase {
     assertTrue(p1.isNumericallyIdentical(p2));
   }
 
-  @Test
   public void testIdenticalVector() {
     final Vector v1 = new Vector(1, 0, 0);
     final Vector v2 = new Vector(1, 0, 0);
@@ -47,7 +44,6 @@ public class TestPlane extends LuceneTestCase {
     assertFalse(v1.isNumericallyIdentical(v3));
   }
 
-  @Test
   public void testInterpolation() {
     // [X=0.35168818443386646, Y=-0.19637966197066342, Z=0.9152870857244183],
     // [X=0.5003343189532654, Y=0.522128543226148, Z=0.6906861469771293],
@@ -68,7 +64,6 @@ public class TestPlane extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testFindArcPoints() {
     // Create two points
     final GeoPoint p1 = new GeoPoint(PlanetModel.WGS84, 0.123, -0.456);

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestRandomBinaryCodec.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestRandomBinaryCodec.java
@@ -27,11 +27,9 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /** Test to check Serialization */
 public class TestRandomBinaryCodec extends LuceneTestCase {
-  @Test
   @Repeat(iterations = 10)
   public void testRandomPointCodec() throws IOException {
     PlanetModel planetModel = randomPlanetModel();
@@ -43,7 +41,6 @@ public class TestRandomBinaryCodec extends LuceneTestCase {
     assertEquals(shape.toString(), shape, shapeCopy);
   }
 
-  @Test
   @Repeat(iterations = 100)
   public void testRandomPlanetObjectCodec() throws IOException {
     PlanetModel planetModel = randomPlanetModel();
@@ -56,7 +53,6 @@ public class TestRandomBinaryCodec extends LuceneTestCase {
     assertEquals(shape.toString(), shape, shapeCopy);
   }
 
-  @Test
   @Repeat(iterations = 100)
   public void testRandomShapeCodec() throws IOException {
     PlanetModel planetModel = randomPlanetModel();

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestRandomGeoPolygon.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestRandomGeoPolygon.java
@@ -25,11 +25,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /** Random test for polygons. */
 public class TestRandomGeoPolygon extends LuceneTestCase {
-  @Test
   public void testRandomLUCENE8157() {
     final PlanetModel planetModel = randomPlanetModel();
     final GeoPoint startPoint = randomGeoPoint(planetModel);
@@ -71,7 +69,6 @@ public class TestRandomGeoPolygon extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testCoplanarityTilePolygon() {
     // POLYGON((-90.55764 -0.34907,-90.55751 -0.34868,-90.55777 -0.34842,-90.55815
     // -0.34766,-90.55943 -0.34842, -90.55918 -0.34842,-90.55764 -0.34907))
@@ -100,13 +97,11 @@ public class TestRandomGeoPolygon extends LuceneTestCase {
   }
 
   /** Test comparing different polygon (Big) technologies using random biased doubles. */
-  @Test
   public void testCompareBigPolygons() {
     testComparePolygons(Math.PI);
   }
 
   /** Test comparing different polygon (Small) technologies using random biased doubles. */
-  @Test
   public void testCompareSmallPolygons() {
     testComparePolygons(1e-4 * Math.PI);
   }

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestRandomGeoShapeRelationship.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestRandomGeoShapeRelationship.java
@@ -36,7 +36,6 @@ import static org.apache.lucene.spatial3d.tests.RandomGeo3dShapeGenerator.random
 import static org.apache.lucene.spatial3d.tests.RandomGeo3dShapeGenerator.randomShapeType;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /** Random test to check relationship between GeoAreaShapes and GeoShapes. */
 public class TestRandomGeoShapeRelationship extends LuceneTestCase {
@@ -44,7 +43,6 @@ public class TestRandomGeoShapeRelationship extends LuceneTestCase {
    * Test for WITHIN points. We build a WITHIN shape with respect the geoAreaShape and create a
    * point WITHIN the shape. The resulting shape should be WITHIN the original shape.
    */
-  @Test
   public void testRandomPointWithin() {
     int referenceShapeType = CONVEX_POLYGON;
     PlanetModel planetModel = randomPlanetModel();
@@ -104,7 +102,6 @@ public class TestRandomGeoShapeRelationship extends LuceneTestCase {
    *
    * <p>Note that both shapes cannot be concave.
    */
-  @Test
   public void testRandomDisjoint() {
     int referenceShapeType = CONVEX_SIMPLE_POLYGON;
     PlanetModel planetModel = randomPlanetModel();
@@ -141,7 +138,6 @@ public class TestRandomGeoShapeRelationship extends LuceneTestCase {
    *
    * <p>Note that if the geoAreaShape is not concave the other shape must be not concave.
    */
-  @Test
   public void testRandomWithIn() {
     PlanetModel planetModel = randomPlanetModel();
     int geoAreaShapeType = randomGeoAreaShapeType();
@@ -189,7 +185,6 @@ public class TestRandomGeoShapeRelationship extends LuceneTestCase {
    * concave, the shape for reference should be concave as well.
    */
   // TODO: this test seems to hit pathological cases that cause it to run for many minutes?!
-  @Test
   @Nightly
   public void testRandomContains() {
     int referenceShapeType = CONVEX_SIMPLE_POLYGON;
@@ -238,7 +233,6 @@ public class TestRandomGeoShapeRelationship extends LuceneTestCase {
    * disjoint to other part and contains a disjoint shape. We create shapes according the criteria.
    * The resulting shape should OVERLAP the geoAreaShape.
    */
-  @Test
   public void testRandomOverlaps() {
     PlanetModel planetModel = randomPlanetModel();
     int geoAreaShapeType = randomGeoAreaShapeType();

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestRandomPlane.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestRandomPlane.java
@@ -24,12 +24,10 @@ import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /** Random test for planes. */
 public class TestRandomPlane extends LuceneTestCase {
 
-  @Test
   @Repeat(iterations = 10)
   public void testPlaneAccuracy() {
     PlanetModel planetModel = randomPlanetModel();
@@ -53,7 +51,6 @@ public class TestRandomPlane extends LuceneTestCase {
     }
   }
 
-  @Test
   @Repeat(iterations = 10)
   public void testPlaneThreePointsAccuracy() {
     PlanetModel planetModel = randomPlanetModel();
@@ -91,7 +88,6 @@ public class TestRandomPlane extends LuceneTestCase {
     }
   }
 
-  @Test
   @Repeat(iterations = 10)
   public void testPolygonAccuracy() {
     PlanetModel planetModel = randomPlanetModel();

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestSimpleGeoPolygonRelationships.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestSimpleGeoPolygonRelationships.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 /**
  * Check relationship between polygon and GeoShapes of basic polygons. Normally we construct the
@@ -30,7 +29,6 @@ import org.junit.Test;
 public class TestSimpleGeoPolygonRelationships extends LuceneTestCase {
 
   /** Test with two shapes with no crossing edges and no points in common in convex case. */
-  @Test
   public void testGeoSimplePolygon1() {
 
     // POLYGON ((19.845091 -60.452631, 20.119948 -61.655652, 23.207901 -61.453298, 22.820804
@@ -109,7 +107,6 @@ public class TestSimpleGeoPolygonRelationships extends LuceneTestCase {
   }
 
   /** Test with two shapes with crossing edges and some points inside in convex case. */
-  @Test
   public void testGeoSimplePolygon2() {
 
     // POLYGON ((19.845091 -60.452631, 20.119948 -61.655652, 23.207901 -61.453298, 22.820804
@@ -189,7 +186,6 @@ public class TestSimpleGeoPolygonRelationships extends LuceneTestCase {
   }
 
   /** Test with two shapes with no crossing edges and all points inside in convex case. */
-  @Test
   public void testGeoSimplePolygon3() {
 
     // POLYGON ((19.845091 -60.452631, 20.119948 -61.655652, 23.207901 -61.453298, 22.820804
@@ -269,7 +265,6 @@ public class TestSimpleGeoPolygonRelationships extends LuceneTestCase {
   }
 
   /** Test with two shapes with crossing edges and no points inside in convex case. */
-  @Test
   public void testGeoSimplePolygon4() {
     // POLYGON ((19.845091 -60.452631, 20.119948 -61.655652, 23.207901 -61.453298, 22.820804
     // -60.257713, 19.845091 -60.452631)) disjoint
@@ -349,7 +344,6 @@ public class TestSimpleGeoPolygonRelationships extends LuceneTestCase {
   }
 
   /** Test with two shapes with no crossing edges and polygon in hole in convex case. */
-  @Test
   public void testGeoSimplePolygonWithHole1() {
     // POLYGON((-135 -31, -135 -30, -137 -30, -137 -31, -135 -31),(-135.5 -30.7, -135.5 -30.4,
     // -136.5 -30.4, -136.5 -30.7, -135.5 -30.7))
@@ -393,7 +387,6 @@ public class TestSimpleGeoPolygonRelationships extends LuceneTestCase {
   }
 
   /** Test with two shapes with crossing edges in hole and some points inside in convex case. */
-  @Test
   public void testGeoSimplePolygonWithHole2() {
     // POLYGON((-135 -31, -135 -30, -137 -30, -137 -31, -135 -31),(-135.5 -30.7, -135.5 -30.4,
     // -136.5 -30.4, -136.5 -30.7, -135.5 -30.7))
@@ -438,7 +431,6 @@ public class TestSimpleGeoPolygonRelationships extends LuceneTestCase {
   }
 
   /** Test with two shapes with crossing edges and some points inside in convex case. */
-  @Test
   public void testGeoSimplePolygonWithHole3() {
     // POLYGON((-135 -31, -135 -30, -137 -30, -137 -31, -135 -31),(-135.5 -30.7, -135.5 -30.4,
     // -136.5 -30.4, -136.5 -30.7, -135.5 -30.7))
@@ -483,7 +475,6 @@ public class TestSimpleGeoPolygonRelationships extends LuceneTestCase {
   }
 
   /** Test with two shapes with no crossing edges and all points inside in convex case. */
-  @Test
   public void testGeoSimplePolygonWithHole4() {
     // POLYGON((-135 -31, -135 -30, -137 -30, -137 -31, -135 -31),(-135.5 -30.7, -135.5 -30.4,
     // -136.5 -30.4, -136.5 -30.7, -135.5 -30.7))
@@ -526,7 +517,6 @@ public class TestSimpleGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.OVERLAPS, rel);
   }
 
-  @Test
   public void testGeoSimplePolygonWithCircle() {
     // POLYGON ((19.845091 -60.452631, 20.119948 -61.655652, 23.207901 -61.453298, 22.820804
     // -60.257713, 19.845091 -60.452631)) disjoint
@@ -616,7 +606,6 @@ public class TestSimpleGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.CONTAINS, rel);
   }
 
-  @Test
   public void testGeoSimplePolygonWithBBox() {
     // POLYGON ((19.845091 -60.452631, 20.119948 -61.655652, 23.207901 -61.453298, 22.820804
     // -60.257713, 19.845091 -60.452631)) disjoint
@@ -718,7 +707,6 @@ public class TestSimpleGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.CONTAINS, rel);
   }
 
-  @Test
   public void testGeoSimplePolygonWithComposite() {
     GeoShape shape = getCompositeShape();
 
@@ -773,7 +761,6 @@ public class TestSimpleGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.OVERLAPS, rel);
   }
 
-  @Test
   public void testDegeneratedPointIntersectShape() {
     GeoBBox bBox1 = GeoBBoxFactory.makeGeoBBox(PlanetModel.SPHERE, 1, 0, 0, 1);
     GeoBBox bBox2 = GeoBBoxFactory.makeGeoBBox(PlanetModel.SPHERE, 1, 1, 1, 1);
@@ -787,7 +774,6 @@ public class TestSimpleGeoPolygonRelationships extends LuceneTestCase {
     assertEquals(GeoArea.CONTAINS, rel);
   }
 
-  @Test
   public void testDegeneratedPointInPole() {
     GeoBBox bBox1 =
         GeoBBoxFactory.makeGeoBBox(PlanetModel.SPHERE, Math.PI * 0.5, Math.PI * 0.5, 0, 0);
@@ -796,7 +782,6 @@ public class TestSimpleGeoPolygonRelationships extends LuceneTestCase {
     assertTrue(bBox1.isWithin(point));
   }
 
-  @Test
   public void testDegeneratePathShape() {
     GeoPoint point1 = new GeoPoint(PlanetModel.SPHERE, 0, 0);
     GeoPoint point2 = new GeoPoint(PlanetModel.SPHERE, 0, 1);

--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestXYZSolid.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestXYZSolid.java
@@ -17,11 +17,9 @@
 package org.apache.lucene.spatial3d.geom;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
 
 public class TestXYZSolid extends LuceneTestCase {
 
-  @Test
   public void testNonDegenerateRelationships() {
     XYZSolid s;
     GeoShape shape;
@@ -60,7 +58,6 @@ public class TestXYZSolid extends LuceneTestCase {
     assertEquals(GeoArea.DISJOINT, s.getRelationship(shape));
   }
 
-  @Test
   public void testDegenerateRelationships() {
     GeoArea solid;
     GeoShape shape;
@@ -217,7 +214,6 @@ public class TestXYZSolid extends LuceneTestCase {
 
   }
 
-  @Test
   public void testLUCENE8457() {
     GeoShape shape =
         GeoBBoxFactory.makeGeoBBox(

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/TestDocumentDictionary.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/TestDocumentDictionary.java
@@ -44,10 +44,10 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 // See: https://issues.apache.org/jira/browse/SOLR-12028 Tests cannot remove files on Windows
 // machines occasionally
+
 public class TestDocumentDictionary extends LuceneTestCase {
 
   static final String FIELD_NAME = "f1";
@@ -55,7 +55,6 @@ public class TestDocumentDictionary extends LuceneTestCase {
   static final String PAYLOAD_FIELD_NAME = "p1";
   static final String CONTEXT_FIELD_NAME = "c1";
 
-  @Test
   public void testEmptyReader() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -77,7 +76,6 @@ public class TestDocumentDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testBasic() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -118,7 +116,6 @@ public class TestDocumentDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testWithOptionalPayload() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -154,7 +151,6 @@ public class TestDocumentDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testWithoutPayload() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -193,7 +189,6 @@ public class TestDocumentDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testWithContexts() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -241,7 +236,6 @@ public class TestDocumentDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testWithDeletions() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -301,7 +295,6 @@ public class TestDocumentDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testMultiValuedField() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/TestDocumentValueSourceDictionary.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/TestDocumentValueSourceDictionary.java
@@ -47,7 +47,6 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 public class TestDocumentValueSourceDictionary extends LuceneTestCase {
 
@@ -58,7 +57,6 @@ public class TestDocumentValueSourceDictionary extends LuceneTestCase {
   static final String PAYLOAD_FIELD_NAME = "p1";
   static final String CONTEXTS_FIELD_NAME = "c1";
 
-  @Test
   public void testValueSourceEmptyReader() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -81,7 +79,6 @@ public class TestDocumentValueSourceDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testLongValuesSourceEmptyReader() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -104,7 +101,6 @@ public class TestDocumentValueSourceDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testValueSourceBasic() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -204,7 +200,6 @@ public class TestDocumentValueSourceDictionary extends LuceneTestCase {
     };
   }
 
-  @Test
   public void testLongValuesSourceBasic() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -240,7 +235,6 @@ public class TestDocumentValueSourceDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testValueSourceWithContext() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -281,7 +275,6 @@ public class TestDocumentValueSourceDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testLongValuesSourceWithContext() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -322,7 +315,6 @@ public class TestDocumentValueSourceDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testValueSourceWithoutPayload() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -354,7 +346,6 @@ public class TestDocumentValueSourceDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testLongValuesSourceWithoutPayload() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -386,7 +377,6 @@ public class TestDocumentValueSourceDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testValueSourceWithDeletions() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -441,7 +431,6 @@ public class TestDocumentValueSourceDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testLongValuesSourceWithDeletions() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -496,7 +485,6 @@ public class TestDocumentValueSourceDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testWithValueSource() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());
@@ -528,7 +516,6 @@ public class TestDocumentValueSourceDictionary extends LuceneTestCase {
     IOUtils.close(ir, analyzer, dir);
   }
 
-  @Test
   public void testWithLongValuesSource() throws IOException {
     Directory dir = newDirectory();
     Analyzer analyzer = new MockAnalyzer(random());

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/TestFileDictionary.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/TestFileDictionary.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
-import org.junit.Test;
 
 public class TestFileDictionary extends LuceneTestCase {
 
@@ -74,7 +73,6 @@ public class TestFileDictionary extends LuceneTestCase {
     return new SimpleEntry<>(entries, sb.toString());
   }
 
-  @Test
   public void testFileWithTerm() throws IOException {
     Map.Entry<List<List<String>>, String> fileInput =
         generateFileInput(atLeast(100), FileDictionary.DEFAULT_FIELD_DELIMITER, false, false);
@@ -98,7 +96,6 @@ public class TestFileDictionary extends LuceneTestCase {
     assertEquals(count, entries.size());
   }
 
-  @Test
   public void testFileWithWeight() throws IOException {
     Map.Entry<List<List<String>>, String> fileInput =
         generateFileInput(atLeast(100), FileDictionary.DEFAULT_FIELD_DELIMITER, true, false);
@@ -122,7 +119,6 @@ public class TestFileDictionary extends LuceneTestCase {
     assertEquals(count, entries.size());
   }
 
-  @Test
   public void testFileWithWeightAndPayload() throws IOException {
     Map.Entry<List<List<String>>, String> fileInput =
         generateFileInput(atLeast(100), FileDictionary.DEFAULT_FIELD_DELIMITER, true, true);
@@ -150,7 +146,6 @@ public class TestFileDictionary extends LuceneTestCase {
     assertEquals(count, entries.size());
   }
 
-  @Test
   public void testFileWithOneEntry() throws IOException {
     Map.Entry<List<List<String>>, String> fileInput =
         generateFileInput(1, FileDictionary.DEFAULT_FIELD_DELIMITER, true, true);
@@ -178,7 +173,6 @@ public class TestFileDictionary extends LuceneTestCase {
     assertEquals(count, entries.size());
   }
 
-  @Test
   public void testFileWithDifferentDelimiter() throws IOException {
     Map.Entry<List<List<String>>, String> fileInput =
         generateFileInput(atLeast(100), " , ", true, true);

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/analyzing/TestAnalyzingInfixSuggester.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/analyzing/TestAnalyzingInfixSuggester.java
@@ -50,7 +50,6 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
-import org.junit.Test;
 
 public class TestAnalyzingInfixSuggester extends LuceneTestCase {
 
@@ -1332,7 +1331,6 @@ public class TestAnalyzingInfixSuggester extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testAddPrefixMatch() throws IOException {
     Analyzer a = new MockAnalyzer(random(), MockTokenizer.WHITESPACE, false);
     Directory dir = newDirectory();

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestContextQuery.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestContextQuery.java
@@ -37,7 +37,6 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.ArrayUtil;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 
 public class TestContextQuery extends LuceneTestCase {
   public Directory dir;
@@ -52,7 +51,6 @@ public class TestContextQuery extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testIllegalInnerQuery() throws Exception {
     IllegalArgumentException expected =
         expectThrows(
@@ -66,7 +64,6 @@ public class TestContextQuery extends LuceneTestCase {
     assertTrue(expected.getMessage().contains(ContextQuery.class.getSimpleName()));
   }
 
-  @Test
   public void testSimpleContextQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -106,7 +103,6 @@ public class TestContextQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testContextQueryOnSuggestField() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -142,7 +138,6 @@ public class TestContextQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testNonExactContextQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -179,7 +174,6 @@ public class TestContextQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testContextPrecedenceBoost() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -210,7 +204,6 @@ public class TestContextQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testEmptyContext() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -240,7 +233,6 @@ public class TestContextQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testEmptyContextWithBoosts() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -278,7 +270,6 @@ public class TestContextQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testSameSuggestionMultipleContext() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -317,7 +308,6 @@ public class TestContextQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testMixedContextQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -356,7 +346,6 @@ public class TestContextQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testFilteringContextQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -392,7 +381,6 @@ public class TestContextQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testContextQueryRewrite() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -427,7 +415,6 @@ public class TestContextQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testMultiContextQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -468,7 +455,6 @@ public class TestContextQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testBigNumberOfContextsQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -500,7 +486,6 @@ public class TestContextQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testAllContextQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -536,7 +521,6 @@ public class TestContextQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testRandomContextQueryScoring() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     try (RandomIndexWriter iw =

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestContextSuggestField.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestContextSuggestField.java
@@ -38,7 +38,6 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRefBuilder;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 
 public class TestContextSuggestField extends LuceneTestCase {
 
@@ -54,7 +53,6 @@ public class TestContextSuggestField extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testEmptySuggestion() throws Exception {
     IllegalArgumentException expected =
         expectThrows(
@@ -65,7 +63,6 @@ public class TestContextSuggestField extends LuceneTestCase {
     assertTrue(expected.getMessage().contains("value"));
   }
 
-  @Test
   public void testReservedChars() throws Exception {
     CharsRefBuilder charsRefBuilder = new CharsRefBuilder();
     charsRefBuilder.append("sugg");
@@ -105,7 +102,6 @@ public class TestContextSuggestField extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testTokenStream() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     ContextSuggestField field =
@@ -159,7 +155,6 @@ public class TestContextSuggestField extends LuceneTestCase {
         null);
   }
 
-  @Test
   public void testMixedSuggestFields() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     Document document = new Document();
@@ -180,7 +175,6 @@ public class TestContextSuggestField extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testWithSuggestFields() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -230,7 +224,6 @@ public class TestContextSuggestField extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testCompletionAnalyzer() throws Exception {
     CompletionAnalyzer completionAnalyzer =
         new CompletionAnalyzer(new StandardAnalyzer(), true, true);

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestFuzzyCompletionQuery.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestFuzzyCompletionQuery.java
@@ -30,7 +30,6 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 
 public class TestFuzzyCompletionQuery extends LuceneTestCase {
   public Directory dir;
@@ -45,7 +44,6 @@ public class TestFuzzyCompletionQuery extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testFuzzyQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -79,7 +77,6 @@ public class TestFuzzyCompletionQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testFuzzyContextQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -117,7 +114,6 @@ public class TestFuzzyCompletionQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testFuzzyFilteredContextQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestPrefixCompletionQuery.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestPrefixCompletionQuery.java
@@ -46,7 +46,6 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 
 public class TestPrefixCompletionQuery extends LuceneTestCase {
 
@@ -142,7 +141,6 @@ public class TestPrefixCompletionQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testEmptyPrefixQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestRegexCompletionQuery.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestRegexCompletionQuery.java
@@ -31,7 +31,6 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 
 public class TestRegexCompletionQuery extends LuceneTestCase {
   public Directory dir;
@@ -46,7 +45,6 @@ public class TestRegexCompletionQuery extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testRegexQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -82,7 +80,6 @@ public class TestRegexCompletionQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testEmptyRegexQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -106,7 +103,6 @@ public class TestRegexCompletionQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testSimpleRegexContextQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -144,7 +140,6 @@ public class TestRegexCompletionQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testRegexContextQueryWithBoost() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -185,7 +180,6 @@ public class TestRegexCompletionQuery extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testEmptyRegexContextQuery() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestSuggestField.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestSuggestField.java
@@ -69,7 +69,6 @@ import org.apache.lucene.util.CharsRefBuilder;
 import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 
 public class TestSuggestField extends LuceneTestCase {
 
@@ -85,7 +84,6 @@ public class TestSuggestField extends LuceneTestCase {
     dir.close();
   }
 
-  @Test
   public void testEmptySuggestion() throws Exception {
     IllegalArgumentException expected =
         expectThrows(
@@ -93,7 +91,6 @@ public class TestSuggestField extends LuceneTestCase {
     MatcherAssert.assertThat(expected.getMessage(), containsString("value"));
   }
 
-  @Test
   public void testNegativeWeight() throws Exception {
     IllegalArgumentException expected =
         expectThrows(
@@ -101,7 +98,6 @@ public class TestSuggestField extends LuceneTestCase {
     MatcherAssert.assertThat(expected.getMessage(), containsString("weight"));
   }
 
-  @Test
   public void testReservedChars() throws Exception {
     CharsRefBuilder charsRefBuilder = new CharsRefBuilder();
     charsRefBuilder.append("sugg");
@@ -127,7 +123,6 @@ public class TestSuggestField extends LuceneTestCase {
     MatcherAssert.assertThat(expected.getMessage(), containsString("[0x0]"));
   }
 
-  @Test
   public void testEmpty() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -142,7 +137,6 @@ public class TestSuggestField extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testTokenStream() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     SuggestField suggestField = new SuggestField("field", "input", 1);
@@ -179,7 +173,6 @@ public class TestSuggestField extends LuceneTestCase {
         null);
   }
 
-  @Test
   public void testDupSuggestFieldValues() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -438,7 +431,6 @@ public class TestSuggestField extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testNRTDeletedDocFiltering() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     // using IndexWriter instead of RandomIndexWriter
@@ -478,7 +470,6 @@ public class TestSuggestField extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testSuggestOnAllFilteredDocuments() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -514,7 +505,6 @@ public class TestSuggestField extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testSuggestOnAllDeletedDocuments() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     // using IndexWriter instead of RandomIndexWriter
@@ -544,7 +534,6 @@ public class TestSuggestField extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testSuggestOnMostlyDeletedDocuments() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     // using IndexWriter instead of RandomIndexWriter
@@ -575,7 +564,6 @@ public class TestSuggestField extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testMultipleSuggestFieldsPerDoc() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -615,7 +603,6 @@ public class TestSuggestField extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testEarlyTermination() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -645,7 +632,6 @@ public class TestSuggestField extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testMultipleSegments() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -678,7 +664,6 @@ public class TestSuggestField extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testReturnedDocID() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -716,7 +701,6 @@ public class TestSuggestField extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testScoring() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -761,7 +745,6 @@ public class TestSuggestField extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testRealisticKeys() throws Exception {
     Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =
@@ -812,7 +795,6 @@ public class TestSuggestField extends LuceneTestCase {
     iw.close();
   }
 
-  @Test
   public void testThreads() throws Exception {
     final Analyzer analyzer = new MockAnalyzer(random());
     RandomIndexWriter iw =

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/fst/TestBytesRefSorters.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/fst/TestBytesRefSorters.java
@@ -29,10 +29,8 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.OfflineSorter;
-import org.junit.Test;
 
 public class TestBytesRefSorters extends LuceneTestCase {
-  @Test
   public void testExternalRefSorter() throws Exception {
     Directory tempDir = newDirectory();
     ExternalRefSorter s = new ExternalRefSorter(new OfflineSorter(tempDir, "temp"));
@@ -40,7 +38,6 @@ public class TestBytesRefSorters extends LuceneTestCase {
     IOUtils.close(s, tempDir);
   }
 
-  @Test
   public void testExternalRefSortersIteratorIsCloseable() throws Exception {
     try (Directory tempDir = newDirectory();
         ExternalRefSorter s = new ExternalRefSorter(new OfflineSorter(tempDir, "temp"))) {
@@ -56,7 +53,6 @@ public class TestBytesRefSorters extends LuceneTestCase {
     }
   }
 
-  @Test
   public void testInMemorySorter() throws Exception {
     check(new InMemorySorter(Comparator.naturalOrder()));
   }


### PR DESCRIPTION
This removes spurious Test annotations and some junit4-specific syntax. I'll commit it separately so that #16027 is cleaner.