### PR TITLE
FacetCutter: unify rollup and range remapping

### DIFF
--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/cutters/FacetCutter.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/cutters/FacetCutter.java
@@ -34,21 +34,32 @@ public interface FacetCutter {
   LeafFacetCutter createLeafCutter(LeafReaderContext context) throws IOException;
 
   /**
-   * For facets that have hierarchy (levels), return all top level dimension ordinals that require
-   * rollup.
+   * Returns true if this cutter records raw ordinals during collection that must be remapped to
+   * final ordinals at reduce time via {@link #remapOrd}.
    *
-   * <p>Rollup is an optimization for facets types that support hierarchy, if single document
-   * belongs to at most one node in the hierarchy, we can first record data for these nodes only,
-   * and then roll up values to parent ordinals.
+   * <p>When false (the default), recorded ordinals are already final and the recorder skips the
+   * remap step entirely.
    *
-   * <p>Default implementation returns null, which means that rollup is not needed.
+   * <p>Called once per {@link org.apache.lucene.sandbox.facet.recorders.FacetRecorder#reduce}
+   * invocation.
    */
-  default OrdinalIterator getOrdinalsToRollup() throws IOException {
-    return null;
+  default boolean needsRemapping() throws IOException {
+    return false;
   }
 
-  /** For facets that have hierarchy (levels), get all children ordinals for given ord. */
-  default OrdinalIterator getChildrenOrds(int ord) throws IOException {
-    return null;
+  /**
+   * Map a raw ordinal recorded during collection to zero or more final ordinals.
+   *
+   * <p>Only called when {@link #needsRemapping()} returns true. Called once per distinct recorded
+   * ordinal inside {@link org.apache.lucene.sandbox.facet.recorders.FacetRecorder#reduce}.
+   * Implementations must return a fresh or reset iterator on every invocation.
+   *
+   * @param mergedOrd raw ordinal as recorded by the leaf cutter
+   * @return iterator over final ordinals; may be {@link OrdinalIterator#EMPTY}
+   */
+  default OrdinalIterator remapOrd(int mergedOrd) throws IOException {
+    throw new UnsupportedOperationException(
+        "remapOrd called on a cutter that does not override it; "
+            + "needsRemapping() must return true only when remapOrd() is implemented");
   }
 }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/cutters/TaxonomyFacetsCutter.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/cutters/TaxonomyFacetsCutter.java
@@ -17,8 +17,6 @@
 package org.apache.lucene.sandbox.facet.cutters;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.Map;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.taxonomy.FacetLabel;
@@ -27,7 +25,9 @@ import org.apache.lucene.facet.taxonomy.TaxonomyReader;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.internal.hppc.IntHashSet;
 import org.apache.lucene.sandbox.facet.iterators.OrdinalIterator;
+import org.apache.lucene.util.ArrayUtil;
 
 /**
  * {@link FacetCutter} for facets that use taxonomy side-car index.
@@ -41,8 +41,14 @@ public final class TaxonomyFacetsCutter implements FacetCutter {
   private final String indexFieldName;
   private final boolean disableRollup;
 
-  private ParallelTaxonomyArrays.IntArray children;
-  private ParallelTaxonomyArrays.IntArray siblings;
+  // Lazy; loaded on first remapOrd call (which is single-threaded, inside reduce).
+  private ParallelTaxonomyArrays.IntArray parents;
+  // Null until first getSingleValuedDimOrds() call; empty when disableRollup=true.
+  private IntHashSet singleValuedDimOrds;
+
+  // Reusable scratch buffer for the ancestor path (reduce is single-threaded, and the
+  // returned OrdinalIterator is always fully consumed before the next remapOrd call).
+  private int[] ancestorBuf = new int[8];
 
   /** Create {@link FacetCutter} for taxonomy facets. */
   public TaxonomyFacetsCutter(
@@ -70,25 +76,83 @@ public final class TaxonomyFacetsCutter implements FacetCutter {
   }
 
   /**
-   * Returns int[] mapping each ordinal to its first child; this is a large array and is computed
-   * (and then saved) the first time this method is invoked.
+   * Returns int[] mapping each ordinal to its parent; this is a large array and is computed (and
+   * then saved) the first time this method is invoked.
    */
-  ParallelTaxonomyArrays.IntArray getChildren() throws IOException {
-    if (children == null) {
-      children = taxoReader.getParallelTaxonomyArrays().children();
+  private ParallelTaxonomyArrays.IntArray getParents() throws IOException {
+    if (parents == null) {
+      parents = taxoReader.getParallelTaxonomyArrays().parents();
     }
-    return children;
+    return parents;
   }
 
   /**
-   * Returns int[] mapping each ordinal to its next sibling; this is a large array and is computed
-   * (and then saved) the first time this method is invoked.
+   * Returns the set of dimension ordinals that require rollup (single-valued dims whose index field
+   * matches this cutter). Returns an empty set when rollup is disabled. Computed lazily and cached.
    */
-  ParallelTaxonomyArrays.IntArray getSiblings() throws IOException {
-    if (siblings == null) {
-      siblings = taxoReader.getParallelTaxonomyArrays().siblings();
+  private IntHashSet getSingleValuedDimOrds() throws IOException {
+    if (singleValuedDimOrds != null) {
+      return singleValuedDimOrds;
     }
-    return siblings;
+    singleValuedDimOrds = new IntHashSet();
+    if (disableRollup) {
+      return singleValuedDimOrds;
+    }
+    for (Map.Entry<String, FacetsConfig.DimConfig> ent : facetsConfig.getDimConfigs().entrySet()) {
+      String dim = ent.getKey();
+      FacetsConfig.DimConfig ft = ent.getValue();
+      if (ft.multiValued == false && ft.indexFieldName.equals(indexFieldName)) {
+        // ft.hierarchical is ignored - rollup even if path length is only two
+        int dimOrd = taxoReader.getOrdinal(new FacetLabel(dim));
+        if (dimOrd != TaxonomyReader.INVALID_ORDINAL) {
+          singleValuedDimOrds.add(dimOrd);
+        }
+      }
+    }
+    return singleValuedDimOrds;
+  }
+
+  @Override
+  public boolean needsRemapping() throws IOException {
+    // Skip remapping when rollup is disabled or when all dims are multi-valued
+    // (single-valued dim set is empty). In both cases every ordinal maps to itself.
+    return !getSingleValuedDimOrds().isEmpty();
+  }
+
+  @Override
+  public OrdinalIterator remapOrd(int ord) throws IOException {
+    ParallelTaxonomyArrays.IntArray parentsArr = getParents();
+
+    // Walk up from ord to the direct child of ROOT, collecting the ancestor path into a
+    // reusable scratch buffer.
+    int len = 0;
+    int cur = ord;
+    while (true) {
+      ancestorBuf = ArrayUtil.grow(ancestorBuf, len + 1);
+      ancestorBuf[len++] = cur;
+      int parent = parentsArr.get(cur);
+      if (parent == TaxonomyReader.ROOT_ORDINAL) {
+        break;
+      }
+      cur = parent;
+    }
+    if (getSingleValuedDimOrds().contains(cur) == false) {
+      // Multi-valued dim or rollup disabled: ordinal maps only to itself.
+      return OrdinalIterator.fromSingleOrd(ord);
+    }
+
+    // Single-valued dim: emit the full path from the leaf ordinal up to and including the
+    // dim ordinal. The returned iterator reads directly from ancestorBuf and is always fully
+    // consumed before the next remapOrd call, so the shared buffer is safe to reuse.
+    final int capturedLen = len;
+    return new OrdinalIterator() {
+      int idx = 0;
+
+      @Override
+      public int nextOrd() {
+        return idx < capturedLen ? ancestorBuf[idx++] : NO_MORE_ORDS;
+      }
+    };
   }
 
   @Override
@@ -99,76 +163,11 @@ public final class TaxonomyFacetsCutter implements FacetCutter {
     assert multiValued != null;
     // TODO: if multiValued is emptySortedNumeric we can throw CollectionTerminatedException
     //       in FacetFieldLeafCollector and save some CPU cycles.
-    TaxonomyLeafFacetCutterMultiValue leafCutter =
-        new TaxonomyLeafFacetCutterMultiValue(multiValued);
-    return leafCutter;
+    return new TaxonomyLeafFacetCutterMultiValue(multiValued);
 
     // TODO: does unwrapping Single valued make things any faster? We still need to wrap it into
     //       LeafFacetCutter
     // NumericDocValues singleValued = DocValues.unwrapSingleton(multiValued);
-  }
-
-  @Override
-  public OrdinalIterator getOrdinalsToRollup() throws IOException {
-    if (disableRollup) {
-      return null;
-    }
-
-    // Rollup any necessary dims:
-    Iterator<Map.Entry<String, FacetsConfig.DimConfig>> dimensions =
-        facetsConfig.getDimConfigs().entrySet().iterator();
-
-    ArrayList<FacetLabel> dimsToRollup = new ArrayList<>();
-
-    while (dimensions.hasNext()) {
-      Map.Entry<String, FacetsConfig.DimConfig> ent = dimensions.next();
-      String dim = ent.getKey();
-      FacetsConfig.DimConfig ft = ent.getValue();
-      if (ft.multiValued == false && ft.indexFieldName.equals(indexFieldName)) {
-        // ft.hierarchical is ignored - rollup even if path length is only two
-        dimsToRollup.add(new FacetLabel(dim));
-      }
-    }
-
-    int[] dimOrdToRollup = taxoReader.getBulkOrdinals(dimsToRollup.toArray(FacetLabel[]::new));
-
-    return new OrdinalIterator() {
-      int currentIndex = 0;
-
-      @Override
-      public int nextOrd() throws IOException {
-        for (; currentIndex < dimOrdToRollup.length; currentIndex++) {
-          // It can be invalid if this field was declared in the
-          // config but never indexed
-          if (dimOrdToRollup[currentIndex] != TaxonomyReader.INVALID_ORDINAL) {
-            return dimOrdToRollup[currentIndex++];
-          }
-        }
-        return NO_MORE_ORDS;
-      }
-    };
-  }
-
-  @Override
-  public OrdinalIterator getChildrenOrds(final int parentOrd) throws IOException {
-    ParallelTaxonomyArrays.IntArray children = getChildren();
-    ParallelTaxonomyArrays.IntArray siblings = getSiblings();
-    return new OrdinalIterator() {
-      int currentChild = parentOrd;
-
-      @Override
-      public int nextOrd() {
-        if (currentChild == parentOrd) {
-          currentChild = children.get(currentChild);
-        } else {
-          currentChild = siblings.get(currentChild);
-        }
-        if (currentChild != TaxonomyReader.INVALID_ORDINAL) {
-          return currentChild;
-        }
-        return NO_MORE_ORDS;
-      }
-    };
   }
 
   private static class TaxonomyLeafFacetCutterMultiValue implements LeafFacetCutter {

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/cutters/TaxonomyFacetsCutter.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/cutters/TaxonomyFacetsCutter.java
@@ -46,9 +46,11 @@ public final class TaxonomyFacetsCutter implements FacetCutter {
   // Null until first getSingleValuedDimOrds() call; empty when disableRollup=true.
   private IntHashSet singleValuedDimOrds;
 
-  // Reusable scratch buffer for the ancestor path (reduce is single-threaded, and the
-  // returned OrdinalIterator is always fully consumed before the next remapOrd call).
+  // Reusable scratch buffer and iterator for the ancestor path. Both are safe to reuse
+  // because reduce is single-threaded and the iterator is always fully consumed before
+  // the next remapOrd call.
   private int[] ancestorBuf = new int[8];
+  private final AncestorOrdinalIterator ancestorIterator = new AncestorOrdinalIterator();
 
   /** Create {@link FacetCutter} for taxonomy facets. */
   public TaxonomyFacetsCutter(
@@ -142,17 +144,24 @@ public final class TaxonomyFacetsCutter implements FacetCutter {
     }
 
     // Single-valued dim: emit the full path from the leaf ordinal up to and including the
-    // dim ordinal. The returned iterator reads directly from ancestorBuf and is always fully
-    // consumed before the next remapOrd call, so the shared buffer is safe to reuse.
-    final int capturedLen = len;
-    return new OrdinalIterator() {
-      int idx = 0;
+    // dim ordinal.
+    ancestorIterator.reset(len);
+    return ancestorIterator;
+  }
 
-      @Override
-      public int nextOrd() {
-        return idx < capturedLen ? ancestorBuf[idx++] : NO_MORE_ORDS;
-      }
-    };
+  private class AncestorOrdinalIterator implements OrdinalIterator {
+    private int len;
+    private int idx;
+
+    void reset(int len) {
+      this.len = len;
+      this.idx = 0;
+    }
+
+    @Override
+    public int nextOrd() {
+      return idx < len ? ancestorBuf[idx++] : NO_MORE_ORDS;
+    }
   }
 
   @Override

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/cutters/ranges/DoubleRangeFacetCutter.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/cutters/ranges/DoubleRangeFacetCutter.java
@@ -25,6 +25,7 @@ import org.apache.lucene.facet.range.LongRange;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.sandbox.facet.cutters.FacetCutter;
 import org.apache.lucene.sandbox.facet.cutters.LeafFacetCutter;
+import org.apache.lucene.sandbox.facet.iterators.OrdinalIterator;
 import org.apache.lucene.search.DoubleValuesSource;
 import org.apache.lucene.search.LongValuesSource;
 import org.apache.lucene.util.NumericUtils;
@@ -45,7 +46,6 @@ public final class DoubleRangeFacetCutter implements FacetCutter {
   /** Constructor. */
   public DoubleRangeFacetCutter(
       MultiDoubleValuesSource multiDoubleValuesSource, DoubleRange[] doubleRanges) {
-    super();
     DoubleValuesSource singleDoubleValuesSource =
         MultiDoubleValuesSource.unwrapSingleton(multiDoubleValuesSource);
     LongValuesSource singleLongValuesSource;
@@ -71,9 +71,19 @@ public final class DoubleRangeFacetCutter implements FacetCutter {
     return longRangeFacetCutter.createLeafCutter(context);
   }
 
+  @Override
+  public boolean needsRemapping() throws IOException {
+    return longRangeFacetCutter.needsRemapping();
+  }
+
+  @Override
+  public OrdinalIterator remapOrd(int mergedOrd) throws IOException {
+    return longRangeFacetCutter.remapOrd(mergedOrd);
+  }
+
   // TODO: it is exactly the same as DoubleRangeFacetCounts#getLongRanges (protected), we should
   // dedup
-  private LongRange[] mapDoubleRangesToSortableLong(DoubleRange[] doubleRanges) {
+  private static LongRange[] mapDoubleRangesToSortableLong(DoubleRange[] doubleRanges) {
     LongRange[] longRanges = new LongRange[doubleRanges.length];
     for (int i = 0; i < longRanges.length; i++) {
       DoubleRange dr = doubleRanges[i];

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/cutters/ranges/NonOverlappingLongRangeFacetCutter.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/cutters/ranges/NonOverlappingLongRangeFacetCutter.java
@@ -24,11 +24,13 @@ import org.apache.lucene.facet.MultiLongValuesSource;
 import org.apache.lucene.facet.range.LongRange;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.sandbox.facet.cutters.LeafFacetCutter;
+import org.apache.lucene.sandbox.facet.iterators.OrdinalIterator;
 import org.apache.lucene.search.LongValues;
 import org.apache.lucene.search.LongValuesSource;
 
 /** {@link LongRangeFacetCutter} for ranges of long value that don't overlap. * */
 class NonOverlappingLongRangeFacetCutter extends LongRangeFacetCutter {
+
   NonOverlappingLongRangeFacetCutter(
       MultiLongValuesSource longValuesSource,
       LongValuesSource singleLongValuesSource,
@@ -67,6 +69,20 @@ class NonOverlappingLongRangeFacetCutter extends LongRangeFacetCutter {
   }
 
   @Override
+  public boolean needsRemapping() {
+    return true;
+  }
+
+  @Override
+  public OrdinalIterator remapOrd(int mergedOrd) {
+    // pos[] maps elementary interval ordinal to user range position, or SKIP_INTERVAL_POSITION
+    // for gap intervals that don't correspond to any requested range.
+    return pos[mergedOrd] == SKIP_INTERVAL_POSITION
+        ? OrdinalIterator.EMPTY
+        : OrdinalIterator.fromSingleOrd(pos[mergedOrd]);
+  }
+
+  @Override
   public LeafFacetCutter createLeafCutter(LeafReaderContext context) throws IOException {
     if (singleValues != null) {
       LongValues values = singleValues.getValues(context, null);
@@ -92,21 +108,15 @@ class NonOverlappingLongRangeFacetCutter extends LongRangeFacetCutter {
 
     @Override
     public int nextOrd() throws IOException {
-      while (true) {
-        int ordinal = elementaryIntervalTracker.nextOrd();
-        if (ordinal == NO_MORE_ORDS) {
-          return NO_MORE_ORDS;
-        }
-        int result = pos[ordinal];
-        if (result != SKIP_INTERVAL_POSITION) {
-          return result;
-        }
-      }
+      // Leaf cutter now yields raw elementary-interval ordinals; pos[] remapping happens
+      // in FacetCutter#remapOrd at reduce time.
+      return elementaryIntervalTracker.nextOrd();
     }
   }
 
   static class NonOverlappingLongRangeSingleValueLeafFacetCutter
       extends LongRangeSingleValuedLeafFacetCutter {
+
     NonOverlappingLongRangeSingleValueLeafFacetCutter(
         LongValues longValues, long[] boundaries, int[] pos) {
       super(longValues, boundaries, pos);
@@ -114,12 +124,11 @@ class NonOverlappingLongRangeFacetCutter extends LongRangeFacetCutter {
 
     @Override
     public int nextOrd() throws IOException {
-      if (elementaryIntervalOrd == NO_MORE_ORDS) {
-        return NO_MORE_ORDS;
-      }
-      int result = pos[elementaryIntervalOrd];
+      // Leaf cutter now yields the raw elementary-interval ordinal; pos[] remapping happens
+      // in FacetCutter#remapOrd at reduce time.
+      int ord = elementaryIntervalOrd;
       elementaryIntervalOrd = NO_MORE_ORDS;
-      return result != SKIP_INTERVAL_POSITION ? result : NO_MORE_ORDS;
+      return ord;
     }
   }
 }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/iterators/OrdinalIterator.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/iterators/OrdinalIterator.java
@@ -66,4 +66,18 @@ public interface OrdinalIterator {
 
   /** Return empty ordinal iterator */
   OrdinalIterator EMPTY = () -> NO_MORE_ORDS;
+
+  /** Return an ordinal iterator that yields exactly one ordinal. */
+  static OrdinalIterator fromSingleOrd(int ord) {
+    return new OrdinalIterator() {
+      boolean done;
+
+      @Override
+      public int nextOrd() {
+        if (done) return NO_MORE_ORDS;
+        done = true;
+        return ord;
+      }
+    };
+  }
 }

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/recorders/CountFacetRecorder.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/recorders/CountFacetRecorder.java
@@ -120,37 +120,21 @@ public final class CountFacetRecorder implements FacetRecorder {
       values = new IntIntHashMap();
     }
 
-    OrdinalIterator dimOrds = facetCutter.getOrdinalsToRollup();
-    if (dimOrds != null) {
-      for (int dimOrd = dimOrds.nextOrd(); dimOrd != NO_MORE_ORDS; dimOrd = dimOrds.nextOrd()) {
-        int rolledUp = rollup(dimOrd, facetCutter);
-        if (rolledUp > 0) {
-          values.addTo(dimOrd, rolledUp);
+    if (facetCutter.needsRemapping()) {
+      IntIntHashMap remapped = new IntIntHashMap();
+      for (IntIntHashMap.IntIntCursor e : values) {
+        OrdinalIterator finals = facetCutter.remapOrd(e.key);
+        for (int g = finals.nextOrd(); g != NO_MORE_ORDS; g = finals.nextOrd()) {
+          remapped.addTo(g, e.value);
         }
       }
+      values = remapped;
     }
   }
 
   @Override
   public boolean contains(int ordinal) {
     return values.containsKey(ordinal);
-  }
-
-  private int rollup(int ord, FacetCutter facetCutter) throws IOException {
-    OrdinalIterator childOrds = facetCutter.getChildrenOrds(ord);
-    int accum = 0;
-    for (int nextChild = childOrds.nextOrd();
-        nextChild != NO_MORE_ORDS;
-        nextChild = childOrds.nextOrd()) {
-      int rolledUp = rollup(nextChild, facetCutter);
-      // Don't rollup zeros to not add ordinals that we don't actually have counts for to the map
-      if (rolledUp > 0) {
-        accum += values.addTo(nextChild, rolledUp);
-      } else {
-        accum += values.get(nextChild);
-      }
-    }
-    return accum;
   }
 
   private static class CountLeafFacetRecorder implements LeafFacetRecorder {

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/recorders/FacetRecorder.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/recorders/FacetRecorder.java
@@ -47,14 +47,12 @@ public interface FacetRecorder {
   boolean isEmpty();
 
   /**
-   * Reduce leaf recorder results into this recorder. If {@link FacetCutter#getOrdinalsToRollup()}
-   * result is not null, it also rolls up values.
+   * Reduce leaf recorder results into this recorder. If {@link
+   * org.apache.lucene.sandbox.facet.cutters.FacetCutter#needsRemapping} returns true, ordinals are
+   * also remapped to their final values (e.g. taxonomy rollup, range position mapping).
    *
    * <p>After this method is called, it's illegal to add values to recorder, i.e. calling {@link
    * #getLeafRecorder} or {@link LeafFacetRecorder#record} on its leaf recorders.
-   *
-   * @throws UnsupportedOperationException if {@link FacetCutter#getOrdinalsToRollup()} returns not
-   *     null but this recorder doesn't support rollup.
    */
   void reduce(FacetCutter facetCutter) throws IOException;
 

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/recorders/LongAggregationsFacetRecorder.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/facet/recorders/LongAggregationsFacetRecorder.java
@@ -111,41 +111,31 @@ public final class LongAggregationsFacetRecorder implements FacetRecorder {
       values = new IntObjectHashMap<>();
     }
 
-    OrdinalIterator dimOrds = facetCutter.getOrdinalsToRollup();
-    if (dimOrds != null) {
-      for (int dimOrd = dimOrds.nextOrd(); dimOrd != NO_MORE_ORDS; dimOrd = dimOrds.nextOrd()) {
-        rollup(values.get(dimOrd), dimOrd, facetCutter);
+    if (facetCutter.needsRemapping()) {
+      IntObjectHashMap<long[]> remapped = new IntObjectHashMap<>();
+      for (IntObjectHashMap.IntObjectCursor<long[]> e : values) {
+        OrdinalIterator finals = facetCutter.remapOrd(e.key);
+        for (int g = finals.nextOrd(); g != NO_MORE_ORDS; g = finals.nextOrd()) {
+          long[] dst = remapped.get(g);
+          if (dst == null) {
+            // Reuse the source array when target ord equals source ord (e.g. multi-valued taxonomy
+            // or the leaf ordinal in a single-valued rollup) to avoid an unnecessary clone.
+            dst = (g == e.key) ? e.value : e.value.clone();
+            remapped.put(g, dst);
+          } else {
+            for (int i = 0; i < reducers.length; i++) {
+              dst[i] = reducers[i].reduce(dst[i], e.value[i]);
+            }
+          }
+        }
       }
+      values = remapped;
     }
   }
 
   @Override
   public boolean contains(int ordinal) {
     return values.containsKey(ordinal);
-  }
-
-  /**
-   * Rollup all child values of ord to accum, and return accum. Accum param can be null. In this
-   * case, if recursive rollup for every child returns null, this method returns null. Otherwise,
-   * accum is initialized.
-   */
-  private long[] rollup(long[] accum, int ord, FacetCutter facetCutter) throws IOException {
-    OrdinalIterator childOrds = facetCutter.getChildrenOrds(ord);
-    for (int nextChild = childOrds.nextOrd();
-        nextChild != NO_MORE_ORDS;
-        nextChild = childOrds.nextOrd()) {
-      long[] current = rollup(values.get(nextChild), nextChild, facetCutter);
-      if (current != null) {
-        if (accum == null) {
-          accum = new long[longValuesSources.length];
-          values.put(ord, accum);
-        }
-        for (int i = 0; i < longValuesSources.length; i++) {
-          accum[i] = reducers[i].reduce(accum[i], current[i]);
-        }
-      }
-    }
-    return accum;
   }
 
   /** Return aggregated value for facet ordinal and aggregation ID, or zero as default. */


### PR DESCRIPTION
Two structurally identical problems were solved by two separate mechanisms:

- **Taxonomy rollup**: `getOrdinalsToRollup()` + `getChildrenOrds(int)` drove a recursive tree-walk in `CountFacetRecorder` and `LongAggregationsFacetRecorder`, descending from each dim root through the full taxonomy subtree regardless of which nodes had hits.
- **Range remapping**: the `pos[]` lookup (elementary interval → user range position) was baked into each `NonOverlappingLongRangeFacetCutter` leaf cutter's `nextOrd()`, running once per matching document during collection.

### What this PR does

Adds two default methods to `FacetCutter`:

```java
default boolean needsRemapping() throws IOException { return false; }
default OrdinalIterator remapOrd(int mergedOrd) throws IOException { ... }
```

When `needsRemapping()` is true, recorders iterate over recorded ordinals and call `remapOrd()` to obtain final ordinal(s).

**`TaxonomyFacetsCutter`**: switches from `children`/`siblings` to a `parents` array walk. `remapOrd(ord)` walks from `ord` up to the dim root, emitting every ancestor so counts accumulate at each level.

**`NonOverlappingLongRangeFacetCutter`**: leaf cutters now yield raw elementary-interval ordinals. `remapOrd()` applies the `pos[]` lookup at reduce time.

### Performance

- **Taxonomy**: cost is now O(recorded ordinals × hierarchy depth) instead of O(full taxonomy subtree). Sparse result sets benefit significantly.
- **Ranges**: pos[] lookup cost drops from O(matching documents) to O(distinct elementary intervals with hits).

### Removed from `FacetCutter`

- `getOrdinalsToRollup()`
- `getChildrenOrds(int)`

### New helpers

- `OrdinalIterator.fromSingleOrd(int)` -- one-shot iterator over a single ordinal; used by `remapOrd` implementations that map 1-to-1.

### Benchmarks

TBD