### PR TITLE
Handle zero vectors in quantized codecs to prevent crashes during merge and search

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -508,6 +508,8 @@ Bug Fixes
 
 * GITHUB#15878: Fix LargeNumHitsTopDocsCollector not handling requested hit count correctly (Binlong Gao)
 
+* GITHUB#16100: Fix zero-vector crashes in quantized vector codecs. (Prithvi S)
+
 * GITHUB#16046: Fix double-counting of underlying Automaton in CompiledAutomaton#ramBytesUsed. (Eugene Rizhkov)
 
 * GITHUB#15901: Fix undercounting of RAM used by vectors buffered in in-memory segments.

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/ScalarQuantizedVectorScorer.java
@@ -46,7 +46,7 @@ public class ScalarQuantizedVectorScorer implements FlatVectorsScorer {
           case EUCLIDEAN, DOT_PRODUCT, MAXIMUM_INNER_PRODUCT -> query;
           case COSINE -> {
             float[] queryCopy = ArrayUtil.copyArray(query);
-            VectorUtil.l2normalize(queryCopy);
+            VectorUtil.l2normalize(queryCopy, false);
             yield queryCopy;
           }
         };

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorScorer.java
@@ -75,7 +75,7 @@ public class Lucene104ScalarQuantizedVectorScorer implements FlatVectorsScorer {
       // We make a copy as the quantization process mutates the input
       float[] copy = ArrayUtil.copyOfSubArray(target, 0, target.length);
       if (similarityFunction == COSINE) {
-        VectorUtil.l2normalize(copy);
+        VectorUtil.l2normalize(copy, false);
       }
       target = copy;
       var targetCorrectiveTerms =

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsWriter.java
@@ -144,7 +144,7 @@ public class Lucene104ScalarQuantizedVectorsWriter extends FlatVectorsWriter {
           clusterCenter[i] = field.dimensionSums[i] / vectorCount;
         }
         if (VectorSimilarityFunction.COSINE == field.fieldInfo.getVectorSimilarityFunction()) {
-          VectorUtil.l2normalize(clusterCenter);
+          VectorUtil.l2normalize(clusterCenter, false);
         }
       }
       if (segmentWriteState.infoStream.isEnabled(QUANTIZED_VECTOR_COMPONENT)) {
@@ -463,7 +463,7 @@ public class Lucene104ScalarQuantizedVectorsWriter extends FlatVectorsWriter {
         mergedCentroid[j] = mergedCentroid[j] / totalVectorCount;
       }
       if (fieldInfo.getVectorSimilarityFunction() == COSINE) {
-        VectorUtil.l2normalize(mergedCentroid);
+        VectorUtil.l2normalize(mergedCentroid, false);
       }
       return totalVectorCount;
     }
@@ -501,7 +501,7 @@ public class Lucene104ScalarQuantizedVectorsWriter extends FlatVectorsWriter {
       centroid[i] /= count;
     }
     if (fieldInfo.getVectorSimilarityFunction() == COSINE) {
-      VectorUtil.l2normalize(centroid);
+      VectorUtil.l2normalize(centroid, false);
     }
     return count;
   }
