### PR TITLE
Join post-HNSW block rescore for diversifying child KNN (POC)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -108,6 +108,11 @@ New Features
 
 Improvements
 ---------------------
+* GITHUB#15839: DiversifyingChildren KNN queries now support optional post-HNSW block rescoring:
+  when enabled, all children in each found parent's block are scored after approximate search,
+  guaranteeing the best child per parent is returned and correctly tracking extra visited nodes.
+  (Prithvi S)
+
 * GITHUB#15704: Replace LinkedList with more efficient data structure. (Renato Haeberli)
 
 * GITHUB#15682: Use ArrayDeque instead of LinkedList in CompoundWordTokenFilterBase.java. (Renato Haeberli)

--- a/lucene/benchmark-jmh/build.gradle
+++ b/lucene/benchmark-jmh/build.gradle
@@ -20,6 +20,7 @@ description = 'Lucene JMH micro-benchmarking module'
 dependencies {
   moduleImplementation project(':lucene:core')
   moduleImplementation project(':lucene:expressions')
+  moduleImplementation project(':lucene:join')
   moduleImplementation project(':lucene:sandbox')
   moduleTestImplementation project(':lucene:test-framework')
 

--- a/lucene/benchmark-jmh/src/java/module-info.java
+++ b/lucene/benchmark-jmh/src/java/module-info.java
@@ -24,6 +24,7 @@ module org.apache.lucene.benchmark.jmh {
   requires jdk.unsupported;
   requires org.apache.lucene.core;
   requires org.apache.lucene.expressions;
+  requires org.apache.lucene.join;
   requires org.apache.lucene.sandbox;
   requires commons.math3;
 

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/DiversifyingChildrenFloatKnnJoinBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/DiversifyingChildrenFloatKnnJoinBenchmark.java
@@ -37,6 +37,7 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
 import org.apache.lucene.search.join.QueryBitSetProducer;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.VectorUtil;
@@ -60,22 +61,21 @@ import org.openjdk.jmh.infra.Blackhole;
  * index (children + parent marker per block), using the default HNSW approximate path ({@code
  * childFilter == null}).
  *
- * <p>The {@code blockRescore} parameter switches the feature on/off so both modes can be compared
+ * <p>The {@code rescoreBlocks} parameter switches the feature on/off so both modes can be compared
  * in a single run (see <a href="https://github.com/apache/lucene/issues/15839">LUCENE-15839</a>).
  * Extra work scales roughly with {@code topK * childrenPerParent}.
  *
- * <p>Indicative results on Apple M-series, JDK 25, dim=96, topK=64, 4096 parent blocks (lower is
- * better):
+ * <p>Indicative results — 3 forks, 5 warmup / 10 measurement iterations, JDK 25, {@code -Xmx2g},
+ * dim=96, topK=64, 4096 parent blocks (lower is better):
  *
  * <pre>
- * blockRescore  childrenPerParent  Score (ms/op)
- * false         8                  0.123
- * false         32                 0.226
- * false         64                 0.254
- * true          8                  0.151  (+23%)
- * true          32                 0.316  (+40%)
- * true          64                 0.412  (+62%)
+ * childrenPerParent  rescoreBlocks=false    rescoreBlocks=true
+ * 8                  0.117 ± 0.002 ms/op    0.149 ± 0.002 ms/op  (+27%)
+ * 32                 0.237 ± 0.006 ms/op    0.326 ± 0.009 ms/op  (+38%)
+ * 64                 0.259 ± 0.005 ms/op    0.426 ± 0.013 ms/op  (+64%)
  * </pre>
+ *
+ * <p>Overhead grows with block width (and with {@code topK}).
  *
  * <p>Example:
  *
@@ -83,16 +83,16 @@ import org.openjdk.jmh.infra.Blackhole;
  * ./gradlew :lucene:benchmark-jmh:assemble
  * cd lucene/benchmark-jmh/build/benchmarks
  * java -jar lucene-benchmark-jmh-*-SNAPSHOT.jar DiversifyingChildrenFloatKnnJoin \\
- *     -f 2 -wi 3 -i 8 -tu ms
+ *     -f 3 -wi 5 -i 10 -tu ms
  * }</pre>
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 6, time = 1)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
 @Fork(
-    value = 2,
+    value = 3,
     jvmArgsAppend = {
       "-Xmx2g",
       "-Xms2g",
@@ -117,12 +117,12 @@ public class DiversifyingChildrenFloatKnnJoinBenchmark {
 
   /**
    * Whether to enable post-HNSW block rescoring. When {@code true}, after HNSW search all children
-   * in each found parent's block are scored to guarantee the best child is returned. Compare
-   * {@code false} (baseline / no rescoring) against {@code true} (rescoring enabled) to measure
-   * latency overhead.
+   * in each found parent's block are scored to guarantee the best child is returned. Compare {@code
+   * false} (baseline / no rescoring) against {@code true} (rescoring enabled) to measure latency
+   * overhead.
    */
   @Param({"false", "true"})
-  public boolean blockRescore;
+  public boolean rescoreBlocks;
 
   private Directory directory;
   private IndexSearcher searcher;
@@ -176,12 +176,9 @@ public class DiversifyingChildrenFloatKnnJoinBenchmark {
     searcher = new IndexSearcher(reader);
     BitSetProducer parentsFilter =
         new QueryBitSetProducer(new TermQuery(new Term("docType", "_parent")));
+    // [1, 0, ..., 0] is already L2-normalized.
     float[] queryVector = new float[dimension];
     queryVector[0] = 1f;
-    for (int i = 1; i < dimension; i++) {
-      queryVector[i] = 0f;
-    }
-    VectorUtil.l2normalize(queryVector, false);
     diversifyingJoinQuery =
         new DiversifyingChildrenFloatKnnVectorQuery(
             "vec",
@@ -189,8 +186,8 @@ public class DiversifyingChildrenFloatKnnJoinBenchmark {
             null,
             topK,
             parentsFilter,
-            org.apache.lucene.search.knn.KnnSearchStrategy.Hnsw.DEFAULT,
-            blockRescore);
+            KnnSearchStrategy.Hnsw.DEFAULT,
+            rescoreBlocks);
   }
 
   @TearDown(Level.Trial)

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/DiversifyingChildrenFloatKnnJoinBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/DiversifyingChildrenFloatKnnJoinBenchmark.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
+import org.apache.lucene.search.join.QueryBitSetProducer;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.VectorUtil;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * End-to-end {@link DiversifyingChildrenFloatKnnVectorQuery} search on a single-segment block-join
+ * index (children + parent marker per block), using the default HNSW approximate path ({@code
+ * childFilter == null}).
+ *
+ * <p>The {@code blockRescore} parameter switches the feature on/off so both modes can be compared
+ * in a single run (see <a href="https://github.com/apache/lucene/issues/15839">LUCENE-15839</a>).
+ * Extra work scales roughly with {@code topK * childrenPerParent}.
+ *
+ * <p>Indicative results on Apple M-series, JDK 25, dim=96, topK=64, 4096 parent blocks (lower is
+ * better):
+ *
+ * <pre>
+ * blockRescore  childrenPerParent  Score (ms/op)
+ * false         8                  0.123
+ * false         32                 0.226
+ * false         64                 0.254
+ * true          8                  0.151  (+23%)
+ * true          32                 0.316  (+40%)
+ * true          64                 0.412  (+62%)
+ * </pre>
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ * ./gradlew :lucene:benchmark-jmh:assemble
+ * cd lucene/benchmark-jmh/build/benchmarks
+ * java -jar lucene-benchmark-jmh-*-SNAPSHOT.jar DiversifyingChildrenFloatKnnJoin \\
+ *     -f 2 -wi 3 -i 8 -tu ms
+ * }</pre>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 6, time = 1)
+@Fork(
+    value = 2,
+    jvmArgsAppend = {
+      "-Xmx2g",
+      "-Xms2g",
+      "-XX:+AlwaysPreTouch",
+      "--add-modules=jdk.incubator.vector"
+    })
+public class DiversifyingChildrenFloatKnnJoinBenchmark {
+
+  /** Approximate neighbors per diversified parent bucket. */
+  @Param({"64"})
+  public int topK;
+
+  /**
+   * Children with vectors per parent block. Post-HNSW block rescoring iterates sibling children in
+   * each retained block, so incremental cost rises with this parameter.
+   */
+  @Param({"8", "32", "64"})
+  public int childrenPerParent;
+
+  @Param({"96"})
+  public int dimension;
+
+  /**
+   * Whether to enable post-HNSW block rescoring. When {@code true}, after HNSW search all children
+   * in each found parent's block are scored to guarantee the best child is returned. Compare
+   * {@code false} (baseline / no rescoring) against {@code true} (rescoring enabled) to measure
+   * latency overhead.
+   */
+  @Param({"false", "true"})
+  public boolean blockRescore;
+
+  private Directory directory;
+  private IndexSearcher searcher;
+  private Query diversifyingJoinQuery;
+
+  static Document parentDoc() {
+    Document d = new Document();
+    d.add(new StringField("docType", "_parent", Field.Store.NO));
+    return d;
+  }
+
+  /** Fixed corpus size for stable HNSW behavior; must be >= topK. */
+  private static final int NUM_PARENT_BLOCKS = 4096;
+
+  private static float[] randomUnitVector(Random random, int dim, float[] scratch) {
+    for (int i = 0; i < dim; i++) {
+      scratch[i] = random.nextFloat() * 2f - 1f;
+    }
+    return VectorUtil.l2normalize(scratch, false);
+  }
+
+  @Setup(Level.Trial)
+  public void setupTrial() throws IOException {
+    if (topK > NUM_PARENT_BLOCKS) {
+      throw new IllegalStateException("topK must be <= NUM_PARENT_BLOCKS");
+    }
+    directory = new ByteBuffersDirectory();
+    IndexWriterConfig iwc = new IndexWriterConfig();
+    long randomSeed = 0xC0FFEE42F00DL ^ ((long) childrenPerParent << 32) ^ dimension;
+    Random random = new Random(randomSeed);
+    float[] scratch = new float[dimension];
+    try (IndexWriter w = new IndexWriter(directory, iwc)) {
+      for (int p = 0; p < NUM_PARENT_BLOCKS; p++) {
+        List<Document> block = new ArrayList<>(childrenPerParent + 1);
+        for (int c = 0; c < childrenPerParent; c++) {
+          Document child = new Document();
+          child.add(
+              new KnnFloatVectorField(
+                  "vec",
+                  randomUnitVector(random, dimension, scratch),
+                  VectorSimilarityFunction.DOT_PRODUCT));
+          block.add(child);
+        }
+        block.add(parentDoc());
+        w.addDocuments(block);
+      }
+      w.forceMerge(1);
+    }
+
+    var reader = DirectoryReader.open(directory);
+    searcher = new IndexSearcher(reader);
+    BitSetProducer parentsFilter =
+        new QueryBitSetProducer(new TermQuery(new Term("docType", "_parent")));
+    float[] queryVector = new float[dimension];
+    queryVector[0] = 1f;
+    for (int i = 1; i < dimension; i++) {
+      queryVector[i] = 0f;
+    }
+    VectorUtil.l2normalize(queryVector, false);
+    diversifyingJoinQuery =
+        new DiversifyingChildrenFloatKnnVectorQuery(
+            "vec",
+            queryVector,
+            null,
+            topK,
+            parentsFilter,
+            org.apache.lucene.search.knn.KnnSearchStrategy.Hnsw.DEFAULT,
+            blockRescore);
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDownTrial() throws IOException {
+    if (searcher != null) {
+      searcher.getIndexReader().close();
+    }
+    if (directory != null) {
+      directory.close();
+    }
+  }
+
+  @Benchmark
+  public void searchDiversifyingJoinHnsw(Blackhole bh) throws IOException {
+    TopDocs hits = searcher.search(diversifyingJoinQuery, topK);
+    bh.consume(hits.scoreDocs.length);
+    bh.consume(hits.totalHits.value());
+    if (hits.scoreDocs.length > 0) {
+      bh.consume(hits.scoreDocs[0].doc);
+      bh.consume(hits.scoreDocs[0].score);
+    }
+  }
+}

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenByteKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenByteKnnVectorQuery.java
@@ -60,7 +60,7 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
   private final Query childFilter;
   private final int k;
   private final byte[] query;
-  private final boolean blockRescore;
+  private final boolean rescoreBlocks;
 
   /**
    * Create a ToParentBlockJoinByteVectorQuery.
@@ -102,10 +102,15 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
   /**
    * Create a DiversifyingChildrenByteKnnVectorQuery with optional post-HNSW block rescoring.
    *
-   * <p>When {@code blockRescore} is {@code true}, after the approximate HNSW search completes, all
-   * children in each found parent's block are scored to guarantee the truly best child is returned.
-   * See {@link DiversifyingChildrenFloatKnnVectorQuery#DiversifyingChildrenFloatKnnVectorQuery(
-   * String, float[], Query, int, BitSetProducer, KnnSearchStrategy, boolean)} for details.
+   * <p>When {@code rescoreBlocks} is {@code true}, after the approximate HNSW search completes, all
+   * children in each found parent's block are scored to guarantee the truly best child is returned
+   * — not merely the sibling the graph traversal happened to reach first. This adds O(k &times;
+   * childrenPerParent) extra scoring work; enable it when block sizes are small or result quality
+   * is more important than latency.
+   *
+   * <p>This applies only to the approximate (HNSW) search path. When the index is small enough that
+   * Lucene falls back to exact search, all children are already scored exhaustively and no
+   * additional rescoring is performed.
    *
    * @param field the query field
    * @param query the vector query
@@ -113,7 +118,7 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
    * @param k how many parent documents to return given the matching children
    * @param parentsFilter Filter identifying the parent documents.
    * @param searchStrategy the search strategy to use.
-   * @param blockRescore if {@code true}, enables post-HNSW block rescoring.
+   * @param rescoreBlocks if {@code true}, enables post-HNSW block rescoring.
    * @lucene.experimental
    */
   public DiversifyingChildrenByteKnnVectorQuery(
@@ -123,13 +128,13 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
       int k,
       BitSetProducer parentsFilter,
       KnnSearchStrategy searchStrategy,
-      boolean blockRescore) {
+      boolean rescoreBlocks) {
     super(field, query, k, childFilter, searchStrategy);
     this.childFilter = childFilter;
     this.parentsFilter = parentsFilter;
     this.k = k;
     this.query = query;
-    this.blockRescore = blockRescore;
+    this.rescoreBlocks = rescoreBlocks;
   }
 
   @Override
@@ -204,7 +209,7 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
     }
     context.reader().searchNearestVectors(field, query, collector, acceptDocs);
     TopDocs results = collector.topDocs();
-    if (!blockRescore || results.scoreDocs.length == 0) {
+    if (!rescoreBlocks || results.scoreDocs.length == 0) {
       return results;
     }
     BitSet parentBitSet = parentsFilter.getBitSet(context);
@@ -243,7 +248,7 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
     if (!super.equals(o)) return false;
     DiversifyingChildrenByteKnnVectorQuery that = (DiversifyingChildrenByteKnnVectorQuery) o;
     return k == that.k
-        && blockRescore == that.blockRescore
+        && rescoreBlocks == that.rescoreBlocks
         && Objects.equals(parentsFilter, that.parentsFilter)
         && Objects.equals(childFilter, that.childFilter)
         && Arrays.equals(query, that.query);
@@ -251,7 +256,7 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(super.hashCode(), parentsFilter, childFilter, k, blockRescore);
+    int result = Objects.hash(super.hashCode(), parentsFilter, childFilter, k, rescoreBlocks);
     result = 31 * result + Arrays.hashCode(query);
     return result;
   }

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenByteKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenByteKnnVectorQuery.java
@@ -60,6 +60,7 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
   private final Query childFilter;
   private final int k;
   private final byte[] query;
+  private final boolean blockRescore;
 
   /**
    * Create a ToParentBlockJoinByteVectorQuery.
@@ -72,7 +73,7 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
    */
   public DiversifyingChildrenByteKnnVectorQuery(
       String field, byte[] query, Query childFilter, int k, BitSetProducer parentsFilter) {
-    this(field, query, childFilter, k, parentsFilter, DEFAULT);
+    this(field, query, childFilter, k, parentsFilter, DEFAULT, false);
   }
 
   /**
@@ -95,11 +96,40 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
       int k,
       BitSetProducer parentsFilter,
       KnnSearchStrategy searchStrategy) {
+    this(field, query, childFilter, k, parentsFilter, searchStrategy, false);
+  }
+
+  /**
+   * Create a DiversifyingChildrenByteKnnVectorQuery with optional post-HNSW block rescoring.
+   *
+   * <p>When {@code blockRescore} is {@code true}, after the approximate HNSW search completes, all
+   * children in each found parent's block are scored to guarantee the truly best child is returned.
+   * See {@link DiversifyingChildrenFloatKnnVectorQuery#DiversifyingChildrenFloatKnnVectorQuery(
+   * String, float[], Query, int, BitSetProducer, KnnSearchStrategy, boolean)} for details.
+   *
+   * @param field the query field
+   * @param query the vector query
+   * @param childFilter the child filter
+   * @param k how many parent documents to return given the matching children
+   * @param parentsFilter Filter identifying the parent documents.
+   * @param searchStrategy the search strategy to use.
+   * @param blockRescore if {@code true}, enables post-HNSW block rescoring.
+   * @lucene.experimental
+   */
+  public DiversifyingChildrenByteKnnVectorQuery(
+      String field,
+      byte[] query,
+      Query childFilter,
+      int k,
+      BitSetProducer parentsFilter,
+      KnnSearchStrategy searchStrategy,
+      boolean blockRescore) {
     super(field, query, k, childFilter, searchStrategy);
     this.childFilter = childFilter;
     this.parentsFilter = parentsFilter;
     this.k = k;
     this.query = query;
+    this.blockRescore = blockRescore;
   }
 
   @Override
@@ -173,7 +203,25 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
       return NO_RESULTS;
     }
     context.reader().searchNearestVectors(field, query, collector, acceptDocs);
