### PR TITLE
Improve cost estimation in SortedSetDocValuesRangeQuery when using DocValuesSkipper

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -370,6 +370,10 @@ Optimizations
 
 * GITHUB#16001: IndexSearcher.count() was calling query.rewrite twice, a regression since v9.10 (David Smiley)
 
+* GITHUB16061#: Improve cost estimation in SortedSetDocValuesRangeQuery when using DocValuesSkipper and the field
+  is dense and is the primary sort of the index and reduce the number of doc values visited. (Ignacio Vera)
+
+
 Bug Fixes
 ---------------------
 * GITHUB#15754: Fix HTMLStripCharFilter to prevent tags from incorrectly consuming subsequent

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.document;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Objects;
 import java.util.function.LongPredicate;
 import org.apache.lucene.index.DocValues;
@@ -121,22 +122,8 @@ final class SortedSetDocValuesRangeQuery extends Query {
         SortedSetDocValues values = DocValues.getSortedSet(context.reader(), field);
         final SortedDocValues singleton = DocValues.unwrapSingleton(values);
         if (singleton != null && skipper != null && isDensePrimarySort(context.reader(), skipper)) {
-          final long minOrd = minOrd(values);
-          final long maxOrd = maxOrd(values);
-          if (minOrd > maxOrd || minOrd > skipper.maxValue() || maxOrd < skipper.minValue()) {
-            return null;
-          }
-          if (skipper.minValue() >= minOrd && skipper.maxValue() <= maxOrd) {
-            return ConstantScoreScorerSupplier.matchAll(
-                score(), scoreMode, context.reader().maxDoc());
-          }
-          final DocIdSetIterator psIterator =
-              getDocIdSetIteratorForDensePrimarySort(
-                  context.reader(), singleton, skipper, minOrd, maxOrd);
-          return ConstantScoreScorerSupplier.fromIterator(
-              psIterator, score(), scoreMode, context.reader().maxDoc());
+          return getScorerSupplierFromDensePrimarySort(context, singleton, values, skipper);
         }
-
         // implement ScorerSupplier, since we do some expensive stuff to make a scorer
         return new ConstantScoreScorerSupplier(score(), scoreMode, context.reader().maxDoc()) {
           @Override
@@ -171,6 +158,119 @@ final class SortedSetDocValuesRangeQuery extends Query {
           @Override
           public long cost() {
             return values.cost();
+          }
+        };
+      }
+
+      private ScorerSupplier getScorerSupplierFromDensePrimarySort(
+          LeafReaderContext context,
+          SortedDocValues singleton,
+          SortedSetDocValues values,
+          DocValuesSkipper skipper) {
+        final Sort indexSort = context.reader().getMetaData().sort();
+        return new ConstantScoreScorerSupplier(score(), scoreMode, context.reader().maxDoc()) {
+          int skipperMinDocId = -1, skipperMaxDocId = -1;
+          long minOrd, maxOrd;
+          boolean skipperMinDocIdSet = false, skipperMaxDocIdSet = false;
+
+          @Override
+          public DocIdSetIterator iterator(long leadCost) throws IOException {
+            if (skipperMinDocId == -1) {
+              computeSkipperDocIds();
+            }
+            final int minDocID;
+            final int maxDocID;
+            if (indexSort.getSort()[0].getReverse()) {
+              minDocID =
+                  skipperMinDocIdSet
+                      ? skipperMinDocId
+                      : nextDoc(skipperMinDocId, singleton, l -> l <= maxOrd);
+              maxDocID =
+                  skipperMaxDocIdSet
+                      ? skipperMaxDocId
+                      : nextDoc(skipperMaxDocId, singleton, l -> l < minOrd);
+            } else {
+              minDocID =
+                  skipperMinDocIdSet
+                      ? skipperMinDocId
+                      : nextDoc(skipperMinDocId, singleton, l -> l >= minOrd);
+              maxDocID =
+                  skipperMaxDocIdSet
+                      ? skipperMaxDocId
+                      : nextDoc(skipperMaxDocId, singleton, l -> l > maxOrd);
+            }
+            return minDocID == maxDocID
+                ? DocIdSetIterator.empty()
+                : DocIdSetIterator.range(minDocID, maxDocID);
+          }
+
+          @Override
+          public long cost() {
+            if (skipperMinDocId == -1) {
+              try {
+                // Similar to PointValues, IOExceptions needs to be catch and rethrown as
+                // UncheckedIOException
+                computeSkipperDocIds();
+              } catch (IOException e) {
+                throw new UncheckedIOException(e);
+              }
+            }
+            if (skipperMinDocIdSet && skipperMaxDocIdSet) {
+              return skipperMaxDocId - skipperMinDocId;
+            }
+            // TODO: expose skipper block size here?
+            return 4096 + skipperMaxDocId - skipperMinDocId;
+          }
+
+          private void computeSkipperDocIds() throws IOException {
+            minOrd = minOrd(values);
+            maxOrd = maxOrd(values);
+            if (minOrd > maxOrd || minOrd > skipper.maxValue() || maxOrd < skipper.minValue()) {
+              skipperMinDocId = DocIdSetIterator.NO_MORE_DOCS;
+              skipperMaxDocId = DocIdSetIterator.NO_MORE_DOCS;
+              skipperMinDocIdSet = skipperMaxDocIdSet = true;
+              return;
+            }
+            if (skipper.minValue() >= minOrd && skipper.maxValue() <= maxOrd) {
+              skipperMinDocId = 0;
+              skipperMaxDocId = skipper.docCount();
+              skipperMinDocIdSet = skipperMaxDocIdSet = true;
+              return;
+            }
+            if (indexSort.getSort()[0].getReverse()) {
+              if (skipper.maxValue() <= maxOrd) {
+                skipperMinDocId = 0;
+                skipperMinDocIdSet = true;
+              } else {
+                skipper.advance(Long.MIN_VALUE, maxOrd);
+                skipperMinDocId = skipper.minDocID(0);
+                skipperMinDocIdSet = false;
+              }
+              if (skipper.minValue() >= minOrd) {
+                skipperMaxDocId = skipper.docCount();
+                skipperMaxDocIdSet = true;
+              } else {
+                skipper.advance(Long.MIN_VALUE, minOrd);
+                skipperMaxDocId = skipper.minDocID(0);
+                skipperMaxDocIdSet = false;
+              }
+            } else {
+              if (skipper.minValue() >= minOrd) {
+                skipperMinDocId = 0;
+              } else {
+                skipper.advance(minOrd, Long.MAX_VALUE);
+                skipperMinDocId = skipper.minDocID(0);
+                skipperMinDocIdSet = false;
+              }
+              if (skipper.maxValue() <= maxOrd) {
+                skipperMaxDocId = skipper.docCount();
+                skipperMaxDocIdSet = true;
+              } else {
+                skipper.advance(maxOrd, Long.MAX_VALUE);
+                skipperMaxDocId = skipper.minDocID(0);
+                skipperMaxDocIdSet = false;
+              }
+            }
           }
         };
       }
@@ -227,49 +327,6 @@ final class SortedSetDocValuesRangeQuery extends Query {
       return false;
     }
     return true;
-  }
-
-  private DocIdSetIterator getDocIdSetIteratorForDensePrimarySort(
-      LeafReader reader,
-      SortedDocValues sortedDocValues,
-      DocValuesSkipper skipper,
-      long minOrd,
-      long maxOrd)
-      throws IOException {
-    assert isDensePrimarySort(reader, skipper);
-    final Sort indexSort = reader.getMetaData().sort();
-    final int minDocID;
-    final int maxDocID;
-    if (indexSort.getSort()[0].getReverse()) {
-      if (skipper.maxValue() <= maxOrd) {
-        minDocID = 0;
-      } else {
-        skipper.advance(Long.MIN_VALUE, maxOrd);
-        minDocID = nextDoc(skipper.minDocID(0), sortedDocValues, l -> l <= maxOrd);
-      }
-      if (skipper.minValue() >= minOrd) {
-        maxDocID = skipper.docCount();
-      } else {
-        skipper.advance(Long.MIN_VALUE, minOrd);
-        maxDocID = nextDoc(skipper.minDocID(0), sortedDocValues, l -> l < minOrd);
-      }
-    } else {
-      if (skipper.minValue() >= minOrd) {
-        minDocID = 0;
-      } else {
-        skipper.advance(minOrd, Long.MAX_VALUE);
-        minDocID = nextDoc(skipper.minDocID(0), sortedDocValues, l -> l >= minOrd);
-      }
-      if (skipper.maxValue() <= maxOrd) {
-        maxDocID = skipper.docCount();
-      } else {
-        skipper.advance(maxOrd, Long.MAX_VALUE);
-        maxDocID = nextDoc(skipper.minDocID(0), sortedDocValues, l -> l > maxOrd);
-      }
-    }
-    return minDocID == maxDocID
-        ? DocIdSetIterator.empty()
-        : DocIdSetIterator.range(minDocID, maxDocID);
   }
 
   private static int nextDoc(int startDoc, SortedDocValues docValues, LongPredicate predicate)

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
@@ -224,7 +224,7 @@ final class SortedSetDocValuesRangeQuery extends Query {
 
           private void computeSkipperDocIds() throws IOException {
             minOrd = minOrd(values);
-            maxOrd = maxOrd(values);
+            maxOrd = upperValue.equals(lowerValue) ? minOrd : maxOrd(values);
             if (minOrd > maxOrd || minOrd > skipper.maxValue() || maxOrd < skipper.minValue()) {
               skipperMinDocId = skipperMaxDocId = DocIdSetIterator.NO_MORE_DOCS;
               skipperMinDocIdExact = skipperMaxDocIdExact = true;
@@ -243,14 +243,19 @@ final class SortedSetDocValuesRangeQuery extends Query {
               } else {
                 skipper.advance(Long.MIN_VALUE, maxOrd);
                 skipperMinDocId = skipper.minDocID(0);
-                skipperMinDocIdExact = false;
+                skipperMinDocIdExact = skipper.maxValue(0) == maxOrd;
               }
               if (skipper.minValue() >= minOrd) {
                 skipperMaxDocId = skipper.docCount();
                 skipperMaxDocIdExact = true;
               } else {
                 skipper.advance(Long.MIN_VALUE, minOrd);
-                skipperMaxDocId = skipper.minDocID(0);
+                skipperMaxDocId =
+                    skipper.minValue(0) == minOrd ? skipper.maxDocID(0) : skipper.minDocID(0);
+                // we can read the next block, if the maxValue is different to minOrd, then we
+                // should be done, we
+                // don't need to visit the doc values. But what is more expensive, visit one doc
+                // value or one skipper block?
                 skipperMaxDocIdExact = false;
               }
             } else {
@@ -259,14 +264,19 @@ final class SortedSetDocValuesRangeQuery extends Query {
               } else {
                 skipper.advance(minOrd, Long.MAX_VALUE);
                 skipperMinDocId = skipper.minDocID(0);
-                skipperMinDocIdExact = false;
+                skipperMinDocIdExact = skipper.minValue(0) == minOrd;
               }
               if (skipper.maxValue() <= maxOrd) {
                 skipperMaxDocId = skipper.docCount();
                 skipperMaxDocIdExact = true;
               } else {
                 skipper.advance(maxOrd, Long.MAX_VALUE);
-                skipperMaxDocId = skipper.minDocID(0);
+                skipperMaxDocId =
+                    skipper.maxValue(0) == maxOrd ? skipper.maxDocID(0) : skipper.minDocID(0);
+                // we can read the next block, if the minValue is different to maxOrd, then we
+                // should be done, we
+                // don't need to visit the doc values. But what is more expensive, visit one doc
+                // value or one skipper block?
                 skipperMaxDocIdExact = false;
               }
             }

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
@@ -219,7 +219,7 @@ final class SortedSetDocValuesRangeQuery extends Query {
               return skipperMaxDocId - skipperMinDocId;
             }
             // TODO: expose skipper block size here?
-            return 4096 + skipperMaxDocId - skipperMinDocId;
+            return Math.min(context.reader().maxDoc(), 4096 + skipperMaxDocId - skipperMinDocId);
           }
 
           private void computeSkipperDocIds() throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
@@ -224,7 +224,7 @@ final class SortedSetDocValuesRangeQuery extends Query {
 
           private void computeSkipperDocIds() throws IOException {
             minOrd = minOrd(values);
-            maxOrd = upperValue.equals(lowerValue) ? minOrd : maxOrd(values);
+            maxOrd = upperValue != null && upperValue.equals(lowerValue) ? minOrd : maxOrd(values);
             if (minOrd > maxOrd || minOrd > skipper.maxValue() || maxOrd < skipper.minValue()) {
               skipperMinDocId = skipperMaxDocId = DocIdSetIterator.NO_MORE_DOCS;
               skipperMinDocIdExact = skipperMaxDocIdExact = true;

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
@@ -171,7 +171,7 @@ final class SortedSetDocValuesRangeQuery extends Query {
         return new ConstantScoreScorerSupplier(score(), scoreMode, context.reader().maxDoc()) {
           int skipperMinDocId = -1, skipperMaxDocId = -1;
           long minOrd, maxOrd;
-          boolean skipperMinDocIdSet = false, skipperMaxDocIdSet = false;
+          boolean skipperMinDocIdExact = false, skipperMaxDocIdExact = false;
 
           @Override
           public DocIdSetIterator iterator(long leadCost) throws IOException {
@@ -182,20 +182,20 @@ final class SortedSetDocValuesRangeQuery extends Query {
             final int maxDocID;
             if (indexSort.getSort()[0].getReverse()) {
               minDocID =
-                  skipperMinDocIdSet
+                  skipperMinDocIdExact
                       ? skipperMinDocId
                       : nextDoc(skipperMinDocId, singleton, l -> l <= maxOrd);
               maxDocID =
-                  skipperMaxDocIdSet
+                  skipperMaxDocIdExact
                       ? skipperMaxDocId
                       : nextDoc(skipperMaxDocId, singleton, l -> l < minOrd);
             } else {
               minDocID =
-                  skipperMinDocIdSet
+                  skipperMinDocIdExact
                       ? skipperMinDocId
                       : nextDoc(skipperMinDocId, singleton, l -> l >= minOrd);
               maxDocID =
-                  skipperMaxDocIdSet
+                  skipperMaxDocIdExact
                       ? skipperMaxDocId
                       : nextDoc(skipperMaxDocId, singleton, l -> l > maxOrd);
             }
@@ -215,7 +215,7 @@ final class SortedSetDocValuesRangeQuery extends Query {
                 throw new UncheckedIOException(e);
               }
             }
-            if (skipperMinDocIdSet && skipperMaxDocIdSet) {
+            if (skipperMinDocIdExact && skipperMaxDocIdExact) {
               return skipperMaxDocId - skipperMinDocId;
             }
             // TODO: expose skipper block size here?
@@ -227,31 +227,31 @@ final class SortedSetDocValuesRangeQuery extends Query {
             maxOrd = maxOrd(values);
             if (minOrd > maxOrd || minOrd > skipper.maxValue() || maxOrd < skipper.minValue()) {
               skipperMinDocId = skipperMaxDocId = DocIdSetIterator.NO_MORE_DOCS;
-              skipperMinDocIdSet = skipperMaxDocIdSet = true;
+              skipperMinDocIdExact = skipperMaxDocIdExact = true;
               return;
             }
             if (skipper.minValue() >= minOrd && skipper.maxValue() <= maxOrd) {
               skipperMinDocId = 0;
               skipperMaxDocId = skipper.docCount();
-              skipperMinDocIdSet = skipperMaxDocIdSet = true;
+              skipperMinDocIdExact = skipperMaxDocIdExact = true;
               return;
             }
             if (indexSort.getSort()[0].getReverse()) {
               if (skipper.maxValue() <= maxOrd) {
                 skipperMinDocId = 0;
-                skipperMinDocIdSet = true;
+                skipperMinDocIdExact = true;
               } else {
                 skipper.advance(Long.MIN_VALUE, maxOrd);
                 skipperMinDocId = skipper.minDocID(0);
-                skipperMinDocIdSet = false;
+                skipperMinDocIdExact = false;
               }
               if (skipper.minValue() >= minOrd) {
                 skipperMaxDocId = skipper.docCount();
-                skipperMaxDocIdSet = true;
+                skipperMaxDocIdExact = true;
               } else {
                 skipper.advance(Long.MIN_VALUE, minOrd);
                 skipperMaxDocId = skipper.minDocID(0);
-                skipperMaxDocIdSet = false;
+                skipperMaxDocIdExact = false;
               }
             } else {
               if (skipper.minValue() >= minOrd) {
@@ -259,15 +259,15 @@ final class SortedSetDocValuesRangeQuery extends Query {
               } else {
                 skipper.advance(minOrd, Long.MAX_VALUE);
                 skipperMinDocId = skipper.minDocID(0);
-                skipperMinDocIdSet = false;
+                skipperMinDocIdExact = false;
               }
               if (skipper.maxValue() <= maxOrd) {
                 skipperMaxDocId = skipper.docCount();
-                skipperMaxDocIdSet = true;
+                skipperMaxDocIdExact = true;
               } else {
                 skipper.advance(maxOrd, Long.MAX_VALUE);
                 skipperMaxDocId = skipper.minDocID(0);
-                skipperMaxDocIdSet = false;
+                skipperMaxDocIdExact = false;
               }
             }
           }

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
@@ -251,7 +251,7 @@ final class SortedSetDocValuesRangeQuery extends Query {
               } else {
                 skipper.advance(Long.MIN_VALUE, minOrd);
                 skipperMaxDocId =
-                    skipper.minValue(0) == minOrd ? skipper.maxDocID(0) : skipper.minDocID(0);
+                    skipper.minValue(0) == minOrd ? skipper.maxDocID(0) + 1 : skipper.minDocID(0);
                 // we can read the next block, if the maxValue is different to minOrd, then we
                 // should be done, we
                 // don't need to visit the doc values. But what is more expensive, visit one doc
@@ -261,6 +261,7 @@ final class SortedSetDocValuesRangeQuery extends Query {
             } else {
               if (skipper.minValue() >= minOrd) {
                 skipperMinDocId = 0;
+                skipperMinDocIdExact = true;
               } else {
                 skipper.advance(minOrd, Long.MAX_VALUE);
                 skipperMinDocId = skipper.minDocID(0);
@@ -272,7 +273,7 @@ final class SortedSetDocValuesRangeQuery extends Query {
               } else {
                 skipper.advance(maxOrd, Long.MAX_VALUE);
                 skipperMaxDocId =
-                    skipper.maxValue(0) == maxOrd ? skipper.maxDocID(0) : skipper.minDocID(0);
+                    skipper.maxValue(0) == maxOrd ? skipper.maxDocID(0) + 1 : skipper.minDocID(0);
                 // we can read the next block, if the minValue is different to maxOrd, then we
                 // should be done, we
                 // don't need to visit the doc values. But what is more expensive, visit one doc

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
@@ -208,7 +208,7 @@ final class SortedSetDocValuesRangeQuery extends Query {
           public long cost() {
             if (skipperMinDocId == -1) {
               try {
-                // Similar to PointValues, IOExceptions needs to be catch and rethrown as
+                // Similar to PointValues, IOExceptions needs to be caught and rethrown as
                 // UncheckedIOException
                 computeSkipperDocIds();
               } catch (IOException e) {
@@ -226,8 +226,7 @@ final class SortedSetDocValuesRangeQuery extends Query {
             minOrd = minOrd(values);
             maxOrd = maxOrd(values);
             if (minOrd > maxOrd || minOrd > skipper.maxValue() || maxOrd < skipper.minValue()) {
-              skipperMinDocId = DocIdSetIterator.NO_MORE_DOCS;
-              skipperMaxDocId = DocIdSetIterator.NO_MORE_DOCS;
+              skipperMinDocId = skipperMaxDocId = DocIdSetIterator.NO_MORE_DOCS;
               skipperMinDocIdSet = skipperMaxDocIdSet = true;
               return;
             }

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSetDocValuesRangeQuery.java
@@ -119,39 +119,31 @@ final class SortedSetDocValuesRangeQuery extends Query {
         }
         DocValuesSkipper skipper = context.reader().getDocValuesSkipper(field);
         SortedSetDocValues values = DocValues.getSortedSet(context.reader(), field);
+        final SortedDocValues singleton = DocValues.unwrapSingleton(values);
+        if (singleton != null && skipper != null && isDensePrimarySort(context.reader(), skipper)) {
+          final long minOrd = minOrd(values);
+          final long maxOrd = maxOrd(values);
+          if (minOrd > maxOrd || minOrd > skipper.maxValue() || maxOrd < skipper.minValue()) {
+            return null;
+          }
+          if (skipper.minValue() >= minOrd && skipper.maxValue() <= maxOrd) {
+            return ConstantScoreScorerSupplier.matchAll(
+                score(), scoreMode, context.reader().maxDoc());
+          }
+          final DocIdSetIterator psIterator =
+              getDocIdSetIteratorForDensePrimarySort(
+                  context.reader(), singleton, skipper, minOrd, maxOrd);
+          return ConstantScoreScorerSupplier.fromIterator(
+              psIterator, score(), scoreMode, context.reader().maxDoc());
+        }
 
         // implement ScorerSupplier, since we do some expensive stuff to make a scorer
         return new ConstantScoreScorerSupplier(score(), scoreMode, context.reader().maxDoc()) {
           @Override
           public DocIdSetIterator iterator(long leadCost) throws IOException {
 
-            final long minOrd;
-            if (lowerValue == null) {
-              minOrd = 0;
-            } else {
-              final long ord = values.lookupTerm(lowerValue);
-              if (ord < 0) {
-                minOrd = -1 - ord;
-              } else if (lowerInclusive) {
-                minOrd = ord;
-              } else {
-                minOrd = ord + 1;
-              }
-            }
-
-            final long maxOrd;
-            if (upperValue == null) {
-              maxOrd = values.getValueCount() - 1;
-            } else {
-              final long ord = values.lookupTerm(upperValue);
-              if (ord < 0) {
-                maxOrd = -2 - ord;
-              } else if (upperInclusive) {
-                maxOrd = ord;
-              } else {
-                maxOrd = ord - 1;
-              }
-            }
+            final long minOrd = minOrd(values);
+            final long maxOrd = maxOrd(values);
 
             // no terms matched in this segment
             if (minOrd > maxOrd
@@ -168,16 +160,7 @@ final class SortedSetDocValuesRangeQuery extends Query {
               return DocIdSetIterator.all(skipper.docCount());
             }
 
-            final SortedDocValues singleton = DocValues.unwrapSingleton(values);
             if (singleton != null) {
-              if (skipper != null) {
-                final DocIdSetIterator psIterator =
-                    getDocIdSetIteratorOrNullForPrimarySort(
-                        context.reader(), singleton, skipper, minOrd, maxOrd);
-                if (psIterator != null) {
-                  return psIterator;
-                }
-              }
               return TwoPhaseIterator.asDocIdSetIterator(
                   DocValuesRangeIterator.forOrdinalRange(singleton, skipper, minOrd, maxOrd));
             }
@@ -199,23 +182,62 @@ final class SortedSetDocValuesRangeQuery extends Query {
     };
   }
 
-  private DocIdSetIterator getDocIdSetIteratorOrNullForPrimarySort(
+  private long minOrd(SortedSetDocValues values) throws IOException {
+    final long minOrd;
+    if (lowerValue == null) {
+      minOrd = 0;
+    } else {
+      final long ord = values.lookupTerm(lowerValue);
+      if (ord < 0) {
+        minOrd = -1 - ord;
+      } else if (lowerInclusive) {
+        minOrd = ord;
+      } else {
+        minOrd = ord + 1;
+      }
+    }
+    return minOrd;
+  }
+
+  private long maxOrd(SortedSetDocValues values) throws IOException {
+    final long maxOrd;
+    if (upperValue == null) {
+      maxOrd = values.getValueCount() - 1;
+    } else {
+      final long ord = values.lookupTerm(upperValue);
+      if (ord < 0) {
+        maxOrd = -2 - ord;
+      } else if (upperInclusive) {
+        maxOrd = ord;
+      } else {
+        maxOrd = ord - 1;
+      }
+    }
+    return maxOrd;
+  }
+
+  private boolean isDensePrimarySort(LeafReader reader, DocValuesSkipper skipper) {
+    if (skipper.docCount() != reader.maxDoc()) {
+      return false;
+    }
+    final Sort indexSort = reader.getMetaData().sort();
+    if (indexSort == null
+        || indexSort.getSort().length == 0
+        || indexSort.getSort()[0].getField().equals(field) == false) {
+      return false;
+    }
+    return true;
+  }
+
+  private DocIdSetIterator getDocIdSetIteratorForDensePrimarySort(
       LeafReader reader,
       SortedDocValues sortedDocValues,
       DocValuesSkipper skipper,
       long minOrd,
       long maxOrd)
       throws IOException {
-    if (skipper.docCount() != reader.maxDoc()) {
-      return null;
-    }
+    assert isDensePrimarySort(reader, skipper);
     final Sort indexSort = reader.getMetaData().sort();
-    if (indexSort == null
-        || indexSort.getSort().length == 0
-        || indexSort.getSort()[0].getField().equals(field) == false) {
-      return null;
-    }
-
     final int minDocID;
     final int maxDocID;
     if (indexSort.getSort()[0].getReverse()) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
@@ -794,7 +794,7 @@ public class TestDocValuesQueries extends LuceneTestCase {
       Weight weight = rewritten.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1.0f);
       ScorerSupplier supplier = weight.scorerSupplier(ctx);
       assertThat(supplier.cost(), greaterThanOrEqualTo((long) sizes[i]));
-      assertThat(supplier.cost(), lessThanOrEqualTo((long) sizes[i] + 4096));
+      assertThat(supplier.cost(), lessThanOrEqualTo((long) sizes[i] + 2 * 4096));
     }
     reader.close();
     dir.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
@@ -17,7 +17,9 @@
 package org.apache.lucene.search;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,6 +40,7 @@ import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
@@ -779,11 +782,19 @@ public class TestDocValuesQueries extends LuceneTestCase {
     iw.close();
 
     for (int i = 0; i < numBlocks; i++) {
-      final Query q1 =
+      final Query q =
           SortedDocValuesField.newSlowRangeQuery(
               "dv", new BytesRef("" + i), new BytesRef("" + i), true, true);
-      assertEquals(sizes[i], searcher.count(q1));
-      assertEquals(sizes[i], searcher.search(q1, 1000).totalHits.value());
+      assertEquals(sizes[i], searcher.count(q));
+      assertEquals(sizes[i], searcher.search(q, 1000).totalHits.value());
+      // check cost
+      assertEquals(1, reader.leaves().size());
+      LeafReaderContext ctx = reader.leaves().get(0);
+      Query rewritten = searcher.rewrite(q);
+      Weight weight = rewritten.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1.0f);
+      ScorerSupplier supplier = weight.scorerSupplier(ctx);
+      assertThat(supplier.cost(), greaterThanOrEqualTo((long) sizes[i]));
+      assertThat(supplier.cost(), lessThanOrEqualTo((long) sizes[i] + 4096));
     }
     reader.close();
     dir.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
@@ -762,8 +762,10 @@ public class TestDocValuesQueries extends LuceneTestCase {
         new Sort(new SortField("dv", SortField.Type.STRING, random().nextBoolean())));
     int numBlocks = random().nextInt(4, 16);
     int[] sizes = new int[numBlocks];
+    int totalDocs = 0;
     for (int i = 0; i < numBlocks; i++) {
       sizes[i] = random().nextInt(1, 250);
+      totalDocs += sizes[i];
     }
     RandomIndexWriter iw = new RandomIndexWriter(random(), dir, config);
     for (int i = 0; i < numBlocks; i++) {
@@ -794,7 +796,8 @@ public class TestDocValuesQueries extends LuceneTestCase {
       Weight weight = rewritten.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1.0f);
       ScorerSupplier supplier = weight.scorerSupplier(ctx);
       assertThat(supplier.cost(), greaterThanOrEqualTo((long) sizes[i]));
-      assertThat(supplier.cost(), lessThanOrEqualTo((long) sizes[i] + 2 * 4096));
+      assertThat(
+          supplier.cost(), lessThanOrEqualTo(Math.min((long) sizes[i] + 2 * 4096, totalDocs)));
     }
     reader.close();
     dir.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
@@ -44,6 +44,7 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.search.QueryUtils;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.NumericUtils;
 
@@ -749,5 +750,42 @@ public class TestDocValuesQueries extends LuceneTestCase {
         }
       }
     }
+  }
+
+  public void testPrimarySortDenseSortedDocValuesExactMatch() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriterConfig config = new IndexWriterConfig().setCodec(getCodec());
+    config.setIndexSort(
+        new Sort(new SortField("dv", SortField.Type.STRING, random().nextBoolean())));
+    int numBlocks = random().nextInt(4, 16);
+    int[] sizes = new int[numBlocks];
+    for (int i = 0; i < numBlocks; i++) {
+      sizes[i] = random().nextInt(1, 250);
+    }
+    RandomIndexWriter iw = new RandomIndexWriter(random(), dir, config);
+    for (int i = 0; i < numBlocks; i++) {
+      BytesRef bytesRef = new BytesRef("" + i);
+      for (int j = 0; j < sizes[i]; j++) {
+        Document doc = new Document();
+        doc.add(SortedDocValuesField.indexedField("dv", bytesRef));
+        iw.addDocument(doc);
+      }
+    }
+    iw.commit();
+    iw.forceMerge(1);
+
+    final IndexReader reader = iw.getReader();
+    final IndexSearcher searcher = newSearcher(reader, false);
+    iw.close();
+
+    for (int i = 0; i < numBlocks; i++) {
+      final Query q1 =
+          SortedDocValuesField.newSlowRangeQuery(
+              "dv", new BytesRef("" + i), new BytesRef("" + i), true, true);
+      assertEquals(sizes[i], searcher.count(q1));
+      assertEquals(sizes[i], searcher.search(q1, 1000).totalHits.value());
+    }
+    reader.close();
+    dir.close();
   }
 }


### PR DESCRIPTION
I noticed that the current implementation always return values.cost() because we are delaying the construction of the iterator until the last moment. This is because we need to do some lookups for resolving the ordinals of the query.

Still when there is a skipper and the index is dense and used as primary sort, we have a very fast way to compute the iterator and the exact cost so let's move that conditions when building the score supplier. This is inline to what we are doing in SortedNumericDocValuesRangeQuery.