### PR TITLE
Specify the field name when getting the FlatVectorsScorer

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -276,6 +276,9 @@ API Changes
 * GITHUB#15584: Add support for termdoc fields that use custom term freqs (via IndexOptions.DOCS_AND_CUSTOM_FREQS).
   IndexWriter counts their terms rather than summing their freqs.  Use
 
+* GITHUB#16043: Add field parameter to FlatVectorsReader.getFlatVectorScorer to match the other
+  scorer methods in that class. (Simon Cooper)
+
 New Features
 ---------------------
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene102/Lucene102BinaryQuantizedVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene102/Lucene102BinaryQuantizedVectorsReader.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CorruptIndexException;
@@ -94,7 +95,6 @@ public class Lucene102BinaryQuantizedVectorsReader extends FlatVectorsReader
       FlatVectorsReader rawVectorsReader,
       Lucene102BinaryFlatVectorsScorer vectorsScorer)
       throws IOException {
-    super(vectorsScorer);
     this.vectorScorer = vectorsScorer;
     this.rawVectorsReader = rawVectorsReader;
     int versionMeta = -1;
@@ -175,6 +175,11 @@ public class Lucene102BinaryQuantizedVectorsReader extends FlatVectorsReader
               + ") = "
               + numQuantizedVectorBytes);
     }
+  }
+
+  @Override
+  public FlatVectorsScorer getFlatVectorScorer(String field) throws IOException {
+    return vectorScorer;
   }
 
   @Override

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
@@ -66,6 +66,7 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
       RamUsageEstimator.shallowSizeOfInstance(Lucene99ScalarQuantizedVectorsReader.class);
 
   private final IntObjectHashMap<FieldEntry> fields = new IntObjectHashMap<>();
+  private final FlatVectorsScorer vectorScorer;
   private final IndexInput quantizedVectorData;
   private final FlatVectorsReader rawVectorsReader;
   private final FieldInfos fieldInfos;
@@ -74,7 +75,7 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
   public Lucene99ScalarQuantizedVectorsReader(
       SegmentReadState state, FlatVectorsReader rawVectorsReader, FlatVectorsScorer scorer)
       throws IOException {
-    super(scorer);
+    this.vectorScorer = scorer;
     this.rawVectorsReader = rawVectorsReader;
     this.fieldInfos = state.fieldInfos;
     int versionMeta = -1;
@@ -261,6 +262,11 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
       IOUtils.closeWhileSuppressingExceptions(t, in);
       throw t;
     }
+  }
+
+  @Override
+  public FlatVectorsScorer getFlatVectorScorer(String field) throws IOException {
+    return vectorScorer;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsReader.java
@@ -40,20 +40,12 @@ import org.apache.lucene.util.hnsw.RandomVectorScorer;
  */
 public abstract class FlatVectorsReader extends KnnVectorsReader implements Accountable {
 
-  /** Scorer for flat vectors */
-  protected final FlatVectorsScorer vectorScorer;
-
-  /** Sole constructor */
-  protected FlatVectorsReader(FlatVectorsScorer vectorsScorer) {
-    this.vectorScorer = vectorsScorer;
-  }
-
   /**
-   * @return the {@link FlatVectorsScorer} for this reader.
+   * Returns a {@link FlatVectorsScorer} for the given field.
+   *
+   * @param field the field to search
    */
-  public FlatVectorsScorer getFlatVectorScorer() {
-    return vectorScorer;
-  }
+  public abstract FlatVectorsScorer getFlatVectorScorer(String field) throws IOException;
 
   @Override
   public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsReader.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CorruptIndexException;
@@ -98,7 +99,6 @@ public class Lucene104ScalarQuantizedVectorsReader extends FlatVectorsReader
       Lucene104ScalarQuantizedVectorScorer vectorsScorer,
       DataAccessHint accessHint)
       throws IOException {
-    super(vectorsScorer);
     this.vectorScorer = vectorsScorer;
     this.rawVectorsReader = rawVectorsReader;
     int versionMeta = -1;
@@ -184,6 +184,11 @@ public class Lucene104ScalarQuantizedVectorsReader extends FlatVectorsReader
               + ") = "
               + numQuantizedVectorBytes);
     }
+  }
+
+  @Override
+  public FlatVectorsScorer getFlatVectorScorer(String field) throws IOException {
+    return vectorScorer;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
@@ -62,6 +62,7 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
       RamUsageEstimator.shallowSizeOfInstance(Lucene99FlatVectorsFormat.class);
 
   private final IntObjectHashMap<FieldEntry> fields = new IntObjectHashMap<>();
+  private final FlatVectorsScorer vectorScorer;
   private final IndexInput vectorData;
   private final FieldInfos fieldInfos;
   private final IOContext dataContext;
@@ -81,8 +82,8 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
   public Lucene99FlatVectorsReader(
       SegmentReadState state, FlatVectorsScorer scorer, DataAccessHint accessHint)
       throws IOException {
-    super(scorer);
     int versionMeta = readMetadata(state);
+    this.vectorScorer = scorer;
     this.fieldInfos = state.fieldInfos;
     FileOpenHint[] hints =
         Stream.of(FileTypeHint.DATA, FileDataHint.KNN_VECTORS, accessHint)
@@ -249,6 +250,11 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
         fieldEntry.vectorDataOffset,
         fieldEntry.vectorDataLength,
         vectorData);
+  }
+
+  @Override
+  public FlatVectorsScorer getFlatVectorScorer(String field) throws IOException {
+    return vectorScorer;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
@@ -447,7 +447,7 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
         } else {
           RandomVectorScorerSupplier scorerSupplier =
               flatVectorsReader
-                  .getFlatVectorScorer()
+                  .getFlatVectorScorer(fieldInfo.getName())
                   .getRandomVectorScorerSupplier(
                       fieldInfo.getVectorSimilarityFunction(), vectorValues);
           buildAndWriteGraph(fieldInfo, mergeState, vectorValues, scorerSupplier, totalVectorCount);


### PR DESCRIPTION
`FlatVectorsReader` is currently inconsistent - the field name is specified when getting the random vectors scorer, but not when getting the flat vectors scorer. This adds the name as a method parameter to match the other getters in the class.

Change is aimed at 10.5. The reader class is marked as experimental, so this is ok to change in minor versions.