### PR TITLE
Add range encoding in RoaringDocIdSet

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -392,6 +392,8 @@ Optimizations
 
 * GITHUB#16081: Implement LeafCollector#collectRange in the collectors used in LRUCache. (Ignacio Vera)
 
+* GITHUB#16084: Added range encoding to  RoaringDocIdSet. (Ignacio Vera)
+
 Bug Fixes
 ---------------------
 * GITHUB#15754: Fix HTMLStripCharFilter to prevent tags from incorrectly consuming subsequent

--- a/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
@@ -38,7 +38,7 @@ public class RoaringDocIdSet extends DocIdSet {
   // The maximum length for an array, beyond that point we switch to a bitset
   private static final int MAX_ARRAY_LENGTH = 1 << 12;
   // The minimum length for a range, beyond that point we build a range if the block is dense
-  private static final int MIN_RANGE_LENGTH = 3;
+  private static final int MIN_RANGE_LENGTH = 2;
   private static final long BASE_RAM_BYTES_USED =
       RamUsageEstimator.shallowSizeOfInstance(RoaringDocIdSet.class);
 
@@ -73,11 +73,10 @@ public class RoaringDocIdSet extends DocIdSet {
       if (currentBlockCardinality == BLOCK_SIZE) {
         // all docs in the block
         sets[currentBlock] = AllDocIdSet.INSTANCE;
-      } else if (currentBlockCardinality > MIN_RANGE_LENGTH
+      } else if (currentBlockCardinality >= MIN_RANGE_LENGTH
           && currentBlockCardinality == lastDocId - firstDocId + 1) {
         // doc ids are continuous, use range encoding
-        int offset = (currentBlock << 16);
-        sets[currentBlock] = new RangeDocIdSet(firstDocId - offset, lastDocId - offset + 1);
+        sets[currentBlock] = new RangeDocIdSet((short) firstDocId, (short) lastDocId);
       } else if (currentBlockCardinality <= MAX_ARRAY_LENGTH) {
         // Use sparse encoding
         assert denseBuffer == null;
@@ -260,17 +259,17 @@ public class RoaringDocIdSet extends DocIdSet {
     private static final long BASE_RAM_BYTES_USED =
         RamUsageEstimator.shallowSizeOfInstance(RangeDocIdSet.class);
 
-    final int minDocId;
-    final int maxDocId;
+    final short minDocId;
+    final short maxDocId;
 
-    private RangeDocIdSet(int minDocId, int maxDocId) {
+    private RangeDocIdSet(short minDocId, short maxDocId) {
       this.minDocId = minDocId;
       this.maxDocId = maxDocId;
     }
 
     @Override
     public DocIdSetIterator iterator() {
-      return DocIdSetIterator.range(minDocId, maxDocId);
+      return DocIdSetIterator.range(minDocId & 0xFFFF, (maxDocId & 0xFFFF) + 1);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
@@ -249,7 +249,7 @@ public class RoaringDocIdSet extends DocIdSet {
 
     @Override
     public long ramBytesUsed() {
-      // it is a static class
+      // we use a static instance
       return 0;
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
@@ -37,6 +37,8 @@ public class RoaringDocIdSet extends DocIdSet {
   private static final int BLOCK_SIZE = 1 << 16;
   // The maximum length for an array, beyond that point we switch to a bitset
   private static final int MAX_ARRAY_LENGTH = 1 << 12;
+  // The minimum length for a range, beyond that point we build a range if the block is dense
+  private static final int MIN_RANGE_LENGTH = 3;
   private static final long BASE_RAM_BYTES_USED =
       RamUsageEstimator.shallowSizeOfInstance(RoaringDocIdSet.class);
 
@@ -47,6 +49,7 @@ public class RoaringDocIdSet extends DocIdSet {
     private final DocIdSet[] sets;
 
     private int cardinality;
+    private int firstDocId;
     private int lastDocId;
     private int currentBlock;
     private int currentBlockCardinality;
@@ -67,7 +70,15 @@ public class RoaringDocIdSet extends DocIdSet {
 
     private void flush() {
       assert currentBlockCardinality <= BLOCK_SIZE;
-      if (currentBlockCardinality <= MAX_ARRAY_LENGTH) {
+      if (currentBlockCardinality == BLOCK_SIZE) {
+        // all docs in the block
+        sets[currentBlock] = AllDocIdSet.INSTANCE;
+      } else if (currentBlockCardinality > MIN_RANGE_LENGTH
+          && currentBlockCardinality == lastDocId - firstDocId + 1) {
+        // doc ids are continuous, use range encoding
+        int offset = (currentBlock << 16);
+        sets[currentBlock] = new RangeDocIdSet(firstDocId - offset, lastDocId - offset + 1);
+      } else if (currentBlockCardinality <= MAX_ARRAY_LENGTH) {
         // Use sparse encoding
         assert denseBuffer == null;
         if (currentBlockCardinality > 0) {
@@ -114,6 +125,7 @@ public class RoaringDocIdSet extends DocIdSet {
         // we went to a different block, let's flush what we buffered and start from fresh
         flush();
         currentBlock = block;
+        firstDocId = docId;
       }
 
       appendDocInCurrentBlock(docId, block);
@@ -156,6 +168,7 @@ public class RoaringDocIdSet extends DocIdSet {
         if (block != currentBlock) {
           flush();
           currentBlock = block;
+          firstDocId = doc;
         }
         appendRangeInCurrentBlock(doc, blockEnd, block);
         doc = blockEnd;
@@ -164,6 +177,7 @@ public class RoaringDocIdSet extends DocIdSet {
     }
 
     private void appendDocInCurrentBlock(int docId, int block) {
+      assert docId >= firstDocId;
       if (currentBlockCardinality < MAX_ARRAY_LENGTH) {
         buffer[currentBlockCardinality] = (short) docId;
       } else {
@@ -183,6 +197,7 @@ public class RoaringDocIdSet extends DocIdSet {
     }
 
     private void appendRangeInCurrentBlock(int fromDoc, int toDocExclusive, int block) {
+      assert fromDoc >= firstDocId;
       assert (fromDoc >>> 16) == block;
       assert (toDocExclusive >>> 16) == block || toDocExclusive == (block + 1) << 16;
       assert fromDoc < toDocExclusive;
@@ -219,6 +234,48 @@ public class RoaringDocIdSet extends DocIdSet {
     public RoaringDocIdSet build() {
       flush();
       return new RoaringDocIdSet(sets, cardinality);
+    }
+  }
+
+  private static class AllDocIdSet extends DocIdSet {
+
+    private static final AllDocIdSet INSTANCE = new AllDocIdSet();
+
+    private AllDocIdSet() {}
+
+    @Override
+    public DocIdSetIterator iterator() {
+      return DocIdSetIterator.range(0, BLOCK_SIZE);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+      // it is a static class
+      return 0;
+    }
+  }
+
+  private static class RangeDocIdSet extends DocIdSet {
+
+    private static final long BASE_RAM_BYTES_USED =
+        RamUsageEstimator.shallowSizeOfInstance(RangeDocIdSet.class);
+
+    final int minDocId;
+    final int maxDocId;
+
+    private RangeDocIdSet(int minDocId, int maxDocId) {
+      this.minDocId = minDocId;
+      this.maxDocId = maxDocId;
+    }
+
+    @Override
+    public DocIdSetIterator iterator() {
+      return DocIdSetIterator.range(minDocId, maxDocId);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+      return BASE_RAM_BYTES_USED;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
@@ -37,8 +37,6 @@ public class RoaringDocIdSet extends DocIdSet {
   private static final int BLOCK_SIZE = 1 << 16;
   // The maximum length for an array, beyond that point we switch to a bitset
   private static final int MAX_ARRAY_LENGTH = 1 << 12;
-  // The minimum length for a range, beyond that point we build a range if the block is dense
-  private static final int MIN_RANGE_LENGTH = 2;
   private static final long BASE_RAM_BYTES_USED =
       RamUsageEstimator.shallowSizeOfInstance(RoaringDocIdSet.class);
 
@@ -73,9 +71,9 @@ public class RoaringDocIdSet extends DocIdSet {
       if (currentBlockCardinality == BLOCK_SIZE) {
         // all docs in the block
         sets[currentBlock] = AllDocIdSet.INSTANCE;
-      } else if (currentBlockCardinality >= MIN_RANGE_LENGTH
+      } else if (currentBlockCardinality > 0
           && currentBlockCardinality == lastDocId - firstDocId + 1) {
-        // doc ids are continuous, use range encoding
+        // doc ids are continuous, use range encoding. Even for a unique value it uses less heap.
         sets[currentBlock] = new RangeDocIdSet((short) firstDocId, (short) lastDocId);
       } else if (currentBlockCardinality <= MAX_ARRAY_LENGTH) {
         // Use sparse encoding

--- a/lucene/core/src/test/org/apache/lucene/util/TestRoaringDocIdSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestRoaringDocIdSet.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.util;
 
+import static org.hamcrest.Matchers.greaterThan;
+
 import java.io.IOException;
 import java.util.BitSet;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -124,20 +126,56 @@ public class TestRoaringDocIdSet extends BaseDocIdSetTestCase<RoaringDocIdSet> {
 
   public void testAddRangeSmall() throws IOException {
     int maxDoc = 100;
-    BitSet expected = new BitSet(maxDoc);
-    expected.set(10, 80);
-    RoaringDocIdSet.Builder b = new RoaringDocIdSet.Builder(maxDoc);
-    b.add(10, 80);
-    assertEquals(maxDoc, expected, b.build());
+    long bytesSparseValues;
+    long bytesDenseRange;
+    {
+      BitSet expected = new BitSet(maxDoc);
+      expected.set(10, 79);
+      expected.set(80);
+      RoaringDocIdSet.Builder b = new RoaringDocIdSet.Builder(maxDoc);
+      b.add(10, 79);
+      b.add(80);
+      RoaringDocIdSet set = b.build();
+      assertEquals(maxDoc, expected, set);
+      bytesSparseValues = set.ramBytesUsed();
+    }
+    {
+      BitSet expected = new BitSet(maxDoc);
+      expected.set(10, 80);
+      RoaringDocIdSet.Builder b = new RoaringDocIdSet.Builder(maxDoc);
+      b.add(10, 80);
+      RoaringDocIdSet set = b.build();
+      assertEquals(maxDoc, expected, set);
+      bytesDenseRange = set.ramBytesUsed();
+    }
+    assertThat(bytesSparseValues, greaterThan(bytesDenseRange));
   }
 
-  public void testAddRangeDenseBlockUsesBitSetEncoding() throws IOException {
+  public void testAddRangeDenseBig() throws IOException {
     int maxDoc = 50_000;
-    BitSet expected = new BitSet(maxDoc);
-    expected.set(7, 43_000);
-    RoaringDocIdSet.Builder b = new RoaringDocIdSet.Builder(maxDoc);
-    b.add(7, 43_000);
-    assertEquals(maxDoc, expected, b.build());
+    long bytesSparseValues;
+    long bytesDenseRange;
+    {
+      BitSet expected = new BitSet(maxDoc);
+      expected.set(7, 42_999);
+      expected.set(43_000);
+      RoaringDocIdSet.Builder b = new RoaringDocIdSet.Builder(maxDoc);
+      b.add(7, 42_999);
+      b.add(43_000);
+      RoaringDocIdSet set = b.build();
+      assertEquals(maxDoc, expected, set);
+      bytesSparseValues = set.ramBytesUsed();
+    }
+    {
+      BitSet expected = new BitSet(maxDoc);
+      expected.set(7, 43_000);
+      RoaringDocIdSet.Builder b = new RoaringDocIdSet.Builder(maxDoc);
+      b.add(7, 43_000);
+      RoaringDocIdSet set = b.build();
+      assertEquals(maxDoc, expected, set);
+      bytesDenseRange = set.ramBytesUsed();
+    }
+    assertThat(bytesSparseValues, greaterThan(bytesDenseRange));
   }
 
   public void testAddRangeCrossesBlockBoundary() throws IOException {


### PR DESCRIPTION
This PR proposes to add block encoding to RoaringDocIdSet to optimize the situation when docIds inside a block are continuous.
