### PR TITLE
Filter out MatchNoDocsQuery disjuncts in DisjunctionMaxQuery.rewrite()

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -458,6 +458,9 @@ Optimizations
 
 * GITHUB#16147: Optimize column batch parent field with bulk fill. (Tim Brooks)
 
+* GITHUB#16103: DisjunctionMaxQuery now filters out MatchNoDocsQuery disjuncts during rewrite,
+  avoiding unnecessary scorer overhead. (Prithvi S)
+
 Bug Fixes
 ---------------------
 * GITHUB#15754: Fix HTMLStripCharFilter to prevent tags from incorrectly consuming subsequent

--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
@@ -282,15 +282,27 @@ public final class DisjunctionMaxQuery extends Query implements Iterable<Query> 
     List<Query> rewrittenDisjuncts = new ArrayList<>();
     for (Query sub : disjuncts) {
       Query rewrittenSub = sub.rewrite(indexSearcher);
-      actuallyRewritten |= rewrittenSub != sub;
-      rewrittenDisjuncts.add(rewrittenSub);
+      if (rewrittenSub != sub || sub.getClass() == MatchNoDocsQuery.class) {
+        actuallyRewritten = true;
+      }
+      if (rewrittenSub.getClass() != MatchNoDocsQuery.class) {
+        rewrittenDisjuncts.add(rewrittenSub);
+      }
     }
 
-    if (actuallyRewritten) {
-      return new DisjunctionMaxQuery(rewrittenDisjuncts, tieBreakerMultiplier);
+    if (actuallyRewritten == false) {
+      return super.rewrite(indexSearcher);
     }
 
-    return super.rewrite(indexSearcher);
+    if (rewrittenDisjuncts.isEmpty()) {
+      return new MatchNoDocsQuery("empty DisjunctionMaxQuery");
+    }
+
+    if (rewrittenDisjuncts.size() == 1) {
+      return rewrittenDisjuncts.get(0);
+    }
+
+    return new DisjunctionMaxQuery(rewrittenDisjuncts, tieBreakerMultiplier);
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
@@ -482,6 +482,46 @@ public class TestDisjunctionMaxQuery extends LuceneTestCase {
     assertEquals(expected, rewritten);
   }
 
+  public void testRewriteAllMatchNoDocs() throws Exception {
+    // All disjuncts rewrite to MatchNoDocsQuery -> should return MatchNoDocsQuery
+    Query sub1 = new MatchNoDocsQuery("test1");
+    Query sub2 = new MatchNoDocsQuery("test2");
+    DisjunctionMaxQuery q = new DisjunctionMaxQuery(Arrays.asList(sub1, sub2), 0.0f);
+    Query rewritten = s.rewrite(q);
+    assertEquals(MatchNoDocsQuery.INSTANCE, rewritten);
+  }
+
+  public void testRewriteSingleSurvivor() throws Exception {
+    // One disjunct rewrites to MatchNoDocsQuery, other matches -> should return the matching one
+    Query sub = tq("hed", "albino");
+    DisjunctionMaxQuery q =
+        new DisjunctionMaxQuery(Arrays.asList(sub, new MatchNoDocsQuery("test")), 0.0f);
+    Query rewritten = s.rewrite(q);
+    assertEquals(sub, rewritten);
+  }
+
+  public void testRewriteFilterMatchNoDocs() throws Exception {
+    // Mixed: some MatchNoDocsQuery, some real queries -> should filter out MatchNoDocsQuery
+    Query sub1 = tq("hed", "albino");
+    Query sub2 = tq("hed", "elephant");
+    DisjunctionMaxQuery q =
+        new DisjunctionMaxQuery(Arrays.asList(sub1, sub2, new MatchNoDocsQuery("test")), 0.0f);
+    Query rewritten = s.rewrite(q);
+    DisjunctionMaxQuery expected = new DisjunctionMaxQuery(Arrays.asList(sub1, sub2), 0.0f);
+    assertEquals(expected, rewritten);
+  }
+
+  public void testRewriteFilterMatchNoDocsWithTieBreaker() throws Exception {
+    // Verify tie breaker multiplier is preserved when filtering MatchNoDocsQuery
+    Query sub1 = tq("hed", "albino");
+    Query sub2 = tq("hed", "elephant");
+    DisjunctionMaxQuery q =
+        new DisjunctionMaxQuery(Arrays.asList(sub1, sub2, new MatchNoDocsQuery("test")), 0.1f);
+    Query rewritten = s.rewrite(q);
+    DisjunctionMaxQuery expected = new DisjunctionMaxQuery(Arrays.asList(sub1, sub2), 0.1f);
+    assertEquals(expected, rewritten);
+  }
+
   public void testDisjunctOrderAndEquals() throws Exception {
     // the order that disjuncts are provided in should not matter for equals() comparisons
     Query sub1 = tq("hed", "albino");

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -2669,9 +2669,11 @@ public class TestLRUQueryCache extends LuceneTestCase {
           }
         };
 
-    // Force exactly 1 segment so cache behavior is deterministic
+    // Force exactly 1 segment so cache behavior is deterministic.
+    // Use a non-randomized IndexWriterConfig to prevent randomized flush thresholds
+    // (e.g., tiny RAM buffer) from splitting 3 docs into multiple segments.
     Directory dir = newDirectory();
-    IndexWriterConfig iwc = newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE);
+    IndexWriterConfig iwc = new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE);
     IndexWriter iw = new IndexWriter(dir, iwc);
     Document doc = new Document();
     doc.add(new StringField("color", "red", Store.NO));

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -2669,11 +2669,9 @@ public class TestLRUQueryCache extends LuceneTestCase {
           }
         };
 
-    // Force exactly 1 segment so cache behavior is deterministic.
-    // Use a non-randomized IndexWriterConfig to prevent randomized flush thresholds
-    // (e.g., tiny RAM buffer) from splitting 3 docs into multiple segments.
+    // Force exactly 1 segment so cache behavior is deterministic
     Directory dir = newDirectory();
-    IndexWriterConfig iwc = new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE);
+    IndexWriterConfig iwc = newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE);
     IndexWriter iw = new IndexWriter(dir, iwc);
     Document doc = new Document();
     doc.add(new StringField("color", "red", Store.NO));


### PR DESCRIPTION
DisjunctionMaxQuery.rewrite() now filters out MatchNoDocsQuery instances from its disjuncts after rewriting sub-queries, matching the behavior of BooleanQuery.rewrite()