### PR TITLE
Remove IOException from LeafReader#terms signature

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -95,6 +95,8 @@ API Changes
 
 * GITHUB#16057: Remove IOException from LeafReader#getPointValues signature. (Ignacio Vera)
 
+* GITHUB#16057: Remove IOException from LeafReader#terms signature. (Ignacio Vera)
+
 New Features
 ---------------------
 * GITHUB#15505: Upgrade snowball to 2d2e312df56f2ede014a4ffb3e91e6dea43c24be. New stemmer: PolishStemmer (and

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -95,7 +95,7 @@ API Changes
 
 * GITHUB#16057: Remove IOException from LeafReader#getPointValues signature. (Ignacio Vera)
 
-* GITHUB#16057: Remove IOException from LeafReader#terms signature. (Ignacio Vera)
+* GITHUB#16058: Remove IOException from LeafReader#terms signature. (Ignacio Vera)
 
 New Features
 ---------------------

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/blocktree/Lucene90BlockTreeTermsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/blocktree/Lucene90BlockTreeTermsReader.java
@@ -315,7 +315,7 @@ public final class Lucene90BlockTreeTermsReader extends FieldsProducer {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     assert field != null;
     FieldInfo fieldInfo = fieldInfos.fieldInfo(field);
     return fieldInfo == null ? null : fieldMap.get(fieldInfo.number);

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/blockterms/BlockTermsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/blockterms/BlockTermsReader.java
@@ -207,7 +207,7 @@ public class BlockTermsReader extends FieldsProducer {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     assert field != null;
     return fields.get(field);
   }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/blocktreeords/OrdsBlockTreeTermsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/blocktreeords/OrdsBlockTreeTermsReader.java
@@ -215,7 +215,7 @@ public final class OrdsBlockTreeTermsReader extends FieldsProducer {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     assert field != null;
     return fields.get(field);
   }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/bloom/BloomFilteringPostingsFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/bloom/BloomFilteringPostingsFormat.java
@@ -191,7 +191,7 @@ public final class BloomFilteringPostingsFormat extends PostingsFormat {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       FuzzySet filter = bloomsByFieldName.get(field);
       if (filter == null) {
         return delegateFieldsProducer.terms(field);

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsReader.java
@@ -152,7 +152,7 @@ public class FSTTermsReader extends FieldsProducer {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     assert field != null;
     return fields.get(field);
   }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextFieldsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextFieldsReader.java
@@ -817,6 +817,7 @@ class SimpleTextFieldsReader extends FieldsProducer {
         return null;
       } else {
         try {
+          // TODO: rework SimpleTextTerms to avoid IO during construction
           terms = new SimpleTextTerms(field, fp, maxDoc);
         } catch (IOException e) {
           throw new UncheckedIOException(e);

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextFieldsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextFieldsReader.java
@@ -28,6 +28,7 @@ import static org.apache.lucene.codecs.simpletext.SimpleTextFieldsWriter.TERM;
 import static org.apache.lucene.codecs.simpletext.SimpleTextSkipWriter.SKIP_LIST;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
@@ -808,14 +809,18 @@ class SimpleTextFieldsReader extends FieldsProducer {
   private final Map<String, SimpleTextTerms> termsCache = new HashMap<>();
 
   @Override
-  public synchronized Terms terms(String field) throws IOException {
+  public synchronized Terms terms(String field) {
     SimpleTextTerms terms = termsCache.get(field);
     if (terms == null) {
       Long fp = fields.get(field);
       if (fp == null) {
         return null;
       } else {
-        terms = new SimpleTextTerms(field, fp, maxDoc);
+        try {
+          terms = new SimpleTextTerms(field, fp, maxDoc);
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
         termsCache.put(field, terms);
       }
     }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
@@ -261,7 +261,7 @@ public class SimpleTextTermVectorsReader extends TermVectorsReader {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       return fields.get(field);
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/Lucene103BlockTreeTermsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene103/blocktree/Lucene103BlockTreeTermsReader.java
@@ -284,7 +284,7 @@ public final class Lucene103BlockTreeTermsReader extends FieldsProducer {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     assert field != null;
     FieldInfo fieldInfo = fieldInfos.fieldInfo(field);
     return fieldInfo == null ? null : fieldMap.get(fieldInfo.number);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
@@ -898,7 +898,7 @@ public final class Lucene90CompressingTermVectorsReader extends TermVectorsReade
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       final FieldInfo fieldInfo = fieldInfos.fieldInfo(field);
       if (fieldInfo == null) {
         return null;

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldMergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldMergeState.java
@@ -241,7 +241,7 @@ final class PerFieldMergeState {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       if (!filtered.contains(field)) {
         throw new IllegalArgumentException(
             "The field named '"

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldPostingsFormat.java
@@ -332,7 +332,7 @@ public abstract class PerFieldPostingsFormat extends PostingsFormat {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       FieldsProducer fieldsProducer = fields.get(field);
       return fieldsProducer == null ? null : fieldsProducer.terms(field);
     }

--- a/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
@@ -114,7 +114,7 @@ public abstract class CodecReader extends LeafReader {
   }
 
   @Override
-  public final Terms terms(String field) throws IOException {
+  public final Terms terms(String field) {
     ensureOpen();
     FieldInfo fi = getFieldInfos().fieldInfo(field);
     if (fi == null || fi.getIndexOptions() == IndexOptions.NONE) {

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesLeafReader.java
@@ -29,7 +29,7 @@ abstract class DocValuesLeafReader extends LeafReader {
   }
 
   @Override
-  public final Terms terms(String field) throws IOException {
+  public final Terms terms(String field) {
     throw new UnsupportedOperationException();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -87,7 +87,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       Terms terms = in.terms(field);
       if (terms == null) {
         return null;

--- a/lucene/core/src/java/org/apache/lucene/index/Fields.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Fields.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.index;
 
-import java.io.IOException;
 import java.util.Iterator;
 import org.apache.lucene.codecs.FieldsProducer;
 
@@ -37,7 +36,7 @@ public abstract class Fields implements Iterable<String> {
   public abstract Iterator<String> iterator();
 
   /** Get the {@link Terms} for this field. This will return null if the field does not exist. */
-  public abstract Terms terms(String field) throws IOException;
+  public abstract Terms terms(String field);
 
   /**
    * Returns the number of fields or -1 if the number of distinct field names is unknown. If &gt;=

--- a/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
@@ -77,7 +77,7 @@ public abstract class FilterLeafReader extends LeafReader {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       return in.terms(field);
     }
 
@@ -407,7 +407,7 @@ public abstract class FilterLeafReader extends LeafReader {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     ensureOpen();
     return in.terms(field);
   }

--- a/lucene/core/src/java/org/apache/lucene/index/FreqProxFields.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FreqProxFields.java
@@ -47,7 +47,7 @@ class FreqProxFields extends Fields {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     FreqProxTermsWriterPerField perField = fields.get(field);
     return perField == null ? null : new FreqProxTerms(perField);
   }

--- a/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FreqProxTermsWriter.java
@@ -117,7 +117,7 @@ final class FreqProxTermsWriter extends TermsHash {
           new FilterLeafReader.FilterFields(fields) {
 
             @Override
-            public Terms terms(final String field) throws IOException {
+            public Terms terms(final String field) {
               Terms terms = in.terms(field);
               if (terms == null) {
                 return null;

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -131,7 +131,7 @@ public abstract non-sealed class LeafReader extends IndexReader {
   }
 
   /** Returns the {@link Terms} index for this field, or null if it has none. */
-  public abstract Terms terms(String field) throws IOException;
+  public abstract Terms terms(String field);
 
   /**
    * Returns {@link PostingsEnum} for the specified term. This will return null if either the field

--- a/lucene/core/src/java/org/apache/lucene/index/MappedMultiFields.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MappedMultiFields.java
@@ -41,7 +41,7 @@ public class MappedMultiFields extends FilterFields {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     MultiTerms terms = (MultiTerms) in.terms(field);
     if (terms == null) {
       return null;

--- a/lucene/core/src/java/org/apache/lucene/index/MultiFields.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiFields.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.index;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -58,7 +57,7 @@ public final class MultiFields extends Fields {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     Terms result = terms.get(field);
     if (result != null) return result;
 

--- a/lucene/core/src/java/org/apache/lucene/index/MultiTerms.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiTerms.java
@@ -42,8 +42,7 @@ public final class MultiTerms extends Terms {
    * @param subSlices A parallel array (matching {@code subs}) describing the sub-reader slices.
    * @lucene.internal
    */
-  public MultiTerms(Terms[] subs, ReaderSlice[] subSlices)
-      throws IOException { // TODO make private?
+  public MultiTerms(Terms[] subs, ReaderSlice[] subSlices) { // TODO make private?
     this.subs = subs;
     this.subSlices = subSlices;
 

--- a/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
@@ -255,7 +255,7 @@ public class ParallelLeafReader extends LeafReader {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     ensureOpen();
     LeafReader leafReader = termsFieldToReader.get(field);
     return leafReader == null ? null : leafReader.terms(field);

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
@@ -359,7 +359,7 @@ public final class SlowCodecReaderWrapper {
       }
 
       @Override
-      public Terms terms(String field) throws IOException {
+      public Terms terms(String field) {
         return reader.terms(field);
       }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCompositeCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCompositeCodecReaderWrapper.java
@@ -542,7 +542,7 @@ final class SlowCompositeCodecReaderWrapper extends CodecReader {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       return fields.terms(field);
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -468,7 +468,7 @@ public final class SortingCodecReader extends FilterCodecReader {
       }
 
       @Override
-      public Terms terms(String field) throws IOException {
+      public Terms terms(String field) {
         Terms terms = postingsReader.terms(field);
         return terms == null
             ? null

--- a/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
@@ -88,7 +88,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       Terms terms = super.terms(field);
       return terms == null ? null : new TestTerms(terms);
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFilterLeafReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFilterLeafReader.java
@@ -89,7 +89,7 @@ public class TestFilterLeafReader extends LuceneTestCase {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       Terms terms = super.terms(field);
       return terms == null ? null : new TestTerms(terms);
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFrozenBufferedUpdates.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFrozenBufferedUpdates.java
@@ -45,7 +45,7 @@ public class TestFrozenBufferedUpdates extends LuceneTestCase {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       return new FilterTerms(in.terms(field)) {
         @Override
         public TermsEnum iterator() throws IOException {

--- a/lucene/core/src/test/org/apache/lucene/index/TestMultiTermsEnum.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMultiTermsEnum.java
@@ -75,7 +75,7 @@ public class TestMultiTermsEnum extends LuceneTestCase {
       }
 
       @Override
-      public Terms terms(String field) throws IOException {
+      public Terms terms(String field) {
         if ("deleted".equals(field)) {
           Terms deletedTerms = super.terms("deleted");
           if (deletedTerms != null) {
@@ -212,7 +212,7 @@ public class TestMultiTermsEnum extends LuceneTestCase {
       }
 
       @Override
-      public Terms terms(String field) throws IOException {
+      public Terms terms(String field) {
         return delegate.terms(field);
       }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
@@ -58,7 +58,7 @@ public class TestSegmentToThreadMapping extends LuceneTestCase {
       }
 
       @Override
-      public Terms terms(String field) throws IOException {
+      public Terms terms(String field) {
         return null;
       }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestMatchesIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMatchesIterator.java
@@ -599,7 +599,7 @@ public class TestMatchesIterator extends MatchesTestBase {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       Terms terms = super.terms(field);
       if (terms == null) {
         return null;

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -1463,7 +1463,7 @@ public class TestSortOptimization extends LuceneTestCase {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       return null;
     }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermInSetQuery.java
@@ -403,7 +403,7 @@ public class TestTermInSetQuery extends LuceneTestCase {
       }
 
       @Override
-      public Terms terms(String field) throws IOException {
+      public Terms terms(String field) {
         Terms terms = super.terms(field);
         if (terms == null) {
           return null;

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermQuery.java
@@ -246,7 +246,7 @@ public class TestTermQuery extends LuceneTestCase {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       Terms terms = super.terms(field);
       return terms == null
           ? null

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
@@ -66,7 +66,7 @@ public class TermVectorLeafReader extends LeafReader {
           }
 
           @Override
-          public Terms terms(String fld) throws IOException {
+          public Terms terms(String fld) {
             if (!field.equals(fld)) {
               return null;
             }
@@ -116,7 +116,7 @@ public class TermVectorLeafReader extends LeafReader {
   protected void doClose() throws IOException {}
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     return fields.terms(field);
   }
 

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/WeightedSpanTermExtractor.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/WeightedSpanTermExtractor.java
@@ -452,7 +452,7 @@ public class WeightedSpanTermExtractor {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       return super.terms(DelegatingLeafReader.FIELD_NAME);
     }
 

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/FieldOffsetStrategy.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/FieldOffsetStrategy.java
@@ -117,7 +117,7 @@ public abstract class FieldOffsetStrategy {
     LeafReader leafReader =
         new FilterLeafReader(_leafReader) {
           @Override
-          public Terms terms(String field) throws IOException {
+          public Terms terms(String field) {
             if (components.fieldMatcher().test(field)) {
               return super.terms(components.field());
             } else {

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/OverlaySingleDocTermsLeafReader.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/OverlaySingleDocTermsLeafReader.java
@@ -48,7 +48,7 @@ public class OverlaySingleDocTermsLeafReader extends FilterLeafReader {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     if (!in2Field.equals(field)) {
       return in.terms(field);
     }

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/PhraseHelper.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/PhraseHelper.java
@@ -305,7 +305,7 @@ public class PhraseHelper {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       // ensure the underlying PostingsEnum returns offsets.  It's sad we have to do this to use the
       // SpanCollector.
       return new FilterTerms(super.terms(fieldName)) {

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/TermVectorFilteredLeafReader.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/TermVectorFilteredLeafReader.java
@@ -54,7 +54,7 @@ final class TermVectorFilteredLeafReader extends FilterLeafReader {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     if (!field.equals(fieldFilter)) {
       return super.terms(field); // proceed like normal for fields we're not interested in
     }

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -1770,7 +1770,7 @@ public class MemoryIndex {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       return memoryFields.terms(field);
     }
 

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/idversion/VersionBlockTreeTermsReader.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/idversion/VersionBlockTreeTermsReader.java
@@ -223,7 +223,7 @@ public final class VersionBlockTreeTermsReader extends FieldsProducer {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     assert field != null;
     return fields.get(field);
   }

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionFieldsProducer.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionFieldsProducer.java
@@ -165,7 +165,7 @@ final class CompletionFieldsProducer extends FieldsProducer implements Accountab
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     Terms terms = delegateFieldsProducer.terms(field);
     if (terms == null) {
       return null;

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionQuery.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/CompletionQuery.java
@@ -89,11 +89,7 @@ public abstract class CompletionQuery extends Query {
     Terms terms;
     for (LeafReaderContext context : indexSearcher.getLeafContexts()) {
       LeafReader leafReader = context.reader();
-      try {
-        if ((terms = leafReader.terms(getField())) == null) {
-          continue;
-        }
-      } catch (IOException _) {
+      if ((terms = leafReader.terms(getField())) == null) {
         continue;
       }
       if (terms instanceof CompletionTerms completionTerms) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingPostingsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingPostingsFormat.java
@@ -77,7 +77,7 @@ public final class AssertingPostingsFormat extends PostingsFormat {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       Terms terms = in.terms(field);
       return terms == null ? null : new AssertingLeafReader.AssertingTerms(terms);
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -113,7 +113,7 @@ public class AssertingLeafReader extends FilterLeafReader {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     Terms terms = super.terms(field);
     return terms == null ? null : new AssertingTerms(terms);
   }
@@ -190,7 +190,7 @@ public class AssertingLeafReader extends FilterLeafReader {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       assertThread("Fields", creationThread);
       Terms terms = super.terms(field);
       return terms == null ? null : new AssertingTerms(terms);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseIndexFileFormatTestCase.java
@@ -411,7 +411,7 @@ public abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
             }
 
             @Override
-            public Terms terms(String field) throws IOException {
+            public Terms terms(String field) {
               return oneDocReader.terms(field);
             }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/FieldFilterLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/FieldFilterLeafReader.java
@@ -137,7 +137,7 @@ public final class FieldFilterLeafReader extends FilterLeafReader {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     return hasField(field) ? super.terms(field) : null;
   }
 
@@ -198,7 +198,7 @@ public final class FieldFilterLeafReader extends FilterLeafReader {
     }
 
     @Override
-    public Terms terms(String field) throws IOException {
+    public Terms terms(String field) {
       return hasField(field) ? super.terms(field) : null;
     }
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/MergeReaderWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/MergeReaderWrapper.java
@@ -92,7 +92,7 @@ class MergeReaderWrapper extends LeafReader {
   }
 
   @Override
-  public Terms terms(String field) throws IOException {
+  public Terms terms(String field) {
     ensureOpen();
     // We could check the FieldInfo IndexOptions but there's no point since
     //   PostingsReader will simply return null for fields that don't exist or that have no terms

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
@@ -195,7 +195,7 @@ public class QueryUtils {
     return new LeafReader() {
 
       @Override
-      public Terms terms(String field) throws IOException {
+      public Terms terms(String field) {
         return null;
       }
 


### PR DESCRIPTION
The current lucene implementation does not perform any IO in this method so removing it gives a clear indication that calling it should be "cheap".

(The SimpleTextFieldsReader does perform IO but it shouldn't although not worthy to change it IMO)

relates https://github.com/apache/lucene/issues/16052
