### PR TITLE
Deprecate `getCollectors()` from `TopFieldCollectorManager`

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -23,6 +23,10 @@ API Changes
 * GITHUB#15584: Add support for termdoc fields that use custom term freqs (via IndexOptions.DOCS_AND_CUSTOM_FREQS).
   IndexWriter counts their terms rather than summing their freqs.  Use
 
+* GITHUB#15605: Deprecate getCollectors() in TopFieldCollectorManager. The internal collector
+  tracking is unnecessary and will be removed in Lucene 11. Clarify thread-safety
+  documentation. (Prudhvi Godithi)
+
 New Features
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -26,8 +26,8 @@ API Changes
 * GITHUB#16043: Add field parameter to FlatVectorsReader.getFlatVectorScorer to match the other
   scorer methods in that class. (Simon Cooper)
 
-* GITHUB#15605: Remove unused getCollectors() and internal collector tracking from
-  TopFieldCollectorManager. Clarify thread-safety documentation. (Prudhvi Godithi)
+* GITHUB#16042: Deprecate TopFieldCollectorManager#getCollectors. The result of the search operation is returned
+  as part of a TopFieldDocs instance, there is no need to check the state of each collector after search
 
 New Features
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -23,9 +23,9 @@ API Changes
 * GITHUB#15584: Add support for termdoc fields that use custom term freqs (via IndexOptions.DOCS_AND_CUSTOM_FREQS).
   IndexWriter counts their terms rather than summing their freqs.  Use
 
-* GITHUB#15605: Deprecate getCollectors() in TopFieldCollectorManager. The internal collector
-  tracking is unnecessary and will be removed in Lucene 11. Clarify thread-safety
-  documentation. (Prudhvi Godithi)
+* GITHUB#15605: Deprecate TopFieldCollectorManager#getCollectors. The result of the search
+  operation is returned as part of a TopFieldDocs instance, there is no need to check the state
+  of each collector after search. (Prudhvi Godithi)
 
 New Features
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -27,7 +27,7 @@ API Changes
   scorer methods in that class. (Simon Cooper)
 
 * GITHUB#16042: Deprecate TopFieldCollectorManager#getCollectors. The result of the search operation is returned
-  as part of a TopFieldDocs instance, there is no need to check the state of each collector after search
+  as part of a TopFieldDocs instance, there is no need to check the state of each collector after search. (Prudhvi Godithi)
 
 New Features
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollectorManager.java
@@ -189,11 +189,8 @@ public class TopFieldCollectorManager implements CollectorManager<TopFieldCollec
   /**
    * Returns the collectors created by this manager.
    *
-   * @deprecated This method and internal collector tracking will be removed in Lucene 11. The
-   *     internal collector tracking is unnecessary since collectors are passed to {@link
-   *     #reduce(Collection)} by {@link IndexSearcher}. Users who need to track collectors (e.g.,
-   *     for early termination detection via {@link TopFieldCollector#isEarlyTerminated()}) should
-   *     maintain their own collection.
+   * @deprecated This method will be removed in Lucene 11. All needed information, including early
+   *     termination, is available in the {@link TopFieldDocs} returned by reduction.
    */
   @Deprecated
   public List<TopFieldCollector> getCollectors() {

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollectorManager.java
@@ -61,8 +61,12 @@ public class TopFieldCollectorManager implements CollectorManager<TopFieldCollec
   }
 
   /**
-   * Creates a new {@link TopFieldCollectorManager} from the given arguments, with thread-safe
-   * internal states.
+   * Creates a new {@link TopFieldCollectorManager} from the given arguments.
+   *
+   * <p>Thread safety is guaranteed for the shared internal states (hit counting, minimum score
+   * propagation) across collectors created by {@link #newCollector()}. Note that {@link
+   * #newCollector()} itself is designed to be called from a single thread; {@link IndexSearcher}
+   * handles this by calling it sequentially before parallel slice execution.
    *
    * <p><b>NOTE</b>: The instances returned by this method pre-allocate a full array of length
    * <code>numHits</code>.
@@ -182,6 +186,16 @@ public class TopFieldCollectorManager implements CollectorManager<TopFieldCollec
     return TopDocs.merge(sort, 0, numHits, topDocs);
   }
 
+  /**
+   * Returns the collectors created by this manager.
+   *
+   * @deprecated This method and internal collector tracking will be removed in Lucene 11. The
+   *     internal collector tracking is unnecessary since collectors are passed to {@link
+   *     #reduce(Collection)} by {@link IndexSearcher}. Users who need to track collectors (e.g.,
+   *     for early termination detection via {@link TopFieldCollector#isEarlyTerminated()}) should
+   *     maintain their own collection.
+   */
+  @Deprecated
   public List<TopFieldCollector> getCollectors() {
     return collectors;
   }


### PR DESCRIPTION
### Description

Coming from https://github.com/apache/lucene/pull/15608. Deprecates `getCollectors()` in `TopFieldCollectorManager` in `branch_10x`  and clarifies thread-safety documentation.


Resolves https://github.com/apache/lucene/issues/15605.
