### PR TITLE
Remove IOException from LeafReader#getDocCount signature

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -93,11 +93,8 @@ API Changes
 * GITHUB#15605: Remove unused getCollectors() and internal collector tracking from
   TopFieldCollectorManager. Clarify thread-safety documentation. (Prudhvi Godithi)
 
-* GITHUB#16057: Remove IOException from LeafReader#getPointValues signature. (Ignacio Vera)
-
-* GITHUB#16058: Remove IOException from LeafReader#terms signature. (Ignacio Vera)
-
-* GITHUB#16058: Remove IOException from LeafReader#getDocCount signature. (Ignacio Vera)
+* GITHUB#16052: Remove IOException from LeafReader#getPointValues, LeafReader#terms,
+  LeafReader#getDocCount signatures. (Ignacio Vera)
 
 New Features
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -97,6 +97,8 @@ API Changes
 
 * GITHUB#16058: Remove IOException from LeafReader#terms signature. (Ignacio Vera)
 
+* GITHUB#16058: Remove IOException from LeafReader#getDocCount signature. (Ignacio Vera)
+
 New Features
 ---------------------
 * GITHUB#15505: Upgrade snowball to 2d2e312df56f2ede014a4ffb3e91e6dea43c24be. New stemmer: PolishStemmer (and

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/blockterms/BlockTermsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/blockterms/BlockTermsReader.java
@@ -292,7 +292,7 @@ public class BlockTermsReader extends FieldsProducer {
     }
 
     @Override
-    public int getDocCount() throws IOException {
+    public int getDocCount() {
       return docCount;
     }
 

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/bloom/BloomFilteringPostingsFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/bloom/BloomFilteringPostingsFormat.java
@@ -245,7 +245,7 @@ public final class BloomFilteringPostingsFormat extends PostingsFormat {
       }
 
       @Override
-      public int getDocCount() throws IOException {
+      public int getDocCount() {
         return delegateTerms.getDocCount();
       }
 

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/memory/FSTTermsReader.java
@@ -251,7 +251,7 @@ public class FSTTermsReader extends FieldsProducer {
     }
 
     @Override
-    public int getDocCount() throws IOException {
+    public int getDocCount() {
       return docCount;
     }
 

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextFieldsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextFieldsReader.java
@@ -774,7 +774,7 @@ class SimpleTextFieldsReader extends FieldsProducer {
     }
 
     @Override
-    public int getDocCount() throws IOException {
+    public int getDocCount() {
       return docCount;
     }
 

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
@@ -312,7 +312,7 @@ public class SimpleTextTermVectorsReader extends TermVectorsReader {
     }
 
     @Override
-    public int getDocCount() throws IOException {
+    public int getDocCount() {
       return 1;
     }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
@@ -1027,7 +1027,7 @@ public final class Lucene90CompressingTermVectorsReader extends TermVectorsReade
     }
 
     @Override
-    public int getDocCount() throws IOException {
+    public int getDocCount() {
       return 1;
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
@@ -131,7 +131,7 @@ public abstract class FilterLeafReader extends LeafReader {
     }
 
     @Override
-    public int getDocCount() throws IOException {
+    public int getDocCount() {
       return in.getDocCount();
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -113,7 +113,7 @@ public abstract non-sealed class LeafReader extends IndexReader {
   }
 
   @Override
-  public final int getDocCount(String field) throws IOException {
+  public final int getDocCount(String field) {
     final Terms terms = terms(field);
     if (terms == null) {
       return 0;

--- a/lucene/core/src/java/org/apache/lucene/index/MappedMultiFields.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MappedMultiFields.java
@@ -87,7 +87,7 @@ public class MappedMultiFields extends FilterFields {
     }
 
     @Override
-    public int getDocCount() throws IOException {
+    public int getDocCount() {
       throw new UnsupportedOperationException();
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/index/MultiTerms.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiTerms.java
@@ -222,7 +222,7 @@ public final class MultiTerms extends Terms {
   }
 
   @Override
-  public int getDocCount() throws IOException {
+  public int getDocCount() {
     int sum = 0;
     for (Terms terms : subs) {
       final int v = terms.getDocCount();

--- a/lucene/core/src/java/org/apache/lucene/index/Terms.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Terms.java
@@ -118,7 +118,7 @@ public abstract class Terms {
    * Returns the number of documents that have at least one term for this field. Note that, just
    * like other term measures, this measure does not take deleted documents into account.
    */
-  public abstract int getDocCount() throws IOException;
+  public abstract int getDocCount();
 
   /**
    * Returns true if documents in this field store per-document term frequency ({@link
@@ -247,7 +247,7 @@ public abstract class Terms {
         }
 
         @Override
-        public int getDocCount() throws IOException {
+        public int getDocCount() {
           return 0;
         }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestMultiTermsEnum.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMultiTermsEnum.java
@@ -149,7 +149,7 @@ public class TestMultiTermsEnum extends LuceneTestCase {
         }
 
         @Override
-        public int getDocCount() throws IOException {
+        public int getDocCount() {
           throw new UnsupportedOperationException();
         }
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
@@ -293,7 +293,7 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
     }
 
     @Override
-    public int getDocCount() throws IOException {
+    public int getDocCount() {
       return docCount;
     }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/ramonly/RAMOnlyPostingsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/ramonly/RAMOnlyPostingsFormat.java
@@ -119,7 +119,7 @@ public final class RAMOnlyPostingsFormat extends PostingsFormat {
     }
 
     @Override
-    public int getDocCount() throws IOException {
+    public int getDocCount() {
       return docCount;
     }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -231,7 +231,7 @@ public class AssertingLeafReader extends FilterLeafReader {
     }
 
     @Override
-    public int getDocCount() throws IOException {
+    public int getDocCount() {
       assertThread("Terms", creationThread);
       final int docCount = in.getDocCount();
       assert docCount > 0;


### PR DESCRIPTION
The current lucene implementation does not perform any IO in this method so removing it gives a clear indication that calling it should be "cheap".

relates https://github.com/apache/lucene/issues/16052