-    return collector.topDocs();
+    TopDocs results = collector.topDocs();
+    if (!blockRescore || results.scoreDocs.length == 0) {
+      return results;
+    }
+    BitSet parentBitSet = parentsFilter.getBitSet(context);
+    if (parentBitSet == null) {
+      return results;
+    }
+    ByteVectorValues vectorValues = context.reader().getByteVectorValues(field);
+    if (vectorValues == null) {
+      return results;
+    }
+    VectorScorer scorer = vectorValues.scorer(query);
+    if (scorer == null) {
+      return results;
+    }
+    // Delegate to the shared static implementation in the float variant.
+    return DiversifyingChildrenFloatKnnVectorQuery.blockRescore(
+        results, acceptDocs, parentBitSet, scorer);
   }
 
   @Override
@@ -195,6 +243,7 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
     if (!super.equals(o)) return false;
     DiversifyingChildrenByteKnnVectorQuery that = (DiversifyingChildrenByteKnnVectorQuery) o;
     return k == that.k
+        && blockRescore == that.blockRescore
         && Objects.equals(parentsFilter, that.parentsFilter)
         && Objects.equals(childFilter, that.childFilter)
         && Arrays.equals(query, that.query);
@@ -202,7 +251,7 @@ public class DiversifyingChildrenByteKnnVectorQuery extends KnnByteVectorQuery {
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(super.hashCode(), parentsFilter, childFilter, k);
+    int result = Objects.hash(super.hashCode(), parentsFilter, childFilter, k, blockRescore);
     result = 31 * result + Arrays.hashCode(query);
     return result;
   }

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenFloatKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenFloatKnnVectorQuery.java
@@ -20,6 +20,7 @@ import static org.apache.lucene.search.knn.KnnSearchStrategy.Hnsw.DEFAULT;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Objects;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.LeafReaderContext;
@@ -39,6 +40,7 @@ import org.apache.lucene.search.VectorScorer;
 import org.apache.lucene.search.knn.KnnCollectorManager;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.Bits;
 
 /**
  * kNN float vector query that joins matching children vector documents with their parent doc id.
@@ -60,6 +62,7 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
   private final Query childFilter;
   private final int k;
   private final float[] query;
+  private final boolean blockRescore;
 
   /**
    * Create a DiversifyingChildrenFloatKnnVectorQuery.
@@ -72,7 +75,7 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
    */
   public DiversifyingChildrenFloatKnnVectorQuery(
       String field, float[] query, Query childFilter, int k, BitSetProducer parentsFilter) {
-    this(field, query, childFilter, k, parentsFilter, DEFAULT);
+    this(field, query, childFilter, k, parentsFilter, DEFAULT, false);
   }
 
   /**
@@ -95,11 +98,41 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
       int k,
       BitSetProducer parentsFilter,
       KnnSearchStrategy searchStrategy) {
+    this(field, query, childFilter, k, parentsFilter, searchStrategy, false);
+  }
+
+  /**
+   * Create a DiversifyingChildrenFloatKnnVectorQuery with optional post-HNSW block rescoring.
+   *
+   * <p>When {@code blockRescore} is {@code true}, after the approximate HNSW search completes, all
+   * children in each found parent's block are scored to guarantee the truly best child is returned —
+   * not merely the sibling the graph traversal happened to reach first. This adds O(k &times;
+   * childrenPerParent) extra scoring work; enable it when block sizes are small or result quality is
+   * more important than latency.
+   *
+   * @param field the query field
+   * @param query the vector query
+   * @param childFilter the child filter
+   * @param k how many parent documents to return given the matching children
+   * @param parentsFilter Filter identifying the parent documents.
+   * @param searchStrategy the search strategy to use.
+   * @param blockRescore if {@code true}, enables post-HNSW block rescoring.
+   * @lucene.experimental
+   */
+  public DiversifyingChildrenFloatKnnVectorQuery(
+      String field,
+      float[] query,
+      Query childFilter,
+      int k,
+      BitSetProducer parentsFilter,
+      KnnSearchStrategy searchStrategy,
+      boolean blockRescore) {
     super(field, query, k, childFilter, searchStrategy);
     this.childFilter = childFilter;
     this.parentsFilter = parentsFilter;
     this.k = k;
     this.query = query;
+    this.blockRescore = blockRescore;
   }
 
   @Override
