### PR TITLE
Remove redundant final modifiers

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -227,6 +227,8 @@ Build
 Other
 ---------------------
 
+* GITHUB#16063: Remove redundant final modifiers. (Zhou Hui)
+
 * GITHUB#14801: Removed all security manager and java.security-related code, which is effectively dead
   in Java 24+. (Dawid Weiss)
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/classic/ClassicTokenizer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/classic/ClassicTokenizer.java
@@ -129,7 +129,7 @@ public final class ClassicTokenizer extends Tokenizer {
    * @see org.apache.lucene.analysis.TokenStream#next()
    */
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     clearAttributes();
     skippedPositions = 0;
 
@@ -161,7 +161,7 @@ public final class ClassicTokenizer extends Tokenizer {
   }
 
   @Override
-  public final void end() throws IOException {
+  public void end() throws IOException {
     super.end();
     // set final offset
     int finalOffset = correctOffset(scanner.yychar() + scanner.yylength());

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/KeywordTokenizer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/KeywordTokenizer.java
@@ -62,7 +62,7 @@ public final class KeywordTokenizer extends Tokenizer {
   }
 
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     if (!done) {
       clearAttributes();
       done = true;
@@ -83,7 +83,7 @@ public final class KeywordTokenizer extends Tokenizer {
   }
 
   @Override
-  public final void end() throws IOException {
+  public void end() throws IOException {
     super.end();
     // set final offset
     offsetAtt.setOffset(finalOffset, finalOffset);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/UpperCaseFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/UpperCaseFilter.java
@@ -43,7 +43,7 @@ public final class UpperCaseFilter extends TokenFilter {
   }
 
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     if (input.incrementToken()) {
       CharacterUtils.toUpperCase(termAtt.buffer(), 0, termAtt.length());
       return true;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/cz/CzechAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/cz/CzechAnalyzer.java
@@ -48,7 +48,7 @@ public final class CzechAnalyzer extends StopwordAnalyzerBase {
    *
    * @return a set of default Czech-stopwords
    */
-  public static final CharArraySet getDefaultStopSet() {
+  public static CharArraySet getDefaultStopSet() {
     return DefaultSetHolder.DEFAULT_SET;
   }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanAnalyzer.java
@@ -64,7 +64,7 @@ public final class GermanAnalyzer extends StopwordAnalyzerBase {
    *
    * @return a set of default German-stopwords
    */
-  public static final CharArraySet getDefaultStopSet() {
+  public static CharArraySet getDefaultStopSet() {
     return DefaultSetHolder.DEFAULT_SET;
   }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/el/GreekAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/el/GreekAnalyzer.java
@@ -50,7 +50,7 @@ public final class GreekAnalyzer extends StopwordAnalyzerBase {
    *
    * @return a set of default Greek-stopwords
    */
-  public static final CharArraySet getDefaultStopSet() {
+  public static CharArraySet getDefaultStopSet() {
     return DefaultSetHolder.DEFAULT_SET;
   }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/email/UAX29URLEmailTokenizer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/email/UAX29URLEmailTokenizer.java
@@ -143,7 +143,7 @@ public final class UAX29URLEmailTokenizer extends Tokenizer {
   private final TypeAttribute typeAtt = addAttribute(TypeAttribute.class);
 
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     clearAttributes();
     skippedPositions = 0;
 
@@ -169,7 +169,7 @@ public final class UAX29URLEmailTokenizer extends Tokenizer {
   }
 
   @Override
-  public final void end() throws IOException {
+  public void end() throws IOException {
     super.end();
     // set final offset
     int finalOffset = correctOffset(scanner.yychar() + scanner.yylength());

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/PorterStemFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/PorterStemFilter.java
@@ -58,7 +58,7 @@ public final class PorterStemFilter extends TokenFilter {
   }
 
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     if (!input.incrementToken()) return false;
 
     if ((!keywordAttr.isKeyword()) && stemmer.stem(termAtt.buffer(), 0, termAtt.length()))

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ASCIIFoldingFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ASCIIFoldingFilter.java
@@ -187,7 +187,7 @@ public final class ASCIIFoldingFilter extends TokenFilter {
    * @return length of output
    * @lucene.internal
    */
-  public static final int foldToASCII(
+  public static int foldToASCII(
       char[] input, int inputPos, char[] output, int outputPos, int length) {
     final int end = inputPos + length;
     for (int pos = inputPos; pos < end; ++pos) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/EmptyTokenStream.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/EmptyTokenStream.java
@@ -22,7 +22,7 @@ import org.apache.lucene.analysis.TokenStream;
 public final class EmptyTokenStream extends TokenStream {
 
   @Override
-  public final boolean incrementToken() {
+  public boolean incrementToken() {
     return false;
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/TruncateTokenFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/TruncateTokenFilter.java
@@ -81,7 +81,7 @@ public final class TruncateTokenFilter extends TokenFilter {
   }
 
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     if (!input.incrementToken()) {
       return false;
     }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/EdgeNGramTokenFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/EdgeNGramTokenFilter.java
@@ -87,7 +87,7 @@ public final class EdgeNGramTokenFilter extends TokenFilter {
   }
 
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     while (true) {
       if (curTermBuffer == null) {
         if (!input.incrementToken()) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/NGramTokenFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/NGramTokenFilter.java
@@ -95,7 +95,7 @@ public final class NGramTokenFilter extends TokenFilter {
   }
 
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     while (true) {
       if (curTermBuffer == null) {
         if (!input.incrementToken()) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/no/NorwegianNormalizationFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/no/NorwegianNormalizationFilter.java
@@ -45,7 +45,7 @@ public final class NorwegianNormalizationFilter extends TokenFilter {
   private final CharTermAttribute charTermAttribute = addAttribute(CharTermAttribute.class);
 
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     if (!input.incrementToken()) {
       return false;
     }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ro/RomanianNormalizationFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ro/RomanianNormalizationFilter.java
@@ -31,7 +31,7 @@ public final class RomanianNormalizationFilter extends TokenFilter {
   }
 
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     if (input.incrementToken()) {
       int newlen = normalizer.normalize(termAtt.buffer(), termAtt.length());
       termAtt.setLength(newlen);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/shingle/ShingleAnalyzerWrapper.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/shingle/ShingleAnalyzerWrapper.java
@@ -146,7 +146,7 @@ public final class ShingleAnalyzerWrapper extends AnalyzerWrapper {
   }
 
   @Override
-  public final Analyzer getWrappedAnalyzer(String fieldName) {
+  public Analyzer getWrappedAnalyzer(String fieldName) {
     return delegate;
   }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/sinks/TeeSinkTokenFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/sinks/TeeSinkTokenFilter.java
@@ -90,7 +90,7 @@ public final class TeeSinkTokenFilter extends TokenFilter {
   }
 
   @Override
-  public final void end() throws IOException {
+  public void end() throws IOException {
     super.end();
     cachedStates.setFinalState(captureState());
   }
@@ -112,7 +112,7 @@ public final class TeeSinkTokenFilter extends TokenFilter {
     }
 
     @Override
-    public final boolean incrementToken() {
+    public boolean incrementToken() {
       if (!it.hasNext()) {
         return false;
       }
@@ -131,7 +131,7 @@ public final class TeeSinkTokenFilter extends TokenFilter {
     }
 
     @Override
-    public final void reset() {
+    public void reset() {
       it = cachedStates.getStates();
     }
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/snowball/SnowballFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/snowball/SnowballFilter.java
@@ -89,7 +89,7 @@ public final class SnowballFilter extends TokenFilter {
 
   /** Returns the next input Token, after being stemmed */
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     if (input.incrementToken()) {
       if (!keywordAttr.isKeyword()) {
         char[] termBuffer = termAtt.buffer();

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/tr/ApostropheFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/tr/ApostropheFilter.java
@@ -39,7 +39,7 @@ public final class ApostropheFilter extends TokenFilter {
   }
 
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     if (!input.incrementToken()) return false;
 
     final char[] buffer = termAtt.buffer();

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/tr/TurkishLowerCaseFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/tr/TurkishLowerCaseFilter.java
@@ -46,7 +46,7 @@ public final class TurkishLowerCaseFilter extends TokenFilter {
   }
 
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     boolean iOrAfter = false;
 
     if (input.incrementToken()) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/ElisionFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/ElisionFilter.java
@@ -46,7 +46,7 @@ public final class ElisionFilter extends TokenFilter {
 
   /** Increments the {@link TokenStream} with a {@link CharTermAttribute} without elisioned start */
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     if (input.incrementToken()) {
       char[] termBuffer = termAtt.buffer();
       int termLength = termAtt.length();

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/wikipedia/WikipediaTokenizer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/wikipedia/WikipediaTokenizer.java
@@ -178,7 +178,7 @@ public final class WikipediaTokenizer extends Tokenizer {
    * @see org.apache.lucene.analysis.TokenStream#next()
    */
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     if (tokens != null && tokens.hasNext()) {
       AttributeSource.State state = tokens.next();
       restoreState(state);

--- a/lucene/core/src/java/org/apache/lucene/analysis/CachingTokenFilter.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/CachingTokenFilter.java
@@ -63,7 +63,7 @@ public final class CachingTokenFilter extends TokenFilter {
 
   /** The first time called, it'll read and cache all tokens from the input. */
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     if (cache == null) { // first-time
       // fill cache lazily
       cache = new ArrayList<>(64);
@@ -81,7 +81,7 @@ public final class CachingTokenFilter extends TokenFilter {
   }
 
   @Override
-  public final void end() {
+  public void end() {
     if (finalState != null) {
       restoreState(finalState);
     }

--- a/lucene/core/src/java/org/apache/lucene/analysis/standard/StandardTokenizer.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/standard/StandardTokenizer.java
@@ -149,7 +149,7 @@ public final class StandardTokenizer extends Tokenizer {
    * @see org.apache.lucene.analysis.TokenStream#next()
    */
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     clearAttributes();
     skippedPositions = 0;
 
@@ -175,7 +175,7 @@ public final class StandardTokenizer extends Tokenizer {
   }
 
   @Override
-  public final void end() throws IOException {
+  public void end() throws IOException {
     super.end();
     // set final offset
     int finalOffset = correctOffset(scanner.yychar() + scanner.yylength());

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingTermVectorsReader.java
@@ -1176,7 +1176,7 @@ public final class Lucene90CompressingTermVectorsReader extends TermVectorsReade
     }
 
     @Override
-    public final PostingsEnum postings(PostingsEnum reuse, int flags) throws IOException {
+    public PostingsEnum postings(PostingsEnum reuse, int flags) throws IOException {
       final TVPostingsEnum docsEnum;
       if (reuse != null && reuse instanceof TVPostingsEnum tvpe) {
         docsEnum = tvpe;

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceFeatureQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceFeatureQuery.java
@@ -69,7 +69,7 @@ final class LatLonPointDistanceFeatureQuery extends Query {
   }
 
   @Override
-  public final boolean equals(Object o) {
+  public boolean equals(Object o) {
     return sameClassAs(o) && equalsTo(getClass().cast(o));
   }
 

--- a/lucene/core/src/java/org/apache/lucene/document/LongDistanceFeatureQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LongDistanceFeatureQuery.java
@@ -57,7 +57,7 @@ final class LongDistanceFeatureQuery extends Query {
   }
 
   @Override
-  public final boolean equals(Object o) {
+  public boolean equals(Object o) {
     return sameClassAs(o) && equalsTo(getClass().cast(o));
   }
 

--- a/lucene/core/src/java/org/apache/lucene/geo/Tessellator.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Tessellator.java
@@ -1663,12 +1663,12 @@ public final class Tessellator {
     }
 
     /** get the x value */
-    public final double getX() {
+    public double getX() {
       return polyX[vrtxIdx];
     }
 
     /** get the y value */
-    public final double getY() {
+    public double getY() {
       return polyY[vrtxIdx];
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentApproximatePriorityQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentApproximatePriorityQueue.java
@@ -30,7 +30,7 @@ final class ConcurrentApproximatePriorityQueue<T> {
   static final int MIN_CONCURRENCY = 1;
   static final int MAX_CONCURRENCY = 256;
 
-  private static final int getConcurrency() {
+  private static int getConcurrency() {
     int coreCount = Runtime.getRuntime().availableProcessors();
     // Aim for ~4 entries per slot when indexing with one thread per CPU core. The trade-off is
     // that if we set the concurrency too high then we'll completely lose the bias towards larger

--- a/lucene/core/src/java/org/apache/lucene/index/DocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValues.java
@@ -27,7 +27,7 @@ public final class DocValues {
   private DocValues() {}
 
   /** An empty {@link BinaryDocValues} which returns no documents */
-  public static final BinaryDocValues emptyBinary() {
+  public static BinaryDocValues emptyBinary() {
     return new BinaryDocValues() {
       private int doc = -1;
 
@@ -66,7 +66,7 @@ public final class DocValues {
   }
 
   /** An empty NumericDocValues which returns no documents */
-  public static final NumericDocValues emptyNumeric() {
+  public static NumericDocValues emptyNumeric() {
     return new NumericDocValues() {
       private int doc = -1;
 
@@ -105,7 +105,7 @@ public final class DocValues {
   }
 
   /** An empty SortedDocValues which returns {@link BytesRef#EMPTY_BYTES} for every document */
-  public static final SortedDocValues emptySorted() {
+  public static SortedDocValues emptySorted() {
     final BytesRef empty = new BytesRef();
     return new SortedDocValues() {
 
@@ -156,12 +156,12 @@ public final class DocValues {
   }
 
   /** An empty SortedNumericDocValues which returns zero values for every document */
-  public static final SortedNumericDocValues emptySortedNumeric() {
+  public static SortedNumericDocValues emptySortedNumeric() {
     return singleton(emptyNumeric());
   }
 
   /** An empty SortedDocValues which returns {@link BytesRef#EMPTY_BYTES} for every document */
-  public static final SortedSetDocValues emptySortedSet() {
+  public static SortedSetDocValues emptySortedSet() {
     return singleton(emptySorted());
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
@@ -773,7 +773,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
   }
 
   /** Returns the largest non-pending flushable DWPT or <code>null</code> if there is none. */
-  final DocumentsWriterPerThread checkoutLargestNonPendingWriter() {
+  DocumentsWriterPerThread checkoutLargestNonPendingWriter() {
     DocumentsWriterPerThread largestNonPendingWriter = findLargestNonPendingWriter();
     if (largestNonPendingWriter != null) {
       // we only lock this very briefly to swap it's DWPT out - we don't go through the DWPTPool and

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterPerThread.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterPerThread.java
@@ -57,7 +57,7 @@ final class DocumentsWriterPerThread implements Accountable, Lock {
     abortingException = throwable;
   }
 
-  final boolean isAborted() {
+  boolean isAborted() {
     return aborted;
   }
 
@@ -198,7 +198,7 @@ final class DocumentsWriterPerThread implements Accountable, Lock {
     this.hasParentField = indexWriterConfig.getParentField() != null;
   }
 
-  final void testPoint(String message) {
+  void testPoint(String message) {
     if (enableTestPoints) {
       assert infoStream.isEnabled("TP"); // don't enable unless you need them.
       infoStream.message("TP", message);

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -279,7 +279,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
    * @throws CorruptIndexException if the index is corrupt
    * @throws IOException if there is a low-level IO error
    */
-  public static final SegmentInfos readCommit(Directory directory, String segmentFileName)
+  public static SegmentInfos readCommit(Directory directory, String segmentFileName)
       throws IOException {
     return readCommit(directory, segmentFileName, Version.MIN_SUPPORTED_MAJOR);
   }
@@ -291,7 +291,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
    * IndexFormatTooOldException} will be thrown. Note that this may throw an IOException if a commit
    * is in process.
    */
-  public static final SegmentInfos readCommit(
+  public static SegmentInfos readCommit(
       Directory directory, String segmentFileName, int minSupportedMajorVersion)
       throws IOException {
 
@@ -308,13 +308,13 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
   }
 
   /** Read the commit from the provided {@link ChecksumIndexInput}. */
-  public static final SegmentInfos readCommit(
+  public static SegmentInfos readCommit(
       Directory directory, ChecksumIndexInput input, long generation) throws IOException {
     return readCommit(directory, input, generation, Version.MIN_SUPPORTED_MAJOR);
   }
 
   /** Read the commit from the provided {@link ChecksumIndexInput}. */
-  public static final SegmentInfos readCommit(
+  public static SegmentInfos readCommit(
       Directory directory, ChecksumIndexInput input, long generation, int minSupportedMajorVersion)
       throws IOException {
     Throwable priorE = null;
@@ -541,7 +541,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
   }
 
   /** Find the latest commit ({@code segments_N file}) and load all {@link SegmentCommitInfo}s. */
-  public static final SegmentInfos readLatestCommit(Directory directory) throws IOException {
+  public static SegmentInfos readLatestCommit(Directory directory) throws IOException {
     return readLatestCommit(directory, Version.MIN_SUPPORTED_MAJOR);
   }
 
@@ -551,7 +551,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
    * than the provided minimum supported major version. If the commit's version is older, an {@link
    * IndexFormatTooOldException} will be thrown.
    */
-  public static final SegmentInfos readLatestCommit(
+  public static SegmentInfos readLatestCommit(
       Directory directory, int minSupportedMajorVersion) throws IOException {
     return new FindSegmentsFile<SegmentInfos>(directory) {
       @Override
@@ -888,7 +888,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
     this.generation = generation;
   }
 
-  final void rollbackCommit(Directory dir) {
+  void rollbackCommit(Directory dir) {
     if (pendingCommit) {
       pendingCommit = false;
 
@@ -912,7 +912,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
    * <p>Note: {@link #changed()} should be called prior to this method if changes have been made to
    * this {@link SegmentInfos} instance
    */
-  final void prepareCommit(Directory dir) throws IOException {
+  void prepareCommit(Directory dir) throws IOException {
     if (pendingCommit) {
       throw new IllegalStateException("prepareCommit was already called");
     }
@@ -942,7 +942,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
   }
 
   /** Returns the committed segments_N filename. */
-  final String finishCommit(Directory dir) throws IOException {
+  String finishCommit(Directory dir) throws IOException {
     if (pendingCommit == false) {
       throw new IllegalStateException("prepareCommit was not called");
     }
@@ -977,7 +977,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
    * <p>Note: {@link #changed()} should be called prior to this method if changes have been made to
    * this {@link SegmentInfos} instance
    */
-  public final void commit(Directory dir) throws IOException {
+  public void commit(Directory dir) throws IOException {
     prepareCommit(dir);
     finishCommit(dir);
   }

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -551,8 +551,8 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
    * than the provided minimum supported major version. If the commit's version is older, an {@link
    * IndexFormatTooOldException} will be thrown.
    */
-  public static SegmentInfos readLatestCommit(
-      Directory directory, int minSupportedMajorVersion) throws IOException {
+  public static SegmentInfos readLatestCommit(Directory directory, int minSupportedMajorVersion)
+      throws IOException {
     return new FindSegmentsFile<SegmentInfos>(directory) {
       @Override
       protected SegmentInfos doBody(String segmentFileName) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/index/Term.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Term.java
@@ -173,7 +173,7 @@ public final class Term implements Comparable<Term>, Accountable {
    * not be modified after construction, for example, you should clone a copy rather than pass
    * reused bytes from a TermsEnum.
    */
-  final void set(String fld, BytesRef bytes) {
+  void set(String fld, BytesRef bytes) {
     field = fld;
     this.bytes = bytes;
   }

--- a/lucene/core/src/java/org/apache/lucene/search/BlendedTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BlendedTermQuery.java
@@ -268,7 +268,7 @@ public final class BlendedTermQuery extends Query {
   }
 
   @Override
-  public final Query rewrite(IndexSearcher indexSearcher) throws IOException {
+  public Query rewrite(IndexSearcher indexSearcher) throws IOException {
     final TermStates[] contexts = ArrayUtil.copyArray(this.contexts);
     for (int i = 0; i < contexts.length; ++i) {
       if (contexts[i] == null

--- a/lucene/core/src/java/org/apache/lucene/search/CachingCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/CachingCollector.java
@@ -50,7 +50,7 @@ public abstract class CachingCollector extends FilterCollector {
     float score;
 
     @Override
-    public final float score() {
+    public float score() {
       return score;
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/search/PhrasePositions.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PhrasePositions.java
@@ -40,7 +40,7 @@ final class PhrasePositions {
     this.terms = terms;
   }
 
-  final void firstPosition() throws IOException {
+  void firstPosition() throws IOException {
     count = freq; // use cached frequency
     nextPosition();
   }
@@ -50,7 +50,7 @@ final class PhrasePositions {
    * location - offset</code>, so that a matching exact phrase is easily identified when all
    * PhrasePositions have exactly the same <code>position</code>.
    */
-  final boolean nextPosition() throws IOException {
+  boolean nextPosition() throws IOException {
     if (count-- > 0) { // read subsequent pos's
       position = postings.nextPosition() - offset;
       return true;

--- a/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
@@ -267,7 +267,7 @@ final class WANDScorer extends Scorer {
   }
 
   @Override
-  public final Collection<ChildScorable> getChildren() throws IOException {
+  public Collection<ChildScorable> getChildren() throws IOException {
     List<ChildScorable> matchingChildren = new ArrayList<>();
     advanceAllTail();
     for (DisiWrapper s = lead; s != null; s = s.next) {

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
@@ -429,11 +429,11 @@ public final class ByteBuffersDataInput extends DataInput
         offset == 0 ? "" : String.format(Locale.ROOT, " [offset: %,d]", offset));
   }
 
-  private final int blockIndex(long pos) {
+  private int blockIndex(long pos) {
     return Math.toIntExact(pos >> blockBits);
   }
 
-  private final int blockOffset(long pos) {
+  private int blockOffset(long pos) {
     return (int) pos & blockMask;
   }
 
@@ -441,7 +441,7 @@ public final class ByteBuffersDataInput extends DataInput
     return 1 << blockBits;
   }
 
-  private static final boolean isPowerOfTwo(int v) {
+  private static boolean isPowerOfTwo(int v) {
     return (v & (v - 1)) == 0;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDirectory.java
@@ -247,8 +247,8 @@ public final class ByteBuffersDirectory extends BaseDirectory {
       return local.clone();
     }
 
-    IndexOutput createOutput(
-        BiFunction<String, ByteBuffersDataOutput, IndexInput> outputToInput) throws IOException {
+    IndexOutput createOutput(BiFunction<String, ByteBuffersDataOutput, IndexInput> outputToInput)
+        throws IOException {
       if (content != null) {
         throw new IOException("Can only write to a file once: " + fileName);
       }

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDirectory.java
@@ -247,7 +247,7 @@ public final class ByteBuffersDirectory extends BaseDirectory {
       return local.clone();
     }
 
-    final IndexOutput createOutput(
+    IndexOutput createOutput(
         BiFunction<String, ByteBuffersDataOutput, IndexInput> outputToInput) throws IOException {
       if (content != null) {
         throw new IOException("Can only write to a file once: " + fileName);

--- a/lucene/core/src/java/org/apache/lucene/store/NIOFSDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/NIOFSDirectory.java
@@ -156,7 +156,7 @@ public class NIOFSDirectory extends FSDirectory {
     }
 
     @Override
-    public final long length() {
+    public long length() {
       return end - off;
     }
 

--- a/lucene/core/src/java/org/apache/lucene/store/NativeFSLockFactory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/NativeFSLockFactory.java
@@ -127,7 +127,7 @@ public final class NativeFSLockFactory extends FSLockFactory {
     }
   }
 
-  private static final void clearLockHeld(Path path) throws IOException {
+  private static void clearLockHeld(Path path) throws IOException {
     boolean remove = LOCK_HELD.remove(path.toString());
     if (remove == false) {
       throw new AlreadyClosedException("Lock path was cleared but never marked as held: " + path);

--- a/lucene/core/src/java/org/apache/lucene/util/StrictStringTokenizer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/StrictStringTokenizer.java
@@ -27,7 +27,7 @@ final class StrictStringTokenizer {
     this.delimiter = delimiter;
   }
 
-  public final String nextToken() {
+  public String nextToken() {
     if (pos < 0) {
       throw new IllegalStateException("no more tokens");
     }
@@ -45,7 +45,7 @@ final class StrictStringTokenizer {
     return s1;
   }
 
-  public final boolean hasMoreTokens() {
+  public boolean hasMoreTokens() {
     return pos >= 0;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/compress/LowercaseAsciiCompression.java
+++ b/lucene/core/src/java/org/apache/lucene/util/compress/LowercaseAsciiCompression.java
@@ -28,7 +28,7 @@ import org.apache.lucene.util.BytesRef;
  */
 public final class LowercaseAsciiCompression {
 
-  private static final boolean isCompressible(int b) {
+  private static boolean isCompressible(int b) {
     final int high3Bits = (b + 1) & ~0x1F;
     return high3Bits == 0x20 || high3Bits == 0x60;
   }

--- a/lucene/core/src/java/org/apache/lucene/util/packed/BulkOperationPackedSingleBlock.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/BulkOperationPackedSingleBlock.java
@@ -32,12 +32,12 @@ final class BulkOperationPackedSingleBlock extends BulkOperation {
   }
 
   @Override
-  public int longBlockCount() {
+  public final int longBlockCount() {
     return BLOCK_COUNT;
   }
 
   @Override
-  public int byteBlockCount() {
+  public final int byteBlockCount() {
     return BLOCK_COUNT * 8;
   }
 
@@ -47,7 +47,7 @@ final class BulkOperationPackedSingleBlock extends BulkOperation {
   }
 
   @Override
-  public int byteValueCount() {
+  public final int byteValueCount() {
     return valueCount;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/packed/BulkOperationPackedSingleBlock.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/BulkOperationPackedSingleBlock.java
@@ -32,12 +32,12 @@ final class BulkOperationPackedSingleBlock extends BulkOperation {
   }
 
   @Override
-  public final int longBlockCount() {
+  public int longBlockCount() {
     return BLOCK_COUNT;
   }
 
   @Override
-  public final int byteBlockCount() {
+  public int byteBlockCount() {
     return BLOCK_COUNT * 8;
   }
 
@@ -47,7 +47,7 @@ final class BulkOperationPackedSingleBlock extends BulkOperation {
   }
 
   @Override
-  public final int byteValueCount() {
+  public int byteValueCount() {
     return valueCount;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/packed/PackedLongValues.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/PackedLongValues.java
@@ -153,12 +153,12 @@ public class PackedLongValues extends LongValues implements Accountable {
     }
 
     /** Whether or not there are remaining values. */
-    public final boolean hasNext() {
+    public boolean hasNext() {
       return pOff < currentCount;
     }
 
     /** Return the next long in the buffer. */
-    public final long next() {
+    public long next() {
       assert hasNext();
       long result = currentValues[pOff++];
       if (pOff == currentCount) {

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/QueryTermExtractor.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/QueryTermExtractor.java
@@ -55,7 +55,7 @@ public final class QueryTermExtractor {
    * @param query Query to extract term texts from
    * @return an array of the terms used in a query, plus their weights.
    */
-  public static final WeightedTerm[] getTerms(Query query) {
+  public static WeightedTerm[] getTerms(Query query) {
     return getTerms(query, false);
   }
 
@@ -68,7 +68,7 @@ public final class QueryTermExtractor {
    * @param fieldName the field on which Inverse Document Frequency (IDF) calculations are based
    * @return an array of the terms used in a query, plus their weights.
    */
-  public static final WeightedTerm[] getIdfWeightedTerms(
+  public static WeightedTerm[] getIdfWeightedTerms(
       Query query, IndexReader reader, String fieldName) {
     WeightedTerm[] terms = getTerms(query, false, fieldName);
     int totalNumDocs = reader.maxDoc();
@@ -107,7 +107,7 @@ public final class QueryTermExtractor {
    * @param prohibited <code>true</code> to extract "prohibited" terms, too
    * @return an array of the terms used in a query, plus their weights.
    */
-  public static final WeightedTerm[] getTerms(Query query, boolean prohibited) {
+  public static WeightedTerm[] getTerms(Query query, boolean prohibited) {
     return getTerms(query, prohibited, null);
   }
 

--- a/lucene/misc/src/java/org/apache/lucene/misc/index/MultiPassIndexSplitter.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/index/MultiPassIndexSplitter.java
@@ -220,7 +220,7 @@ public class MultiPassIndexSplitter {
       return null;
     }
 
-    final List<? extends FakeDeleteLeafIndexReader> getSequentialSubReadersWrapper() {
+    List<? extends FakeDeleteLeafIndexReader> getSequentialSubReadersWrapper() {
       return getSequentialSubReaders();
     }
 

--- a/lucene/misc/src/java/org/apache/lucene/misc/store/RAFDirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/RAFDirectory.java
@@ -144,7 +144,7 @@ public class RAFDirectory extends FSDirectory {
     }
 
     @Override
-    public final long length() {
+    public long length() {
       return end - off;
     }
 

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/SuffixingNGramTokenFilter.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/SuffixingNGramTokenFilter.java
@@ -73,7 +73,7 @@ final class SuffixingNGramTokenFilter extends TokenFilter {
 
   /** Returns the next token in the stream, or null at EOS. */
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     while (true) {
       if (curTermBuffer == null) {
 

--- a/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanOrQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/spans/SpanOrQuery.java
@@ -48,7 +48,7 @@ public final class SpanOrQuery extends SpanQuery {
   }
 
   /** Adds a clause to this query */
-  private final void addClause(SpanQuery clause) {
+  private void addClause(SpanQuery clause) {
     if (field == null) {
       field = clause.getField();
     } else if (clause.getField() != null && !clause.getField().equals(field)) {

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/charstream/FastCharStream.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/charstream/FastCharStream.java
@@ -47,7 +47,7 @@ public final class FastCharStream implements CharStream {
   }
 
   @Override
-  public final char readChar() throws IOException {
+  public char readChar() throws IOException {
     if (bufferPosition >= bufferLength) refill();
     return buffer[bufferPosition++];
   }
@@ -79,30 +79,30 @@ public final class FastCharStream implements CharStream {
   }
 
   @Override
-  public final char BeginToken() throws IOException {
+  public char BeginToken() throws IOException {
     tokenStart = bufferPosition;
     return readChar();
   }
 
   @Override
-  public final void backup(int amount) {
+  public void backup(int amount) {
     bufferPosition -= amount;
   }
 
   @Override
-  public final String GetImage() {
+  public String GetImage() {
     return new String(buffer, tokenStart, bufferPosition - tokenStart);
   }
 
   @Override
-  public final char[] GetSuffix(int len) {
+  public char[] GetSuffix(int len) {
     char[] value = new char[len];
     System.arraycopy(buffer, bufferPosition - len, value, 0, len);
     return value;
   }
 
   @Override
-  public final void Done() {
+  public void Done() {
     try {
       input.close();
     } catch (IOException e) {
@@ -111,22 +111,22 @@ public final class FastCharStream implements CharStream {
   }
 
   @Override
-  public final int getEndColumn() {
+  public int getEndColumn() {
     return bufferStart + bufferPosition;
   }
 
   @Override
-  public final int getEndLine() {
+  public int getEndLine() {
     return 1;
   }
 
   @Override
-  public final int getBeginColumn() {
+  public int getBeginColumn() {
     return bufferStart + tokenStart;
   }
 
   @Override
-  public final int getBeginLine() {
+  public int getBeginLine() {
     return 1;
   }
 }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/util/QueryNodeOperation.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/util/QueryNodeOperation.java
@@ -43,7 +43,7 @@ public final class QueryNodeOperation {
    * children of that node if q1 or q2 is null it returns the not null node if q1 = q2 = null it
    * returns null
    */
-  public static final QueryNode logicalAnd(QueryNode q1, QueryNode q2) {
+  public static QueryNode logicalAnd(QueryNode q1, QueryNode q2) {
     if (q1 == null) return q2;
     if (q2 == null) return q1;
 

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CoveringScorer.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/CoveringScorer.java
@@ -61,7 +61,7 @@ final class CoveringScorer extends Scorer {
   }
 
   @Override
-  public final Collection<ChildScorable> getChildren() throws IOException {
+  public Collection<ChildScorable> getChildren() throws IOException {
     List<ChildScorable> matchingChildren = new ArrayList<>();
     setTopListAndFreqIfNecessary();
     for (DisiWrapper s = topList; s != null; s = s.next) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/MockLowerCaseFilter.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/analysis/MockLowerCaseFilter.java
@@ -32,7 +32,7 @@ public final class MockLowerCaseFilter extends TokenFilter {
   }
 
   @Override
-  public final boolean incrementToken() throws IOException {
+  public boolean incrementToken() throws IOException {
     if (input.incrementToken()) {
       CharacterUtils.toLowerCase(termAtt.buffer(), 0, termAtt.length());
       return true;


### PR DESCRIPTION
### Description

This change removes redundant `final` modifiers throughout all final classes -- except for `BulkOperationPackedSingleBlock`,  which is referenced by certain generated classes and needs to be verified against its MD5 checksum.