### PR TITLE
Make HNSW graph building and CheckIndex resilient to zero vectors with cosine similarity

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -508,6 +508,8 @@ Bug Fixes
 
 * GITHUB#15878: Fix LargeNumHitsTopDocsCollector not handling requested hit count correctly (Binlong Gao)
 
+* GITHUB#16099: Make HNSW graph building and CheckIndex resilient to zero vectors with cosine similarity. (Prithvi S)
+
 * GITHUB#16046: Fix double-counting of underlying Automaton in CompiledAutomaton#ramBytesUsed. (Eugene Rizhkov)
 
 * GITHUB#15901: Fix undercounting of RAM used by vectors buffered in in-memory segments.

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -92,6 +92,7 @@ import org.apache.lucene.util.LongBitSet;
 import org.apache.lucene.util.NamedThreadFactory;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.SuppressForbidden;
+import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.Version;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
@@ -412,6 +413,9 @@ public final class CheckIndex implements Closeable {
 
       /** Total number of fields with vectors. */
       public int totalKnnVectorFields;
+
+      /** Number of zero vectors found with cosine similarity (these cannot be searched). */
+      public int zeroVectorWithCosineCount;
 
       /** Exception thrown during vector values test (null on success) */
       public Throwable error;
@@ -3106,8 +3110,14 @@ public final class CheckIndex implements Closeable {
                   AcceptDocs.fromLiveDocs(null, codecReader.maxDoc()));
           TopDocs docs = collector.topDocs();
           if (docs.scoreDocs.length == 0) {
-            throw new CheckIndexException(
-                "Field \"" + fieldInfo.name + "\" failed to search k nearest neighbors");
+            // Zero vectors with cosine similarity cannot be searched.
+            if (fieldInfo.getVectorSimilarityFunction() == VectorSimilarityFunction.COSINE
+                && VectorUtil.isZeroVector(values.vectorValue(count))) {
+              status.zeroVectorWithCosineCount++;
+            } else {
+              throw new CheckIndexException(
+                  "Field \"" + fieldInfo.name + "\" failed to search k nearest neighbors");
+            }
           }
         }
       }
@@ -3158,8 +3168,14 @@ public final class CheckIndex implements Closeable {
                 AcceptDocs.fromLiveDocs(null, codecReader.maxDoc()));
         TopDocs docs = collector.topDocs();
         if (docs.scoreDocs.length == 0) {
-          throw new CheckIndexException(
-              "Field \"" + fieldInfo.name + "\" failed to search k nearest neighbors");
+          // Zero vectors with cosine similarity cannot be searched.
+          if (fieldInfo.getVectorSimilarityFunction() == VectorSimilarityFunction.COSINE
+              && VectorUtil.isZeroVector(values.vectorValue(count))) {
+            status.zeroVectorWithCosineCount++;
+          } else {
+            throw new CheckIndexException(
+                "Field \"" + fieldInfo.name + "\" failed to search k nearest neighbors");
+          }
         }
       }
       int valueLength = values.vectorValue(count).length;

--- a/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
@@ -24,6 +24,8 @@ import static org.apache.lucene.util.VectorUtil.normalizeToUnitInterval;
 import static org.apache.lucene.util.VectorUtil.scaleMaxInnerProductScore;
 import static org.apache.lucene.util.VectorUtil.squareDistance;
 
