### PR TITLE
Tighten constant-score bulk routing

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -456,7 +456,10 @@ Optimizations
 
 * GITHUB#16126: Implement #intoBitSet and #docIDRunEnd in DocValuesWriter implementations. (Ignacio Vera)
 
-* GITHUB#16141: Optimize constant-score bulk scoring via intoBitSet batching. (Costin Leau)
+* GITHUB#16141, GITHUB#16143: Optimize constant-score bulk scoring via intoBitSet
+  batching, route more constant-score iterators through ConstantScoreScorerSupplier,
+  and preserve two-phase iterator semantics when falling back to DefaultBulkScorer.
+  (Costin Leau)
 
 * GITHUB#16147: Optimize column batch parent field with bulk fill. (Tim Brooks)
 

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractMultiTermQueryConstantScoreWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractMultiTermQueryConstantScoreWrapper.java
@@ -291,8 +291,9 @@ abstract class AbstractMultiTermQueryConstantScoreWrapper<Q extends MultiTermQue
             bulkScorer = weightOrIterator.weight.bulkScorer(context);
           } else {
             bulkScorer =
-                new DefaultBulkScorer(
-                    new ConstantScoreScorer(score(), scoreMode, weightOrIterator.iterator));
+                ConstantScoreScorerSupplier.fromIterator(
+                        weightOrIterator.iterator, score(), scoreMode, context.reader().maxDoc())
+                    .bulkScorer();
           }
 
           // It's against the API contract to return a null scorer from a non-null ScoreSupplier.

--- a/lucene/core/src/java/org/apache/lucene/search/ConstantScoreScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ConstantScoreScorerSupplier.java
@@ -93,7 +93,11 @@ public abstract class ConstantScoreScorerSupplier extends ScorerSupplier {
     } else if (scoreMode.needsScores() == false && twoPhase == null) {
       return new ConstantScoreBulkScorer(score, scoreMode, iterator);
     } else {
-      return new Weight.DefaultBulkScorer(new ConstantScoreScorer(score, scoreMode, iterator));
+      Scorer scorer =
+          twoPhase == null
+              ? new ConstantScoreScorer(score, scoreMode, iterator)
+              : new ConstantScoreScorer(score, scoreMode, twoPhase);
+      return new Weight.DefaultBulkScorer(scorer);
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
@@ -212,8 +212,8 @@ public class FieldExistsQuery extends Query {
         if (iterator == null) {
           return null;
         }
-        final var scorer = new ConstantScoreScorer(score(), scoreMode, iterator);
-        return new DefaultScorerSupplier(scorer);
+        return ConstantScoreScorerSupplier.fromIterator(
+            iterator, score(), scoreMode, context.reader().maxDoc());
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -156,17 +156,8 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends NumericDocValuesR
         IteratorAndCount itAndCount = getDocIdSetIteratorOrNull(context);
         if (itAndCount != null) {
           DocIdSetIterator disi = itAndCount.it;
-          return new ScorerSupplier() {
-            @Override
-            public Scorer get(long leadCost) throws IOException {
-              return new ConstantScoreScorer(score(), scoreMode, disi);
-            }
-
-            @Override
-            public long cost() {
-              return disi.cost();
-            }
-          };
+          return ConstantScoreScorerSupplier.fromIterator(
+              disi, score(), scoreMode, context.reader().maxDoc());
         }
         return fallbackWeight.scorerSupplier(context);
       }

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanScorer.java
@@ -260,6 +260,50 @@ public class TestBooleanScorer extends LuceneTestCase {
                 1f, ScoreMode.COMPLETE, new CountingDocIdSetIterator(new int[] {1})));
   }
 
+  public void testConstantScoreScorerSupplierPreservesTwoPhaseIterator() throws IOException {
+    int[] docs = {1, 2, 3};
+    CountingDocIdSetIterator approximation = new CountingDocIdSetIterator(docs);
+    DocIdSetIterator iterator =
+        TwoPhaseIterator.asDocIdSetIterator(
+            new TwoPhaseIterator(approximation) {
+              @Override
+              public boolean matches() {
+                return approximation.docID() != 2;
+              }
+
+              @Override
+              public float matchCost() {
+                return 1f;
+              }
+            });
+
+    int[] collected = new int[docs.length];
+    int[] count = new int[1];
+    LeafCollector collector =
+        new LeafCollector() {
+          @Override
+          public void setScorer(Scorable scorer) {}
+
+          @Override
+          public void collect(int doc) {
+            collected[count[0]++] = doc;
+          }
+
+          @Override
+          public void collect(DocIdStream stream) {
+            fail("two-phase iterators must preserve per-doc confirmation");
+          }
+        };
+
+    BulkScorer bulkScorer =
+        ConstantScoreScorerSupplier.fromIterator(iterator, 1f, ScoreMode.COMPLETE_NO_SCORES, 9000)
+            .bulkScorer();
+    assertThat(bulkScorer, instanceOf(DefaultBulkScorer.class));
+    assertEquals(DocIdSetIterator.NO_MORE_DOCS, bulkScorer.score(collector, null, 0, 9000));
+    assertArrayEquals(new int[] {1, 3}, Arrays.copyOf(collected, count[0]));
+    assertEquals(0, approximation.intoBitSetCalls);
+  }
+
   public void testDefaultBulkScorerDoesNotUseDocIdStreamForTopScores() throws IOException {
     assertDefaultBulkScorerDoesNotUseDocIdStreamForScores(ScoreMode.TOP_SCORES);
   }


### PR DESCRIPTION
Follow-up based on the comments from #16141.

With `ConstantScoreBulkScorer` now in main, this routes the remaining constant-score iterator paths through the shared supplier instead of leaving one-off bulk scorer construction around the codebase. It also makes the batch-collection scorer-positioning rule explicit, which is the contract #16141 had to rely on.

The changes are:
- Route additional constant-score iterator paths through `ConstantScoreScorerSupplier`.
- Preserve two-phase iterator semantics when the supplier falls back to `DefaultBulkScorer`.
- Document that `collect(DocIdStream)` and `collectRange()` do not guarantee scorer positioning.
- Assert the unsafe iterator-backed scorer case in `AssertingLeafCollector`.
- Make `RangeBulkScorer` use a synthetic constant `Scorable` for range batches.