### PR TITLE
Add count() to BayesianScoreQuery.BayesianScoreWeight

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -154,6 +154,9 @@ Optimizations
 
 * GITHUB#15597, GITHUB#15777: Reduce memory usage of NeighborArray (Viliam Durina)
 
+* GITHUB#16110: Add count() to BayesianScoreQuery.BayesianScoreWeight, delegating to
+  the inner weight. (Prithvi S)
+
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -154,9 +154,6 @@ Optimizations
 
 * GITHUB#15597, GITHUB#15777: Reduce memory usage of NeighborArray (Viliam Durina)
 
-* GITHUB#16110: Add count() to BayesianScoreQuery.BayesianScoreWeight, delegating to
-  the inner weight. (Prithvi S)
-
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
@@ -318,6 +315,9 @@ New Features
 
 * GITHUB#15794: Add DocValuesSkipper metadata for the maximum number of values
   on any document in a field. (Prithvi S)
+
+* GITHUB#16110: Add count() to BayesianScoreQuery.BayesianScoreWeight, delegating to
+  the inner weight. (Prithvi S)
 
 Improvements
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/BayesianScoreQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BayesianScoreQuery.java
@@ -190,6 +190,11 @@ public final class BayesianScoreQuery extends Query {
     }
 
     @Override
+    public int count(LeafReaderContext context) throws IOException {
+      return innerWeight.count(context);
+    }
+
+    @Override
     public boolean isCacheable(LeafReaderContext ctx) {
       return innerWeight.isCacheable(ctx);
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestBayesianScoreQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBayesianScoreQuery.java
@@ -235,6 +235,36 @@ public class TestBayesianScoreQuery extends LuceneTestCase {
     assertTrue("should contain alpha", s.contains("alpha"));
   }
 
+  public void testCountDelegatesToInner() throws Exception {
+    Query inner = new TermQuery(new Term("body", "alpha"));
+    BayesianScoreQuery bsq = new BayesianScoreQuery(inner, 0.5f, 5.0f);
+
+    Weight w = searcher.createWeight(searcher.rewrite(bsq), ScoreMode.COMPLETE, 1);
+    LeafReaderContext context = searcher.getIndexReader().leaves().get(0);
+
+    // BayesianScoreQuery only transforms scores; matching docs are unchanged.
+    // count() should delegate to the inner weight.
+    int count = w.count(context);
+    assertEquals(2, count);
+
+    // Verify it matches the inner query's count
+    Weight innerW = searcher.createWeight(inner, ScoreMode.COMPLETE, 1);
+    assertEquals(innerW.count(context), count);
+  }
+
+  public void testCountWithNoScoring() throws Exception {
+    // When scoreMode.needsScores() == false, createWeight returns innerWeight directly
+    Query inner = new TermQuery(new Term("body", "alpha"));
+    BayesianScoreQuery bsq = new BayesianScoreQuery(inner, 0.5f, 5.0f);
+
+    Weight w = searcher.createWeight(searcher.rewrite(bsq), ScoreMode.COMPLETE_NO_SCORES, 1);
+    LeafReaderContext context = searcher.getIndexReader().leaves().get(0);
+
+    // Should delegate to inner weight's count
+    int count = w.count(context);
+    assertEquals(2, count);
+  }
+
   public void testDifferentAlphaBeta() throws Exception {
     Query inner = new TermQuery(new Term("body", "alpha"));
 


### PR DESCRIPTION
enables IndexSearcher.count() and other count-optimized paths to work efficiently with BayesianScoreQuery