### PR TITLE
Simplifiy SortedSkipperScorerSupplier

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -405,8 +405,8 @@ Optimizations
 * GITHUB#16050: Add SIMD-accelerated bulk range evaluation for dense numeric doc values via
   BatchDocValuesRangeIterator and DocValuesRangeSupport. (Sagar Upadhyaya)
 
-* GITHUB#16061, GITHUB#16070, GITHUB#16085: Improve cost estimation in SortedSetDocValuesRangeQuery  and
-  SortedNumericDocValuesRangeQuery when using DocValuesSkipper, the field is dense and is the primary sort of
+* GITHUB#16061, GITHUB#16070, GITHUB#16085, GITHUB#16120: Improve cost estimation in SortedSetDocValuesRangeQuery
+  and SortedNumericDocValuesRangeQuery when using DocValuesSkipper, the field is dense and is the primary sort of
   the index to reduce the number of doc values visited. (Ignacio Vera)
 
 * GITHUB#16048: Defer Sorter.DocMap packing until after flush (Tim Brooks)

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSkipperScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSkipperScorerSupplier.java
@@ -165,15 +165,9 @@ abstract class SortedSkipperScorerSupplier extends ScorerSupplier {
         skipperMaxDocId = skipper.docCount();
         skipperMaxDocIdExact = true;
       } else {
-        skipper.advance(Long.MIN_VALUE, minOrd);
-        if (skipper.minValue(0) == minOrd) {
-          skipperMaxDocId = skipper.maxDocID(0) + 1;
-          skipper.advance(skipperMaxDocId);
-          skipperMaxDocIdExact = skipper.maxValue(0) != minOrd;
-        } else {
-          skipperMaxDocId = skipper.minDocID(0);
-          skipperMaxDocIdExact = false;
-        }
+        skipper.advance(Long.MIN_VALUE, minOrd - 1);
+        skipperMaxDocId = skipper.minDocID(0);
+        skipperMaxDocIdExact = skipper.maxValue(0) < minOrd;
       }
     } else {
       if (skipper.minValue() >= minOrd) {
@@ -188,15 +182,9 @@ abstract class SortedSkipperScorerSupplier extends ScorerSupplier {
         skipperMaxDocId = skipper.docCount();
         skipperMaxDocIdExact = true;
       } else {
-        skipper.advance(maxOrd, Long.MAX_VALUE);
-        if (skipper.maxValue(0) == maxOrd) {
-          skipperMaxDocId = skipper.maxDocID(0) + 1;
-          skipper.advance(skipperMaxDocId);
-          skipperMaxDocIdExact = skipper.minValue(0) != maxOrd;
-        } else {
-          skipperMaxDocId = skipper.minDocID(0);
-          skipperMaxDocIdExact = false;
-        }
+        skipper.advance(maxOrd + 1, Long.MAX_VALUE);
+        skipperMaxDocId = skipper.minDocID(0);
+        skipperMaxDocIdExact = skipper.minValue(0) > maxOrd;
       }
     }
   }


### PR DESCRIPTION
Simplify how we get the  approximate maximum doc Id by searching for the next value. This makes the logic simpler and it can make the execution faster as it will always end up in the skipper block that either contains the next values or the block that has the transition between the value we are looking for and the next value.