### PR TITLE
Validate zero vectors in setVectorValue() for cosine similarity fields

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -508,6 +508,8 @@ Bug Fixes
 
 * GITHUB#15878: Fix LargeNumHitsTopDocsCollector not handling requested hit count correctly (Binlong Gao)
 
+* GITHUB#16098: Validate zero vectors in setVectorValue() for cosine similarity fields. (Prithvi S)
+
 * GITHUB#16046: Fix double-counting of underlying Automaton in CompiledAutomaton#ramBytesUsed. (Eugene Rizhkov)
 
 * GITHUB#15901: Fix undercounting of RAM used by vectors buffered in in-memory segments.

--- a/lucene/core/src/java/org/apache/lucene/document/KnnByteVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnByteVectorField.java
@@ -168,6 +168,10 @@ public class KnnByteVectorField extends Field {
       throw new IllegalArgumentException(
           "value length " + value.length + " must match field dimension " + type.vectorDimension());
     }
+    if (type.vectorSimilarityFunction() == VectorSimilarityFunction.COSINE
+        && VectorUtil.isZeroVector(value)) {
+      throw new IllegalArgumentException("zero vector not allowed with cosine similarity function");
+    }
     fieldsData = value;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnFloatVectorField.java
@@ -169,6 +169,10 @@ public class KnnFloatVectorField extends Field {
       throw new IllegalArgumentException(
           "value length " + value.length + " must match field dimension " + type.vectorDimension());
     }
-    fieldsData = value;
+    if (type.vectorSimilarityFunction() == VectorSimilarityFunction.COSINE
+        && VectorUtil.isZeroVector(value)) {
+      throw new IllegalArgumentException("zero vector not allowed with cosine similarity function");
+    }
+    fieldsData = VectorUtil.checkFinite(value);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -453,7 +453,7 @@ public final class VectorUtil {
 
   /** Returns true if all dimensions of provided vector are zero, false otherwise. */
   public static boolean isZeroVector(byte[] v) {
-    for (float value : v) {
+    for (byte value : v) {
       if (value != 0) {
         return false;
       }

--- a/lucene/core/src/test/org/apache/lucene/document/TestField.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestField.java
@@ -765,6 +765,51 @@ public class TestField extends LuceneTestCase {
     assertTrue(zeroError.getMessage().contains("zero vector not allowed"));
   }
 
+  public void testKnnFieldSetVectorValueZeroVectors() throws Exception {
+    // Float vector field: setVectorValue with zero vector on COSINE field should fail
+    KnnFloatVectorField floatField =
+        new KnnFloatVectorField(
+            "knnFloats", new float[] {1, 2, 3, 4, 5}, VectorSimilarityFunction.COSINE);
+    IllegalArgumentException zeroError =
+        expectThrows(IllegalArgumentException.class, () -> floatField.setVectorValue(new float[5]));
+    assertTrue(zeroError.getMessage().contains("zero vector not allowed"));
+
+    // Non-zero setVectorValue should succeed
+    floatField.setVectorValue(new float[] {5, 4, 3, 2, 1});
+
+    // Byte vector field: setVectorValue with zero vector on COSINE field should fail
+    KnnByteVectorField byteField =
+        new KnnByteVectorField(
+            "knnBytes", new byte[] {1, 2, 3, 4, 5}, VectorSimilarityFunction.COSINE);
+    zeroError =
+        expectThrows(IllegalArgumentException.class, () -> byteField.setVectorValue(new byte[5]));
+    assertTrue(zeroError.getMessage().contains("zero vector not allowed"));
+
+    // Non-zero setVectorValue should succeed
+    byteField.setVectorValue(new byte[] {5, 4, 3, 2, 1});
+
+    // EUCLIDEAN fields should allow zero vectors via setVectorValue
+    KnnFloatVectorField euclideanFloatField =
+        new KnnFloatVectorField(
+            "knnFloatsEuc", new float[] {1, 2, 3, 4, 5}, VectorSimilarityFunction.EUCLIDEAN);
+    euclideanFloatField.setVectorValue(new float[5]);
+
+    KnnByteVectorField euclideanByteField =
+        new KnnByteVectorField(
+            "knnBytesEuc", new byte[] {1, 2, 3, 4, 5}, VectorSimilarityFunction.EUCLIDEAN);
+    euclideanByteField.setVectorValue(new byte[5]);
+
+    // Float vector field: setVectorValue with NaN should fail
+    KnnFloatVectorField nanField =
+        new KnnFloatVectorField(
+            "knnFloatsNaN", new float[] {1, 2, 3, 4, 5}, VectorSimilarityFunction.EUCLIDEAN);
+    IllegalArgumentException nanError =
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> nanField.setVectorValue(new float[] {1, 2, Float.NaN, 4, 5}));
+    assertTrue(nanError.getMessage().contains("non-finite"));
+  }
+
   private void trySetByteValue(Field f) {
     expectThrows(
         IllegalArgumentException.class,


### PR DESCRIPTION
PR #15751 added zero-vector validation in KnnByteVectorField and KnnFloatVectorField constructors when cosine similarity is configured. However, setVectorValue() was not covered, allowing users to bypass the check by creating a field with a valid vector and then mutating it to a zero vector. This can still lead to the same MergeAbortedException / CheckIndex failures described in #15540.