### PR TITLE
Stop returning null in SearchGroup#merge

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -340,6 +340,8 @@ Improvements
 
 * GITHUB#16000: Clarify that Accountable#ramBytesUsed() reports JVM heap memory only. (Luca Cavanna)
 
+* GITHUB#16088: SearchGroup#merge now returns an empty collection instead of null when topGroups is empty. (Luca Cavanna)
+
 Optimizations
 ---------------------
 * GITHUB#15861: Optimise PhraseScorer by short circuiting non competitive documents in TOP_SCORES mode. (Prithvi S)

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/SearchGroup.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/SearchGroup.java
@@ -19,7 +19,6 @@ package org.apache.lucene.search.grouping;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -320,11 +319,7 @@ public class SearchGroup<T> {
         }
       }
 
-      if (newTopGroups.isEmpty()) {
-        return null;
-      } else {
-        return newTopGroups;
-      }
+      return newTopGroups;
     }
   }
 
@@ -336,10 +331,6 @@ public class SearchGroup<T> {
    */
   public static <T> Collection<SearchGroup<T>> merge(
       List<Collection<SearchGroup<T>>> topGroups, int offset, int topN, Sort groupSort) {
-    if (topGroups.isEmpty()) {
-      return Collections.emptyList();
-    } else {
-      return new GroupMerger<T>(groupSort).merge(topGroups, offset, topN);
-    }
+    return new GroupMerger<T>(groupSort).merge(topGroups, offset, topN);
   }
 }

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/SearchGroup.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/SearchGroup.java
@@ -19,6 +19,7 @@ package org.apache.lucene.search.grouping;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -332,13 +333,11 @@ public class SearchGroup<T> {
    * provided groupSort must match how the groups were sorted, and the provided SearchGroups must
    * have been computed with fillFields=true passed to {@link
    * FirstPassGroupingCollector#getTopGroups}.
-   *
-   * <p>NOTE: this returns null if the topGroups is empty.
    */
   public static <T> Collection<SearchGroup<T>> merge(
       List<Collection<SearchGroup<T>>> topGroups, int offset, int topN, Sort groupSort) {
     if (topGroups.isEmpty()) {
-      return null;
+      return Collections.emptyList();
     } else {
       return new GroupMerger<T>(groupSort).merge(topGroups, offset, topN);
     }

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
@@ -1512,17 +1512,13 @@ public class TestGrouping extends LuceneTestCase {
         SearchGroup.merge(shardGroups, groupOffset, topNGroups, groupSort);
     if (VERBOSE) {
       System.out.println(" top groups merged:");
-      if (mergedTopGroups == null) {
-        System.out.println("    null");
-      } else {
-        System.out.println("    " + mergedTopGroups.size() + " top groups:");
-        for (SearchGroup<BytesRef> group : mergedTopGroups) {
-          System.out.println(
-              "    ["
-                  + groupToString(group.groupValue)
-                  + "] groupSort="
-                  + Arrays.toString(group.sortValues));
-        }
+      System.out.println("    " + mergedTopGroups.size() + " top groups:");
+      for (SearchGroup<BytesRef> group : mergedTopGroups) {
+        System.out.println(
+            "    ["
+                + groupToString(group.groupValue)
+                + "] groupSort="
+                + Arrays.toString(group.sortValues));
       }
     }
 

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
@@ -269,6 +269,24 @@ public class TestGrouping extends LuceneTestCase {
     dir.close();
   }
 
+  public void testSearchGroupMergeEmptyResult() {
+    // Empty shard list must return an empty collection, not null
+    Collection<SearchGroup<BytesRef>> result =
+        SearchGroup.merge(Collections.emptyList(), 0, 5, Sort.RELEVANCE);
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+
+    // When offset skips past all groups the result must also be an empty collection, not null
+    SearchGroup<BytesRef> group = new SearchGroup<>();
+    group.groupValue = new BytesRef("a");
+    group.sortValues = new Object[] {1.0f}; // Float value for Sort.RELEVANCE
+    List<Collection<SearchGroup<BytesRef>>> shardGroups =
+        Collections.singletonList(Collections.singletonList(group));
+    result = SearchGroup.merge(shardGroups, 10, 5, Sort.RELEVANCE); // offset 10 > 1 group
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
   private void addGroupField(Document doc, String groupField, String value) {
     doc.add(new SortedDocValuesField(groupField, new BytesRef(value)));
   }
@@ -1522,7 +1540,7 @@ public class TestGrouping extends LuceneTestCase {
       }
     }
 
-    if (mergedTopGroups != null) {
+    if (!mergedTopGroups.isEmpty()) {
       // Now 2nd pass:
       final List<TopGroups<BytesRef>> shardTopGroups = new ArrayList<>(subSearchers.length);
       for (int shardIDX = 0; shardIDX < subSearchers.length; shardIDX++) {


### PR DESCRIPTION
Returning null can cause issues down the line once we move to using collector managers and leverage the merge method for results reduction.

This commit replaces the null return type with an empty list.

Relates to #15574