### PR TITLE
Allow supplying KnnSearchStrategy to vector similarity queries

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -98,6 +98,8 @@ API Changes
 * GITHUB#16052: Remove IOException from LeafReader#getPointValues, LeafReader#terms,
   LeafReader#getDocCount signatures. (Ignacio Vera)
 
+* GITHUB#16104: Add public constructors and a public getSearchStrategy() to FloatVectorSimilarityQuery, ByteVectorSimilarityQuery and VectorSimilarityCollector that accept a KnnSearchStrategy. (Sasilekha R)
+
 New Features
 ---------------------
 * GITHUB#15505: Upgrade snowball to 2d2e312df56f2ede014a4ffb3e91e6dea43c24be. New stemmer: PolishStemmer (and

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -98,8 +98,6 @@ API Changes
 * GITHUB#16052: Remove IOException from LeafReader#getPointValues, LeafReader#terms,
   LeafReader#getDocCount signatures. (Ignacio Vera)
 
-* GITHUB#16104: Add public constructors and a public getSearchStrategy() to FloatVectorSimilarityQuery, ByteVectorSimilarityQuery and VectorSimilarityCollector that accept a KnnSearchStrategy. (Sasilekha R)
-
 New Features
 ---------------------
 * GITHUB#15505: Upgrade snowball to 2d2e312df56f2ede014a4ffb3e91e6dea43c24be. New stemmer: PolishStemmer (and
@@ -304,6 +302,8 @@ API Changes
   vectors to be written. (Lorenzo Dematte)
 
 * GITHUB#16101 Add DictionaryColumn for SORTED / SORTED_SET docvalues using experimental column api (Tim Brooks)
+
+* GITHUB#16104: Add public constructors and a public getSearchStrategy() to FloatVectorSimilarityQuery, ByteVectorSimilarityQuery and VectorSimilarityCollector that accept a KnnSearchStrategy. (Sasilekha R)
 
 New Features
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractVectorSimilarityQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractVectorSimilarityQuery.java
@@ -32,10 +32,19 @@ import org.apache.lucene.util.Bits;
  * Search for all (approximate) vectors above a similarity threshold using {@link
  * VectorSimilarityCollector}.
  *
