### PR TITLE
Remove IOException from LeafReader#getPointValues signature

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -93,6 +93,8 @@ API Changes
 * GITHUB#15605: Remove unused getCollectors() and internal collector tracking from
   TopFieldCollectorManager. Clarify thread-safety documentation. (Prudhvi Godithi)
 
+* Remove IOException from LeafReader#getPointValues signature. (Ignacio Vera)
+
 New Features
 ---------------------
 * GITHUB#15505: Upgrade snowball to 2d2e312df56f2ede014a4ffb3e91e6dea43c24be. New stemmer: PolishStemmer (and

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -93,7 +93,7 @@ API Changes
 * GITHUB#15605: Remove unused getCollectors() and internal collector tracking from
   TopFieldCollectorManager. Clarify thread-safety documentation. (Prudhvi Godithi)
 
-* Remove IOException from LeafReader#getPointValues signature. (Ignacio Vera)
+* GITHUB#16057: Remove IOException from LeafReader#getPointValues signature. (Ignacio Vera)
 
 New Features
 ---------------------

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextPointsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextPointsReader.java
@@ -205,7 +205,7 @@ class SimpleTextPointsReader extends PointsReader {
   }
 
   @Override
-  public PointValues getValues(String fieldName) throws IOException {
+  public PointValues getValues(String fieldName) {
     FieldInfo fieldInfo = readState.fieldInfos.fieldInfo(fieldName);
     if (fieldInfo == null) {
       throw new IllegalArgumentException("field=\"" + fieldName + "\" is unrecognized");

--- a/lucene/core/src/java/org/apache/lucene/codecs/PointsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/PointsReader.java
@@ -45,7 +45,7 @@ public abstract class PointsReader implements Closeable {
    * Return {@link PointValues} for the given {@code field}. The behavior is undefined if the given
    * field doesn't have points enabled on its {@link FieldInfo}.
    */
-  public abstract PointValues getValues(String field) throws IOException;
+  public abstract PointValues getValues(String field);
 
   /**
    * Returns an instance optimized for merging. This instance may only be used in the thread that

--- a/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
@@ -219,7 +219,7 @@ public abstract class CodecReader extends LeafReader {
   }
 
   @Override
-  public final PointValues getPointValues(String field) throws IOException {
+  public final PointValues getPointValues(String field) {
     ensureOpen();
     FieldInfo fi = getFieldInfos().fieldInfo(field);
     if (fi == null || fi.getPointDimensionCount() == 0) {

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesLeafReader.java
@@ -44,7 +44,7 @@ abstract class DocValuesLeafReader extends LeafReader {
   }
 
   @Override
-  public final PointValues getPointValues(String field) throws IOException {
+  public final PointValues getPointValues(String field) {
     throw new UnsupportedOperationException();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -78,7 +78,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     }
 
     @Override
-    public PointValues getPointValues(String field) throws IOException {
+    public PointValues getPointValues(String field) {
       final PointValues pointValues = in.getPointValues(field);
       if (pointValues == null) {
         return null;

--- a/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
@@ -349,7 +349,7 @@ public abstract class FilterLeafReader extends LeafReader {
   }
 
   @Override
-  public PointValues getPointValues(String field) throws IOException {
+  public PointValues getPointValues(String field) {
     return in.getPointValues(field);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -415,7 +415,7 @@ public abstract non-sealed class LeafReader extends IndexReader {
    * Returns the {@link PointValues} used for numeric or spatial searches for the given field, or
    * null if there are no point fields.
    */
-  public abstract PointValues getPointValues(String field) throws IOException;
+  public abstract PointValues getPointValues(String field);
 
   /**
    * Checks consistency of this reader.

--- a/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
@@ -443,7 +443,7 @@ public class ParallelLeafReader extends LeafReader {
   }
 
   @Override
-  public PointValues getPointValues(String fieldName) throws IOException {
+  public PointValues getPointValues(String fieldName) {
     ensureOpen();
     LeafReader reader = fieldToReader.get(fieldName);
     return reader == null ? null : reader.getPointValues(fieldName);

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
@@ -148,7 +148,7 @@ public final class SlowCodecReaderWrapper {
     return new PointsReader() {
 
       @Override
-      public PointValues getValues(String field) throws IOException {
+      public PointValues getValues(String field) {
         return reader.getPointValues(field);
       }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCompositeCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCompositeCodecReaderWrapper.java
@@ -594,7 +594,7 @@ final class SlowCompositeCodecReaderWrapper extends CodecReader {
     }
 
     @Override
-    public PointValues getValues(String field) throws IOException {
+    public PointValues getValues(String field) {
       List<PointValuesSub> values = new ArrayList<>();
       for (int i = 0; i < readers.length; ++i) {
         FieldInfo fi = codecReaders[i].getFieldInfos().fieldInfo(field);

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -544,12 +544,12 @@ public final class SortingCodecReader extends FilterCodecReader {
       }
 
       @Override
-      public PointValues getValues(String field) throws IOException {
-        var values = delegate.getValues(field);
+      public PointValues getValues(String field) {
+        PointValues values = delegate.getValues(field);
         if (values == null) {
           return null;
         }
-        return new SortingPointValues(delegate.getValues(field), docMap);
+        return new SortingPointValues(values, docMap);
       }
 
       @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -1468,7 +1468,7 @@ public class TestSortOptimization extends LuceneTestCase {
     }
 
     @Override
-    public PointValues getPointValues(String field) throws IOException {
+    public PointValues getPointValues(String field) {
       return null;
     }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingPointsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingPointsFormat.java
@@ -83,7 +83,7 @@ public final class AssertingPointsFormat extends PointsFormat {
     }
 
     @Override
-    public PointValues getValues(String field) throws IOException {
+    public PointValues getValues(String field) {
       FieldInfo fi = fis.fieldInfo(field);
       assert fi != null && fi.getPointDimensionCount() > 0;
       if (merging) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/cranky/CrankyPointsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/cranky/CrankyPointsFormat.java
@@ -115,7 +115,7 @@ class CrankyPointsFormat extends PointsFormat {
     }
 
     @Override
-    public PointValues getValues(String fieldName) throws IOException {
+    public PointValues getValues(String fieldName) {
       final PointValues delegate = this.delegate.getValues(fieldName);
       if (delegate == null) {
         return null;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -1817,7 +1817,7 @@ public class AssertingLeafReader extends FilterLeafReader {
   }
 
   @Override
-  public PointValues getPointValues(String field) throws IOException {
+  public PointValues getPointValues(String field) {
     PointValues values = in.getPointValues(field);
     if (values == null) {
       return null;

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/MergeReaderWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/MergeReaderWrapper.java
@@ -226,7 +226,7 @@ class MergeReaderWrapper extends LeafReader {
   }
 
   @Override
-  public PointValues getPointValues(String fieldName) throws IOException {
+  public PointValues getPointValues(String fieldName) {
     return in.getPointValues(fieldName);
   }
 


### PR DESCRIPTION
The current lucene implementation does not perform any IO in this method so removing it gives a clear indication that calling it should be "cheap".

relates https://github.com/apache/lucene/issues/16052