### PR TITLE
Fix --tests filtering with -Dtests.iters for JUnit4 tests

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
@@ -21,6 +21,7 @@ import com.carrotsearch.gradle.buildinfra.buildoptions.BuildOptionsPlugin;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import java.io.File;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Provider;
@@ -216,7 +218,8 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
     }
     optionsInheritedAsProperties.add("tests.seed");
 
-    buildOptions.addIntOption("tests.iters", "Duplicate (re-run) each test case N times.");
+    Provider<Integer> testsItersOption =
+        buildOptions.addIntOption("tests.iters", "Duplicate (re-run) each test case N times.");
     optionsInheritedAsProperties.add("tests.iters");
 
     buildOptions.addIntOption("tests.multiplier", "Value multiplier for randomized tests.");
@@ -516,6 +519,63 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
               // java.io.tmpdir is passed via the LoggingFileArgumentProvider (marked @Internal)
               // instead of systemProperty to avoid absolute paths affecting the build cache key.
               loggingFileProvider.getJavaTmpDir().set(workDirOption.get());
+
+              // GITHUB#16121: When tests.iters > 1, JUnit Vintage's MethodSelectorResolver
+              // cannot match RandomizedRunner's synthetic test names ({seed=...}).
+              // Transform method-level --tests filters to class-only filters + tests.method.
+              task.doFirst(
+                  _ -> {
+                    if (testsItersOption.isPresent() && testsItersOption.get() > 1) {
+                      var filter = (DefaultTestFilter) task.getFilter();
+                      var patterns = filter.getCommandLineIncludePatterns();
+                      if (!patterns.isEmpty()) {
+                        List<String> newPatterns = new ArrayList<>();
+                        List<String> methodFilters = new ArrayList<>();
+                        for (String pattern : patterns) {
+                          // Check if pattern contains a method name (has a dot where the last
+                          // segment starts with lowercase, typical for Java method names).
+                          int lastDot = pattern.lastIndexOf('.');
+                          if (lastDot > 0) {
+                            String afterDot = pattern.substring(lastDot + 1);
+                            if (!afterDot.isEmpty() && Character.isLowerCase(afterDot.charAt(0))) {
+                              // This looks like ClassName.methodName or ClassName.methodName*
+                              // Extract class and method pattern (may contain wildcards)
+                              String classPattern = pattern.substring(0, lastDot);
+                              newPatterns.add(classPattern);
+                              methodFilters.add(afterDot);
+                              continue;
+                            }
+                          }
+                          newPatterns.add(pattern);
+                        }
+                        if (!methodFilters.isEmpty()) {
+                          List<String> dedupedPatterns = newPatterns.stream().distinct().toList();
+                          filter.setCommandLineIncludePatterns(dedupedPatterns);
+                          // Use a single glob pattern. If there are multiple method filters,
+                          // use '*' to match all methods in the class (RandomizedRunner's
+                          // MethodGlobFilter doesn't support comma-separated patterns).
+                          String methodGlob;
+                          if (methodFilters.size() == 1) {
+                            methodGlob = methodFilters.get(0);
+                          } else {
+                            methodGlob = "*";
+                            task.getLogger()
+                                .warn(
+                                    "Multiple method filters with tests.iters are not supported"
+                                        + " for JUnit4 tests; running all methods in class {}.",
+                                    dedupedPatterns);
+                          }
+                          task.systemProperty("tests.method", methodGlob);
+                          task.getLogger()
+                              .lifecycle(
+                                  "Transformed --tests filter for tests.iters compatibility:"
+                                      + " class patterns={}, tests.method={}",
+                                  dedupedPatterns,
+                                  methodGlob);
+                        }
+                      }
+                    }
+                  });
 
               task.doFirst(
                   _ -> {

--- a/help/tests.txt
+++ b/help/tests.txt
@@ -127,6 +127,25 @@ won't be the case (all tasks will use exactly the same starting seed):
 gradlew -p lucene/core beast -Ptests.dups=10 --tests TestPerFieldDocValuesFormat -Dtests.seed=deadbeef
 
 
+Method-level filtering with tests.iters
+---------------------------------------
+
+When using '--tests ClassName.methodName' together with '-Ptests.iters=N',
+the build automatically rewrites the filter to work with JUnit4 tests
+(which generate synthetic test names for each iteration). The method name
+is passed internally as 'tests.method=methodName*' and filtering is applied
+by the test runner. This works transparently for both JUnit4 and JUnit5 tests.
+
+If you need to filter methods manually (for example, when running tests in
+an IDE that doesn't support '--tests'), you can pass 'tests.method' directly:
+
+gradlew -p lucene/core test --tests TestDemo -Dtests.method=testFoo*
+
+The 'tests.method' value supports glob patterns with '*' (any sequence) and
+'?' (single character). Multiple comma-separated patterns are supported for
+JUnit5 tests; for JUnit4 tests only a single pattern is supported.
+
+
 Verbose mode and debugging
 --------------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -265,6 +265,8 @@ Other
 
 * GITHUB#15949: Use junit5 engine vintage runner to run junit4 tests. (Dawid Weiss)
 
+* GITHUB#16121: Fix --tests method-level filtering with -Dtests.iters for JUnit4 tests. (Prithvi S)
+
 * GITHUB#15893: Refactor to move common SHOULD/MUST dedup logic inside BooleanQuery into a common function. (Sagar Upadhyaya)
 
 * GITHUB#16082: Added a new JMH microbenchmark for DiversifyingChildrenFloatKnnVectorQuery. (Anna Ruggero via Alessandro Benedetti)

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCaseJupiter.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCaseJupiter.java
@@ -111,7 +111,7 @@ ignoreAfterMaxFailures
 @Execution(
     value = ExecutionMode.SAME_THREAD,
     reason = "single-threaded for backward compatibility.")
-@ExtendWith(EnsureSequentialExecution.class)
+@ExtendWith({EnsureSequentialExecution.class, MethodFilterExtension.class})
 @TestMethodOrder(CustomMethodOrderer.class)
 public abstract non-sealed class LuceneTestCaseJupiter extends LuceneTestCaseParent {
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/MethodFilterExtension.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/MethodFilterExtension.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.tests.util;
+
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * A JUnit5 {@link ExecutionCondition} that filters test methods based on the {@code tests.method}
+ * system property. This mirrors the behavior of RandomizedRunner's {@code MethodGlobFilter} for
+ * JUnit4 tests, ensuring that {@code --tests} filtering works consistently when {@code tests.iters}
+ * is used.
+ *
+ * <p>When {@code tests.method} is set, only test methods whose names match the glob pattern (with
+ * {@code *} as wildcard) will be executed. All other tests in the class are disabled.
+ *
+ * @lucene.internal
+ */
+class MethodFilterExtension implements ExecutionCondition {
+
+  private static final String TESTS_METHOD_PROPERTY = "tests.method";
+
+  /** Cached compiled pattern for the current tests.method value. */
+  private static volatile Pattern cachedPattern;
+
+  /** The tests.method value that cachedPattern was compiled from. */
+  private static volatile String cachedPatternSource;
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    String methodFilter = System.getProperty(TESTS_METHOD_PROPERTY);
+    if (methodFilter == null || methodFilter.isBlank()) {
+      return ConditionEvaluationResult.enabled("No tests.method filter set");
+    }
+
+    // Only apply to test methods, not containers (classes)
+    if (!context.getTestMethod().isPresent()) {
+      return ConditionEvaluationResult.enabled("Not a test method");
+    }
+
+    String testMethodName = context.getTestMethod().get().getName();
+    if (globMatches(methodFilter, testMethodName)) {
+      return ConditionEvaluationResult.enabled(
+          "Test method '"
+              + testMethodName
+              + "' matches tests.method filter '"
+              + methodFilter
+              + "'");
+    }
+
+    return ConditionEvaluationResult.disabled(
+        "Test method '"
+            + testMethodName
+            + "' does not match tests.method filter '"
+            + methodFilter
+            + "'");
+  }
+
+  /**
+   * Checks if a string matches any of the comma-separated simplified glob patterns where {@code *}
+   * matches any sequence of characters and {@code ?} matches any single character.
+   */
+  private static boolean globMatches(String glob, String string) {
+    Pattern pattern = compileGlobPattern(glob);
+    return pattern.matcher(string).matches();
+  }
+
+  /** Compiles a glob pattern (with caching) to a regex Pattern. */
+  private static Pattern compileGlobPattern(String glob) {
+    // Double-checked locking for lazy initialization of the cached pattern.
+    Pattern result = cachedPattern;
+    if (result == null || !glob.equals(cachedPatternSource)) {
+      synchronized (MethodFilterExtension.class) {
+        result = cachedPattern;
+        if (result == null || !glob.equals(cachedPatternSource)) {
+          StringBuilder regex = new StringBuilder("^");
+          for (String part : glob.split(",")) {
+            if (regex.length() > 1) {
+              regex.append("|");
+            }
+            regex.append("(?:");
+            StringBuilder literalRun = new StringBuilder();
+            for (int i = 0; i < part.length(); i++) {
+              char c = part.charAt(i);
+              switch (c) {
+                case '*':
+                  flushLiteralRun(regex, literalRun);
+                  regex.append(".*");
+                  break;
+                case '?':
+                  flushLiteralRun(regex, literalRun);
+                  regex.append('.');
+                  break;
+                default:
+                  literalRun.append(c);
+                  break;
+              }
+            }
+            flushLiteralRun(regex, literalRun);
+            regex.append(')');
+          }
+          regex.append('$');
+          result = Pattern.compile(regex.toString());
+          cachedPattern = result;
+          cachedPatternSource = glob;
+        }
+      }
+    }
+    return result;
+  }
+
+  /** Appends any accumulated literal characters to the regex, quoted as a group. */
+  private static void flushLiteralRun(StringBuilder regex, StringBuilder literalRun) {
+    if (literalRun.length() > 0) {
+      regex.append(Pattern.quote(literalRun.toString()));
+      literalRun.setLength(0);
+    }
+  }
+}

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestMethodFilterExtension.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestMethodFilterExtension.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.tests.util;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+
+/// Tests for {@link MethodFilterExtension}.
+///
+/// <p>Note: {@link LuceneTestCaseJupiter} adds 3 infrastructure tests
+/// (verifyTestAssertionStatus, enforceClassNamingConvention, allTestMethodsAreAnnotated)
+/// to every subclass, so the inner test class below has 6 tests total.
+public class TestMethodFilterExtension {
+
+  /// Total number of tests in {@link FilterableTestClass} (3 parent + 3 own).
+  private static final int TOTAL_TESTS = 6;
+
+  /// A test class with methods that can be filtered.
+  static class FilterableTestClass extends LuceneTestCaseJupiter {
+    @org.junit.jupiter.api.Test
+    void testMethodA() {}
+
+    @org.junit.jupiter.api.Test
+    void testMethodB() {}
+
+    @org.junit.jupiter.api.Test
+    void otherMethod() {}
+  }
+
+  @Test
+  public void testNoFilterRunsAllTests() {
+    System.clearProperty("tests.method");
+    Events tests = runTests(FilterableTestClass.class);
+    tests.assertStatistics(stats -> stats.started(TOTAL_TESTS).succeeded(TOTAL_TESTS));
+  }
+
+  @Test
+  public void testSinglePatternFilter() {
+    System.setProperty("tests.method", "testMethod*");
+    try {
+      Events tests = runTests(FilterableTestClass.class);
+      // testMethodA and testMethodB match; 4 others are skipped.
+      tests.assertStatistics(stats -> stats.started(2).succeeded(2).skipped(4));
+    } finally {
+      System.clearProperty("tests.method");
+    }
+  }
+
+  @Test
+  public void testExactMethodFilter() {
+    System.setProperty("tests.method", "testMethodA");
+    try {
+      Events tests = runTests(FilterableTestClass.class);
+      // Only testMethodA matches; 5 others are skipped.
+      tests.assertStatistics(stats -> stats.started(1).succeeded(1).skipped(5));
+    } finally {
+      System.clearProperty("tests.method");
+    }
+  }
+
+  @Test
+  public void testCommaSeparatedPatterns() {
+    System.setProperty("tests.method", "testMethodA,testMethodB");
+    try {
+      Events tests = runTests(FilterableTestClass.class);
+      // testMethodA and testMethodB match; 4 others are skipped.
+      tests.assertStatistics(stats -> stats.started(2).succeeded(2).skipped(4));
+    } finally {
+      System.clearProperty("tests.method");
+    }
+  }
+
+  @Test
+  public void testQuestionMarkWildcard() {
+    System.setProperty("tests.method", "testMethod?");
+    try {
+      Events tests = runTests(FilterableTestClass.class);
+      // testMethodA and testMethodB match (the ? matches the last char); 4 others are skipped.
+      tests.assertStatistics(stats -> stats.started(2).succeeded(2).skipped(4));
+    } finally {
+      System.clearProperty("tests.method");
+    }
+  }
+
+  @Test
+  public void testNonMatchingFilter() {
+    System.setProperty("tests.method", "nonExistent*");
+    try {
+      Events tests = runTests(FilterableTestClass.class);
+      // Nothing matches; all 6 are skipped.
+      tests.assertStatistics(stats -> stats.started(0).skipped(TOTAL_TESTS));
+    } finally {
+      System.clearProperty("tests.method");
+    }
+  }
+
+  private static Events runTests(Class<?> testClass) {
+    return EngineTestKit.engine("junit-jupiter")
+        .selectors(selectClass(testClass))
+        .execute()
+        .testEvents();
+  }
+}


### PR DESCRIPTION
when `tests.iters > 1`, randomizedrunner changes the test names by adding a `{seed=...}` part. so the method name is no longer exactly `testMethod`, it becomes something longer.

because of that, when we pass `--tests ClassName.methodName`, junit can’t find it and fails saying no tests matched.

this change just fixes that automatically. instead of trying to match the method directly, we run the whole class and pass the method name through `tests.method`, which randomizedrunner already understands.

also added the same support for junit5 so it behaves the same there.

so basically, method filtering works properly again even when tests are repeated multiple times

https://github.com/apache/lucene/issues/16121