@@ -546,9 +546,12 @@ public class Lucene104ScalarQuantizedVectorsWriter extends FlatVectorsWriter {
       for (int i = 0; i < flatFieldVectorsWriter.getVectors().size(); i++) {
         float[] vector = flatFieldVectorsWriter.getVectors().get(i);
         float magnitude = magnitudes.get(i);
-        for (int j = 0; j < vector.length; j++) {
-          vector[j] /= magnitude;
+        if (magnitude > 0) {
+          for (int j = 0; j < vector.length; j++) {
+            vector[j] /= magnitude;
+          }
         }
+        // Zero vectors (magnitude == 0) are left as-is
       }
     }
 
@@ -578,9 +581,12 @@ public class Lucene104ScalarQuantizedVectorsWriter extends FlatVectorsWriter {
         float dp = VectorUtil.dotProduct(vectorValue, vectorValue);
         float divisor = (float) Math.sqrt(dp);
         magnitudes.add(divisor);
-        for (int i = 0; i < vectorValue.length; i++) {
-          dimensionSums[i] += (vectorValue[i] / divisor);
+        if (divisor > 0) {
+          for (int i = 0; i < vectorValue.length; i++) {
+            dimensionSums[i] += (vectorValue[i] / divisor);
+          }
         }
+        // If divisor == 0 (zero vector), skip adding NaN to dimensionSums
       } else {
         for (int i = 0; i < vectorValue.length; i++) {
           dimensionSums[i] += vectorValue[i];
@@ -755,7 +761,7 @@ public class Lucene104ScalarQuantizedVectorsWriter extends FlatVectorsWriter {
     @Override
     public float[] vectorValue(int ord) throws IOException {
       System.arraycopy(values.vectorValue(ord), 0, normalizedVector, 0, normalizedVector.length);
-      VectorUtil.l2normalize(normalizedVector);
+      VectorUtil.l2normalize(normalizedVector, false);
       return normalizedVector;
     }
 

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/OptimizedScalarQuantizer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/OptimizedScalarQuantizer.java
@@ -118,8 +118,12 @@ public class OptimizedScalarQuantizer {
    */
   public QuantizationResult[] multiScalarQuantize(
       float[] vector, byte[][] destinations, byte[] bits, float[] centroid) {
-    assert similarityFunction != COSINE || VectorUtil.isUnitVector(vector);
-    assert similarityFunction != COSINE || VectorUtil.isUnitVector(centroid);
+    assert similarityFunction != COSINE
+        || VectorUtil.isZeroVector(vector)
+        || VectorUtil.isUnitVector(vector);
+    assert similarityFunction != COSINE
+        || VectorUtil.isZeroVector(centroid)
+        || VectorUtil.isUnitVector(centroid);
     assert bits.length == destinations.length;
     float[] intervalScratch = new float[2];
     double vecMean = 0;
@@ -186,8 +190,12 @@ public class OptimizedScalarQuantizer {
    */
   public QuantizationResult scalarQuantize(
       float[] vector, byte[] destination, byte bits, float[] centroid) {
-    assert similarityFunction != COSINE || VectorUtil.isUnitVector(vector);
-    assert similarityFunction != COSINE || VectorUtil.isUnitVector(centroid);
+    assert similarityFunction != COSINE
+        || VectorUtil.isZeroVector(vector)
+        || VectorUtil.isUnitVector(vector);
+    assert similarityFunction != COSINE
+        || VectorUtil.isZeroVector(centroid)
+        || VectorUtil.isUnitVector(centroid);
     assert vector.length <= destination.length;
     assert bits > 0 && bits <= 8;
     float[] intervalScratch = new float[2];

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene104/TestLucene104ScalarQuantizedVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene104/TestLucene104ScalarQuantizedVectorsFormat.java
@@ -30,6 +30,7 @@ import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FloatVectorValues;
@@ -38,6 +39,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.KnnFloatVectorQuery;
@@ -138,6 +140,76 @@ public class TestLucene104ScalarQuantizedVectorsFormat extends BaseKnnVectorsFor
   @Override
   public void testSearchWithVisitedLimit() {
     // visited limit is not respected, as it is brute force search
+  }
+
+  /** Field subclass that bypasses zero-vector validation for testing. */
+  private static class UnvalidatedKnnFloatVectorField extends KnnFloatVectorField {
+    private final float[] vector;
+
+    UnvalidatedKnnFloatVectorField(String name, float[] vector, VectorSimilarityFunction sim) {
+      // Pass a non-zero vector and matching FieldType to pass validation,
+      // then override vectorValue() to return the actual (possibly zero) vector.
+      super(name, createDummyVector(vector.length), createType(vector.length, sim));
+      this.vector = vector;
+    }
+
+    private static float[] createDummyVector(int dims) {
+      float[] v = new float[dims];
+      v[0] = 1.0f; // non-zero to pass validation
+      return v;
+    }
+
+    private static FieldType createType(int dims, VectorSimilarityFunction sim) {
+      FieldType type = new FieldType();
+      type.setVectorAttributes(dims, VectorEncoding.FLOAT32, sim);
+      type.freeze();
+      return type;
+    }
+
+    @Override
+    public float[] vectorValue() {
+      return vector;
+    }
+  }
+
+  /**
+   * Test that quantized codecs handle zero vectors with cosine similarity without crashing during
+   * merge. Uses a custom Field subclass to bypass KnnFloatVectorField validation.
+   */
+  public void testQuantizedWithZeroVectorAndCosine() throws Exception {
+    String fieldName = "field";
+    int dims = 4;
+    VectorSimilarityFunction similarityFunction = VectorSimilarityFunction.COSINE;
+
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+        // Add a zero vector (bypassing KnnFloatVectorField validation)
+        Document doc = new Document();
+        doc.add(new UnvalidatedKnnFloatVectorField(fieldName, new float[dims], similarityFunction));
+        w.addDocument(doc);
+
+        // Add non-zero vectors
+        for (int i = 0; i < 10; i++) {
+          doc = new Document();
+          doc.add(
+              new KnnFloatVectorField(
+                  fieldName, new float[] {i + 1f, i + 2f, i + 3f, i + 4f}, similarityFunction));
+          w.addDocument(doc);
+        }
+
+        w.commit();
+        // Merge should not crash
+        w.forceMerge(1);
+      }
+
+      // Search should work
+      try (IndexReader reader = DirectoryReader.open(dir)) {
+        IndexSearcher searcher = new IndexSearcher(reader);
+        Query q = new KnnFloatVectorQuery(fieldName, new float[] {1, 2, 3, 4}, 5);
+        TopDocs topDocs = searcher.search(q, 5);
+        assertTrue("Search should find results", topDocs.totalHits.value() > 0);
+      }
+    }
   }
 
   public void testQuantizedVectorsWriteAndRead() throws IOException {


### PR DESCRIPTION
Quantized vector codecs (Lucene104ScalarQuantizedVectorsFormat) crash on zero vectors with COSINE similarity, fixed it!