+import org.apache.lucene.util.VectorUtil;
+
 /**
  * Vector similarity function; used in search to return top K most similar vectors to a target
  * vector. This is a label describing the method used during indexing and searching of the vectors
@@ -72,11 +74,17 @@ public enum VectorSimilarityFunction {
   COSINE {
     @Override
     public float compare(float[] v1, float[] v2) {
+      if (VectorUtil.isZeroVector(v1) || VectorUtil.isZeroVector(v2)) {
+        return 0;
+      }
       return normalizeToUnitInterval(cosine(v1, v2));
     }
 
     @Override
     public float compare(byte[] v1, byte[] v2) {
+      if (VectorUtil.isZeroVector(v1) || VectorUtil.isZeroVector(v2)) {
+        return 0;
+      }
       return (1 + cosine(v1, v2)) / 2;
     }
   },

--- a/lucene/core/src/test/org/apache/lucene/index/TestCheckIndex.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestCheckIndex.java
@@ -242,6 +242,16 @@ public class TestCheckIndex extends BaseTestCheckIndex {
   // the index is OK, but older commit points are broken, CheckIndex fails to detect and
   // correct that, while opening an IndexWriter on the index will fail since IndexWriter
   // loads all commit points on init
+  /**
+   * Compile-time check that VectorValuesStatus has the zeroVectorWithCosineCount field. A full
+   * integration test would require injecting a pre-existing zero vector into an index (bypassing
+   * KnnFloatVectorField constructor validation), which is beyond the scope of this fix.
+   */
+  public void testVectorValuesStatusHasZeroVectorField() {
+    CheckIndex.Status.VectorValuesStatus status = new CheckIndex.Status.VectorValuesStatus();
+    assertEquals(0, status.zeroVectorWithCosineCount);
+  }
+
   public void testPriorBrokenCommitPoint() throws Exception {
 
     try (MockDirectoryWrapper dir = newMockDirectory()) {

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -599,4 +599,27 @@ public class TestVectorUtil extends LuceneTestCase {
     }
     return res;
   }
+
+  public void testIsZeroVector() {
+    assertTrue(VectorUtil.isZeroVector(new float[] {0, 0, 0}));
+    assertFalse(VectorUtil.isZeroVector(new float[] {0, 1, 0}));
+    assertTrue(VectorUtil.isZeroVector(new byte[] {0, 0, 0}));
+    assertFalse(VectorUtil.isZeroVector(new byte[] {0, 1, 0}));
+  }
+
+  public void testCosineSimilarityWithZeroVector() {
+    // VectorSimilarityFunction.COSINE should return 0 for zero vectors instead of NaN,
+    // which breaks HNSW graph building and CheckIndex.
+    float[] zeroFloat = new float[] {0, 0, 0};
+    float[] nonZeroFloat = new float[] {1, 2, 3};
+    assertEquals(0f, VectorSimilarityFunction.COSINE.compare(zeroFloat, nonZeroFloat), 0f);
+    assertEquals(0f, VectorSimilarityFunction.COSINE.compare(nonZeroFloat, zeroFloat), 0f);
+    assertEquals(0f, VectorSimilarityFunction.COSINE.compare(zeroFloat, zeroFloat), 0f);
+
+    byte[] zeroByte = new byte[] {0, 0, 0};
+    byte[] nonZeroByte = new byte[] {1, 2, 3};
+    assertEquals(0f, VectorSimilarityFunction.COSINE.compare(zeroByte, nonZeroByte), 0f);
+    assertEquals(0f, VectorSimilarityFunction.COSINE.compare(nonZeroByte, zeroByte), 0f);
+    assertEquals(0f, VectorSimilarityFunction.COSINE.compare(zeroByte, zeroByte), 0f);
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswByteVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswByteVectorGraph.java
@@ -27,7 +27,9 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.KnnByteVectorQuery;
+import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.ArrayUtil;
 import org.junit.Before;
 
@@ -131,5 +133,40 @@ public class TestHnswByteVectorGraph extends HnswGraphTestCase<byte[]> {
   @Override
   byte[] getTargetVector() {
     return new byte[] {1, 0};
+  }
+
+  /**
+   * Test that HnswGraphBuilder handles zero vectors with cosine similarity gracefully. Zero vectors
+   * produce NaN cosine scores which previously caused assertions to fail during graph building.
+   */
+  public void testBuildGraphWithZeroVectorsAndCosine() throws IOException {
+    similarityFunction = VectorSimilarityFunction.COSINE;
+    int nDoc = 20;
+    int dim = 2;
+    byte[][] vectors = new byte[nDoc][];
+    for (int i = 0; i < nDoc; i++) {
+      if (i == 0) {
+        // First vector is zero — this should not crash graph building
+        vectors[i] = new byte[dim];
+      } else {
+        // Use deterministic non-zero values to avoid random zero vectors
+        vectors[i] = new byte[] {(byte) (i + 1), (byte) (i + 2)};
+      }
+    }
+    MockByteVectorValues vectorValues = MockByteVectorValues.fromValues(vectors);
+    RandomVectorScorerSupplier scorerSupplier = buildScorerSupplier(vectorValues);
+    HnswGraphBuilder builder = HnswGraphBuilder.create(scorerSupplier, 16, 100, random().nextInt());
+    // Should complete without assertion errors
+    OnHeapHnswGraph hnsw = builder.build(vectorValues.size());
+    assertNotNull(hnsw);
+    assertEquals(nDoc, hnsw.size());
+
+    // Verify the graph is still navigable — search should find non-zero vectors
+    RandomVectorScorer scorer =
+        flatVectorScorer.getRandomVectorScorer(similarityFunction, vectorValues, new byte[] {1, 1});
+    KnnCollector results = HnswGraphSearcher.search(scorer, 5, hnsw, null, Integer.MAX_VALUE);
+    TopDocs topDocs = results.topDocs();
+    // Should find results (non-zero vectors)
+    assertTrue("Search should find results", topDocs.scoreDocs.length > 0);
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
@@ -145,4 +145,40 @@ public class TestHnswFloatVectorGraph extends HnswGraphTestCase<float[]> {
     // are closest to the query vector: sum(500,509) = 5045
     assertTrue("sum(result docs)=" + sum, sum < 5100);
   }
+
+  /**
+   * Test that HnswGraphBuilder handles zero vectors with cosine similarity gracefully. Zero vectors
+   * produce NaN cosine scores which previously caused assertions to fail during graph building.
+   */
+  public void testBuildGraphWithZeroVectorsAndCosine() throws IOException {
+    similarityFunction = VectorSimilarityFunction.COSINE;
+    int nDoc = 20;
+    int dim = 2;
+    float[][] vectors = new float[nDoc][];
+    for (int i = 0; i < nDoc; i++) {
+      if (i == 0) {
+        // First vector is zero — this should not crash graph building
+        vectors[i] = new float[dim];
+      } else {
+        // Use deterministic non-zero values to avoid random zero vectors
+        vectors[i] = new float[] {(i + 1) * 0.1f, (i + 1) * 0.2f};
+      }
+    }
+    MockVectorValues vectorValues = MockVectorValues.fromValues(vectors);
+    RandomVectorScorerSupplier scorerSupplier = buildScorerSupplier(vectorValues);
+    HnswGraphBuilder builder = HnswGraphBuilder.create(scorerSupplier, 16, 100, random().nextInt());
+    // Should complete without assertion errors
+    OnHeapHnswGraph hnsw = builder.build(vectorValues.size());
+    assertNotNull(hnsw);
+    assertEquals(nDoc, hnsw.size());
+
+    // Verify the graph is still navigable — search should find non-zero vectors
+    RandomVectorScorer scorer =
+        flatVectorScorer.getRandomVectorScorer(
+            similarityFunction, vectorValues, new float[] {1, 1});
+    KnnCollector results = HnswGraphSearcher.search(scorer, 5, hnsw, null, Integer.MAX_VALUE);
+    TopDocs topDocs = results.topDocs();
+    // Should find results (non-zero vectors)
+    assertTrue("Search should find results", topDocs.scoreDocs.length > 0);
+  }
 }


### PR DESCRIPTION
PR #15751 prevents new zero vectors from being indexed, but existing indexes with zero vectors still crash during merge (assertion failure in NeighborArray.addInOrder) and CheckIndex (CheckIndexException on zero search results). so fixed it!

Relates to #15540