@@ -172,7 +205,73 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
       return NO_RESULTS;
     }
     context.reader().searchNearestVectors(field, query, collector, acceptDocs);
-    return collector.topDocs();
+    TopDocs results = collector.topDocs();
+    if (!blockRescore || results.scoreDocs.length == 0) {
+      return results;
+    }
+    BitSet parentBitSet = parentsFilter.getBitSet(context);
+    if (parentBitSet == null) {
+      return results;
+    }
+    FloatVectorValues vectorValues = context.reader().getFloatVectorValues(field);
+    if (vectorValues == null) {
+      return results;
+    }
+    VectorScorer scorer = vectorValues.scorer(query);
+    if (scorer == null) {
+      return results;
+    }
+    return blockRescore(results, acceptDocs, parentBitSet, scorer);
+  }
+
+  /**
+   * For each parent already found by approximate search, scores all children in that parent's block
+   * to ensure the truly best child is returned — not merely the sibling the graph traversal happened
+   * to reach first. Children are processed in ascending docId order so the sequential {@link
+   * VectorScorer} only advances forward. Extra nodes scored are added to {@link
+   * TotalHits#value()}.
+   *
+   * <p>This method is package-private so that {@link DiversifyingChildrenByteKnnVectorQuery} can
+   * reuse the same implementation rather than duplicating it.
+   */
+  static TopDocs blockRescore(
+      TopDocs results, AcceptDocs acceptDocs, BitSet parentBitSet, VectorScorer scorer)
+      throws IOException {
+    Bits acceptBits = acceptDocs != null ? acceptDocs.bits() : null;
+    DocIdSetIterator scorerIter = scorer.iterator();
+
+    // Sort by docId so parent blocks are visited in ascending order — the forward-only
+    // VectorScorer cannot go backwards.
+    ScoreDoc[] scoreDocs = results.scoreDocs.clone();
+    Arrays.sort(scoreDocs, Comparator.comparingInt(sd -> sd.doc));
+
+    long extraVisited = 0;
+    for (ScoreDoc scoreDoc : scoreDocs) {
+      int parent = parentBitSet.nextSetBit(scoreDoc.doc);
+      int prevParent = parent > 0 ? parentBitSet.prevSetBit(parent - 1) : -1;
+      int hnswBestChild = scoreDoc.doc;
+      // Score every sibling in [prevParent+1, parent) to find the block's true best.
+      for (int child = prevParent + 1; child < parent; child++) {
+        if (acceptBits != null && !acceptBits.get(child)) {
+          continue;
+        }
+        if (scorerIter.advance(child) == child) {
+          // Don't double-count the child HNSW already visited.
+          if (child != hnswBestChild) {
+            extraVisited++;
+          }
+          float s = scorer.score();
+          if (s > scoreDoc.score) {
+            scoreDoc.score = s;
+            scoreDoc.doc = child;
+          }
+        }
+      }
+    }
+
+    Arrays.sort(scoreDocs, (a, b) -> Float.compare(b.score, a.score));
+    long totalVisited = results.totalHits.value() + extraVisited;
+    return new TopDocs(new TotalHits(totalVisited, results.totalHits.relation()), scoreDocs);
   }
 
   @Override
