### PR TITLE
Simplify SortedDocIDMerger.next()

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -457,6 +457,8 @@ Other
 
 * GITHUB#15960: Move parent field from DWPT to IndexingChain. (Tim Brooks)
 
+* GITHUB#16073: Simplify SortedDocIDMerger.next(). (Tim Brooks)
+
 ======================= Lucene 10.4.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/index/DocIDMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocIDMerger.java
@@ -20,7 +20,6 @@ package org.apache.lucene.index;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.List;
 import org.apache.lucene.search.DocIdSetIterator; // javadocs
 import org.apache.lucene.util.PriorityQueue;
@@ -167,15 +166,16 @@ public abstract class DocIDMerger<T extends DocIDMerger.Sub> {
     public void reset() throws IOException {
       // caller may not have fully consumed the queue:
       queue.clear();
-      Iterator<T> it = subs.iterator();
-      T sub = it.next();
-      // by setting mappedDocID = -1, this entry is guaranteed to be less than any real doc ID
-      // so the first call to next() will advance it
-      sub.mappedDocID = -1;
-      current = sub;
-      while (it.hasNext()) {
-        sub = it.next();
-        if (sub.nextMappedDoc() != NO_MORE_DOCS) {
+      current = null;
+      boolean first = true;
+      for (T sub : subs) {
+        if (first) {
+          // by setting mappedDocID = -1, this entry is guaranteed to be the top of the queue
+          // so the first call to next() will advance it
+          sub.mappedDocID = -1;
+          current = sub;
+          first = false;
+        } else if (sub.nextMappedDoc() != NO_MORE_DOCS) {
           queue.add(sub);
         } // else all docs in this sub were deleted; do not add it to the queue!
       }

--- a/lucene/core/src/java/org/apache/lucene/index/DocIDMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocIDMerger.java
@@ -20,6 +20,7 @@ package org.apache.lucene.index;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 import org.apache.lucene.search.DocIdSetIterator; // javadocs
 import org.apache.lucene.util.PriorityQueue;
@@ -166,16 +167,15 @@ public abstract class DocIDMerger<T extends DocIDMerger.Sub> {
     public void reset() throws IOException {
       // caller may not have fully consumed the queue:
       queue.clear();
-      current = null;
-      boolean first = true;
-      for (T sub : subs) {
-        if (first) {
-          // by setting mappedDocID = -1, this entry is guaranteed to be the top of the queue
-          // so the first call to next() will advance it
-          sub.mappedDocID = -1;
-          current = sub;
-          first = false;
-        } else if (sub.nextMappedDoc() != NO_MORE_DOCS) {
+      Iterator<T> it = subs.iterator();
+      T sub = it.next();
+      // by setting mappedDocID = -1, this entry is guaranteed to be less than any real doc ID
+      // so the first call to next() will advance it
+      sub.mappedDocID = -1;
+      current = sub;
+      while (it.hasNext()) {
+        sub = it.next();
+        if (sub.nextMappedDoc() != NO_MORE_DOCS) {
           queue.add(sub);
         } // else all docs in this sub were deleted; do not add it to the queue!
       }
@@ -197,7 +197,9 @@ public abstract class DocIDMerger<T extends DocIDMerger.Sub> {
         } else {
           current = queue.pop();
         }
-      } else if (queue.size() > 0) {
+      } else {
+        // queue cannot be empty here: if it were, queueMinDocID == NO_MORE_DOCS, and any valid
+        // nextDoc would satisfy nextDoc < queueMinDocID, taking the fast path above
         assert queueMinDocID == queue.top().mappedDocID;
         assert nextDoc > queueMinDocID;
         T newCurrent = queue.top();


### PR DESCRIPTION
The `else if (queue.size() > 0)` guard is always true when reached:
an empty queue sets queueMinDocID to NO_MORE_DOCS, so any valid nextDoc
satisfies nextDoc < queueMinDocID and takes the fast path first. Replace
with `else` and add a comment explaining why the queue is never empty
at that point.