### PR TITLE
add FixedBitSet.nextUnsetBit and use it in MergingHnswGraphBuilder

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/BitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BitSet.java
@@ -102,6 +102,14 @@ public abstract class BitSet implements Bits, Accountable {
    */
   public abstract int nextSetBit(int start, int end);
 
+  /**
+   * Returns the index of the first unset bit starting at the index specified. {@link
+   * DocIdSetIterator#NO_MORE_DOCS} is returned if there are no more unset bits.
+   */
+  public int nextUnsetBit(int index) {
+    throw new UnsupportedOperationException();
+  }
+
   /** Assert that the current doc is -1. */
   protected final void checkUnpositioned(DocIdSetIterator iter) {
     if (iter.docID() != -1) {

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -367,6 +367,32 @@ public final class FixedBitSet extends BitSet {
     return DocIdSetIterator.NO_MORE_DOCS;
   }
 
+  /**
+   * Returns the index of the first unset bit starting at the index specified. {@link
+   * DocIdSetIterator#NO_MORE_DOCS} is returned if there are no more unset bits.
+   */
+  public int nextUnsetBit(int index) {
+    assert index >= 0 && index < numBits : "index=" + index + ", numBits=" + numBits;
+    int i = index >> 6;
+    long word = bits[i] >> index; // skip all the bits to the right of index
+    word = ~word; // invert: set bits become 0, unset bits become 1
+
+    if (word != 0) {
+      int result = index + Long.numberOfTrailingZeros(word);
+      return result < numBits ? result : DocIdSetIterator.NO_MORE_DOCS;
+    }
+
+    while (++i < numWords) {
+      word = ~bits[i];
+      if (word != 0) {
+        int result = (i << 6) + Long.numberOfTrailingZeros(word);
+        return result < numBits ? result : DocIdSetIterator.NO_MORE_DOCS;
+      }
+    }
+
+    return DocIdSetIterator.NO_MORE_DOCS;
+  }
+
   @Override
   public int prevSetBit(int index) {
     assert index >= 0 && index < numBits : "index=" + index + " numBits=" + numBits;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/MergingHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/MergingHnswGraphBuilder.java
@@ -128,12 +128,14 @@ public final class MergingHnswGraphBuilder extends HnswGraphBuilder {
       updateGraph(graphs[i], ordMaps[i]);
     }
 
-    // TODO: optimize to iterate only over unset bits in initializedNodes
     if (initializedNodes != null) {
-      for (int node = 0; node < maxOrd; node++) {
-        if (initializedNodes.get(node) == false) {
-          addGraphNode(node);
-        }
+      for (int node = initializedNodes.nextUnsetBit(0);
+          node != NO_MORE_DOCS;
+          node =
+              node + 1 >= maxOrd
+                  ? NO_MORE_DOCS
+                  : initializedNodes.nextUnsetBit(node + 1)) {
+        addGraphNode(node);
       }
     }
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestFixedBitSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestFixedBitSet.java
@@ -356,6 +356,58 @@ public class TestFixedBitSet extends BaseBitSetTestCase<FixedBitSet> {
     checkNextSetBitArray(new int[0], setBits.length + random().nextInt(10));
   }
 
+  private void checkNextUnsetBitArray(int[] setBits, int numBits) {
+    FixedBitSet obs = makeFixedBitSet(setBits, numBits);
+    java.util.BitSet bs = makeBitSet(setBits);
+
+    int aa = 0;
+    int bb = 0;
+    while (true) {
+      aa = bs.nextClearBit(aa);
+      if (aa >= numBits) {
+        aa = DocIdSetIterator.NO_MORE_DOCS;
+      }
+      bb = bb < obs.length() ? obs.nextUnsetBit(bb) : DocIdSetIterator.NO_MORE_DOCS;
+      assertEquals(aa, bb);
+      if (aa == DocIdSetIterator.NO_MORE_DOCS) {
+        break;
+      }
+      aa++;
+      bb++;
+    }
+  }
+
+  public void testNextUnsetBit() {
+    // Empty bitset: all bits are unset
+    checkNextUnsetBitArray(new int[0], 100);
+
+    // Full bitset: no bits are unset
+    int[] allBits = new int[100];
+    for (int i = 0; i < 100; i++) {
+      allBits[i] = i;
+    }
+    checkNextUnsetBitArray(allBits, 100);
+
+    // Sparse set bits
+    checkNextUnsetBitArray(new int[] {0, 50, 99}, 100);
+
+    // Random
+    int[] setBits = new int[random().nextInt(1000)];
+    for (int i = 0; i < setBits.length; i++) {
+      setBits[i] = random().nextInt(setBits.length);
+    }
+    checkNextUnsetBitArray(setBits, setBits.length + random().nextInt(10));
+
+    // Single bit at boundary
+    checkNextUnsetBitArray(new int[] {0}, 1);
+    checkNextUnsetBitArray(new int[] {0}, 65); // crosses word boundary
+    checkNextUnsetBitArray(new int[] {63, 64}, 128); // at word boundaries
+
+    // Ghost bits: numBits not aligned to word boundary
+    checkNextUnsetBitArray(new int[] {0, 1, 2}, 67);
+    checkNextUnsetBitArray(new int[] {}, 65);
+  }
+
   public void testEnsureCapacity() {
     FixedBitSet bits = new FixedBitSet(5);
     bits.set(1);


### PR DESCRIPTION
there was a TODO in MergingHnswGraphBuilder.build() where we were scanning all nodes even if most were already initialized, this change adds nextUnsetBit and uses that instead, so we only go over nodes that are not set, instead of checking every node, we just jump to the next unset one. 

so earlier it goes through all nodes and check each one, now jump directly to next unset bit.
this is faster when most bits are already set, which is common during merges

benchmark (bitset iteration)

| size      | set % | scan loop (us) | nextUnsetBit (us) | speedup |
|-----------|-------|----------------|-------------------|---------|
| 1,000     | 0%    | 8.76           | 11.89             | slower  |
| 1,000     | 75%   | 2.27           | 1.25              | ~1.8x   |
| 1,000     | 90%   | 2.30           | 0.54              | ~4.2x   |
| 1,000     | 99%   | 2.24           | 0.06              | ~35x    |
| 100,000   | 75%   | 217            | 82.3              | ~2.6x   |
| 100,000   | 90%   | 218            | 33.4              | ~6.5x   |
| 100,000   | 99%   | 215            | 4.69              | ~45x    |
| 1,000,000 | 99%   | 2157           | 43.3              | ~49x    |


luceneutil (real run)

|              | baseline | candidate | result |
|--------------|----------|-----------|--------|
| force merge  | 220.11s  | 218.68s   | same   |
| index time   | 224.73s  | 229.25s   | same   |
| recall       | 0.988    | 0.988     | same   |