### PR TITLE
Document batch collection score contract

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -369,6 +369,8 @@ Improvements
 
 * GITHUB#16088: SearchGroup#merge now returns an empty collection instead of null when topGroups is empty. (Luca Cavanna)
 
+* GITHUB#16144: Clarify LeafCollector batch collection scoring contract. (Costin Leau)
+
 Optimizations
 ---------------------
 * GITHUB#15861: Optimise PhraseScorer by short circuiting non competitive documents in TOP_SCORES mode. (Prithvi S)

--- a/lucene/core/src/java/org/apache/lucene/document/RangeBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/document/RangeBulkScorer.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.LeafCollector;
-import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Scorable;
 import org.apache.lucene.util.Bits;
 
 /**
@@ -35,18 +35,24 @@ import org.apache.lucene.util.Bits;
 final class RangeBulkScorer extends BulkScorer {
   private final int minDocID;
   private final int maxDocID;
-  private final Scorer scorer;
+  private final Scorable scorer;
   private final DocIdSetIterator iterator;
 
   /** Creates a bulk scorer that collects only within {@code [minDocID, maxDocID)}. */
-  public RangeBulkScorer(Scorer scorer, int minDocID, int maxDocID) {
+  public RangeBulkScorer(DocIdSetIterator iterator, float score, int minDocID, int maxDocID) {
     if (minDocID >= maxDocID) {
       throw new IllegalArgumentException("minDocID must be less than maxDocID");
     }
     this.minDocID = minDocID;
     this.maxDocID = maxDocID;
-    this.scorer = Objects.requireNonNull(scorer);
-    this.iterator = scorer.iterator();
+    this.iterator = Objects.requireNonNull(iterator);
+    this.scorer =
+        new Scorable() {
+          @Override
+          public float score() {
+            return score;
+          }
+        };
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/document/SortedSkipperScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedSkipperScorerSupplier.java
@@ -97,8 +97,7 @@ abstract class SortedSkipperScorerSupplier extends ScorerSupplier {
       return emptyBulkScorer();
     }
     DocIdSetIterator iterator = DocIdSetIterator.range(range.minDocID(), range.maxDocID());
-    return new RangeBulkScorer(
-        new ConstantScoreScorer(score, scoreMode, iterator), range.minDocID(), range.maxDocID());
+    return new RangeBulkScorer(iterator, score, range.minDocID(), range.maxDocID());
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
@@ -94,6 +94,11 @@ public interface LeafCollector {
    * <p>The default implementation calls {@link #collect(DocIdStream)} on a {@link DocIdStream} that
    * matches the given range.
    *
+   * <p>The {@link Scorable} set via {@link #setScorer} is not guaranteed to be positioned on any
+   * document within the range. Implementations must not call {@link Scorable#score()} or rely on
+   * scorer positioning inside this method. Use {@link #collect(int)} if per-document scores are
+   * needed.
+   *
    * @see #collect(int)
    */
   default void collectRange(int min, int max) throws IOException {
@@ -116,6 +121,11 @@ public interface LeafCollector {
    *
    * <p>It is legal for callers to mix calls to {@link #collect(DocIdStream)} and {@link
    * #collect(int)}.
+   *
+   * <p>The {@link Scorable} set via {@link #setScorer} is not guaranteed to be positioned on any
+   * document within the stream. Implementations must not call {@link Scorable#score()} or rely on
+   * scorer positioning inside this method. Use {@link #collect(int)} if per-document scores are
+   * needed.
    *
    * <p>The default implementation calls {@code stream.forEach(this::collect)}.
    */

--- a/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LeafCollector.java
@@ -94,10 +94,10 @@ public interface LeafCollector {
    * <p>The default implementation calls {@link #collect(DocIdStream)} on a {@link DocIdStream} that
    * matches the given range.
    *
-   * <p>The {@link Scorable} set via {@link #setScorer} is not guaranteed to be positioned on any
-   * document within the range. Implementations must not call {@link Scorable#score()} or rely on
-   * scorer positioning inside this method. Use {@link #collect(int)} if per-document scores are
-   * needed.
+   * <p>The position of the {@link Scorable} set via {@link #setScorer} is undefined within this
+   * method. Overrides must not call {@link Scorable#score()}, and if the {@link Scorable} is a
+   * {@link Scorer}, must not assume {@link Scorer#docID()} corresponds to any document being
+   * collected. Use {@link #collect(int)} if per-document scores are needed.
    *
    * @see #collect(int)
    */
@@ -122,10 +122,10 @@ public interface LeafCollector {
    * <p>It is legal for callers to mix calls to {@link #collect(DocIdStream)} and {@link
    * #collect(int)}.
    *
-   * <p>The {@link Scorable} set via {@link #setScorer} is not guaranteed to be positioned on any
-   * document within the stream. Implementations must not call {@link Scorable#score()} or rely on
-   * scorer positioning inside this method. Use {@link #collect(int)} if per-document scores are
-   * needed.
+   * <p>The position of the {@link Scorable} set via {@link #setScorer} is undefined within this
+   * method. Overrides must not call {@link Scorable#score()}, and if the {@link Scorable} is a
+   * {@link Scorer}, must not assume {@link Scorer#docID()} corresponds to any document being
+   * collected. Use {@link #collect(int)} if per-document scores are needed.
    *
    * <p>The default implementation calls {@code stream.forEach(this::collect)}.
    */

--- a/lucene/core/src/test/org/apache/lucene/document/TestRangeFilteredBulkScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestRangeFilteredBulkScorer.java
@@ -19,11 +19,9 @@ package org.apache.lucene.document;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.lucene.search.BulkScorer;
-import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorable;
-import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.FixedBitSet;
 
@@ -103,8 +101,7 @@ public class TestRangeFilteredBulkScorer extends LuceneTestCase {
 
   private static RangeBulkScorer newBulkScorer(int rangeMin, int rangeMaxExclusive) {
     var iterator = DocIdSetIterator.range(rangeMin, rangeMaxExclusive);
-    var scorer = new ConstantScoreScorer(1f, ScoreMode.COMPLETE, iterator);
-    return new RangeBulkScorer(scorer, rangeMin, rangeMaxExclusive);
+    return new RangeBulkScorer(iterator, 1f, rangeMin, rangeMaxExclusive);
   }
 
   /** Records {@link LeafCollector#collectRange} calls as {@code [min inclusive, max exclusive)}. */

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
@@ -79,6 +79,8 @@ class AssertingLeafCollector extends FilterLeafCollector {
             }
           });
     } else {
+      // Some bulk scorers install synthetic Scorables that are deliberately safe to score during
+      // batching, so only iterator-backed Scorers get the batch-position assertion above.
       super.setScorer(wrappedScorer);
     }
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/AssertingLeafCollector.java
@@ -23,8 +23,10 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.DocIdStream;
 import org.apache.lucene.search.FilterDocIdSetIterator;
 import org.apache.lucene.search.FilterLeafCollector;
+import org.apache.lucene.search.FilterScorer;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.Scorer;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOIntConsumer;
 
@@ -38,6 +40,7 @@ class AssertingLeafCollector extends FilterLeafCollector {
   private boolean finishCalled;
 
   private int[] docBuffer;
+  private int batchCollectionDepth;
 
   AssertingLeafCollector(LeafCollector collector, int min, int max) {
     super(collector);
@@ -47,7 +50,37 @@ class AssertingLeafCollector extends FilterLeafCollector {
 
   @Override
   public void setScorer(Scorable scorer) throws IOException {
-    super.setScorer(AssertingScorable.wrap(scorer));
+    Scorable wrappedScorer = AssertingScorable.wrap(scorer);
+    if (wrappedScorer instanceof Scorer wrappedScorerAsScorer) {
+      super.setScorer(
+          new FilterScorer(wrappedScorerAsScorer) {
+            @Override
+            public float score() throws IOException {
+              assert batchCollectionDepth == 0
+                  : "Scorable.score() must not be called inside collect(DocIdStream) or "
+                      + "collectRange() since the scorer is not positioned on individual "
+                      + "documents during batch collection";
+              return super.score();
+            }
+
+            @Override
+            public void setMinCompetitiveScore(float minScore) throws IOException {
+              in.setMinCompetitiveScore(minScore);
+            }
+
+            @Override
+            public float getMaxScore(int upTo) throws IOException {
+              return in.getMaxScore(upTo);
+            }
+
+            @Override
+            public int advanceShallow(int target) throws IOException {
+              return in.advanceShallow(target);
+            }
+          });
+    } else {
+      super.setScorer(wrappedScorer);
+    }
   }
 
   @Override
@@ -64,7 +97,12 @@ class AssertingLeafCollector extends FilterLeafCollector {
         }
       }
     } else {
-      in.collect(new AssertingDocIdStream(stream));
+      batchCollectionDepth++;
+      try {
+        in.collect(new AssertingDocIdStream(stream));
+      } finally {
+        batchCollectionDepth--;
+      }
     }
   }
 
@@ -74,7 +112,12 @@ class AssertingLeafCollector extends FilterLeafCollector {
     assert max > min;
     assert min >= this.min : "Out of range: " + min + " < " + this.min;
     assert max <= this.max : "Out of range: " + (max - 1) + " >= " + this.max;
-    in.collectRange(min, max);
+    batchCollectionDepth++;
+    try {
+      in.collectRange(min, max);
+    } finally {
+      batchCollectionDepth--;
+    }
     lastCollected = max - 1;
   }
 

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/search/TestAssertingLeafCollector.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/search/TestAssertingLeafCollector.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.tests.search;
+
+import java.io.IOException;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.DocIdStream;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.IOIntConsumer;
+
+public class TestAssertingLeafCollector extends LuceneTestCase {
+
+  public void testScoreRejectedDuringDocIdStreamCollection() throws IOException {
+    AssertingLeafCollector collector = new AssertingLeafCollector(scoreCallingCollector(), 0, 10);
+    collector.setScorer(new ConstantScoreScorer(1f, ScoreMode.COMPLETE, DocIdSetIterator.all(10)));
+
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(AssertionError.class, () -> collector.collect(singletonStream(1)));
+    } else {
+      collector.collect(singletonStream(1));
+    }
+  }
+
+  public void testScoreRejectedDuringRangeCollection() throws IOException {
+    AssertingLeafCollector collector = new AssertingLeafCollector(scoreCallingCollector(), 0, 10);
+    collector.setScorer(new ConstantScoreScorer(1f, ScoreMode.COMPLETE, DocIdSetIterator.all(10)));
+
+    if (TEST_ASSERTS_ENABLED) {
+      expectThrows(AssertionError.class, () -> collector.collectRange(1, 3));
+    } else {
+      collector.collectRange(1, 3);
+    }
+  }
+
+  public void testScoreAllowedDuringRangeCollectionWithNonScorer() throws IOException {
+    AssertingLeafCollector collector = new AssertingLeafCollector(scoreCallingCollector(), 0, 10);
+    collector.setScorer(scorable());
+
+    collector.collectRange(1, 3);
+  }
+
+  private static Scorable scorable() {
+    return new Scorable() {
+      @Override
+      public float score() {
+        return 1f;
+      }
+    };
+  }
+
+  private static LeafCollector scoreCallingCollector() {
+    return new LeafCollector() {
+      private Scorable scorer;
+
+      @Override
+      public void setScorer(Scorable scorer) {
+        this.scorer = scorer;
+      }
+
+      @Override
+      public void collect(int doc) throws IOException {
+        scorer.score();
+      }
+
+      @Override
+      public void collect(DocIdStream stream) throws IOException {
+        scorer.score();
+      }
+
+      @Override
+      public void collectRange(int min, int max) throws IOException {
+        scorer.score();
+      }
+    };
+  }
+
+  private static DocIdStream singletonStream(int doc) {
+    return new DocIdStream() {
+      private boolean consumed;
+
+      @Override
+      public void forEach(int upTo, IOIntConsumer consumer) throws IOException {
+        if (consumed == false && doc < upTo) {
+          consumed = true;
+          consumer.accept(doc);
+        }
+      }
+
+      @Override
+      public int count(int upTo) {
+        if (consumed || doc >= upTo) {
+          return 0;
+        }
+        consumed = true;
+        return 1;
+      }
+
+      @Override
+      public int intoArray(int upTo, int[] array) {
+        assert array.length > 0;
+        if (consumed || doc >= upTo) {
+          return 0;
+        }
+        consumed = true;
+        array[0] = doc;
+        return 1;
+      }
+
+      @Override
+      public boolean mayHaveRemaining() {
+        return consumed == false;
+      }
+    };
+  }
+}


### PR DESCRIPTION
Split from #16143.

Makes the batch-collection scorer-positioning rule explicit, which is the contract #16141 had to rely on.

The constant-score bulk routing work exposed a small contract gap around batch collection: `collect(DocIdStream)` and `collectRange()` can collect docs without positioning the scorer on each doc, so collectors should not call `Scorable.score()` from those batch methods.

This makes that explicit in `LeafCollector`, teaches `AssertingLeafCollector` to catch accidental score calls when the installed `Scorable` is an iterator-backed `Scorer`, and updates `RangeBulkScorer` to pass a synthetic constant-score `Scorable` instead of a scorer whose iterator is also being consumed by the bulk scorer. 
I kept the assertion scoped to iterator-backed `Scorer`s because Lucene has legitimate synthetic `Scorable`s used by bulk scorers, and a broader guard produced false positives rather than a useful contract check.

For safety, I've added a dedicated test case.