### PR TITLE
FaissKnnVectorsFormat byte vectors support

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -109,6 +109,8 @@ New Features
 
 * GITHUB#16065: Add COSINE similarity support to FaissKnnVectorsFormat. (Prithvi S)
 
+* GITHUB#16067: Add byte vector support to FaissKnnVectorsFormat. (Prithvi S)
+
 * GITHUB#15508: Use native vectorization in Lucene. (Ankur Goel, Shubham Chaudhary, Dawid Weiss)
 
 * GITHUB#15818: Add BM25 k3 query-term frequency saturation to BM25Similarity. (Sagar Upadhyaya)

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/faiss/FaissKnnVectorsReader.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/faiss/FaissKnnVectorsReader.java
@@ -122,7 +122,8 @@ final class FaissKnnVectorsReader extends KnnVectorsReader {
         FieldInfo fi = state.fieldInfos.fieldInfo(fieldMeta.name);
         indexMap.put(
             fieldMeta.name,
-            FaissLibrary.INSTANCE.readIndex(indexInput, fi.getVectorSimilarityFunction()));
+            FaissLibrary.INSTANCE.readIndex(
+                indexInput, fi.getVectorSimilarityFunction(), fi.getVectorEncoding()));
       }
     } catch (Throwable t) {
       IOUtils.closeWhileSuppressingExceptions(t, this);
@@ -161,10 +162,8 @@ final class FaissKnnVectorsReader extends KnnVectorsReader {
   }
 
   @Override
-  public ByteVectorValues getByteVectorValues(String field) {
-    // TODO: Support using SQ8 quantization, see:
-    //  - https://github.com/opensearch-project/k-NN/pull/2425
-    throw new UnsupportedOperationException("Byte vectors not supported");
+  public ByteVectorValues getByteVectorValues(String field) throws IOException {
+    return rawVectorsReader.getByteVectorValues(field);
   }
 
   @Override
@@ -179,9 +178,11 @@ final class FaissKnnVectorsReader extends KnnVectorsReader {
   @Override
   public void search(
       String field, byte[] vector, KnnCollector knnCollector, AcceptDocs acceptDocs) {
-    // TODO: Support using SQ8 quantization, see:
-    //  - https://github.com/opensearch-project/k-NN/pull/2425
-    throw new UnsupportedOperationException("Byte vectors not supported");
+    float[] floatVector = new float[vector.length];
+    for (int i = 0; i < vector.length; i++) {
+      floatVector[i] = vector[i];
+    }
+    search(field, floatVector, knnCollector, acceptDocs);
   }
 
   @Override

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/faiss/FaissKnnVectorsWriter.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/faiss/FaissKnnVectorsWriter.java
@@ -31,6 +31,7 @@ import org.apache.lucene.codecs.KnnFieldVectorsWriter;
 import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatFieldVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
@@ -100,10 +101,11 @@ final class FaissKnnVectorsWriter extends KnnVectorsWriter {
   public IORunnable mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
     rawVectorsWriter.mergeOneFlatVectorField(fieldInfo, mergeState);
     switch (fieldInfo.getVectorEncoding()) {
-      case BYTE ->
-          // TODO: Support using SQ8 quantization, see:
-          //  - https://github.com/opensearch-project/k-NN/pull/2425
-          throw new UnsupportedOperationException("Byte vectors not supported");
+      case BYTE -> {
+        ByteVectorValues merged =
+            KnnVectorsWriter.MergedVectorValues.mergeByteVectorValues(fieldInfo, mergeState);
+        writeFloatField(fieldInfo, new ByteToFloatVectorValues(merged), doc -> doc);
+      }
       case FLOAT32 -> {
         FloatVectorValues merged =
             KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
@@ -126,10 +128,20 @@ final class FaissKnnVectorsWriter extends KnnVectorsWriter {
     for (Map.Entry<FieldInfo, FlatFieldVectorsWriter<?>> entry : rawFields.entrySet()) {
       FieldInfo fieldInfo = entry.getKey();
       switch (fieldInfo.getVectorEncoding()) {
-        case BYTE ->
-            // TODO: Support using SQ8 quantization, see:
-            //  - https://github.com/opensearch-project/k-NN/pull/2425
-            throw new UnsupportedOperationException("Byte vectors not supported");
+        case BYTE -> {
+          @SuppressWarnings("unchecked")
+          FlatFieldVectorsWriter<byte[]> rawWriter =
+              (FlatFieldVectorsWriter<byte[]>) entry.getValue();
+
+          List<byte[]> vectors = rawWriter.getVectors();
+          int dimension = fieldInfo.getVectorDimension();
+          DocIdSet docIdSet = rawWriter.getDocsWithFieldSet();
+
+          writeFloatField(
+              fieldInfo,
+              new ByteToFloatVectorValues(ByteVectorValues.fromBytes(vectors, dimension), docIdSet),
+              (sortMap != null) ? sortMap::oldToNew : doc -> doc);
+        }
 
         case FLOAT32 -> {
           @SuppressWarnings("unchecked")
@@ -195,6 +207,54 @@ final class FaissKnnVectorsWriter extends KnnVectorsWriter {
   public long ramBytesUsed() {
     // TODO: How to estimate Faiss usage?
     return rawVectorsWriter.ramBytesUsed();
+  }
+
+  private static class ByteToFloatVectorValues extends FloatVectorValues {
+    private final ByteVectorValues bytes;
+    private final DocIdSet docIdSet;
+    private final float[] scratch;
+
+    public ByteToFloatVectorValues(ByteVectorValues bytes) {
+      this(bytes, null);
+    }
+
+    public ByteToFloatVectorValues(ByteVectorValues bytes, DocIdSet docIdSet) {
+      this.bytes = bytes;
+      this.docIdSet = docIdSet;
+      this.scratch = new float[bytes.dimension()];
+    }
+
+    @Override
+    public float[] vectorValue(int ord) throws IOException {
+      byte[] b = bytes.vectorValue(ord);
+      for (int i = 0; i < b.length; i++) {
+        scratch[i] = b[i];
+      }
+      return scratch;
+    }
+
+    @Override
+    public int dimension() {
+      return bytes.dimension();
+    }
+
+    @Override
+    public int size() {
+      return bytes.size();
+    }
+
+    @Override
+    public FloatVectorValues copy() throws IOException {
+      return new ByteToFloatVectorValues(bytes.copy(), docIdSet);
+    }
+
+    @Override
+    public DocIndexIterator iterator() {
+      if (docIdSet != null) {
+        return fromDISI(docIdSet.iterator());
+      }
+      return bytes.iterator();
+    }
   }
 
   private static class BufferedFloatVectorValues extends FloatVectorValues {

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/faiss/FaissLibrary.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/faiss/FaissLibrary.java
@@ -18,6 +18,7 @@ package org.apache.lucene.sandbox.codecs.faiss;
 
 import java.io.Closeable;
 import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
@@ -54,5 +55,5 @@ interface FaissLibrary {
       FloatVectorValues floatVectorValues,
       IntToIntFunction oldToNewDocId);
 
-  Index readIndex(IndexInput input, VectorSimilarityFunction function);
+  Index readIndex(IndexInput input, VectorSimilarityFunction function, VectorEncoding encoding);
 }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/faiss/FaissLibraryNativeImpl.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/faiss/FaissLibraryNativeImpl.java
@@ -39,6 +39,7 @@ import java.nio.ByteOrder;
 import java.util.Map;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
@@ -46,6 +47,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.IntToIntFunction;
 
 /**
@@ -227,7 +229,7 @@ final class FaissLibraryNativeImpl implements FaissLibrary {
       // Add docs to index
       handleException(wrapper.faiss_Index_add_with_ids(indexPointer, size, docs, ids));
 
-      return new Index(indexPointer, function);
+      return new Index(indexPointer, function, VectorEncoding.FLOAT32);
 
     } catch (IOException e) {
       throw new UncheckedIOException(e);
@@ -239,7 +241,8 @@ final class FaissLibraryNativeImpl implements FaissLibrary {
   private static final int FAISS_IO_FLAG_READ_ONLY = 2;
 
   @Override
-  public FaissLibrary.Index readIndex(IndexInput input, VectorSimilarityFunction function) {
+  public FaissLibrary.Index readIndex(
+      IndexInput input, VectorSimilarityFunction function, VectorEncoding encoding) {
     try (Arena temp = Arena.ofConfined()) {
       MethodHandle readerHandle = READ_BYTES_HANDLE.bindTo(input);
       MemorySegment readerStub =
@@ -260,7 +263,7 @@ final class FaissLibraryNativeImpl implements FaissLibrary {
               customIOReaderPointer, FAISS_IO_FLAG_MMAP | FAISS_IO_FLAG_READ_ONLY, pointer));
       MemorySegment indexPointer = pointer.get(ADDRESS, 0);
 
-      return new Index(indexPointer, function);
+      return new Index(indexPointer, function, encoding);
     }
   }
 
@@ -277,7 +280,8 @@ final class FaissLibraryNativeImpl implements FaissLibrary {
     private final int dimension;
     private boolean closed;
 
-    private Index(MemorySegment indexPointer, VectorSimilarityFunction function) {
+    private Index(
+        MemorySegment indexPointer, VectorSimilarityFunction function, VectorEncoding encoding) {
       this.arena = Arena.ofShared();
       this.indexPointer =
           indexPointer
@@ -289,10 +293,19 @@ final class FaissLibraryNativeImpl implements FaissLibrary {
       // Scale Faiss distances to Lucene scores, see VectorSimilarityFunction.java
       this.scaler =
           switch (function) {
-            case DOT_PRODUCT, COSINE ->
-                // distance in Faiss === dotProduct in Lucene
+            case DOT_PRODUCT -> {
+              if (encoding == VectorEncoding.BYTE) {
+                // Same scaling as VectorUtil.dotProductScore(byte[], byte[])
+                float denom = (float) (dimension * (1 << 15));
+                yield distance -> 0.5f + distance / denom;
+              } else {
+                yield VectorUtil::normalizeToUnitInterval;
+              }
+            }
+
+            case COSINE ->
                 // For COSINE, vectors are normalized so inner product == cosine similarity
-                distance -> Math.max((1 + distance) / 2, 0);
+                VectorUtil::normalizeToUnitInterval;
 
             case EUCLIDEAN ->
                 // distance in Faiss === squareDistance in Lucene

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/codecs/faiss/TestFaissKnnVectorsFormat.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/codecs/faiss/TestFaissKnnVectorsFormat.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.sandbox.codecs.faiss;
 
+import static org.apache.lucene.index.VectorEncoding.BYTE;
 import static org.apache.lucene.index.VectorEncoding.FLOAT32;
 import static org.apache.lucene.index.VectorSimilarityFunction.COSINE;
 import static org.apache.lucene.index.VectorSimilarityFunction.DOT_PRODUCT;
@@ -45,7 +46,7 @@ import org.junit.Ignore;
 public class TestFaissKnnVectorsFormat extends BaseKnnVectorsFormatTestCase {
   private static final String FAISS_RUN_TESTS = "tests.faiss.run";
 
-  private static final VectorEncoding[] SUPPORTED_ENCODINGS = {FLOAT32};
+  private static final VectorEncoding[] SUPPORTED_ENCODINGS = {FLOAT32, BYTE};
   private static final VectorSimilarityFunction[] SUPPORTED_FUNCTIONS = {
     DOT_PRODUCT, EUCLIDEAN, COSINE
   };
@@ -94,30 +95,6 @@ public class TestFaissKnnVectorsFormat extends BaseKnnVectorsFormatTestCase {
   @Override
   @Ignore // does not honour visitedLimit
   public void testSearchWithVisitedLimit() {}
-
-  @Override
-  @Ignore // does not support byte vectors
-  public void testByteVectorScorerIteration() {}
-
-  @Override
-  @Ignore // does not support byte vectors
-  public void testMismatchedFields() {}
-
-  @Override
-  @Ignore // does not support byte vectors
-  public void testSortedIndexBytes() {}
-
-  @Override
-  @Ignore // does not support byte vectors
-  public void testRandomBytes() {}
-
-  @Override
-  @Ignore // does not support byte vectors
-  public void testEmptyByteVectorData() {}
-
-  @Override
-  @Ignore // does not support byte vectors
-  public void testMergingWithDifferentByteKnnFields() {}
 
   @Monster("Uses large amount of heap and RAM")
   public void testLargeVectorData() throws IOException {


### PR DESCRIPTION
Implemented https://github.com/apache/lucene/issues/16067

added support for VectorSimilarityFunction.COSINE in the Faiss-based vector format.
