### PR TITLE
Implement DocIdSetIterator#intoBitSet in many of the Lucene90DocValuesProducer implementations

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -416,6 +416,9 @@ Optimizations
 
 * GITHUB#16084: Added range encoding to  RoaringDocIdSet. (Ignacio Vera)
 
+* GITHUB#16097: Implement DocIdSetIterator#intoBitSet in dense implememntatios of the
+  Lucene90DocValuesProducer. (Ignacio Vera)
+
 Bug Fixes
 ---------------------
 * GITHUB#15754: Fix HTMLStripCharFilter to prevent tags from incorrectly consuming subsequent

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -590,6 +590,16 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     public int docIDRunEnd() throws IOException {
       return maxDoc;
     }
+
+    @Override
+    public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+      assert offset <= doc;
+      upTo = Math.min(upTo, maxDoc);
+      if (upTo > doc) {
+        bitSet.set(doc - offset, upTo - offset);
+        advance(upTo);
+      }
+    }
   }
 
   private abstract static class SparseNumericDocValues extends NumericDocValues {
@@ -912,6 +922,16 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     public int docIDRunEnd() throws IOException {
       return maxDoc;
     }
+
+    @Override
+    public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+      assert offset <= doc;
+      upTo = Math.min(upTo, maxDoc);
+      if (upTo > doc) {
+        bitSet.set(doc - offset, upTo - offset);
+        advance(upTo);
+      }
+    }
   }
 
   private abstract static class SparseBinaryDocValues extends BinaryDocValues {
@@ -1129,6 +1149,16 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
           public int docIDRunEnd() throws IOException {
             return maxDoc;
           }
+
+          @Override
+          public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+            assert offset <= doc;
+            upTo = Math.min(upTo, maxDoc);
+            if (upTo > doc) {
+              bitSet.set(doc - offset, upTo - offset);
+              advance(upTo);
+            }
+          }
         };
       } else if (ordsEntry.docsWithFieldOffset >= 0) { // sparse but non-empty
         final IndexedDISI disi =
@@ -1221,6 +1251,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
       @Override
       public int docIDRunEnd() throws IOException {
         return ords.docIDRunEnd();
+      }
+
+      @Override
+      public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+        ords.intoBitSet(upTo, bitSet, offset);
       }
     };
   }
@@ -1634,6 +1669,16 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
         public int docIDRunEnd() throws IOException {
           return maxDoc;
         }
