### PR TITLE
Implement BitSetIterator#docIDRunEnd

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -379,6 +379,7 @@ Optimizations
 * GITHUB#16061, GITHUB#16070: Improve cost estimation in SortedSetDocValuesRangeQuery when using DocValuesSkipper
   and the field is dense and is the primary sort of the index to reduce the number of doc values visited. (Ignacio Vera)
 
+* GITHUB#16072: Added efficient implementations for BitSetIterator#docIDRunEnd. (Ignacio Vera)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/util/BitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitSet.java
@@ -102,6 +102,20 @@ public abstract class BitSet implements Bits, Accountable {
    */
   public abstract int nextSetBit(int start, int end);
 
+  /**
+   * Returns the index of the first unset (clear) bit at or after {@code index}, or {@link
+   * DocIdSetIterator#NO_MORE_DOCS} if every bit in {@code [index, length())} is set.
+   */
+  public int nextClearBit(int index) {
+    return nextClearBit(index, length());
+  }
+
+  /**
+   * Returns the first unset bit in {@code [start, upperBound)}, or {@link
+   * DocIdSetIterator#NO_MORE_DOCS} if none.
+   */
+  public abstract int nextClearBit(int start, int upperBound);
+
   /** Assert that the current doc is -1. */
   protected final void checkUnpositioned(DocIdSetIterator iter) {
     if (iter.docID() != -1) {

--- a/lucene/core/src/java/org/apache/lucene/util/BitSetIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitSetIterator.java
@@ -94,6 +94,17 @@ public class BitSetIterator extends AbstractDocIdSetIterator {
   }
 
   @Override
+  public int docIDRunEnd() {
+    assert doc != NO_MORE_DOCS;
+    int next = doc + 1;
+    if (next >= length) {
+      return length;
+    }
+    int end = bits.nextClearBit(next);
+    return end == NO_MORE_DOCS ? length : end;
+  }
+
+  @Override
   public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
     if (upTo > doc && bits instanceof FixedBitSet fixedBits) {
       int actualUpto = Math.min(upTo, length);

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -339,6 +339,48 @@ public final class FixedBitSet extends BitSet {
     return res < upperBound ? res : DocIdSetIterator.NO_MORE_DOCS;
   }
 
+  @Override
+  public int nextClearBit(int index) {
+    int res = nextClearBitInRange(index, numBits);
+    // Ghost bits past {@link #length()} read as clear; cap the result like {@link
+    // #nextUnsetBit(int, int)}.
+    return res < numBits ? res : DocIdSetIterator.NO_MORE_DOCS;
+  }
+
+  @Override
+  public int nextClearBit(int start, int upperBound) {
+    int res = nextClearBitInRange(start, upperBound);
+    return res < upperBound ? res : DocIdSetIterator.NO_MORE_DOCS;
+  }
+
+  /**
+   * Returns the next unset bit in the specified range, but treats `upperBound` as a best-effort
+   * hint rather than a hard requirement. Note that this may return a result that is >= upperBound
+   * in some cases, so callers must add their own check if `upperBound` is a hard requirement.
+   */
+  private int nextClearBitInRange(int start, int upperBound) {
+    // Depends on the ghost bits being clear!
+    assert start >= 0 && start < numBits : "index=" + start + ", numBits=" + numBits;
+    assert start < upperBound : "index=" + start + ", upperBound=" + upperBound;
+    assert upperBound <= numBits : "upperBound=" + upperBound + ", numBits=" + numBits;
+    int i = start >> 6;
+    long word = ~(bits[i] >> start);
+
+    if (word != 0) {
+      return start + Long.numberOfTrailingZeros(word);
+    }
+
+    int limit = upperBound == numBits ? numWords : bits2words(upperBound);
+    while (++i < limit) {
+      word = ~bits[i];
+      if (word != 0) {
+        return (i << 6) + Long.numberOfTrailingZeros(word);
+      }
+    }
+
+    return DocIdSetIterator.NO_MORE_DOCS;
+  }
+
   /**
    * Returns the next set bit in the specified range, but treats `upperBound` as a best-effort hint
    * rather than a hard requirement. Note that this may return a result that is >= upperBound in

--- a/lucene/core/src/java/org/apache/lucene/util/SparseFixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/SparseFixedBitSet.java
@@ -348,6 +348,90 @@ public class SparseFixedBitSet extends BitSet {
     return res < upperBound ? res : DocIdSetIterator.NO_MORE_DOCS;
   }
 
+  @Override
+  public int nextClearBit(int index) {
+    int res = nextClearBitInRange(index, length);
+    return res < length ? res : DocIdSetIterator.NO_MORE_DOCS;
+  }
+
+  @Override
+  public int nextClearBit(int start, int upperBound) {
+    int res = nextClearBitInRange(start, upperBound);
+    return res < upperBound ? res : DocIdSetIterator.NO_MORE_DOCS;
+  }
+
+  /**
+   * First unset bit in {@code [fromGlobal, upperBound)} within block {@code i4096}, or {@link
+   * DocIdSetIterator#NO_MORE_DOCS} if none.
+   */
+  private int firstClearInBlock(int i4096, int fromGlobal, int upperBound) {
+    final int blockBase = i4096 << 12;
+    final int blockEnd = Math.min(blockBase + 4096, length);
+    int from = Math.max(fromGlobal, blockBase);
+    final int blockCap = Math.min(upperBound, blockEnd);
+    if (from >= blockCap) {
+      return DocIdSetIterator.NO_MORE_DOCS;
+    }
+    if (indices[i4096] == 0) {
+      return from;
+    }
+    final long index = indices[i4096];
+    final long[] bitArray = bits[i4096];
+    int pos = from;
+    while (pos < blockCap) {
+      final int i64 = pos >>> 6;
+      final long i64bit = 1L << i64;
+      final int wStart = i64 << 6;
+      if (wStart >= blockEnd) {
+        break;
+      }
+      if ((index & i64bit) == 0) {
+        if (pos < blockCap) {
+          return pos;
+        }
+        pos = wStart + 64;
+        continue;
+      }
+      final int o = Long.bitCount(index & (i64bit - 1));
+      final long wordBits = bitArray[o];
+      final int sub = pos - wStart;
+      final long tail = wordBits >>> sub;
+      final int span = 64 - sub;
+      final long spanMask = (sub == 0) ? -1L : ((1L << span) - 1);
+      final long inv = (~tail) & spanMask;
+      if (inv != 0) {
+        final int cand = pos + Long.numberOfTrailingZeros(inv);
+        if (cand < blockCap) {
+          return cand;
+        }
+      }
+      pos = wStart + 64;
+    }
+    return DocIdSetIterator.NO_MORE_DOCS;
+  }
+
+  /**
+   * Returns the next unset bit in {@code [start, upperBound)}, or {@link
+   * DocIdSetIterator#NO_MORE_DOCS} if there is none.
+   */
+  private int nextClearBitInRange(int start, int upperBound) {
+    assert start < length;
+    assert upperBound > start && upperBound <= length
+        : "upperBound=" + upperBound + ", start=" + start + ", length=" + length;
+    int i4096 = start >>> 12;
+    final int i4096Upper = upperBound == length ? indices.length : blockCount(upperBound);
+    int from = start;
+    while (i4096 < i4096Upper) {
+      final int res = firstClearInBlock(i4096, from, upperBound);
+      if (res != DocIdSetIterator.NO_MORE_DOCS) {
+        return res;
+      }
+      i4096++;
+      from = i4096 << 12;
+    }
+    return DocIdSetIterator.NO_MORE_DOCS;
+  }
+
   /**
    * Returns the next set bit in the specified range, but treats `upperBound` as a best-effort hint
    * rather than a hard requirement. Note that this may return a result that is >= upperBound in

--- a/lucene/core/src/test/org/apache/lucene/util/TestBitSetIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestBitSetIterator.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+
+import java.util.Random;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+
+public class TestBitSetIterator extends LuceneTestCase {
+
+  public void testDocIDRunEndContiguous() {
+    final int totalDocs = random().nextInt(1_000, 10_000);
+    final int minDoc = random().nextInt(totalDocs - 2);
+    final int maxDoc = random().nextInt(minDoc + 1, totalDocs);
+    final BitSet fbs =
+        random().nextBoolean() ? new FixedBitSet(totalDocs) : new SparseFixedBitSet(totalDocs);
+    for (int d = minDoc; d < maxDoc; d++) {
+      fbs.set(d);
+    }
+    final BitSetIterator it = new BitSetIterator(fbs, fbs.cardinality());
+    assertEquals(minDoc, it.advance(0));
+    assertEquals(maxDoc, it.docIDRunEnd());
+    assertEquals(NO_MORE_DOCS, it.advance(maxDoc));
+  }
+
+  public void testDocIDRunEndFullFixedBitSet() {
+    final int n = 500;
+    final FixedBitSet fbs = new FixedBitSet(n);
+    fbs.set(0, n);
+    final BitSetIterator it = new BitSetIterator(fbs, n);
+    assertEquals(0, it.nextDoc());
+    assertEquals(n, it.docIDRunEnd());
+    assertEquals(42, it.advance(42));
+    assertEquals(n, it.docIDRunEnd());
+  }
+
+  public void testDocIDRunEndFullSparseBitSet() {
+    final int n = 500;
+    final SparseFixedBitSet bs = new SparseFixedBitSet(n);
+    for (int i = 0; i < n; i++) {
+      bs.set(i);
+    }
+    final BitSetIterator it = new BitSetIterator(bs, n);
+    assertEquals(0, it.nextDoc());
+    assertEquals(n, it.docIDRunEnd());
+    assertEquals(42, it.advance(42));
+    assertEquals(n, it.docIDRunEnd());
+  }
+
+  public void testDocIDRunEndAdvanceFixedBitSet() {
+    final FixedBitSet fbs = new FixedBitSet(2_000);
+    for (int d = 100; d < 800; d++) {
+      fbs.set(d);
+    }
+    final BitSetIterator it = new BitSetIterator(fbs, fbs.cardinality());
+    assertEquals(100, it.advance(50));
+    assertEquals(expectedDocIDRunEnd(fbs, 100), it.docIDRunEnd());
+    assertEquals(400, it.advance(400));
+    assertEquals(expectedDocIDRunEnd(fbs, 400), it.docIDRunEnd());
+    assertEquals(799, it.advance(799));
+    assertEquals(expectedDocIDRunEnd(fbs, 799), it.docIDRunEnd());
+  }
+
+  public void testDocIDRunEndSparseFixedBitSet() {
+    final int n = 30_000;
+    final SparseFixedBitSet sbs = new SparseFixedBitSet(n);
+    for (int d = 12_000; d < 12_100; d++) {
+      sbs.set(d);
+    }
+    for (int d = 20_000; d < 20_003; d++) {
+      sbs.set(d);
+    }
+    final BitSetIterator it = new BitSetIterator(sbs, sbs.cardinality());
+    assertDocIDRunEndMatchesIterator(it, sbs);
+  }
+
+  public void testRandomDocIDRunEndFixedBitSet() {
+    final Random r = random();
+    final int iters = TEST_NIGHTLY ? 200 : 40;
+    for (int iter = 0; iter < iters; iter++) {
+      final int n = TestUtil.nextInt(r, 1, 40_000);
+      final FixedBitSet fbs = new FixedBitSet(n);
+      final int numSets = TestUtil.nextInt(r, 0, Math.min(n, 8_000));
+      for (int s = 0; s < numSets; s++) {
+        fbs.set(r.nextInt(n));
+      }
+      if (fbs.cardinality() == 0) {
+        assertEquals(NO_MORE_DOCS, new BitSetIterator(fbs, 0).nextDoc());
+        continue;
+      }
+      assertDocIDRunEndMatchesIterator(new BitSetIterator(fbs, fbs.cardinality()), fbs);
+    }
+  }
+
+  public void testRandomDocIDRunEndSparseFixedBitSet() {
+    final Random r = random();
+    final int iters = TEST_NIGHTLY ? 200 : 40;
+    for (int iter = 0; iter < iters; iter++) {
+      final int n = TestUtil.nextInt(r, 1, 40_000);
+      final SparseFixedBitSet sbs = new SparseFixedBitSet(n);
+      final int numSets = TestUtil.nextInt(r, 0, Math.min(n, 8_000));
+      for (int s = 0; s < numSets; s++) {
+        sbs.set(r.nextInt(n));
+      }
+      if (sbs.cardinality() == 0) {
+        assertEquals(NO_MORE_DOCS, new BitSetIterator(sbs, 0).nextDoc());
+        continue;
+      }
+      assertDocIDRunEndMatchesIterator(new BitSetIterator(sbs, sbs.cardinality()), sbs);
+    }
+  }
+
+  private static int expectedDocIDRunEnd(BitSet bits, int doc) {
+    int end = doc + 1;
+    final int len = bits.length();
+    while (end < len && bits.get(end)) {
+      end++;
+    }
+    return end;
+  }
+
+  private static void assertDocIDRunEndMatchesIterator(BitSetIterator it, BitSet bits) {
+    for (int d = it.nextDoc(); d != NO_MORE_DOCS; d = it.nextDoc()) {
+      assertTrue(bits.get(d));
+      assertEquals(expectedDocIDRunEnd(bits, d), it.docIDRunEnd());
+    }
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/TestFixedBitSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestFixedBitSet.java
@@ -76,6 +76,24 @@ public class TestFixedBitSet extends BaseBitSetTestCase<FixedBitSet> {
     } while (aa != DocIdSetIterator.NO_MORE_DOCS);
   }
 
+  void doNextClearBit(java.util.BitSet a, FixedBitSet b) {
+    assertEquals(a.cardinality(), b.cardinality());
+    final int len = b.length();
+    int aa = -1;
+    int bb = -1;
+    do {
+      final int from = aa + 1;
+      if (from >= len) {
+        aa = DocIdSetIterator.NO_MORE_DOCS;
+      } else {
+        int nc = a.nextClearBit(from);
+        aa = nc < len ? nc : DocIdSetIterator.NO_MORE_DOCS;
+      }
+      bb = bb < len - 1 ? b.nextClearBit(bb + 1) : DocIdSetIterator.NO_MORE_DOCS;
+      assertEquals(aa, bb);
+    } while (aa != DocIdSetIterator.NO_MORE_DOCS);
+  }
+
   void doPrevSetBit(java.util.BitSet a, FixedBitSet b) {
     assertEquals(a.cardinality(), b.cardinality());
     int aa = a.size() + random().nextInt(100);
@@ -175,6 +193,8 @@ public class TestFixedBitSet extends BaseBitSetTestCase<FixedBitSet> {
 
       doNextSetBit(aa, bb); // a problem here is from clear() or nextSetBit
 
+      doNextClearBit(aa, bb);
+
       doPrevSetBit(aa, bb);
 
       fromIndex = random().nextInt(sz / 2);
@@ -185,6 +205,8 @@ public class TestFixedBitSet extends BaseBitSetTestCase<FixedBitSet> {
       bb.set(fromIndex, toIndex);
 
       doNextSetBit(aa, bb); // a problem here is from set() or nextSetBit
+
+      doNextClearBit(aa, bb);
 
       doPrevSetBit(aa, bb);
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestSparseFixedBitSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestSparseFixedBitSet.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.util;
 
 import java.io.IOException;
+import java.util.Random;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.tests.util.BaseBitSetTestCase;
 import org.apache.lucene.tests.util.TestUtil;
@@ -104,5 +105,33 @@ public class TestSparseFixedBitSet extends BaseBitSetTestCase<SparseFixedBitSet>
     BitSet orCopy = new SparseFixedBitSet(size);
     orCopy.or(new BitSetIterator(original, size));
     assertTrue(Math.abs(original.ramBytesUsed() - orCopy.ramBytesUsed()) <= 64L);
+  }
+
+  private static int bruteNextUnset(SparseFixedBitSet set, int from, int upperBound) {
+    for (int i = from; i < upperBound; i++) {
+      if (set.get(i) == false) {
+        return i;
+      }
+    }
+    return DocIdSetIterator.NO_MORE_DOCS;
+  }
+
+  public void testNextClearBit() {
+    Random rand = random();
+    final int outer = TEST_NIGHTLY ? 300 : 60;
+    for (int iter = 0; iter < outer; iter++) {
+      final int n = TestUtil.nextInt(rand, 1, 40_000);
+      final SparseFixedBitSet set = new SparseFixedBitSet(n);
+      final int numSets = TestUtil.nextInt(rand, 0, Math.min(n, 8_000));
+      for (int s = 0; s < numSets; s++) {
+        set.set(rand.nextInt(n));
+      }
+      for (int t = 0; t < 300; t++) {
+        final int from = rand.nextInt(n);
+        assertEquals(bruteNextUnset(set, from, n), set.nextClearBit(from));
+        final int ub = from + 1 + rand.nextInt(n - from);
+        assertEquals(bruteNextUnset(set, from, ub), set.nextClearBit(from, ub));
+      }
+    }
   }
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/BaseBitSetTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/BaseBitSetTestCase.java
@@ -348,5 +348,14 @@ public abstract class BaseBitSetTestCase<T extends BitSet> extends LuceneTestCas
       }
       return next;
     }
+
+    @Override
+    public int nextClearBit(int start, int upperBound) {
+      int next = bitSet.nextClearBit(start);
+      if (next == -1 || next >= upperBound) {
+        next = DocIdSetIterator.NO_MORE_DOCS;
+      }
+      return next;
+    }
   }
 }


### PR DESCRIPTION
In order to make it efficient, i added a new method to the BitSet interface called #nextClearBit which is implemented for the subclasses.