+ * <p>This class is package-private by design; callers construct one of the concrete public
+ * subclasses ({@link FloatVectorSimilarityQuery} or {@link ByteVectorSimilarityQuery}), which
+ * inherit shared public API such as {@link #getSearchStrategy()}. This mirrors the visibility
+ * pattern of {@link AbstractKnnVectorQuery}.
+ *
  * @lucene.experimental
  */
 abstract class AbstractVectorSimilarityQuery extends Query {
-  // TODO enable supplying KnnSearchStrategy
+  /**
+   * Default search strategy used by similarity-threshold vector queries. Uses {@code
+   * filteredSearchThreshold == 0}, which preserves this query's own filter-handling logic by never
+   * delegating to HNSW's built-in filtered-search short-circuit.
+   */
   static final KnnSearchStrategy.Hnsw DEFAULT_STRATEGY = new KnnSearchStrategy.Hnsw(0);
 
   static final float DECAY_MAX_APPROXIMATION = 0f;
@@ -46,11 +55,13 @@ abstract class AbstractVectorSimilarityQuery extends Query {
   protected final float resultSimilarity;
   protected final float decay;
   protected final Query filter;
+  protected final KnnSearchStrategy searchStrategy;
 
   /**
    * Search for all (approximate) vectors above a similarity threshold using {@link
-   * VectorSimilarityCollector}. If a filter is applied, it traverses as many nodes as the cost of
-   * the filter, and then falls back to exact search if results are incomplete.
+   * VectorSimilarityCollector}, with the {@linkplain #DEFAULT_STRATEGY default search strategy}. If
+   * a filter is applied, it traverses as many nodes as the cost of the filter, and then falls back
+   * to exact search if results are incomplete.
    *
    * @param field a field that has been indexed as a vector field.
    * @param resultSimilarity similarity score for result collection.
@@ -58,6 +69,29 @@ abstract class AbstractVectorSimilarityQuery extends Query {
    * @param filter a filter applied before the vector search.
    */
   AbstractVectorSimilarityQuery(String field, float resultSimilarity, float decay, Query filter) {
+    this(field, resultSimilarity, decay, filter, DEFAULT_STRATEGY);
+  }
+
+  /**
+   * Search for all (approximate) vectors above a similarity threshold using {@link
+   * VectorSimilarityCollector}, with a caller-supplied {@link KnnSearchStrategy}. If a filter is
+   * applied, it traverses as many nodes as the cost of the filter, and then falls back to exact
+   * search if results are incomplete.
+   *
+   * @param field a field that has been indexed as a vector field.
+   * @param resultSimilarity similarity score for result collection.
+   * @param decay decay factor for graph traversal buffer.
+   * @param filter a filter applied before the vector search.
+   * @param searchStrategy the {@link KnnSearchStrategy} to use during graph search. If {@code
+   *     null}, the {@linkplain #DEFAULT_STRATEGY default strategy} is used. The underlying format
+   *     may not support all strategies and is free to ignore the requested strategy.
+   */
+  AbstractVectorSimilarityQuery(
+      String field,
+      float resultSimilarity,
+      float decay,
+      Query filter,
+      KnnSearchStrategy searchStrategy) {
     if (Float.isNaN(resultSimilarity)) {
       throw new IllegalArgumentException(
           "resultSimilarity must have a valid value; got " + resultSimilarity);
@@ -75,10 +109,28 @@ abstract class AbstractVectorSimilarityQuery extends Query {
     this.resultSimilarity = resultSimilarity;
     this.decay = decay;
     this.filter = filter;
+    this.searchStrategy = searchStrategy == null ? DEFAULT_STRATEGY : searchStrategy;
   }
 
+  /**
+   * Returns a {@link KnnCollectorManager} that always builds a {@link VectorSimilarityCollector}
+   * configured with this query's {@link #searchStrategy}.
+   *
+   * <p>The manager's {@code strategy} and {@code LeafReaderContext} parameters are intentionally
+   * ignored: top-k queries may override the strategy on a per-search basis, but similarity-
+   * threshold queries pin the strategy to the query's own value at construction time so that {@link
+   * #equals} / {@link #getSearchStrategy()} remain a faithful description of search behavior.
+   */
   protected KnnCollectorManager getKnnCollectorManager() {
-    return (visitLimit, _, _) -> new VectorSimilarityCollector(resultSimilarity, decay, visitLimit);
+    return (visitLimit, _, _) ->
+        new VectorSimilarityCollector(resultSimilarity, decay, visitLimit, searchStrategy);
+  }
+
+  /**
+   * @return the {@link KnnSearchStrategy} used during graph search.
+   */
+  public KnnSearchStrategy getSearchStrategy() {
+    return searchStrategy;
   }
 
   abstract VectorScorer createVectorScorer(LeafReaderContext context) throws IOException;
@@ -218,12 +270,13 @@ abstract class AbstractVectorSimilarityQuery extends Query {
         && Float.compare(((AbstractVectorSimilarityQuery) o).resultSimilarity, resultSimilarity)
             == 0
         && Float.compare(((AbstractVectorSimilarityQuery) o).decay, decay) == 0
-        && Objects.equals(filter, ((AbstractVectorSimilarityQuery) o).filter);
+        && Objects.equals(filter, ((AbstractVectorSimilarityQuery) o).filter)
+        && Objects.equals(searchStrategy, ((AbstractVectorSimilarityQuery) o).searchStrategy);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(field, resultSimilarity, decay, filter);
+    return Objects.hash(field, resultSimilarity, decay, filter, searchStrategy);
   }
 
   private static class VectorSimilarityScorerSupplier extends ScorerSupplier {

--- a/lucene/core/src/java/org/apache/lucene/search/ByteVectorSimilarityQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ByteVectorSimilarityQuery.java
@@ -24,6 +24,8 @@ import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.knn.KnnCollectorManager;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
+import org.apache.lucene.search.knn.KnnSearchStrategy.Hnsw;
 
 /**
  * Search for all (approximate) byte vectors above a similarity threshold.
@@ -35,8 +37,37 @@ public class ByteVectorSimilarityQuery extends AbstractVectorSimilarityQuery {
 
   /**
    * Search for all (approximate) byte vectors above a similarity threshold using {@link
-   * VectorSimilarityCollector}. If a filter is applied, it traverses as many nodes as the cost of
-   * the filter, and then falls back to exact search if results are incomplete.
+   * VectorSimilarityCollector}, with a caller-supplied {@link KnnSearchStrategy}. If a filter is
+   * applied, it traverses as many nodes as the cost of the filter, and then falls back to exact
+   * search if results are incomplete.
+   *
+   * @param field a field that has been indexed as a {@link KnnByteVectorField}.
+   * @param target the target of the search.
+   * @param resultSimilarity similarity score for result collection.
+   * @param decay decay factor for graph traversal buffer.
+   * @param filter a filter applied before the vector search.
+   * @param searchStrategy the {@link KnnSearchStrategy} to use during graph search. If {@code
+   *     null}, this query's own default is used: an {@link Hnsw} with {@code
+   *     filteredSearchThreshold == 0}, which preserves this query's filter handling. Note this
+   *     differs from {@link Hnsw#DEFAULT}, which uses a threshold of 60. The underlying format may
+   *     not support all strategies and is free to ignore the requested strategy.
+   */
+  public ByteVectorSimilarityQuery(
+      String field,
+      byte[] target,
+      float resultSimilarity,
+      float decay,
+      Query filter,
+      KnnSearchStrategy searchStrategy) {
+    super(field, resultSimilarity, decay, filter, searchStrategy);
+    this.target = Objects.requireNonNull(target, "target");
+  }
+
+  /**
+   * Search for all (approximate) byte vectors above a similarity threshold using {@link
+   * VectorSimilarityCollector}, with the default {@link KnnSearchStrategy}. If a filter is applied,
+   * it traverses as many nodes as the cost of the filter, and then falls back to exact search if
+   * results are incomplete.
    *
    * @param field a field that has been indexed as a {@link KnnByteVectorField}.
    * @param target the target of the search.
@@ -46,8 +77,7 @@ public class ByteVectorSimilarityQuery extends AbstractVectorSimilarityQuery {
    */
   public ByteVectorSimilarityQuery(
       String field, byte[] target, float resultSimilarity, float decay, Query filter) {
-    super(field, resultSimilarity, decay, filter);
-    this.target = Objects.requireNonNull(target, "target");
+    this(field, target, resultSimilarity, decay, filter, DEFAULT_STRATEGY);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/FloatVectorSimilarityQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FloatVectorSimilarityQuery.java
@@ -24,6 +24,8 @@ import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.knn.KnnCollectorManager;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
+import org.apache.lucene.search.knn.KnnSearchStrategy.Hnsw;
 import org.apache.lucene.util.VectorUtil;
 
 /**
@@ -36,8 +38,37 @@ public class FloatVectorSimilarityQuery extends AbstractVectorSimilarityQuery {
 
   /**
    * Search for all (approximate) float vectors above a similarity threshold using {@link
-   * VectorSimilarityCollector}. If a filter is applied, it traverses as many nodes as the cost of
-   * the filter, and then falls back to exact search if results are incomplete.
+   * VectorSimilarityCollector}, with a caller-supplied {@link KnnSearchStrategy}. If a filter is
+   * applied, it traverses as many nodes as the cost of the filter, and then falls back to exact
+   * search if results are incomplete.
+   *
+   * @param field a field that has been indexed as a {@link KnnFloatVectorField}.
+   * @param target the target of the search.
+   * @param resultSimilarity similarity score for result collection.
+   * @param decay decay factor for graph traversal buffer.
+   * @param filter a filter applied before the vector search.
+   * @param searchStrategy the {@link KnnSearchStrategy} to use during graph search. If {@code
+   *     null}, this query's own default is used: an {@link Hnsw} with {@code
+   *     filteredSearchThreshold == 0}, which preserves this query's filter handling. Note this
+   *     differs from {@link Hnsw#DEFAULT}, which uses a threshold of 60. The underlying format may
+   *     not support all strategies and is free to ignore the requested strategy.
+   */
+  public FloatVectorSimilarityQuery(
+      String field,
+      float[] target,
+      float resultSimilarity,
+      float decay,
+      Query filter,
+      KnnSearchStrategy searchStrategy) {
+    super(field, resultSimilarity, decay, filter, searchStrategy);
+    this.target = VectorUtil.checkFinite(Objects.requireNonNull(target, "target"));
+  }
+
+  /**
+   * Search for all (approximate) float vectors above a similarity threshold using {@link
+   * VectorSimilarityCollector}, with the default {@link KnnSearchStrategy}. If a filter is applied,
+   * it traverses as many nodes as the cost of the filter, and then falls back to exact search if
+   * results are incomplete.
    *
    * @param field a field that has been indexed as a {@link KnnFloatVectorField}.
    * @param target the target of the search.
@@ -47,8 +78,7 @@ public class FloatVectorSimilarityQuery extends AbstractVectorSimilarityQuery {
    */
   public FloatVectorSimilarityQuery(
       String field, float[] target, float resultSimilarity, float decay, Query filter) {
-    super(field, resultSimilarity, decay, filter);
-    this.target = VectorUtil.checkFinite(Objects.requireNonNull(target, "target"));
+    this(field, target, resultSimilarity, decay, filter, DEFAULT_STRATEGY);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/VectorSimilarityCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/VectorSimilarityCollector.java
@@ -21,6 +21,7 @@ import static org.apache.lucene.search.AbstractVectorSimilarityQuery.DECAY_MAX_Q
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
 
 /**
  * Perform a similarity-based graph search to find all (approximate) vectors above a similarity
@@ -49,15 +50,33 @@ class VectorSimilarityCollector extends AbstractKnnCollector {
   private float minCompetitiveSimilarity;
 
   /**
-   * Perform a similarity-based graph search.
+   * Perform a similarity-based graph search, using the default {@link KnnSearchStrategy} of
+   * {@linkplain AbstractVectorSimilarityQuery#DEFAULT_STRATEGY similarity-threshold queries}.
    *
    * @param resultSimilarity similarity score for result collection.
    * @param decay decay factor for graph traversal buffer.
    * @param visitLimit limit on number of nodes to visit.
    */
   public VectorSimilarityCollector(float resultSimilarity, float decay, long visitLimit) {
-    // TODO: enable supplying KnnSearchStrategy
-    super(1, visitLimit, AbstractVectorSimilarityQuery.DEFAULT_STRATEGY);
+    this(resultSimilarity, decay, visitLimit, AbstractVectorSimilarityQuery.DEFAULT_STRATEGY);
+  }
+
+  /**
+   * Perform a similarity-based graph search, using a caller-supplied {@link KnnSearchStrategy}.
+   *
+   * @param resultSimilarity similarity score for result collection.
+   * @param decay decay factor for graph traversal buffer.
+   * @param visitLimit limit on number of nodes to visit.
+   * @param searchStrategy the {@link KnnSearchStrategy} to use during graph search. If {@code
+   *     null}, the {@linkplain AbstractVectorSimilarityQuery#DEFAULT_STRATEGY default strategy} is
+   *     used.
+   */
+  public VectorSimilarityCollector(
+      float resultSimilarity, float decay, long visitLimit, KnnSearchStrategy searchStrategy) {
+    super(
+        1,
+        visitLimit,
+        searchStrategy == null ? AbstractVectorSimilarityQuery.DEFAULT_STRATEGY : searchStrategy);
 
     assert Float.isNaN(resultSimilarity) == false
         : "resultSimilarity must have a valid value; got " + resultSimilarity;

--- a/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseVectorSimilarityQueryTestCase.java
@@ -48,6 +48,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.QueryTimeout;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
@@ -72,6 +73,14 @@ abstract class BaseVectorSimilarityQueryTestCase<
 
   abstract Q getVectorQuery(
       String field, V vector, float resultSimilarity, float decay, Query filter);
+
+  abstract Q getVectorQuery(
+      String field,
+      V vector,
+      float resultSimilarity,
+      float decay,
+      Query filter,
+      KnnSearchStrategy searchStrategy);
 
   abstract Q getThrowingVectorQuery(
       String field, V vector, float resultSimilarity, float decay, Query filter);
@@ -113,6 +122,80 @@ abstract class BaseVectorSimilarityQueryTestCase<
 
     // Different filter
     assertNotEquals(query, getVectorQuery(field1, vector1, resultSimilarity1, decay1, filter2));
+  }
+
+  public void testEqualsWithSearchStrategy() {
+    String field = "f";
+    V vector = getRandomVector(dim);
+    float resultSimilarity = 0.4f;
+    float decay = 0.5f;
+    Query filter = new TermQuery(new Term("t", "v"));
+
+    KnnSearchStrategy strategyA = new KnnSearchStrategy.Hnsw(10);
+    KnnSearchStrategy strategyB = new KnnSearchStrategy.Hnsw(20);
+
+    Q queryA = getVectorQuery(field, vector, resultSimilarity, decay, filter, strategyA);
+    Q queryB = getVectorQuery(field, vector, resultSimilarity, decay, filter, strategyB);
+    Q queryADup = getVectorQuery(field, vector, resultSimilarity, decay, filter, strategyA);
+
+    // Queries with the same non-default strategy are equal.
+    assertEquals(queryA, queryADup);
+    assertEquals(queryA.hashCode(), queryADup.hashCode());
+
+    // Queries that differ only in strategy are not equal.
+    assertNotEquals(queryA, queryB);
+
+    // Query with default strategy is not equal to one with non-default strategy.
+    Q queryDefault = getVectorQuery(field, vector, resultSimilarity, decay, filter);
+    assertNotEquals(queryDefault, queryA);
+  }
+
+  public void testGetSearchStrategy() {
+    String field = "f";
+    V vector = getRandomVector(dim);
+    KnnSearchStrategy strategy = new KnnSearchStrategy.Hnsw(42);
+
+    // Default strategy is exposed via getter.
+    AbstractVectorSimilarityQuery defaultQuery = getVectorQuery(field, vector, 0.4f, 0.5f, null);
+    assertEquals(AbstractVectorSimilarityQuery.DEFAULT_STRATEGY, defaultQuery.getSearchStrategy());
+
+    // Custom strategy is propagated through to the getter.
+    AbstractVectorSimilarityQuery customQuery =
+        getVectorQuery(field, vector, 0.4f, 0.5f, null, strategy);
+    assertSame(strategy, customQuery.getSearchStrategy());
+  }
+
+  public void testNullSearchStrategyDefaultsToDefault() {
+    String field = "f";
+    V vector = getRandomVector(dim);
+    Q query = getVectorQuery(field, vector, 0.4f, 0.5f, null, /* searchStrategy= */ null);
+    assertSame(AbstractVectorSimilarityQuery.DEFAULT_STRATEGY, query.getSearchStrategy());
+  }
+
+  /**
+   * Verify that the {@link KnnSearchStrategy} supplied to the query is propagated through the
+   * {@code KnnCollectorManager} into the {@link VectorSimilarityCollector} that performs the
+   * search. This is a contract-level check on the query → manager → collector wiring and does not
+   * depend on which callbacks the underlying graph search happens to invoke. The manager produced
+   * by {@code AbstractVectorSimilarityQuery#getKnnCollectorManager()} ignores its strategy and
+   * {@code LeafReaderContext} arguments (it pins the strategy to the query's own at construction
+   * time), so this test does not need a real index.
+   */
+  public void testSearchStrategyReachesCollector() throws IOException {
+    KnnSearchStrategy strategy = new KnnSearchStrategy.Hnsw(7);
+    Q query =
+        getVectorQuery(
+            "field",
+            getRandomVector(dim),
+            /* resultSimilarity= */ 0.5f,
+            /* decay= */ 0.5f,
+            /* filter= */ null,
+            strategy);
+
+    KnnCollector collector =
+        query.getKnnCollectorManager().newCollector(Integer.MAX_VALUE, null, null);
+
+    assertSame(strategy, collector.getSearchStrategy());
   }
 
   public void testIllegalParams() {

--- a/lucene/core/src/test/org/apache/lucene/search/TestByteVectorSimilarityQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestByteVectorSimilarityQuery.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.util.TestVectorUtil;
 import org.junit.Before;
 
@@ -60,6 +61,18 @@ public class TestByteVectorSimilarityQuery
   ByteVectorSimilarityQuery getVectorQuery(
       String field, byte[] vector, float resultSimilarity, float decay, Query filter) {
     return new ByteVectorSimilarityQuery(field, vector, resultSimilarity, decay, filter);
+  }
+
+  @Override
+  ByteVectorSimilarityQuery getVectorQuery(
+      String field,
+      byte[] vector,
+      float resultSimilarity,
+      float decay,
+      Query filter,
+      KnnSearchStrategy searchStrategy) {
+    return new ByteVectorSimilarityQuery(
+        field, vector, resultSimilarity, decay, filter, searchStrategy);
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestFloatVectorSimilarityQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFloatVectorSimilarityQuery.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.util.TestVectorUtil;
 import org.junit.Before;
 
@@ -61,6 +62,18 @@ public class TestFloatVectorSimilarityQuery
   FloatVectorSimilarityQuery getVectorQuery(
       String field, float[] vector, float resultSimilarity, float decay, Query filter) {
     return new FloatVectorSimilarityQuery(field, vector, resultSimilarity, decay, filter);
+  }
+
+  @Override
+  FloatVectorSimilarityQuery getVectorQuery(
+      String field,
+      float[] vector,
+      float resultSimilarity,
+      float decay,
+      Query filter,
+      KnnSearchStrategy searchStrategy) {
+    return new FloatVectorSimilarityQuery(
+        field, vector, resultSimilarity, decay, filter, searchStrategy);
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestVectorSimilarityCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestVectorSimilarityCollector.java
@@ -17,7 +17,9 @@
 package org.apache.lucene.search;
 
 import static org.apache.lucene.search.AbstractVectorSimilarityQuery.DEFAULT_DECAY;
+import static org.apache.lucene.search.AbstractVectorSimilarityQuery.DEFAULT_STRATEGY;
 
+import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestVectorSimilarityCollector extends LuceneTestCase {
@@ -45,5 +47,24 @@ public class TestVectorSimilarityCollector extends LuceneTestCase {
     // All nodes above resultSimilarity appear in order of collection
     assertArrayEquals(new int[] {4, 3, 2, 7, 9}, resultNodes);
     assertArrayEquals(new float[] {0.5f, 0.6f, 0.9f, 0.7f, 0.8f}, resultScores, 1e-3f);
+  }
+
+  public void testDefaultConstructorUsesDefaultStrategy() {
+    VectorSimilarityCollector collector =
+        new VectorSimilarityCollector(0.5f, DEFAULT_DECAY, Integer.MAX_VALUE);
+    assertEquals(DEFAULT_STRATEGY, collector.getSearchStrategy());
+  }
+
+  public void testCustomStrategyIsPropagated() {
+    KnnSearchStrategy strategy = new KnnSearchStrategy.Hnsw(42);
+    VectorSimilarityCollector collector =
+        new VectorSimilarityCollector(0.5f, DEFAULT_DECAY, Integer.MAX_VALUE, strategy);
+    assertSame(strategy, collector.getSearchStrategy());
+  }
+
+  public void testNullStrategyDefaultsToDefault() {
+    VectorSimilarityCollector collector =
+        new VectorSimilarityCollector(0.5f, DEFAULT_DECAY, Integer.MAX_VALUE, null);
+    assertSame(DEFAULT_STRATEGY, collector.getSearchStrategy());
   }
 }


### PR DESCRIPTION
Callers cannot use KnnSearchStrategy.Seeded or KnnSearchStrategy.Patience with similarity-threshold vector queries, even though they can with top-k vector queries. With this pr, we close that gap so the two query families have parity for strategy configuration.