+
+        @Override
+        public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+          assert offset <= doc;
+          upTo = Math.min(upTo, maxDoc);
+          if (upTo > doc) {
+            bitSet.set(doc - offset, upTo - offset);
+            advance(upTo);
+          }
+        }
       };
     } else {
       // sparse
@@ -1805,6 +1850,16 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
           public int docIDRunEnd() throws IOException {
             return maxDoc;
           }
+
+          @Override
+          public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+            assert offset <= doc;
+            upTo = Math.min(upTo, maxDoc);
+            if (upTo > doc) {
+              bitSet.set(doc - offset, upTo - offset);
+              advance(upTo);
+            }
+          }
         };
       } else if (ordsEntry.docsWithFieldOffset >= 0) { // sparse but non-empty
         final IndexedDISI disi =
@@ -1927,6 +1982,11 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
       @Override
       public int docIDRunEnd() throws IOException {
         return ords.docIDRunEnd();
+      }
+
+      @Override
+      public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
+        ords.intoBitSet(upTo, bitSet, offset);
       }
     };
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseDocValuesFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseDocValuesFormatTestCase.java
@@ -56,7 +56,6 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.util.TestUtil;
-import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOFunction;
@@ -1080,14 +1079,14 @@ public abstract class BaseDocValuesFormatTestCase extends LegacyBaseDocValuesFor
       Supplier<Boolean> addDocument)
       throws IOException {
     int numDocs = atLeast(100);
-    FixedBitSet docsWithField = new FixedBitSet(numDocs);
+    int docsWithField = 0;
     try (Directory dir = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
 
         for (int i = 0; i < numDocs; i++) {
           Document doc = new Document();
           if (addDocument.get()) {
-            docsWithField.set(i);
+            docsWithField++;
             consumer.accept(doc);
           }
           w.addDocument(doc);
@@ -1106,9 +1105,8 @@ public abstract class BaseDocValuesFormatTestCase extends LegacyBaseDocValuesFor
             FixedBitSet expectedBitSet = new FixedBitSet(numDocs - offset);
 
             DocIdSetIterator values = producer.apply(leaf);
-            DocIdSetIterator expected =
-                new BitSetIterator(docsWithField, docsWithField.cardinality());
-            if (docsWithField.cardinality() == 0) {
+            DocIdSetIterator expected = producer.apply(leaf);
+            if (docsWithField == 0) {
               assertNull(values);
               return; // no more to be tested
             }
@@ -1120,7 +1118,9 @@ public abstract class BaseDocValuesFormatTestCase extends LegacyBaseDocValuesFor
               continue;
             }
             values.intoBitSet(upTo, bitSet, offset);
-            expected.intoBitSet(upTo, expectedBitSet, offset);
+            for (int doc = expected.docID(); doc < upTo; doc = expected.nextDoc()) {
+              expectedBitSet.set(doc - offset);
+            }
             assertEquals(expected.docID(), values.docID());
             assertEquals(expectedBitSet, bitSet);
           }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseDocValuesFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseDocValuesFormatTestCase.java
@@ -22,6 +22,7 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.BinaryDocValuesField;
@@ -55,7 +56,10 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.IOFunction;
 import org.apache.lucene.util.IOUtils;
 
 /**
@@ -974,5 +978,154 @@ public abstract class BaseDocValuesFormatTestCase extends LegacyBaseDocValuesFor
     assertEquals(DocIdSetIterator.NO_MORE_DOCS, ssdv.nextDoc());
 
     IOUtils.close(reader, w2, dir1, dir2);
+  }
+
+  public void testRandomDenseNumericIntoBitSet() throws IOException {
+    doTestRandomIntoBitSet(
+        doc -> doc.add(new NumericDocValuesField("num", random().nextLong())),
+        reader -> reader.getNumericDocValues("num"),
+        () -> true);
+  }
+
+  public void testRandomSparseNumericIntoBitSet() throws IOException {
+    doTestRandomIntoBitSet(
+        doc -> doc.add(new NumericDocValuesField("num", random().nextLong())),
+        reader -> reader.getNumericDocValues("num"),
+        () -> random().nextBoolean() ? random().nextBoolean() : random().nextInt(50) == 0);
+  }
+
+  public void testRandomDenseSortedNumericIntoBitSet() throws IOException {
+    doTestRandomIntoBitSet(
+        doc -> {
+          doc.add(new SortedNumericDocValuesField("num", random().nextLong()));
+          doc.add(new SortedNumericDocValuesField("num", random().nextLong()));
+        },
+        reader -> reader.getSortedNumericDocValues("num"),
+        () -> true);
+  }
+
+  public void testRandomSparseSortedNumericIntoBitSet() throws IOException {
+    int n = random().nextInt(50) + 1;
+    doTestRandomIntoBitSet(
+        doc -> {
+          doc.add(new SortedNumericDocValuesField("num", random().nextLong()));
+          doc.add(new SortedNumericDocValuesField("num", random().nextLong()));
+        },
+        reader -> reader.getSortedNumericDocValues("num"),
+        () -> random().nextInt(n) == 0);
+  }
+
+  public void testRandomDenseSortedIntoBitSet() throws IOException {
+    doTestRandomIntoBitSet(
+        doc -> doc.add(new SortedDocValuesField("num", new BytesRef("" + random().nextLong()))),
+        reader -> reader.getSortedDocValues("num"),
+        () -> true);
+  }
+
+  public void testRandomSparseSortedIntoBitSet() throws IOException {
+    int n = random().nextInt(50) + 1;
+    doTestRandomIntoBitSet(
+        doc -> doc.add(new SortedDocValuesField("num", new BytesRef("" + random().nextLong()))),
+        reader -> reader.getSortedDocValues("num"),
+        () -> random().nextInt(n) == 0);
+  }
+
+  public void testRandomDenseSortedSetIntoBitSet() throws IOException {
+    doTestRandomIntoBitSet(
+        doc -> {
+          doc.add(new SortedSetDocValuesField("num", new BytesRef("" + random().nextLong())));
+          doc.add(new SortedSetDocValuesField("num", new BytesRef("" + random().nextLong())));
+        },
+        reader -> reader.getSortedSetDocValues("num"),
+        () -> true);
+  }
+
+  public void testRandomSparseSortedSetIntoBitSet() throws IOException {
+    int n = random().nextInt(50) + 1;
+    doTestRandomIntoBitSet(
+        doc -> {
+          doc.add(new SortedSetDocValuesField("num", new BytesRef("" + random().nextLong())));
+          doc.add(new SortedSetDocValuesField("num", new BytesRef("" + random().nextLong())));
+        },
+        reader -> reader.getSortedSetDocValues("num"),
+        () -> random().nextInt(n) == 0);
+  }
+
+  public void testRandomDenseBinaryIntoBitSet() throws IOException {
+    doTestRandomIntoBitSet(
+        doc -> {
+          byte[] bytes = new byte[10];
+          random().nextBytes(bytes);
+          doc.add(new BinaryDocValuesField("num", new BytesRef(bytes)));
+        },
+        reader -> reader.getBinaryDocValues("num"),
+        () -> true);
+  }
+
+  public void testRandomSparseBinaryIntoBitSet() throws IOException {
+    int n = random().nextInt(50) + 1;
+    doTestRandomIntoBitSet(
+        doc -> {
+          byte[] bytes = new byte[10];
+          random().nextBytes(bytes);
+          doc.add(new BinaryDocValuesField("num", new BytesRef(bytes)));
+        },
+        reader -> reader.getBinaryDocValues("num"),
+        () -> random().nextInt(n) == 0);
+  }
+
+  public void doTestRandomIntoBitSet(
+      Consumer<Document> consumer,
+      IOFunction<LeafReader, DocIdSetIterator> producer,
+      Supplier<Boolean> addDocument)
+      throws IOException {
+    int numDocs = atLeast(100);
+    FixedBitSet docsWithField = new FixedBitSet(numDocs);
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          if (addDocument.get()) {
+            docsWithField.set(i);
+            consumer.accept(doc);
+          }
+          w.addDocument(doc);
+        }
+        w.commit();
+        w.forceMerge(1);
+
+        try (DirectoryReader reader = DirectoryReader.open(w)) {
+          LeafReader leaf = getOnlyLeafReader(reader);
+          for (int i = 0; i < 20; i++) {
+            int start = random().nextInt(numDocs - 1);
+            int upTo = random().nextInt(start, numDocs);
+
+            int offset = start == 0 ? 0 : random().nextInt(start);
+            FixedBitSet bitSet = new FixedBitSet(numDocs - offset);
+            FixedBitSet expectedBitSet = new FixedBitSet(numDocs - offset);
+
+            DocIdSetIterator values = producer.apply(leaf);
+            DocIdSetIterator expected =
+                new BitSetIterator(docsWithField, docsWithField.cardinality());
+            if (docsWithField.cardinality() == 0) {
+              assertNull(values);
+              return; // no more to be tested
+            }
+            assertNotNull(values);
+            values.advance(start);
+            expected.advance(start);
+            assertEquals(expected.docID(), values.docID());
+            if (values.docID() == NO_MORE_DOCS) {
+              continue;
+            }
+            values.intoBitSet(upTo, bitSet, offset);
+            expected.intoBitSet(upTo, expectedBitSet, offset);
+            assertEquals(expected.docID(), values.docID());
+            assertEquals(expectedBitSet, bitSet);
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This should be useful for any consumer of doc values.