### PR TITLE
Fix LargeNumHitsTopDocsCollector not handling requested hit count correctly

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -431,6 +431,8 @@ Bug Fixes
   time since merge start instead of duplicate incremental/total times. Add per-chunk completion
   logging with sub-millisecond precision to aid merge concurrency debugging. (Prithvi S)
 
+* GITHUB#15878: Fix LargeNumHitsTopDocsCollector not handling requested hit count correctly (Binlong Gao)
+
 Other
 ---------------------
 * GITHUB#15586: Document that scoring and ranking may change across major Lucene versions, and that applications requiring stable ranking should explicitly configure Similarity. (Parveen Saini)

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/LargeNumHitsTopDocsCollector.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/search/LargeNumHitsTopDocsCollector.java
@@ -48,6 +48,9 @@ public final class LargeNumHitsTopDocsCollector implements Collector {
   int totalHits;
 
   public LargeNumHitsTopDocsCollector(int requestedHitCount) {
+    if (requestedHitCount <= 0) {
+      throw new IllegalArgumentException("requestedHitCount must be > 0");
+    }
     this.requestedHitCount = requestedHitCount;
     this.totalHits = 0;
   }
@@ -111,10 +114,14 @@ public final class LargeNumHitsTopDocsCollector implements Collector {
 
   /** Returns the top docs that were collected by this collector. */
   public TopDocs topDocs(int howMany) {
-
-    if (howMany <= 0 || howMany > totalHits) {
-      throw new IllegalArgumentException("Incorrect number of hits requested");
+    if (howMany < 0) {
+      throw new IllegalArgumentException(
+          "Number of hits requested must not be negative but value was " + howMany);
     }
+    if (howMany == 0) {
+      return EMPTY_TOPDOCS;
+    }
+    howMany = Math.min(howMany, totalHits);
 
     ScoreDoc[] results = new ScoreDoc[howMany];
 

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestLargeNumHitsTopDocsCollector.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/search/TestLargeNumHitsTopDocsCollector.java
@@ -17,6 +17,8 @@
 
 package org.apache.lucene.sandbox.search;
 
+import static org.apache.lucene.search.TopDocsCollector.EMPTY_TOPDOCS;
+
 import java.io.IOException;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -80,7 +82,15 @@ public class TestLargeNumHitsTopDocsCollector extends LuceneTestCase {
     runNumHits(25);
   }
 
-  public void testIllegalArguments() throws IOException {
+  public void testInvalidRequestedHitCount() {
+    for (int n : new int[] {0, -1}) {
+      IllegalArgumentException e =
+          expectThrows(IllegalArgumentException.class, () -> new LargeNumHitsTopDocsCollector(n));
+      assertTrue(e.getMessage().contains("requestedHitCount must be > 0"));
+    }
+  }
+
+  public void testTopDocs() throws IOException {
     IndexSearcher searcher = newSearcher(reader);
     LargeNumHitsTopDocsCollector largeCollector = new LargeNumHitsTopDocsCollector(15);
     TopScoreDocCollectorManager regularCollectorManager =
@@ -92,13 +102,12 @@ public class TestLargeNumHitsTopDocsCollector extends LuceneTestCase {
     assertEquals(largeCollector.totalHits, topDocs.totalHits.value());
 
     IllegalArgumentException expected =
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-              largeCollector.topDocs(350_000);
-            });
+        expectThrows(IllegalArgumentException.class, () -> largeCollector.topDocs(-1));
 
-    assertTrue(expected.getMessage().contains("Incorrect number of hits requested"));
+    assertTrue(expected.getMessage().contains("Number of hits requested must not be negative"));
+
+    assertEquals(EMPTY_TOPDOCS, largeCollector.topDocs(0));
+    assertEquals(largeCollector.totalHits, largeCollector.topDocs(35_000).totalHits.value());
   }
 
   public void testNoPQBuild() throws IOException {


### PR DESCRIPTION
### Description

This is a follow-up PR for https://github.com/apache/lucene/pull/15660, in LargeNumHitsTopDocsCollector, we should

1) reject 0 and negative values for requestedHitCount in the constructor, that makes more sense
2) in topDocs(int howMany) method, we should return empty TopDocs directly in case of howMany ==0, and return all hits if howMany> totalHitsCount, this is consistent with  TopDocsCollector.topDocs(int start, int howMany)https://github.com/apache/lucene/blob/9f33b54a13a05b2931fc798381a225b10229e704/lucene/core/src/java/org/apache/lucene/search/TopDocsCollector.java#L131