@@ -194,6 +293,7 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
     if (!super.equals(o)) return false;
     DiversifyingChildrenFloatKnnVectorQuery that = (DiversifyingChildrenFloatKnnVectorQuery) o;
     return k == that.k
+        && blockRescore == that.blockRescore
         && Objects.equals(parentsFilter, that.parentsFilter)
         && Objects.equals(childFilter, that.childFilter)
         && Arrays.equals(query, that.query);
@@ -201,7 +301,7 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(super.hashCode(), parentsFilter, childFilter, k);
+    int result = Objects.hash(super.hashCode(), parentsFilter, childFilter, k, blockRescore);
     result = 31 * result + Arrays.hashCode(query);
     return result;
   }

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenFloatKnnVectorQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenFloatKnnVectorQuery.java
@@ -20,7 +20,6 @@ import static org.apache.lucene.search.knn.KnnSearchStrategy.Hnsw.DEFAULT;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Objects;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.LeafReaderContext;
@@ -62,7 +61,7 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
   private final Query childFilter;
   private final int k;
   private final float[] query;
-  private final boolean blockRescore;
+  private final boolean rescoreBlocks;
 
   /**
    * Create a DiversifyingChildrenFloatKnnVectorQuery.
@@ -104,11 +103,15 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
   /**
    * Create a DiversifyingChildrenFloatKnnVectorQuery with optional post-HNSW block rescoring.
    *
-   * <p>When {@code blockRescore} is {@code true}, after the approximate HNSW search completes, all
-   * children in each found parent's block are scored to guarantee the truly best child is returned —
-   * not merely the sibling the graph traversal happened to reach first. This adds O(k &times;
-   * childrenPerParent) extra scoring work; enable it when block sizes are small or result quality is
-   * more important than latency.
+   * <p>When {@code rescoreBlocks} is {@code true}, after the approximate HNSW search completes, all
+   * children in each found parent's block are scored to guarantee the truly best child is returned
+   * — not merely the sibling the graph traversal happened to reach first. This adds O(k &times;
+   * childrenPerParent) extra scoring work; enable it when block sizes are small or result quality
+   * is more important than latency.
+   *
+   * <p>This applies only to the approximate (HNSW) search path. When the index is small enough that
+   * Lucene falls back to exact search, all children are already scored exhaustively and no
+   * additional rescoring is performed.
    *
    * @param field the query field
    * @param query the vector query
@@ -116,7 +119,7 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
    * @param k how many parent documents to return given the matching children
    * @param parentsFilter Filter identifying the parent documents.
    * @param searchStrategy the search strategy to use.
-   * @param blockRescore if {@code true}, enables post-HNSW block rescoring.
+   * @param rescoreBlocks if {@code true}, enables post-HNSW block rescoring.
    * @lucene.experimental
    */
   public DiversifyingChildrenFloatKnnVectorQuery(
@@ -126,13 +129,13 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
       int k,
       BitSetProducer parentsFilter,
       KnnSearchStrategy searchStrategy,
-      boolean blockRescore) {
+      boolean rescoreBlocks) {
     super(field, query, k, childFilter, searchStrategy);
     this.childFilter = childFilter;
     this.parentsFilter = parentsFilter;
     this.k = k;
     this.query = query;
-    this.blockRescore = blockRescore;
+    this.rescoreBlocks = rescoreBlocks;
   }
 
   @Override
