### PR TITLE
Invert eligible BinaryColumns in the column pass

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -351,6 +351,8 @@ Improvements
 
 * GITHUB#16088: SearchGroup#merge now returns an empty collection instead of null when topGroups is empty. (Luca Cavanna)
 
+* GITHUB#16116: Invert eligible BinaryColumns in the column pass. (Tim Brooks)
+
 Optimizations
 ---------------------
 * GITHUB#15861: Optimise PhraseScorer by short circuiting non competitive documents in TOP_SCORES mode. (Prithvi S)

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -706,7 +706,14 @@ final class IndexingChain implements Accountable {
     boolean hasColumnInvert = false;
     long batchGen = nextFieldGen++;
 
-    // First pass: validate all column schemas and initialize field infos
+    // First pass: validate all column schemas, initialize field infos, and cache each column's
+    // PerField in the shared docFields scratch (slot i == i-th column from
+    // columnBatch.columns()). Later passes that iterate the same column list in the same order
+    // — column-invert dispatch, and (when no row pass runs) the column-oriented pass — can
+    // index into docFields instead of repeating the hash lookup. The row pass overwrites
+    // docFields with its own compressed layout, so this cache is only useful when row pass
+    // doesn't run; that's mutually exclusive with column-invert dispatch.
+    int columnIdx = 0;
     for (Column column : columnBatch.columns()) {
       final String fieldName = column.name();
       final IndexableFieldType fieldType = column.fieldType();
@@ -739,6 +746,10 @@ final class IndexingChain implements Accountable {
                 + "\"; multi-valued fields must use a single column with a sparse cursor");
       }
       pf.fieldGen = batchGen;
+      if (columnIdx >= docFields.length) {
+        oversizeDocFields();
+      }
+      docFields[columnIdx++] = pf;
       validateColumnSchema(fieldName, pf, fieldType);
     }
 
@@ -762,23 +773,28 @@ final class IndexingChain implements Accountable {
       // row pass so all indexed fields share a single per-doc termsHash.startDocument() frame.
       processRowColumns(baseDocID, numDocs, columnBatch.columns());
     } else if (hasColumnInvert) {
+      int idx = 0;
       for (Column column : columnBatch.columns()) {
         if (column instanceof BinaryColumn bc && isColumnInvertEligible(bc)) {
-          processBinaryColumnInvert(baseDocID, numDocs, bc, getOrAddPerField(column.name()));
+          processBinaryColumnInvert(baseDocID, numDocs, bc, docFields[idx]);
         }
+        idx++;
       }
     }
 
     // Column-oriented pass: doc values, points, and vectors. Each column is asked for a fresh
