### PR TITLE
docs(util): clarify `Accountable.ramBytesUsed()` ownership semantics

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -473,6 +473,10 @@ Bug Fixes
 
 Other
 ---------------------
+* GITHUB#16114: Clarify Accountable.ramBytesUsed() ownership semantics. The javadoc now
+  recommends reporting only memory the object owns and notes that getChildResources() is
+  a diagnostic accessor, not a deduplicated ownership tree. (Salvatore Campagna)
+
 * GITHUB#15586: Document that scoring and ranking may change across major Lucene versions, and that applications requiring stable ranking should explicitly configure Similarity. (Parveen Saini)
 
 * GITHUB#15764: Added simpler TestTesselator test in support of fix GITHUB#15731. (Craig Taverner)

--- a/lucene/core/src/java/org/apache/lucene/util/Accountable.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Accountable.java
@@ -36,12 +36,26 @@ public interface Accountable {
    * "ram" for historical reasons; only JVM heap memory should be reported. Off-heap resources such
    * as memory-mapped files or native direct buffers should not be included. Negative values are
    * illegal.
+   *
+   * <p>Implementations are encouraged to follow an ownership-oriented convention: report memory
+   * allocated for this object's lifetime, or released by its {@code close()} method if applicable.
+   * Inputs received via constructors or factories may be borrowed, wrapped, sliced, or copied;
+   * implementations should report only the bytes they actually own, not the deep content of
+   * referenced storage they do not own. The reference itself (the pointer slot for a borrowed
+   * field) is part of this object's own layout and is naturally accounted via shallow size; what
+   * should not be added is the deep content of the referenced storage. Reporting the deep content
+   * of borrowed storage can lead to double counting when consumers sum across multiple Accountable
+   * instances that share state.
    */
   long ramBytesUsed();
 
   /**
    * Returns nested resources of this class. The result should be a point-in-time snapshot (to avoid
    * race conditions).
+   *
+   * <p>This method is a diagnostic accessor intended for inspection and printing. The returned
+   * collection is not a deduplicated ownership tree; it may include borrowed or shared references.
+   * Summing {@link #ramBytesUsed()} across its elements is not generally sum-safe.
    *
    * @see Accountables
    */


### PR DESCRIPTION
## TL;DR

Documentation only PR. Clarifies the ownership convention for `Accountable.ramBytesUsed()` and notes that `getChildResources()` is a diagnostic accessor, not a deduplicated ownership tree. No behavior change.

## Summary

`Accountable.ramBytesUsed()` is currently documented as "an estimate of the bytes used by this object" without saying whether bytes from referenced objects are included. Implementations vary: some count everything reachable, others count only owned state. When external code sums `ramBytesUsed()` across multiple `Accountable` instances that share state, the same memory can be counted more than once.

This PR adds an ownership-oriented convention to the javadoc:

- Report memory allocated for the object's lifetime, or released by its `close()` if applicable.
- Inputs received via constructors or factories may be borrowed, wrapped, sliced, or copied. Report only the bytes actually owned, not the deep content of referenced storage that is not owned.
- The reference itself (the pointer slot for a borrowed field) is part of the holder's own object layout and is naturally accounted via shallow size.
- `getChildResources()` is diagnostic; summing `ramBytesUsed()` across its elements is not generally sum-safe.

The convention is already followed informally in parts of the codebase. This PR documents it so future implementers and reviewers have a clear contract to apply.

## Changes

- `Accountable.java`: extended javadoc on `ramBytesUsed()` with the ownership convention; extended javadoc on `getChildResources()` to note it is a diagnostic accessor and not sum-safe.

Refs apache/lucene#16113.