@@ -206,7 +209,7 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
     }
     context.reader().searchNearestVectors(field, query, collector, acceptDocs);
     TopDocs results = collector.topDocs();
-    if (!blockRescore || results.scoreDocs.length == 0) {
+    if (!rescoreBlocks || results.scoreDocs.length == 0) {
       return results;
     }
     BitSet parentBitSet = parentsFilter.getBitSet(context);
@@ -226,13 +229,10 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
 
   /**
    * For each parent already found by approximate search, scores all children in that parent's block
-   * to ensure the truly best child is returned — not merely the sibling the graph traversal happened
-   * to reach first. Children are processed in ascending docId order so the sequential {@link
-   * VectorScorer} only advances forward. Extra nodes scored are added to {@link
+   * to ensure the truly best child is returned — not merely the sibling the graph traversal
+   * happened to reach first. Children are processed in ascending docId order so the sequential
+   * {@link VectorScorer} only advances forward. Extra nodes scored are added to {@link
    * TotalHits#value()}.
-   *
-   * <p>This method is package-private so that {@link DiversifyingChildrenByteKnnVectorQuery} can
-   * reuse the same implementation rather than duplicating it.
    */
   static TopDocs blockRescore(
       TopDocs results, AcceptDocs acceptDocs, BitSet parentBitSet, VectorScorer scorer)
@@ -243,7 +243,7 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
     // Sort by docId so parent blocks are visited in ascending order — the forward-only
     // VectorScorer cannot go backwards.
     ScoreDoc[] scoreDocs = results.scoreDocs.clone();
-    Arrays.sort(scoreDocs, Comparator.comparingInt(sd -> sd.doc));
+    Arrays.sort(scoreDocs, (a, b) -> Integer.compare(a.doc, b.doc));
 
     long extraVisited = 0;
     for (ScoreDoc scoreDoc : scoreDocs) {
@@ -256,10 +256,11 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
           continue;
         }
         if (scorerIter.advance(child) == child) {
-          // Don't double-count the child HNSW already visited.
-          if (child != hnswBestChild) {
-            extraVisited++;
+          if (child == hnswBestChild) {
+            // Advance past the child HNSW already scored; no need to re-compute.
+            continue;
           }
+          extraVisited++;
           float s = scorer.score();
           if (s > scoreDoc.score) {
             scoreDoc.score = s;
@@ -293,7 +294,7 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
     if (!super.equals(o)) return false;
     DiversifyingChildrenFloatKnnVectorQuery that = (DiversifyingChildrenFloatKnnVectorQuery) o;
     return k == that.k
-        && blockRescore == that.blockRescore
+        && rescoreBlocks == that.rescoreBlocks
         && Objects.equals(parentsFilter, that.parentsFilter)
         && Objects.equals(childFilter, that.childFilter)
         && Arrays.equals(query, that.query);
@@ -301,7 +302,7 @@ public class DiversifyingChildrenFloatKnnVectorQuery extends KnnFloatVectorQuery
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(super.hashCode(), parentsFilter, childFilter, k, blockRescore);
+    int result = Objects.hash(super.hashCode(), parentsFilter, childFilter, k, rescoreBlocks);
     result = 31 * result + Arrays.hashCode(query);
     return result;
   }

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinByteKnnVectorQuery.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinByteKnnVectorQuery.java
@@ -18,6 +18,8 @@
 package org.apache.lucene.search.join;
 
 import static org.apache.lucene.index.VectorSimilarityFunction.COSINE;
+import static org.apache.lucene.index.VectorSimilarityFunction.DOT_PRODUCT;
+import static org.apache.lucene.search.TotalHits.Relation.EQUAL_TO;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,13 +31,21 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.VectorScorer;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BytesRef;
 
 public class TestParentBlockJoinByteKnnVectorQuery extends ParentBlockJoinKnnVectorQueryTestCase {
@@ -125,5 +135,152 @@ public class TestParentBlockJoinByteKnnVectorQuery extends ParentBlockJoinKnnVec
       v1[vi++] = b[i];
     }
     return v1;
+  }
+
+  /**
+   * Byte-vector parallel of {@code
+   * TestParentBlockJoinFloatKnnVectorQuery#testBlockRescoreCorrectsSuboptimalResult}: proves the
+   * shared static {@link DiversifyingChildrenFloatKnnVectorQuery#blockRescore} works correctly when
+   * called with a {@link org.apache.lucene.index.ByteVectorValues} scorer.
+   */
+  public void testBlockRescoreCorrectsSuboptimalResult() throws IOException {
+    final byte[] queryVector = new byte[] {1, 0};
+
+    try (Directory d = newDirectory()) {
+      try (IndexWriter w =
+          new IndexWriter(
+              d,
+              new IndexWriterConfig()
+                  .setCodec(TestUtil.getDefaultCodec())
+                  .setMergePolicy(newMergePolicy(random(), false)))) {
+        for (int p = 0; p < 3; p++) {
+          List<Document> block = new ArrayList<>();
+          Document bad = new Document();
+          bad.add(new KnnByteVectorField("field", new byte[] {0, 1}, DOT_PRODUCT));
+          block.add(bad);
+          Document good = new Document();
+          good.add(new KnnByteVectorField("field", new byte[] {1, 0}, DOT_PRODUCT));
+          block.add(good);
+          block.add(makeParent(new int[] {0, 1}));
+          w.addDocuments(block);
+        }
+        w.forceMerge(1);
+      }
+
+      try (IndexReader reader = DirectoryReader.open(d)) {
+        LeafReaderContext leaf = reader.leaves().get(0);
+        BitSetProducer parentFilter = parentFilter(reader);
+        BitSet parentBitSet = parentFilter.getBitSet(leaf);
+
+        VectorScorer badScorer = leaf.reader().getByteVectorValues("field").scorer(queryVector);
+        badScorer.iterator().advance(0);
+        float badScore = badScorer.score();
+
+        //   parent 0 → docId 2,  children are docId 0 (bad) and docId 1 (good)
+        //   parent 1 → docId 5,  children are docId 3 (bad) and docId 4 (good)
+        //   parent 2 → docId 8,  children are docId 6 (bad) and docId 7 (good)
+        ScoreDoc[] badResults =
+            new ScoreDoc[] {
+              new ScoreDoc(0, badScore), new ScoreDoc(3, badScore), new ScoreDoc(6, badScore),
+            };
+        TopDocs badTopDocs = new TopDocs(new TotalHits(10, EQUAL_TO), badResults);
+
+        VectorScorer scorer = leaf.reader().getByteVectorValues("field").scorer(queryVector);
+        TopDocs corrected =
+            DiversifyingChildrenFloatKnnVectorQuery.blockRescore(
+                badTopDocs, null, parentBitSet, scorer);
+
+        assertEquals(3, corrected.scoreDocs.length);
+        assertEquals(1, corrected.scoreDocs[0].doc);
+        assertEquals(4, corrected.scoreDocs[1].doc);
+        assertEquals(7, corrected.scoreDocs[2].doc);
+        for (ScoreDoc sd : corrected.scoreDocs) {
+          assertTrue(
+              "expected score > badScore after rescoring, got " + sd.score,
+              sd.score > badScore + 1e-5f);
+        }
+        assertEquals(10 + 3, corrected.totalHits.value());
+      }
+    }
+  }
+
+  /**
+   * End-to-end verification for the byte variant: with {@code rescoreBlocks=true}, no sibling child
+   * outscores the returned child for any found parent.
+   */
+  public void testBlockRescoreReturnsBestChildPerParent() throws IOException {
+    final int numParents = 10;
+    final int childrenPerParent = 4;
+    final byte[] queryVector = new byte[] {1, 0, 0, 0};
+
+    try (Directory d = newDirectory()) {
+      try (IndexWriter w =
+          new IndexWriter(
+              d,
+              new IndexWriterConfig()
+                  .setCodec(TestUtil.getDefaultCodec())
+                  .setMergePolicy(newMergePolicy(random(), false)))) {
+        for (int p = 0; p < numParents; p++) {
+          List<Document> block = new ArrayList<>();
+          int[] childIds = new int[childrenPerParent];
+          for (int c = 0; c < childrenPerParent; c++) {
+            // Last child is aligned with query; others are orthogonal.
+            byte[] vec = new byte[queryVector.length];
+            vec[c == childrenPerParent - 1 ? 0 : 1 + (c % (queryVector.length - 1))] = 1;
+            Document doc = new Document();
+            doc.add(new KnnByteVectorField("field", vec, DOT_PRODUCT));
+            block.add(doc);
+            childIds[c] = c;
+          }
+          block.add(makeParent(childIds));
+          w.addDocuments(block);
+        }
+        w.forceMerge(1);
+      }
+
+      try (IndexReader reader = DirectoryReader.open(d)) {
+        assertEquals(1, reader.leaves().size());
+        IndexSearcher searcher = new IndexSearcher(reader);
+        BitSetProducer parentFilter = parentFilter(reader);
+
+        DiversifyingChildrenByteKnnVectorQuery query =
+            new DiversifyingChildrenByteKnnVectorQuery(
+                "field",
+                queryVector,
+                null,
+                numParents,
+                parentFilter,
+                KnnSearchStrategy.Hnsw.DEFAULT,
+                true);
+        TopDocs results = searcher.search(query, numParents);
+
+        LeafReaderContext leaf = reader.leaves().get(0);
+        BitSet parentBitSet = parentFilter.getBitSet(leaf);
+
+        for (ScoreDoc sd : results.scoreDocs) {
+          int parent = parentBitSet.nextSetBit(sd.doc);
+          int prevParent = parent > 0 ? parentBitSet.prevSetBit(parent - 1) : -1;
+          VectorScorer sibScorer = leaf.reader().getByteVectorValues("field").scorer(queryVector);
+          DocIdSetIterator sibIter = sibScorer.iterator();
+          for (int child = prevParent + 1; child < parent; child++) {
+            if (sibIter.advance(child) == child) {
+              float sibScore = sibScorer.score();
+              assertTrue(
+                  "block rescore missed a better child: parent="
+                      + parent
+                      + " returnedChild="
+                      + sd.doc
+                      + " returnedScore="
+                      + sd.score
+                      + " siblingChild="
+                      + child
+                      + " siblingScore="
+                      + sibScore,
+                  sd.score + 1e-5f >= sibScore);
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinFloatKnnVectorQuery.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinFloatKnnVectorQuery.java
@@ -18,6 +18,8 @@
 package org.apache.lucene.search.join;
 
 import static org.apache.lucene.index.VectorSimilarityFunction.COSINE;
+import static org.apache.lucene.index.VectorSimilarityFunction.DOT_PRODUCT;
+import static org.apache.lucene.search.TotalHits.Relation.EQUAL_TO;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,13 +32,19 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.VectorScorer;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BitSet;
 
 public class TestParentBlockJoinFloatKnnVectorQuery extends ParentBlockJoinKnnVectorQueryTestCase {
 
@@ -150,5 +158,193 @@ public class TestParentBlockJoinFloatKnnVectorQuery extends ParentBlockJoinKnnVe
       v[i] = random.nextFloat();
     }
     return v;
+  }
+
+  /**
+   * Directly proves that {@code blockRescore} corrects a suboptimal HNSW result: we manually
+   * construct a {@link TopDocs} where every parent is represented by its worst child (the one
+   * pointing away from the query), then verify the static rescore method replaces it with the best
+   * child (the one pointing toward the query).
+   *
+   * <p>This test does not depend on HNSW traversal order and will always demonstrate the
+   * correction.
+   */
+  public void testBlockRescoreCorrectsSuboptimalResult() throws IOException {
+    // 3 parents, each with 2 children:
+    //   child "bad"  → vec orthogonal to query  (DOT_PRODUCT Lucene score ≈ 0.5)
+    //   child "good" → vec aligned with query   (DOT_PRODUCT Lucene score ≈ 1.0)
+    final float[] queryVector = new float[] {1f, 0f};
+
+    try (Directory d = newDirectory()) {
+      try (IndexWriter w =
+          new IndexWriter(
+              d,
+              new IndexWriterConfig()
+                  .setCodec(TestUtil.getDefaultCodec())
+                  .setMergePolicy(newMergePolicy(random(), false)))) {
+        for (int p = 0; p < 3; p++) {
+          List<Document> block = new ArrayList<>();
+          // bad child: orthogonal to query
+          Document bad = new Document();
+          bad.add(new KnnFloatVectorField("field", new float[] {0f, 1f}, DOT_PRODUCT));
+          block.add(bad);
+          // good child: aligned with query
+          Document good = new Document();
+          good.add(new KnnFloatVectorField("field", new float[] {1f, 0f}, DOT_PRODUCT));
+          block.add(good);
+          block.add(makeParent(new int[] {0, 1}));
+          w.addDocuments(block);
+        }
+        w.forceMerge(1);
+      }
+
+      try (IndexReader reader = DirectoryReader.open(d)) {
+        LeafReaderContext leaf = reader.leaves().get(0);
+        BitSetProducer parentFilter = parentFilter(reader);
+        BitSet parentBitSet = parentFilter.getBitSet(leaf);
+
+        // Score the bad child of each parent so we know its score.
+        VectorScorer badScorer = leaf.reader().getFloatVectorValues("field").scorer(queryVector);
+        badScorer.iterator().advance(0); // bad child of parent 0 is docId 0
+        float badScore = badScorer.score();
+
+        // Manually construct a TopDocs that reports only the BAD child per parent —
+        // simulating an HNSW run that reached the wrong sibling first.
+        //   parent 0 → docId 2,  children are docId 0 (bad) and docId 1 (good)
+        //   parent 1 → docId 5,  children are docId 3 (bad) and docId 4 (good)
+        //   parent 2 → docId 8,  children are docId 6 (bad) and docId 7 (good)
+        ScoreDoc[] badResults =
+            new ScoreDoc[] {
+              new ScoreDoc(0, badScore), // bad child of parent 0
+              new ScoreDoc(3, badScore), // bad child of parent 1
+              new ScoreDoc(6, badScore), // bad child of parent 2
+            };
+        TopDocs badTopDocs = new TopDocs(new TotalHits(10, EQUAL_TO), badResults);
+
+        // Rescore using the static package-private method.
+        VectorScorer scorer = leaf.reader().getFloatVectorValues("field").scorer(queryVector);
+        TopDocs corrected =
+            DiversifyingChildrenFloatKnnVectorQuery.blockRescore(
+                badTopDocs, null, parentBitSet, scorer);
+
+        assertEquals(3, corrected.scoreDocs.length);
+        // Every result should now be the GOOD child (one per parent).
+        assertEquals(1, corrected.scoreDocs[0].doc); // good child of parent 0
+        assertEquals(4, corrected.scoreDocs[1].doc); // good child of parent 1
+        assertEquals(7, corrected.scoreDocs[2].doc); // good child of parent 2
+        // Scores must be strictly better than the bad-child scores.
+        for (ScoreDoc sd : corrected.scoreDocs) {
+          assertTrue(
+              "expected score > badScore after rescoring, got " + sd.score,
+              sd.score > badScore + 1e-5f);
+        }
+        // visitedCount must have grown: each parent had 1 extra sibling scored.
+        assertEquals(10 + 3, corrected.totalHits.value());
+      }
+    }
+  }
+
+  /**
+   * End-to-end verification: with {@code blockRescore=true}, the query always returns the best
+   * child for each found parent (no sibling should outscore the returned child).
+   *
+   * <p>The invariant test uses a fresh {@link VectorScorer} per parent (docId-based, not
+   * ordinal-based) to avoid the ordinal/docId confusion that plagues {@code
+   * FloatVectorValues.vectorValue(int ord)}.
+   */
+  public void testBlockRescoreReturnsBestChildPerParent() throws IOException {
+    final int numParents = 20;
+    final int childrenPerParent = 8;
+    final int dim = 4;
+    final float[] queryVector = new float[] {1f, 0f, 0f, 0f};
+
+    try (Directory d = newDirectory()) {
+      try (IndexWriter w =
+          new IndexWriter(
+              d,
+              new IndexWriterConfig()
+                  .setCodec(TestUtil.getDefaultCodec())
+                  .setMergePolicy(newMergePolicy(random(), false)))) {
+        for (int p = 0; p < numParents; p++) {
+          List<Document> block = new ArrayList<>();
+          int[] childIds = new int[childrenPerParent];
+          for (int c = 0; c < childrenPerParent; c++) {
+            // Last child per parent (c == childrenPerParent - 1) is aligned with the query.
+            // All other children use dims 1-3, so DOT_PRODUCT with [1,0,0,0] == 0 → score 0.5.
+            float[] vec = new float[dim];
+            if (c == childrenPerParent - 1) {
+              vec[0] = 1f;
+              vec[1] = (p + 1) * 1e-4f; // tiny perturbation to keep vectors distinct
+            } else {
+              vec[1 + (c % (dim - 1))] = 1f;
+            }
+            normalize(vec);
+            Document doc = new Document();
+            doc.add(new KnnFloatVectorField("field", vec, DOT_PRODUCT));
+            block.add(doc);
+            childIds[c] = c;
+          }
+          block.add(makeParent(childIds));
+          w.addDocuments(block);
+        }
+        w.forceMerge(1);
+      }
+
+      try (IndexReader reader = DirectoryReader.open(d)) {
+        assertEquals(1, reader.leaves().size());
+        IndexSearcher searcher = new IndexSearcher(reader);
+        BitSetProducer parentFilter = parentFilter(reader);
+
+        // blockRescore=true to enable the feature under test.
+        DiversifyingChildrenFloatKnnVectorQuery query =
+            new DiversifyingChildrenFloatKnnVectorQuery(
+                "field",
+                queryVector,
+                null,
+                numParents,
+                parentFilter,
+                org.apache.lucene.search.knn.KnnSearchStrategy.Hnsw.DEFAULT,
+                true);
+        TopDocs results = searcher.search(query, numParents);
+
+        LeafReaderContext leaf = reader.leaves().get(0);
+        BitSet parentBitSet = parentFilter.getBitSet(leaf);
+
+        for (ScoreDoc sd : results.scoreDocs) {
+          int parent = parentBitSet.nextSetBit(sd.doc);
+          int prevParent = parent > 0 ? parentBitSet.prevSetBit(parent - 1) : -1;
+          // Re-score siblings with a fresh docId-based scorer and verify nothing beats the result.
+          VectorScorer sibScorer =
+              leaf.reader().getFloatVectorValues("field").scorer(queryVector);
+          org.apache.lucene.search.DocIdSetIterator sibIter = sibScorer.iterator();
+          for (int child = prevParent + 1; child < parent; child++) {
+            if (sibIter.advance(child) == child) {
+              float sibScore = sibScorer.score();
+              assertTrue(
+                  "block rescore missed a better child: parent="
+                      + parent
+                      + " returnedChild="
+                      + sd.doc
+                      + " returnedScore="
+                      + sd.score
+                      + " siblingChild="
+                      + child
+                      + " siblingScore="
+                      + sibScore,
+                  sd.score + 1e-5f >= sibScore);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private static void normalize(float[] v) {
+    float norm = 0f;
+    for (float x : v) norm += x * x;
+    norm = (float) Math.sqrt(norm);
+    if (norm > 0f) {
+      for (int i = 0; i < v.length; i++) v[i] /= norm;
+    }
   }
 }

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinFloatKnnVectorQuery.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestParentBlockJoinFloatKnnVectorQuery.java
@@ -35,6 +35,7 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
@@ -42,6 +43,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.VectorScorer;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BitSet;
@@ -245,7 +247,7 @@ public class TestParentBlockJoinFloatKnnVectorQuery extends ParentBlockJoinKnnVe
   }
 
   /**
-   * End-to-end verification: with {@code blockRescore=true}, the query always returns the best
+   * End-to-end verification: with {@code rescoreBlocks=true}, the query always returns the best
    * child for each found parent (no sibling should outscore the returned child).
    *
    * <p>The invariant test uses a fresh {@link VectorScorer} per parent (docId-based, not
@@ -295,7 +297,7 @@ public class TestParentBlockJoinFloatKnnVectorQuery extends ParentBlockJoinKnnVe
         IndexSearcher searcher = new IndexSearcher(reader);
         BitSetProducer parentFilter = parentFilter(reader);
 
-        // blockRescore=true to enable the feature under test.
+        // rescoreBlocks=true to enable the feature under test.
         DiversifyingChildrenFloatKnnVectorQuery query =
             new DiversifyingChildrenFloatKnnVectorQuery(
                 "field",
@@ -303,7 +305,7 @@ public class TestParentBlockJoinFloatKnnVectorQuery extends ParentBlockJoinKnnVe
                 null,
                 numParents,
                 parentFilter,
-                org.apache.lucene.search.knn.KnnSearchStrategy.Hnsw.DEFAULT,
+                KnnSearchStrategy.Hnsw.DEFAULT,
                 true);
         TopDocs results = searcher.search(query, numParents);
 
@@ -314,9 +316,8 @@ public class TestParentBlockJoinFloatKnnVectorQuery extends ParentBlockJoinKnnVe
           int parent = parentBitSet.nextSetBit(sd.doc);
           int prevParent = parent > 0 ? parentBitSet.prevSetBit(parent - 1) : -1;
           // Re-score siblings with a fresh docId-based scorer and verify nothing beats the result.
-          VectorScorer sibScorer =
-              leaf.reader().getFloatVectorValues("field").scorer(queryVector);
-          org.apache.lucene.search.DocIdSetIterator sibIter = sibScorer.iterator();
+          VectorScorer sibScorer = leaf.reader().getFloatVectorValues("field").scorer(queryVector);
+          DocIdSetIterator sibIter = sibScorer.iterator();
           for (int child = prevParent + 1; child < parent; child++) {
             if (sibIter.advance(child) == child) {
               float sibScore = sibScorer.score();


### PR DESCRIPTION
## Description

This implements a proof of concept for sibling scoring in block join diversified child vector search, discussed in [#15839 — Maybe Improve join block Vector search performance by block scoring child vectors](https://github.com/apache/lucene/issues/15839).

---

## Benchmarks (JMH)

`DiversifyingChildrenFloatKnnJoinBenchmark`: **3 forks**, **5 warmup / 10 measurement** (30 samples/cell), `-Xmx2g`, dim **96**, topK **64**, **4096** parent blocks.

| children/parent | `rescoreBlocks=false` | `rescoreBlocks=true` |
|----------------|----------------------|----------------------|
| 8  | 0.117 ± 0.002 ms/op | 0.149 ± 0.002 ms/op |
| 32 | 0.237 ± 0.006 ms/op | 0.326 ± 0.009 ms/op |
| 64 | 0.259 ± 0.005 ms/op | 0.426 ± 0.013 ms/op |

Overhead grows with block width (and with `topK`).