-    // cursor.
+    // cursor. PerFields are sourced from the validation-pass cache in docFields[]; the row pass
+    // no longer overwrites that array, so indexing by original column position is safe here too.
+    int colOrientedIdx = 0;
     for (Column column : columnBatch.columns()) {
       final IndexableFieldType fieldType = column.fieldType();
       if (fieldType.docValuesType() == DocValuesType.NONE
           && fieldType.pointDimensionCount() == 0
           && fieldType.vectorDimension() == 0) {
+        colOrientedIdx++;
         continue; // no column-oriented features
       }
-      PerField pf = getOrAddPerField(column.name());
+      PerField pf = docFields[colOrientedIdx++];
 
       switch (column) {
         case LongColumn longCol -> processLongColumn(baseDocID, numDocs, longCol, pf, fieldType);
@@ -807,30 +823,32 @@ final class IndexingChain implements Accountable {
    */
   private void processRowColumns(int baseDocID, int numDocs, Iterable<Column> columns)
       throws IOException {
-    // Collect row-oriented columns. Per-field PerFields are cached in the shared docFields array
-    // (also used by processDocument) to avoid a per-batch allocation; adapters and cursor heads
-    // are local since they're column-specific.
+    // Collect row-oriented columns. PerFields are sourced from processBatch's validation-pass
+    // cache in docFields[] (indexed by original column position) and copied into the local
+    // rowPfs[] in compressed row-mode-only layout for the tight inner loop. docFields[] itself
+    // is not overwritten so the post-row-pass column-oriented pass can still index into it.
     int numRowCols = 0;
     ColumnFieldAdapter[] adapters = new ColumnFieldAdapter[4];
     int[] heads = new int[4];
+    PerField[] rowPfs = new PerField[4];
     boolean hasInverted = false;
     boolean hasStored = false;
 
+    int originalIdx = 0;
     for (Column column : columns) {
       IndexableFieldType fieldType = column.fieldType();
       if (fieldType.stored() == false && fieldType.indexOptions() == IndexOptions.NONE) {
+        originalIdx++;
         continue;
       }
       if (numRowCols >= adapters.length) {
         adapters = ArrayUtil.grow(adapters, numRowCols + 1);
         heads = ArrayUtil.grow(heads, numRowCols + 1);
-      }
-      if (numRowCols >= docFields.length) {
-        oversizeDocFields();
+        rowPfs = ArrayUtil.grow(rowPfs, numRowCols + 1);
       }
       ColumnFieldAdapter adapter = ColumnFieldAdapter.create(column);
       adapters[numRowCols] = adapter;
-      docFields[numRowCols] = getOrAddPerField(column.name());
+      rowPfs[numRowCols] = docFields[originalIdx];
       heads[numRowCols] = adapter.nextDoc();
       if (fieldType.indexOptions() != IndexOptions.NONE) {
         hasInverted = true;
@@ -839,6 +857,7 @@ final class IndexingChain implements Accountable {
         hasStored = true;
       }
       numRowCols++;
+      originalIdx++;
     }
 
     // Row-dense outer loop: frame every doc in [0, numDocs). Column cursors stay sparse, but the
@@ -866,7 +885,7 @@ final class IndexingChain implements Accountable {
                     + head);
           }
           while (head == batchDocID) {
-            PerField pf = docFields[i];
+            PerField pf = rowPfs[i];
             if (pf.fieldGen != fieldGen) {
               pf.fieldGen = fieldGen;
               pf.reset(segDocID, adapters[i].fieldType());
@@ -934,11 +953,21 @@ final class IndexingChain implements Accountable {
   /**
    * Column-pass inversion for a single {@link BinaryColumn} that qualifies via {@link
    * #isColumnInvertEligible}. Each eligible column is processed independently; the cursor is
-   * traversed sparsely — only docs with values get {@code termsHash.startDocument()}/{@code
-   * finishDocument()} framing. This is safe because eligibility excludes term vectors, so the TV
-   * consumer is always a no-op for each framing call. Only invoked when {@code hasRowColumns} is
-   * false; when any row-mode column is present the eligible columns are demoted to the row pass
-   * instead.
+   * traversed sparsely — only docs with values are visited.
+   *
+   * <p>Crucially, this method does <b>not</b> call {@code termsHash.startDocument()} or {@code
+   * termsHash.finishDocument(docID)}. Those calls exist solely to drive the {@link
+   * TermVectorsConsumer}, whose {@code lastDocID} is segment-scoped: calling {@code finishDocument}
+   * advances {@code lastDocID} (writing an empty TV slot when {@code hasVectors} is true). Driving
+   * that from here is unsafe — multiple eligible columns in a single batch would frame each batch
+   * doc more than once, breaking {@code TermVectorsConsumer.lastDocID}'s monotonicity invariant.
+   * Eligibility guarantees {@code doVectors=false} at the per-field level inside {@link
+   * TermVectorsConsumerPerField}, so {@code pf.invert} and {@code pf.finish} never touch TV state
+   * directly; any unframed docs (whether the column is sparse or absent) are reconciled by {@code
+   * TermVectorsConsumer.fill()} at the next row-pass framed doc or at segment flush.
+   *
+   * <p>Only invoked when {@code hasRowColumns} is false; when any row-mode column is present the
+   * eligible columns are demoted to the row pass so {@code termsHash} framing is shared.
    */
   private void processBinaryColumnInvert(
       int baseDocID, int numDocs, BinaryColumn column, PerField pf) throws IOException {
@@ -950,10 +979,7 @@ final class IndexingChain implements Accountable {
       int batchDocID = head;
       if (batchDocID < prevBatchDocID) {
         throw new IllegalArgumentException(
-            "Column \""
-                + column.name()
-                + "\" returned out-of-order batch doc-id "
-                + batchDocID);
+            "Column \"" + column.name() + "\" returned out-of-order batch doc-id " + batchDocID);
       }
       if (batchDocID >= numDocs) {
         throw new IllegalArgumentException(
@@ -971,21 +997,29 @@ final class IndexingChain implements Accountable {
       pf.fieldGen = nextFieldGen++;
       pf.reset(segDocID, adapter.fieldType());
 
-      termsHash.startDocument();
+      // Mirrors processDocument's fields[]/indexedFieldCount gate: pf.finish runs only if the
+      // first pf.invert (which initializes FieldInvertState) returned normally. If a non-aborting
+      // exception (e.g. immense term, duplicate termdoc, too many tokens) escapes the first
+      // invert, the document is rejected and pf.finish must be skipped — same as processDocument
+      // skips fields[i].finish when processField never landed pf in the array. If a subsequent
+      // multi-value invert throws after the first succeeded, pf.finish still runs (parallels
+      // processDocument calling finish on a pf already in fields[]).
+      boolean invertSucceeded = false;
       try {
-        do {
-          invertAndStore(segDocID, adapter, pf);
+        // Eligibility excludes stored fields and requires DOCS/DOCS_AND_FREQS, so we bypass
+        // invertAndStore (which also handles stored fields and re-checks indexOptions) and call
+        // pf.invert directly. The first value in the doc passes first=true to initialize the
+        // FieldInvertState; subsequent same-doc values (multi-value) pass first=false.
+        pf.invert(segDocID, adapter, true);
+        invertSucceeded = true;
+        head = adapter.nextDoc();
+        while (head == batchDocID) {
+          pf.invert(segDocID, adapter, false);
           head = adapter.nextDoc();
-        } while (head == batchDocID);
+        }
       } finally {
-        if (hasHitAbortingException == false) {
+        if (hasHitAbortingException == false && invertSucceeded) {
           pf.finish(segDocID);
-          try {
-            termsHash.finishDocument(segDocID);
-          } catch (Throwable th) {
-            abortingExceptionConsumer.accept(th);
-            throw th;
-          }
         }
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -705,13 +705,7 @@ final class IndexingChain implements Accountable {
     boolean hasRowColumns = false;
     boolean hasColumnInvert = false;
 
-    // First pass: validate all column schemas, initialize field infos, and cache each column's
-    // PerField in the shared docFields scratch (slot i == i-th column from
-    // columnBatch.columns()). Later passes that iterate the same column list in the same order
-    // — column-invert dispatch, and (when no row pass runs) the column-oriented pass — can
-    // index into docFields instead of repeating the hash lookup. The row pass overwrites
-    // docFields with its own compressed layout, so this cache is only useful when row pass
-    // doesn't run; that's mutually exclusive with column-invert dispatch.
+    // First pass: validate all column schemas and initialize field infos
     int columnIdx = 0;
     for (Column column : columnBatch.columns()) {
       final String fieldName = column.name();
@@ -775,8 +769,7 @@ final class IndexingChain implements Accountable {
     }
 
     // Column-oriented pass: doc values, points, and vectors. Each column is asked for a fresh
-    // cursor. PerFields are sourced from the validation-pass cache in docFields[]; the row pass
-    // no longer overwrites that array, so indexing by original column position is safe here too.
+    // cursor.
     int colOrientedIdx = 0;
     for (Column column : columnBatch.columns()) {
       final IndexableFieldType fieldType = column.fieldType();
@@ -816,13 +809,13 @@ final class IndexingChain implements Accountable {
   private void processRowColumns(int baseDocID, int numDocs, Iterable<Column> columns)
       throws IOException {
     // Collect row-oriented columns. PerFields are sourced from processBatch's validation-pass
-    // cache in docFields[] (indexed by original column position) and copied into the local
-    // rowPfs[] in compressed row-mode-only layout for the tight inner loop. docFields[] itself
-    // is not overwritten so the post-row-pass column-oriented pass can still index into it.
+    // cache in docFields[] (indexed by original column position); rowPfIndices[] stores the
+    // original index for each row-mode column so the inner loop can look up via
+    // docFields[rowPfIndices[i]].
     int numRowCols = 0;
     ColumnFieldAdapter[] adapters = new ColumnFieldAdapter[4];
     int[] heads = new int[4];
-    PerField[] rowPfs = new PerField[4];
+    int[] rowPfIndices = new int[4];
     boolean hasInverted = false;
     boolean hasStored = false;
 
@@ -836,11 +829,11 @@ final class IndexingChain implements Accountable {
       if (numRowCols >= adapters.length) {
         adapters = ArrayUtil.grow(adapters, numRowCols + 1);
         heads = ArrayUtil.grow(heads, numRowCols + 1);
-        rowPfs = ArrayUtil.grow(rowPfs, numRowCols + 1);
+        rowPfIndices = ArrayUtil.grow(rowPfIndices, numRowCols + 1);
       }
       ColumnFieldAdapter adapter = ColumnFieldAdapter.create(column);
       adapters[numRowCols] = adapter;
-      rowPfs[numRowCols] = docFields[originalIdx];
+      rowPfIndices[numRowCols] = originalIdx;
       heads[numRowCols] = adapter.nextDoc();
       if (fieldType.indexOptions() != IndexOptions.NONE) {
         hasInverted = true;
@@ -877,7 +870,7 @@ final class IndexingChain implements Accountable {
                     + head);
           }
           while (head == batchDocID) {
-            PerField pf = rowPfs[i];
+            PerField pf = docFields[rowPfIndices[i]];
             if (pf.fieldGen != fieldGen) {
               pf.fieldGen = fieldGen;
               pf.reset(segDocID, adapters[i].fieldType());
@@ -944,22 +937,12 @@ final class IndexingChain implements Accountable {
 
   /**
    * Column-pass inversion for a single {@link BinaryColumn} that qualifies via {@link
-   * #isColumnInvertEligible}. Each eligible column is processed independently; the cursor is
-   * traversed sparsely — only docs with values are visited.
-   *
-   * <p>Crucially, this method does <b>not</b> call {@code termsHash.startDocument()} or {@code
-   * termsHash.finishDocument(docID)}. Those calls exist solely to drive the {@link
-   * TermVectorsConsumer}, whose {@code lastDocID} is segment-scoped: calling {@code finishDocument}
-   * advances {@code lastDocID} (writing an empty TV slot when {@code hasVectors} is true). Driving
-   * that from here is unsafe — multiple eligible columns in a single batch would frame each batch
-   * doc more than once, breaking {@code TermVectorsConsumer.lastDocID}'s monotonicity invariant.
-   * Eligibility guarantees {@code doVectors=false} at the per-field level inside {@link
-   * TermVectorsConsumerPerField}, so {@code pf.invert} and {@code pf.finish} never touch TV state
-   * directly; any unframed docs (whether the column is sparse or absent) are reconciled by {@code
-   * TermVectorsConsumer.fill()} at the next row-pass framed doc or at segment flush.
-   *
-   * <p>Only invoked when {@code hasRowColumns} is false; when any row-mode column is present the
-   * eligible columns are demoted to the row pass so {@code termsHash} framing is shared.
+   * #isColumnInvertEligible}. Skips {@code termsHash.startDocument/finishDocument} — those calls
+   * advance {@link TermVectorsConsumer}'s segment-scoped {@code lastDocID}, and framing multiple
+   * columns per doc would break its monotonicity invariant. Eligibility guarantees {@code
+   * doVectors=false}, so TV state is never touched; unframed docs are reconciled by {@code
+   * TermVectorsConsumer.fill()} at the next row-pass doc or segment flush. Only invoked when no
+   * row-mode columns are present; otherwise eligible columns are demoted to the row pass.
    */
   private void processBinaryColumnInvert(
       int baseDocID, int numDocs, BinaryColumn column, PerField pf) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -703,6 +703,8 @@ final class IndexingChain implements Accountable {
   void processBatch(int baseDocID, ColumnBatch columnBatch) throws IOException {
     final int numDocs = columnBatch.numDocs();
     boolean hasRowColumns = false;
+    boolean hasColumnInvert = false;
+    long batchGen = nextFieldGen++;
 
     // First pass: validate all column schemas and initialize field infos
     for (Column column : columnBatch.columns()) {
@@ -719,7 +721,9 @@ final class IndexingChain implements Accountable {
         ColumnValidation.validateVectorColumn(vc, fieldType);
       }
 
-      if (fieldType.stored() || fieldType.indexOptions() != IndexOptions.NONE) {
+      if (column instanceof BinaryColumn bc && isColumnInvertEligible(bc)) {
+        hasColumnInvert = true;
+      } else if (fieldType.stored() || fieldType.indexOptions() != IndexOptions.NONE) {
         hasRowColumns = true;
       }
 
@@ -728,6 +732,13 @@ final class IndexingChain implements Accountable {
         throw new IllegalArgumentException(
             "\"" + fieldName + "\" is a reserved field and should not be added to any document");
       }
+      if (pf.fieldGen == batchGen) {
+        throw new IllegalArgumentException(
+            "ColumnBatch contains more than one column for field \""
+                + fieldName
+                + "\"; multi-valued fields must use a single column with a sparse cursor");
+      }
+      pf.fieldGen = batchGen;
       validateColumnSchema(fieldName, pf, fieldType);
     }
 
@@ -747,7 +758,15 @@ final class IndexingChain implements Accountable {
 
     // Row-oriented pass: stored fields and term inversion only. Uses fresh tuple cursors.
     if (hasRowColumns) {
+      // When a batch has any row-mode column, eligible column-invert columns are demoted to the
+      // row pass so all indexed fields share a single per-doc termsHash.startDocument() frame.
       processRowColumns(baseDocID, numDocs, columnBatch.columns());
+    } else if (hasColumnInvert) {
+      for (Column column : columnBatch.columns()) {
+        if (column instanceof BinaryColumn bc && isColumnInvertEligible(bc)) {
+          processBinaryColumnInvert(baseDocID, numDocs, bc, getOrAddPerField(column.name()));
+        }
+      }
     }
 
     // Column-oriented pass: doc values, points, and vectors. Each column is asked for a fresh
@@ -891,6 +910,83 @@ final class IndexingChain implements Accountable {
                 + " which is out of range [0, "
                 + numDocs
                 + ")");
+      }
+    }
+  }
+
+  /**
+   * Returns {@code true} if this {@link BinaryColumn} can be inverted entirely inside the
+   * column-oriented pass, without the row pass. Requirements: {@code DOCS} or {@code
+   * DOCS_AND_FREQS} index options, norms omitted, no term vectors, not stored.
+   */
+  private static boolean isColumnInvertEligible(BinaryColumn col) {
+    IndexableFieldType ft = col.fieldType();
+    if (ft.stored()) return false;
+    IndexOptions opts = ft.indexOptions();
+    if (opts != IndexOptions.DOCS && opts != IndexOptions.DOCS_AND_FREQS) return false;
+    if (!ft.omitNorms()) return false;
+    if (ft.storeTermVectors()) return false;
+    if (ft.storeTermVectorPositions()) return false;
+    if (ft.storeTermVectorOffsets()) return false;
+    return !ft.storeTermVectorPayloads();
+  }
+
+  /**
+   * Column-pass inversion for a single {@link BinaryColumn} that qualifies via {@link
+   * #isColumnInvertEligible}. Each eligible column is processed independently; the cursor is
+   * traversed sparsely — only docs with values get {@code termsHash.startDocument()}/{@code
+   * finishDocument()} framing. This is safe because eligibility excludes term vectors, so the TV
+   * consumer is always a no-op for each framing call. Only invoked when {@code hasRowColumns} is
+   * false; when any row-mode column is present the eligible columns are demoted to the row pass
+   * instead.
+   */
+  private void processBinaryColumnInvert(
+      int baseDocID, int numDocs, BinaryColumn column, PerField pf) throws IOException {
+    ColumnFieldAdapter adapter = ColumnFieldAdapter.create(column);
+    int head = adapter.nextDoc();
+    int prevBatchDocID = -1;
+
+    while (head != DocIdSetIterator.NO_MORE_DOCS) {
+      int batchDocID = head;
+      if (batchDocID < prevBatchDocID) {
+        throw new IllegalArgumentException(
+            "Column \""
+                + column.name()
+                + "\" returned out-of-order batch doc-id "
+                + batchDocID);
+      }
+      if (batchDocID >= numDocs) {
+        throw new IllegalArgumentException(
+            "Column \""
+                + column.name()
+                + "\" returned batch doc-id "
+                + batchDocID
+                + " which is out of range [0, "
+                + numDocs
+                + ")");
+      }
+      prevBatchDocID = batchDocID;
+
+      int segDocID = baseDocID + batchDocID;
+      pf.fieldGen = nextFieldGen++;
+      pf.reset(segDocID, adapter.fieldType());
+
+      termsHash.startDocument();
+      try {
+        do {
+          invertAndStore(segDocID, adapter, pf);
+          head = adapter.nextDoc();
+        } while (head == batchDocID);
+      } finally {
+        if (hasHitAbortingException == false) {
+          pf.finish(segDocID);
+          try {
+            termsHash.finishDocument(segDocID);
+          } catch (Throwable th) {
+            abortingExceptionConsumer.accept(th);
+            throw th;
+          }
+        }
       }
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -704,7 +704,6 @@ final class IndexingChain implements Accountable {
     final int numDocs = columnBatch.numDocs();
     boolean hasRowColumns = false;
     boolean hasColumnInvert = false;
-    long batchGen = nextFieldGen++;
 
     // First pass: validate all column schemas, initialize field infos, and cache each column's
     // PerField in the shared docFields scratch (slot i == i-th column from
@@ -739,13 +738,6 @@ final class IndexingChain implements Accountable {
         throw new IllegalArgumentException(
             "\"" + fieldName + "\" is a reserved field and should not be added to any document");
       }
-      if (pf.fieldGen == batchGen) {
-        throw new IllegalArgumentException(
-            "ColumnBatch contains more than one column for field \""
-                + fieldName
-                + "\"; multi-valued fields must use a single column with a sparse cursor");
-      }
-      pf.fieldGen = batchGen;
       if (columnIdx >= docFields.length) {
         oversizeDocFields();
       }

--- a/lucene/core/src/test/org/apache/lucene/document/column/TestColumnBatchBinaryColumn.java
+++ b/lucene/core/src/test/org/apache/lucene/document/column/TestColumnBatchBinaryColumn.java
@@ -38,11 +38,14 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TermQuery;
@@ -640,6 +643,156 @@ public class TestColumnBatchBinaryColumn extends LuceneTestCase {
     IndexSearcher searcher = new IndexSearcher(r);
     assertEquals(1, searcher.count(IntPoint.newExactQuery("field", 10)));
     assertEquals(3, searcher.count(IntPoint.newRangeQuery("field", 10, 30)));
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  // -------------------------------------------------------------------------
+  // Column-pass inversion tests (DOCS / DOCS_AND_FREQS, omitNorms, no TVs, not stored)
+  // -------------------------------------------------------------------------
+
+  private static FieldType columnInvertType(IndexOptions opts) {
+    FieldType t = new FieldType();
+    t.setIndexOptions(opts);
+    t.setOmitNorms(true);
+    t.setTokenized(false);
+    t.freeze();
+    return t;
+  }
+
+  public void testColumnInvertDocsOnly() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+
+    FieldType type = columnInvertType(IndexOptions.DOCS);
+    int[] docIds = {0, 1, 2};
+    BytesRef[] values = {newBytesRef("a"), newBytesRef("b"), newBytesRef("a")};
+    w.addBatch(simpleBatch(3, new ArrayBinaryColumn("tag", type, docIds, values)));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+    IndexSearcher s = new IndexSearcher(r);
+
+    assertEquals(2, s.count(new TermQuery(new Term("tag", "a"))));
+    assertEquals(1, s.count(new TermQuery(new Term("tag", "b"))));
+    assertNull("norms must be absent for omitNorms=true column", leaf.getNormValues("tag"));
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  public void testColumnInvertDocsOnlySparse() throws IOException {
+    // Only docs 0 and 4 of a 6-doc batch have a value.
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+
+    FieldType type = columnInvertType(IndexOptions.DOCS);
+    int[] docIds = {0, 4};
+    BytesRef[] values = {newBytesRef("x"), newBytesRef("x")};
+    w.addBatch(simpleBatch(6, new ArrayBinaryColumn("f", type, docIds, values)));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+    assertEquals(6, leaf.maxDoc());
+    assertEquals(2, new IndexSearcher(r).count(new TermQuery(new Term("f", "x"))));
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  public void testColumnInvertDocsAndFreqs() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+
+    FieldType type = columnInvertType(IndexOptions.DOCS_AND_FREQS);
+    // doc 0: "a" twice (multi-value), doc 1: "a" once, doc 2: "b" once
+    int[] docIds = {0, 0, 1, 2};
+    BytesRef[] values = {newBytesRef("a"), newBytesRef("a"), newBytesRef("a"), newBytesRef("b")};
+    w.addBatch(simpleBatch(3, new ArrayBinaryColumn("f", type, docIds, values)));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+
+    Terms terms = leaf.terms("f");
+    assertNotNull(terms);
+    TermsEnum te = terms.iterator();
+    assertTrue(te.seekExact(newBytesRef("a")));
+    // "a" appears in doc 0 and doc 1 → docFreq=2
+    assertEquals(2, te.docFreq());
+    // total term freq: doc 0 contributes 2, doc 1 contributes 1 → 3
+    assertEquals(3, te.totalTermFreq());
+
+    assertTrue(te.seekExact(newBytesRef("b")));
+    assertEquals(1, te.docFreq());
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  public void testColumnInvertTokenized() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriterConfig config = newIndexWriterConfig(new MockAnalyzer(random()));
+    IndexWriter w = new IndexWriter(dir, config);
+
+    FieldType type = new FieldType();
+    type.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+    type.setOmitNorms(true);
+    type.setTokenized(true);
+    type.freeze();
+
+    int[] docIds = {0, 1, 2};
+    BytesRef[] values = {
+      newBytesRef("quick brown fox"), newBytesRef("lazy brown dog"), newBytesRef("quick fox")
+    };
+    w.addBatch(simpleBatch(3, new ArrayBinaryColumn("text", type, docIds, values)));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    IndexSearcher s = new IndexSearcher(r);
+    assertEquals(2, s.count(new TermQuery(new Term("text", "quick"))));
+    assertEquals(2, s.count(new TermQuery(new Term("text", "brown"))));
+    assertEquals(2, s.count(new TermQuery(new Term("text", "fox"))));
+    assertEquals(1, s.count(new TermQuery(new Term("text", "lazy"))));
+    assertEquals(0, s.count(new TermQuery(new Term("text", "missing"))));
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  public void testColumnInvertWithDocValues() throws IOException {
+    // Eligible inverted column that ALSO has SORTED doc values — both passes run.
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+
+    FieldType type = new FieldType();
+    type.setIndexOptions(IndexOptions.DOCS);
+    type.setOmitNorms(true);
+    type.setTokenized(false);
+    type.setDocValuesType(DocValuesType.SORTED);
+    type.freeze();
+
+    int[] docIds = {0, 1, 2};
+    BytesRef[] values = {newBytesRef("x"), newBytesRef("y"), newBytesRef("x")};
+    w.addBatch(simpleBatch(3, new ArrayBinaryColumn("f", type, docIds, values)));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+
+    // Postings
+    assertEquals(2, new IndexSearcher(r).count(new TermQuery(new Term("f", "x"))));
+    assertEquals(1, new IndexSearcher(r).count(new TermQuery(new Term("f", "y"))));
+
+    // Doc values
+    SortedDocValues dv = leaf.getSortedDocValues("f");
+    for (int i = 0; i < 3; i++) {
+      assertEquals(i, dv.nextDoc());
+      assertEquals(values[i], dv.lookupOrd(dv.ordValue()));
+    }
 
     r.close();
     w.close();

--- a/lucene/core/src/test/org/apache/lucene/document/column/TestColumnBatchBinaryColumn.java
+++ b/lucene/core/src/test/org/apache/lucene/document/column/TestColumnBatchBinaryColumn.java
@@ -648,10 +648,6 @@ public class TestColumnBatchBinaryColumn extends LuceneTestCase {
     dir.close();
   }
 
-  // -------------------------------------------------------------------------
-  // Column-pass inversion tests (DOCS / DOCS_AND_FREQS, omitNorms, no TVs, not stored)
-  // -------------------------------------------------------------------------
-
   private static FieldType columnInvertType(IndexOptions opts) {
     FieldType t = new FieldType();
     t.setIndexOptions(opts);

--- a/lucene/core/src/test/org/apache/lucene/document/column/TestColumnBatchBinaryColumn.java
+++ b/lucene/core/src/test/org/apache/lucene/document/column/TestColumnBatchBinaryColumn.java
@@ -38,7 +38,6 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
@@ -793,6 +792,51 @@ public class TestColumnBatchBinaryColumn extends LuceneTestCase {
       assertEquals(i, dv.nextDoc());
       assertEquals(values[i], dv.lookupOrd(dv.ordValue()));
     }
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  public void testColumnInvertWithDocValuesAndPoints() throws IOException {
+    // Eligible inverted column that ALSO has SORTED DV and a 1-D int point. All three passes
+    // run on the same column: column-invert (postings), column-oriented DV writer, and points
+    // writer. Eligibility doesn't gate pointDimensionCount, so this combination is valid.
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+
+    FieldType type = new FieldType();
+    type.setIndexOptions(IndexOptions.DOCS);
+    type.setOmitNorms(true);
+    type.setTokenized(false);
+    type.setDocValuesType(DocValuesType.SORTED);
+    type.setDimensions(1, Integer.BYTES);
+    type.freeze();
+
+    int[] docIds = {0, 1, 2};
+    BytesRef[] values = {IntPoint.pack(10), IntPoint.pack(20), IntPoint.pack(30)};
+    w.addBatch(simpleBatch(3, new ArrayBinaryColumn("f", type, docIds, values)));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+    IndexSearcher searcher = new IndexSearcher(r);
+
+    // Postings (column-invert pass): each packed-int value is also a unique term.
+    assertEquals(1, searcher.count(new TermQuery(new Term("f", IntPoint.pack(10)))));
+    assertEquals(1, searcher.count(new TermQuery(new Term("f", IntPoint.pack(20)))));
+    assertEquals(0, searcher.count(new TermQuery(new Term("f", IntPoint.pack(99)))));
+
+    // DV (column-oriented pass).
+    SortedDocValues dv = leaf.getSortedDocValues("f");
+    for (int i = 0; i < 3; i++) {
+      assertEquals(i, dv.nextDoc());
+      assertEquals(values[i], dv.lookupOrd(dv.ordValue()));
+    }
+
+    // Points (column-oriented pass).
+    assertEquals(1, searcher.count(IntPoint.newExactQuery("f", 10)));
+    assertEquals(3, searcher.count(IntPoint.newRangeQuery("f", 10, 30)));
+    assertEquals(0, searcher.count(IntPoint.newRangeQuery("f", 31, 100)));
 
     r.close();
     w.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestColumnBatchIndexing.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestColumnBatchIndexing.java
@@ -1662,10 +1662,6 @@ public class TestColumnBatchIndexing extends LuceneTestCase {
     assertEquals(DocIdSetIterator.NO_MORE_DOCS, bIt.nextDoc());
   }
 
-  // -----------------------------------------------------------------------
-  // Column-pass inversion: mixed batches and row-mode fallback
-  // -----------------------------------------------------------------------
-
   private static FieldType eligibleInvertType() {
     FieldType t = new FieldType();
     t.setIndexOptions(IndexOptions.DOCS);

--- a/lucene/core/src/test/org/apache/lucene/index/TestColumnBatchIndexing.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestColumnBatchIndexing.java
@@ -1663,45 +1663,6 @@ public class TestColumnBatchIndexing extends LuceneTestCase {
   }
 
   // -----------------------------------------------------------------------
-  // Duplicate column name rejection
-  // -----------------------------------------------------------------------
-
-  public void testDuplicateColumnNameRejected() throws IOException {
-    Directory dir = newDirectory();
-    try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
-      int[] ids = {0, 1};
-      long[] vals = {1L, 2L};
-      IllegalArgumentException e =
-          expectThrows(
-              IllegalArgumentException.class,
-              () ->
-                  w.addBatch(
-                      simpleBatch(
-                          2,
-                          new ArrayLongColumn("field", NumericDocValuesField.TYPE, ids, vals),
-                          new ArrayLongColumn("field", NumericDocValuesField.TYPE, ids, vals))));
-      assertTrue(e.getMessage(), e.getMessage().contains("field"));
-
-      // Writer still usable after validation failure.
-      w.addBatch(
-          simpleBatch(
-              1,
-              new ArrayLongColumn("v", NumericDocValuesField.TYPE, new int[] {0}, new long[] {7})));
-      w.forceMerge(1);
-      DirectoryReader r = DirectoryReader.open(w);
-      // After forceMerge, fully-deleted segments are pruned; only the recovery doc remains.
-      assertEquals(1, r.numDocs());
-      LeafReader leaf = getOnlyLeafReader(r);
-      NumericDocValues dv = leaf.getNumericDocValues("v");
-      assertNotNull(dv);
-      assertTrue(dv.nextDoc() != DocIdSetIterator.NO_MORE_DOCS);
-      assertEquals(7, dv.longValue());
-      r.close();
-    }
-    dir.close();
-  }
-
-  // -----------------------------------------------------------------------
   // Column-pass inversion: mixed batches and row-mode fallback
   // -----------------------------------------------------------------------
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestColumnBatchIndexing.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestColumnBatchIndexing.java
@@ -1660,4 +1660,250 @@ public class TestColumnBatchIndexing extends LuceneTestCase {
     }
     assertEquals(DocIdSetIterator.NO_MORE_DOCS, bIt.nextDoc());
   }
+
+  // -----------------------------------------------------------------------
+  // Duplicate column name rejection
+  // -----------------------------------------------------------------------
+
+  public void testDuplicateColumnNameRejected() throws IOException {
+    Directory dir = newDirectory();
+    try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      int[] ids = {0, 1};
+      long[] vals = {1L, 2L};
+      IllegalArgumentException e =
+          expectThrows(
+              IllegalArgumentException.class,
+              () ->
+                  w.addBatch(
+                      simpleBatch(
+                          2,
+                          new ArrayLongColumn("field", NumericDocValuesField.TYPE, ids, vals),
+                          new ArrayLongColumn("field", NumericDocValuesField.TYPE, ids, vals))));
+      assertTrue(e.getMessage(), e.getMessage().contains("field"));
+
+      // Writer still usable after validation failure.
+      w.addBatch(
+          simpleBatch(
+              1, new ArrayLongColumn("v", NumericDocValuesField.TYPE, new int[] {0}, new long[] {7})));
+      w.forceMerge(1);
+      DirectoryReader r = DirectoryReader.open(w);
+      // After forceMerge, fully-deleted segments are pruned; only the recovery doc remains.
+      assertEquals(1, r.numDocs());
+      LeafReader leaf = getOnlyLeafReader(r);
+      NumericDocValues dv = leaf.getNumericDocValues("v");
+      assertNotNull(dv);
+      assertTrue(dv.nextDoc() != DocIdSetIterator.NO_MORE_DOCS);
+      assertEquals(7, dv.longValue());
+      r.close();
+    }
+    dir.close();
+  }
+
+  // -----------------------------------------------------------------------
+  // Column-pass inversion: mixed batches and row-mode fallback
+  // -----------------------------------------------------------------------
+
+  private static FieldType eligibleInvertType() {
+    FieldType t = new FieldType();
+    t.setIndexOptions(IndexOptions.DOCS);
+    t.setOmitNorms(true);
+    t.setTokenized(false);
+    t.freeze();
+    return t;
+  }
+
+  /** Eligible inverted column + stored column: eligible is demoted to row pass. */
+  public void testColumnInvertMixedWithStoredForcesRowMode() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+
+    FieldType storedOnly = new FieldType();
+    storedOnly.setStored(true);
+    storedOnly.freeze();
+
+    int[] ids = {0, 1, 2};
+    BytesRef[] tags = {newBytesRef("a"), newBytesRef("b"), newBytesRef("a")};
+    BytesRef[] stored = {newBytesRef("v0"), newBytesRef("v1"), newBytesRef("v2")};
+    w.addBatch(
+        simpleBatch(
+            3,
+            new ArrayBinaryColumn("tag", eligibleInvertType(), ids, tags),
+            new ArrayBinaryColumn("stored", storedOnly, ids, stored)));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+    IndexSearcher s = new IndexSearcher(r);
+
+    assertEquals(2, s.count(new TermQuery(new Term("tag", "a"))));
+    assertEquals(1, s.count(new TermQuery(new Term("tag", "b"))));
+    StoredFields sf = leaf.storedFields();
+    for (int i = 0; i < 3; i++) {
+      IndexableField field = sf.document(i).getField("stored");
+      assertNotNull("doc " + i + " must have stored field", field);
+      assertEquals(stored[i], field.binaryValue());
+    }
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  /** Eligible column + norms-enabled column: both go through row pass. */
+  public void testColumnInvertWithNormsForcesRowMode() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+
+    FieldType withNorms = new FieldType();
+    withNorms.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+    withNorms.setOmitNorms(false);
+    withNorms.setTokenized(false);
+    withNorms.freeze();
+
+    int[] ids = {0, 1};
+    w.addBatch(
+        simpleBatch(
+            2,
+            new ArrayBinaryColumn("eligible", eligibleInvertType(), ids, new BytesRef[]{newBytesRef("x"), newBytesRef("y")}),
+            new ArrayBinaryColumn("normed", withNorms, ids, new BytesRef[]{newBytesRef("p"), newBytesRef("q")})));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+    IndexSearcher s = new IndexSearcher(r);
+
+    assertEquals(1, s.count(new TermQuery(new Term("eligible", "x"))));
+    assertEquals(1, s.count(new TermQuery(new Term("normed", "p"))));
+    assertNotNull("normed field must have norms", leaf.getNormValues("normed"));
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  /** Eligible column + term-vector column: both go through row pass. */
+  public void testColumnInvertWithTermVectorsForcesRowMode() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+
+    FieldType tvType = new FieldType();
+    tvType.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+    tvType.setOmitNorms(true);
+    tvType.setTokenized(false);
+    tvType.setStoreTermVectors(true);
+    tvType.freeze();
+
+    int[] ids = {0, 1};
+    w.addBatch(
+        simpleBatch(
+            2,
+            new ArrayBinaryColumn("eligible", eligibleInvertType(), ids, new BytesRef[]{newBytesRef("a"), newBytesRef("b")}),
+            new ArrayBinaryColumn("tv", tvType, ids, new BytesRef[]{newBytesRef("hello"), newBytesRef("world")})));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    IndexSearcher s = new IndexSearcher(r);
+
+    assertEquals(1, s.count(new TermQuery(new Term("eligible", "a"))));
+    assertEquals(1, s.count(new TermQuery(new Term("tv", "hello"))));
+    // The tv column must have term vectors written.
+    TermVectors tvReader = r.termVectors();
+    assertNotNull(tvReader.get(0));
+    assertNotNull(tvReader.get(0).terms("tv"));
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  /** DOCS_AND_FREQS_AND_POSITIONS falls back to row pass; positions must be present. */
+  public void testColumnInvertPositionsForcesRowMode() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriterConfig config = newIndexWriterConfig(new org.apache.lucene.tests.analysis.MockAnalyzer(random()));
+    IndexWriter w = new IndexWriter(dir, config);
+
+    FieldType posType = new FieldType();
+    posType.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
+    posType.setOmitNorms(true);
+    posType.setTokenized(true);
+    posType.freeze();
+
+    int[] ids = {0, 1};
+    BytesRef[] vals = {newBytesRef("foo"), newBytesRef("bar")};
+    w.addBatch(simpleBatch(2, new ArrayBinaryColumn("pos", posType, ids, vals)));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+    Terms terms = leaf.terms("pos");
+    assertNotNull(terms);
+    TermsEnum te = terms.iterator();
+    assertTrue(te.seekExact(newBytesRef("foo")));
+    // Positions must be stored (seekExact + positions postings enum should succeed).
+    PostingsEnum pe = te.postings(null, PostingsEnum.POSITIONS);
+    assertEquals(0, pe.nextDoc());
+    assertEquals(0, pe.nextPosition());
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  /** Column-invert parity: batch index == addDocument index for eligible field types. */
+  public void testColumnInvertParityVsAddDocument() throws IOException {
+    int numDocs = 20;
+    String[] terms = {"alpha", "beta", "gamma", "delta", "epsilon"};
+
+    // Build batch index
+    Directory batchDir = newDirectory();
+    try (IndexWriter bw = new IndexWriter(batchDir, newIndexWriterConfig())) {
+      int[] ids = new int[numDocs];
+      BytesRef[] vals = new BytesRef[numDocs];
+      for (int i = 0; i < numDocs; i++) {
+        ids[i] = i;
+        vals[i] = newBytesRef(terms[i % terms.length]);
+      }
+      bw.addBatch(simpleBatch(numDocs, new ArrayBinaryColumn("f", eligibleInvertType(), ids, vals)));
+    }
+
+    // Build single-doc index
+    Directory docDir = newDirectory();
+    try (IndexWriter dw = new IndexWriter(docDir, new IndexWriterConfig())) {
+      for (int i = 0; i < numDocs; i++) {
+        Document doc = new Document();
+        // StringField uses DOCS, omitNorms, no TVs — matches eligibleInvertType()
+        doc.add(new StringField("f", terms[i % terms.length], Field.Store.NO));
+        dw.addDocument(doc);
+      }
+      dw.forceMerge(1);
+    }
+
+    try (DirectoryReader bR = DirectoryReader.open(batchDir);
+        DirectoryReader dR = DirectoryReader.open(docDir)) {
+      LeafReader bL = getOnlyLeafReader(bR);
+      LeafReader dL = getOnlyLeafReader(dR);
+      assertEquals(dL.maxDoc(), bL.maxDoc());
+
+      IndexSearcher bS = new IndexSearcher(bR);
+      IndexSearcher dS = new IndexSearcher(dR);
+      for (String t : terms) {
+        Term term = new Term("f", t);
+        assertEquals("count mismatch for term " + t,
+            dS.count(new TermQuery(term)), bS.count(new TermQuery(term)));
+      }
+
+      // Compare full term dictionaries
+      Terms bTerms = bL.terms("f");
+      Terms dTerms = dL.terms("f");
+      assertNotNull(bTerms);
+      assertNotNull(dTerms);
+      TermsEnum bTe = bTerms.iterator();
+      TermsEnum dTe = dTerms.iterator();
+      while (dTe.next() != null) {
+        assertNotNull("batch index missing term", bTe.next());
+        assertEquals(dTe.term(), bTe.term());
+        assertEquals(dTe.docFreq(), bTe.docFreq());
+      }
+      assertNull(bTe.next());
+    }
+
+    batchDir.close();
+    docDir.close();
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestColumnBatchIndexing.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestColumnBatchIndexing.java
@@ -30,6 +30,7 @@ import static org.apache.lucene.document.column.ColumnBatchTestUtil.simpleBatch;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -1684,7 +1685,8 @@ public class TestColumnBatchIndexing extends LuceneTestCase {
       // Writer still usable after validation failure.
       w.addBatch(
           simpleBatch(
-              1, new ArrayLongColumn("v", NumericDocValuesField.TYPE, new int[] {0}, new long[] {7})));
+              1,
+              new ArrayLongColumn("v", NumericDocValuesField.TYPE, new int[] {0}, new long[] {7})));
       w.forceMerge(1);
       DirectoryReader r = DirectoryReader.open(w);
       // After forceMerge, fully-deleted segments are pruned; only the recovery doc remains.
@@ -1763,8 +1765,13 @@ public class TestColumnBatchIndexing extends LuceneTestCase {
     w.addBatch(
         simpleBatch(
             2,
-            new ArrayBinaryColumn("eligible", eligibleInvertType(), ids, new BytesRef[]{newBytesRef("x"), newBytesRef("y")}),
-            new ArrayBinaryColumn("normed", withNorms, ids, new BytesRef[]{newBytesRef("p"), newBytesRef("q")})));
+            new ArrayBinaryColumn(
+                "eligible",
+                eligibleInvertType(),
+                ids,
+                new BytesRef[] {newBytesRef("x"), newBytesRef("y")}),
+            new ArrayBinaryColumn(
+                "normed", withNorms, ids, new BytesRef[] {newBytesRef("p"), newBytesRef("q")})));
 
     DirectoryReader r = DirectoryReader.open(w);
     LeafReader leaf = getOnlyLeafReader(r);
@@ -1795,8 +1802,13 @@ public class TestColumnBatchIndexing extends LuceneTestCase {
     w.addBatch(
         simpleBatch(
             2,
-            new ArrayBinaryColumn("eligible", eligibleInvertType(), ids, new BytesRef[]{newBytesRef("a"), newBytesRef("b")}),
-            new ArrayBinaryColumn("tv", tvType, ids, new BytesRef[]{newBytesRef("hello"), newBytesRef("world")})));
+            new ArrayBinaryColumn(
+                "eligible",
+                eligibleInvertType(),
+                ids,
+                new BytesRef[] {newBytesRef("a"), newBytesRef("b")}),
+            new ArrayBinaryColumn(
+                "tv", tvType, ids, new BytesRef[] {newBytesRef("hello"), newBytesRef("world")})));
 
     DirectoryReader r = DirectoryReader.open(w);
     IndexSearcher s = new IndexSearcher(r);
@@ -1816,7 +1828,8 @@ public class TestColumnBatchIndexing extends LuceneTestCase {
   /** DOCS_AND_FREQS_AND_POSITIONS falls back to row pass; positions must be present. */
   public void testColumnInvertPositionsForcesRowMode() throws IOException {
     Directory dir = newDirectory();
-    IndexWriterConfig config = newIndexWriterConfig(new org.apache.lucene.tests.analysis.MockAnalyzer(random()));
+    IndexWriterConfig config =
+        newIndexWriterConfig(new org.apache.lucene.tests.analysis.MockAnalyzer(random()));
     IndexWriter w = new IndexWriter(dir, config);
 
     FieldType posType = new FieldType();
@@ -1859,7 +1872,8 @@ public class TestColumnBatchIndexing extends LuceneTestCase {
         ids[i] = i;
         vals[i] = newBytesRef(terms[i % terms.length]);
       }
-      bw.addBatch(simpleBatch(numDocs, new ArrayBinaryColumn("f", eligibleInvertType(), ids, vals)));
+      bw.addBatch(
+          simpleBatch(numDocs, new ArrayBinaryColumn("f", eligibleInvertType(), ids, vals)));
     }
 
     // Build single-doc index
@@ -1884,8 +1898,10 @@ public class TestColumnBatchIndexing extends LuceneTestCase {
       IndexSearcher dS = new IndexSearcher(dR);
       for (String t : terms) {
         Term term = new Term("f", t);
-        assertEquals("count mismatch for term " + t,
-            dS.count(new TermQuery(term)), bS.count(new TermQuery(term)));
+        assertEquals(
+            "count mismatch for term " + t,
+            dS.count(new TermQuery(term)),
+            bS.count(new TermQuery(term)));
       }
 
       // Compare full term dictionaries
@@ -1905,5 +1921,300 @@ public class TestColumnBatchIndexing extends LuceneTestCase {
 
     batchDir.close();
     docDir.close();
+  }
+
+  /** Multiple eligible-invert columns in a single batch, no prior TV docs. */
+  public void testColumnInvertMultipleEligibleColumns() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+
+    int[] ids = {0, 1, 2};
+    w.addBatch(
+        simpleBatch(
+            3,
+            new ArrayBinaryColumn(
+                "a",
+                eligibleInvertType(),
+                ids,
+                new BytesRef[] {newBytesRef("x"), newBytesRef("y"), newBytesRef("x")}),
+            new ArrayBinaryColumn(
+                "b",
+                eligibleInvertType(),
+                ids,
+                new BytesRef[] {newBytesRef("p"), newBytesRef("p"), newBytesRef("q")})));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    IndexSearcher s = new IndexSearcher(r);
+
+    assertEquals(2, s.count(new TermQuery(new Term("a", "x"))));
+    assertEquals(1, s.count(new TermQuery(new Term("a", "y"))));
+    assertEquals(2, s.count(new TermQuery(new Term("b", "p"))));
+    assertEquals(1, s.count(new TermQuery(new Term("b", "q"))));
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  /**
+   * Prior addDocument with a TV-enabled field flips TermVectorsConsumer.hasVectors=true, then a
+   * batch with multiple eligible-invert columns runs the column-invert pass. Before the fix the
+   * second column's termsHash.finishDocument call tripped lastDocID==docID. After the fix the
+   * column-invert pass doesn't drive the TV consumer at all; fill() reconciles unframed docs at
+   * flush.
+   */
+  public void testColumnInvertMultipleColumnsAfterPriorTermVectors() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+
+    // Doc 0: a regular doc with a term-vector-enabled field. This flips hasVectors=true on the
+    // segment's TermVectorsConsumer.
+    FieldType tvType = new FieldType();
+    tvType.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
+    tvType.setTokenized(true);
+    tvType.setStoreTermVectors(true);
+    tvType.freeze();
+    Document tvDoc = new Document();
+    tvDoc.add(new Field("tv", "hello world", tvType));
+    w.addDocument(tvDoc);
+
+    // Subsequent batch (segDocIDs 1..3) with two eligible-invert columns.
+    int[] ids = {0, 1, 2};
+    w.addBatch(
+        simpleBatch(
+            3,
+            new ArrayBinaryColumn(
+                "a",
+                eligibleInvertType(),
+                ids,
+                new BytesRef[] {newBytesRef("x"), newBytesRef("y"), newBytesRef("x")}),
+            new ArrayBinaryColumn(
+                "b",
+                eligibleInvertType(),
+                ids,
+                new BytesRef[] {newBytesRef("p"), newBytesRef("q"), newBytesRef("p")})));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    IndexSearcher s = new IndexSearcher(r);
+
+    // Postings for both eligible columns are intact.
+    assertEquals(2, s.count(new TermQuery(new Term("a", "x"))));
+    assertEquals(1, s.count(new TermQuery(new Term("a", "y"))));
+    assertEquals(2, s.count(new TermQuery(new Term("b", "p"))));
+    assertEquals(1, s.count(new TermQuery(new Term("b", "q"))));
+
+    // Doc 0's term vector survives.
+    TermVectors tvReader = r.termVectors();
+    assertNotNull(tvReader.get(0));
+    assertNotNull(tvReader.get(0).terms("tv"));
+    // Batch docs (1, 2, 3) have no TV slots populated by us; reading them should not throw.
+    // They may be null (no fields) or empty depending on the codec — the contract we care about
+    // is that the TV file is not corrupt and reads cleanly.
+    for (int i = 1; i <= 3; i++) {
+      // Either null or an empty Fields object is acceptable.
+      org.apache.lucene.index.Fields tv = tvReader.get(i);
+      if (tv != null) {
+        assertNull("batch doc " + i + " must not have a TV for 'tv' field", tv.terms("tv"));
+      }
+    }
+
+    r.close();
+    w.close();
+    TestUtil.checkIndex(dir);
+    dir.close();
+  }
+
+  /**
+   * Same as above but the eligible columns are sparse (different doc subsets). Validates that
+   * skipping termsHash framing in the column-invert pass doesn't leave the TV writer in a state
+   * where fill() reconciliation produces a corrupt file. Verifies post-merge state by re-opening a
+   * fresh reader and running CheckIndex so silent merge corruption is caught.
+   */
+  public void testColumnInvertSparseMultipleColumnsAfterPriorTermVectors() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+
+    FieldType tvType = new FieldType();
+    tvType.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
+    tvType.setTokenized(true);
+    tvType.setStoreTermVectors(true);
+    tvType.freeze();
+    Document tvDoc = new Document();
+    tvDoc.add(new Field("tv", "alpha beta", tvType));
+    w.addDocument(tvDoc);
+
+    // Batch numDocs=6 (segDocIDs 1..6).
+    // Column a: values on docs 0, 3, 5. Column b: values on docs 1, 2, 5.
+    w.addBatch(
+        simpleBatch(
+            6,
+            new ArrayBinaryColumn(
+                "a",
+                eligibleInvertType(),
+                new int[] {0, 3, 5},
+                new BytesRef[] {newBytesRef("xa"), newBytesRef("ya"), newBytesRef("xa")}),
+            new ArrayBinaryColumn(
+                "b",
+                eligibleInvertType(),
+                new int[] {1, 2, 5},
+                new BytesRef[] {newBytesRef("pb"), newBytesRef("qb"), newBytesRef("pb")})));
+
+    // Pre-merge: verify the in-memory/flushed state via an NRT reader.
+    try (DirectoryReader r = DirectoryReader.open(w)) {
+      IndexSearcher s = new IndexSearcher(r);
+      assertEquals(2, s.count(new TermQuery(new Term("a", "xa"))));
+      assertEquals(1, s.count(new TermQuery(new Term("a", "ya"))));
+      assertEquals(2, s.count(new TermQuery(new Term("b", "pb"))));
+      assertEquals(1, s.count(new TermQuery(new Term("b", "qb"))));
+      assertNotNull(r.termVectors().get(0).terms("tv"));
+      assertEquals(7, r.maxDoc());
+    }
+
+    // ForceMerge collapses the segment(s) into one and re-writes the TV file. A corrupt TV state
+    // surfaces here either as an exception during merge or as wrong content in the merged segment.
+    w.forceMerge(1);
+    w.close();
+
+    // Post-merge: open a brand-new reader on the directory and re-verify everything against the
+    // merged segment.
+    try (DirectoryReader r2 = DirectoryReader.open(dir)) {
+      assertEquals(7, r2.maxDoc());
+      LeafReader merged = getOnlyLeafReader(r2);
+      IndexSearcher s2 = new IndexSearcher(r2);
+      assertEquals(2, s2.count(new TermQuery(new Term("a", "xa"))));
+      assertEquals(1, s2.count(new TermQuery(new Term("a", "ya"))));
+      assertEquals(2, s2.count(new TermQuery(new Term("b", "pb"))));
+      assertEquals(1, s2.count(new TermQuery(new Term("b", "qb"))));
+
+      TermVectors tvReader = r2.termVectors();
+      // Doc 0 keeps its TV.
+      Terms doc0Tv = tvReader.get(0).terms("tv");
+      assertNotNull(doc0Tv);
+      TermsEnum doc0TvTerms = doc0Tv.iterator();
+      assertNotNull(doc0TvTerms.next());
+      // Batch docs (1..6) must report no TV for 'tv'.
+      for (int i = 1; i <= 6; i++) {
+        org.apache.lucene.index.Fields tv = tvReader.get(i);
+        if (tv != null) {
+          assertNull("merged doc " + i + " must not have a TV for 'tv' field", tv.terms("tv"));
+        }
+      }
+      // Sanity: 'a' and 'b' fields exist on the merged segment and have no TVs (eligibility
+      // excludes TVs for them).
+      assertNotNull(merged.terms("a"));
+      assertNotNull(merged.terms("b"));
+    }
+
+    // Full CheckIndex pass — catches silent on-disk corruption that reader-level assertions miss.
+    TestUtil.checkIndex(dir);
+    dir.close();
+  }
+
+  /**
+   * Eligible-invert batch first, then a doc with term vectors. Validates that the TV writer's
+   * lastDocID is correctly advanced via fill() so the post-batch TV doc lands at the right
+   * position.
+   */
+  public void testColumnInvertThenAddDocumentWithTermVectors() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+
+    // Batch of 3 eligible-invert docs (segDocIDs 0..2). hasVectors is still false here.
+    int[] ids = {0, 1, 2};
+    w.addBatch(
+        simpleBatch(
+            3,
+            new ArrayBinaryColumn(
+                "a",
+                eligibleInvertType(),
+                ids,
+                new BytesRef[] {newBytesRef("x"), newBytesRef("y"), newBytesRef("x")})));
+
+    // Now add a doc with TVs (segDocID 3). hasVectors flips true. fill(3) writes empty slots for
+    // docs 0..2 before slot 3 is written.
+    FieldType tvType = new FieldType();
+    tvType.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
+    tvType.setTokenized(true);
+    tvType.setStoreTermVectors(true);
+    tvType.freeze();
+    Document tvDoc = new Document();
+    tvDoc.add(new Field("tv", "hello world", tvType));
+    w.addDocument(tvDoc);
+
+    DirectoryReader r = DirectoryReader.open(w);
+    IndexSearcher s = new IndexSearcher(r);
+
+    assertEquals(2, s.count(new TermQuery(new Term("a", "x"))));
+    assertEquals(1, s.count(new TermQuery(new Term("a", "y"))));
+
+    TermVectors tvReader = r.termVectors();
+    // The post-batch TV doc is at segDocID 3.
+    assertNotNull(tvReader.get(3));
+    assertNotNull(tvReader.get(3).terms("tv"));
+    // Batch docs (0..2) should have no TV for the "tv" field.
+    for (int i = 0; i <= 2; i++) {
+      org.apache.lucene.index.Fields tv = tvReader.get(i);
+      if (tv != null) {
+        assertNull("batch doc " + i + " must not have a TV for 'tv' field", tv.terms("tv"));
+      }
+    }
+
+    r.close();
+    w.forceMerge(1);
+    w.close();
+    TestUtil.checkIndex(dir);
+    dir.close();
+  }
+
+  /**
+   * Feeds a term that exceeds {@link IndexWriter#MAX_TERM_LENGTH} into an eligible-invert column to
+   * trigger {@code MaxBytesLengthExceededException} → {@code IllegalArgumentException} inside
+   * {@code pf.invert}. Confirms the {@code invertSucceeded} gate in {@code
+   * processBinaryColumnInvert} skips {@code pf.finish} on the failed first invert (so partial
+   * FreqProx state isn't flushed), the writer remains usable for a subsequent batch, and CheckIndex
+   * passes on the recovered segment.
+   */
+  public void testColumnInvertImmenseTermNonAbortingIAE() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+
+    // Build a term well over MAX_TERM_LENGTH bytes.
+    byte[] bigBytes = new byte[IndexWriter.MAX_TERM_LENGTH + 10];
+    Arrays.fill(bigBytes, (byte) 'x');
+    BytesRef immense = new BytesRef(bigBytes);
+
+    int[] ids = {0, 1};
+    BytesRef[] values = {newBytesRef("ok"), immense};
+
+    IllegalArgumentException e =
+        expectThrows(
+            IllegalArgumentException.class,
+            () ->
+                w.addBatch(
+                    simpleBatch(2, new ArrayBinaryColumn("f", eligibleInvertType(), ids, values))));
+    assertTrue(e.getMessage(), e.getMessage().contains("immense term"));
+
+    // Writer is still usable after the non-aborting IAE — add a recovery batch.
+    w.addBatch(
+        simpleBatch(
+            1,
+            new ArrayBinaryColumn(
+                "f",
+                eligibleInvertType(),
+                new int[] {0},
+                new BytesRef[] {newBytesRef("recovery")})));
+    w.forceMerge(1);
+    w.close();
+
+    // No on-disk corruption from the failed batch's partial state.
+    TestUtil.checkIndex(dir);
+
+    try (DirectoryReader r = DirectoryReader.open(dir)) {
+      IndexSearcher s = new IndexSearcher(r);
+      assertEquals(1, s.count(new TermQuery(new Term("f", "recovery"))));
+      // The "ok" term from the failed batch must not survive into the final segment.
+      assertEquals(0, s.count(new TermQuery(new Term("f", "ok"))));
+    }
+    dir.close();
   }
 }


### PR DESCRIPTION
BinaryColumns that are DOCS or DOCS_AND_FREQS, omitNorms, no TVs, and
not stored are now inverted directly in the column-oriented pass via
processBinaryColumnInvert, walking each column's cursor sparsely. When
any row-mode column is present in the batch, eligible columns are
demoted to the row pass so all inverted fields share a single
termsHash frame per doc.

processBinaryColumnInvert skips termsHash.startDocument/finishDocument:
those drive TermVectorsConsumer's segment-scoped lastDocID, and framing
the same batch doc from multiple eligible columns would break its
monotonicity invariant. Eligibility guarantees doVectors=false, so TV
state is never touched; unframed docs are reconciled by
TermVectorsConsumer.fill(). Exception handling mirrors processDocument:
pf.finish runs only if the first pf.invert returned normally.

The validation pass caches each column's PerField in docFields[] by
original column position; the row pass tracks original indices in
rowPfIndices[] instead of overwriting docFields[], so both passes can
reuse the cache without a second hash lookup.