### PR TITLE
MemorySegmentIndexInput: always prefetch on RANDOM mode

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -141,7 +141,7 @@ Improvements
 
 Optimizations
 ---------------------
-* GITHUB#XXXXX: Always fire prefetch when ReadAdvice is RANDOM in MemorySegmentIndexInput. The power-of-two throttle in
+* GITHUB#16145: Always fire prefetch when ReadAdvice is RANDOM in MemorySegmentIndexInput. The power-of-two throttle in
   MemorySegmentIndexInput assumes "consecutive cache hits → file is warm", which does not hold for
   random-access patterns where each request visits unpredictable pages. A negative sentinel in the
   shared prefetch counter signals RANDOM mode with zero overhead on the non-RANDOM hot path.

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -141,10 +141,10 @@ Improvements
 
 Optimizations
 ---------------------
-* GITHUB#16145: Always fire prefetch when ReadAdvice is RANDOM in MemorySegmentIndexInput. The power-of-two throttle in
-  MemorySegmentIndexInput assumes "consecutive cache hits → file is warm", which does not hold for
-  random-access patterns where each request visits unpredictable pages. A negative sentinel in the
-  shared prefetch counter signals RANDOM mode with zero overhead on the non-RANDOM hot path.
+* GITHUB#16145: Always fire prefetch when ReadAdvice is RANDOM in MemorySegmentIndexInput. The power-of-two throttle
+  assumes "consecutive cache hits → file is warm", which does not hold for random-access patterns where each request
+  visits unpredictable pages. An isRandom boolean flag bypasses the throttle with zero overhead on the non-RANDOM
+  hot path.
   (Michael Marshall)
 
 * GITHUB#15681, GITHUB#15833, GITHUB#16056: Replace pre-sized array or empty array with lambda expression to call Collection#toArray. (Zhou Hui)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -141,6 +141,12 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#XXXXX: Always fire prefetch when ReadAdvice is RANDOM in MemorySegmentIndexInput. The power-of-two throttle in
+  MemorySegmentIndexInput assumes "consecutive cache hits → file is warm", which does not hold for
+  random-access patterns where each request visits unpredictable pages. A negative sentinel in the
+  shared prefetch counter signals RANDOM mode with zero overhead on the non-RANDOM hot path.
+  (Michael Marshall)
+
 * GITHUB#15681, GITHUB#15833, GITHUB#16056: Replace pre-sized array or empty array with lambda expression to call Collection#toArray. (Zhou Hui)
 
 * GITHUB#13782: Replace handwritten loops compare with Arrays.compareUnsigned in TermsEnum and TermsEnumFrame classes. (Zhou Hui)

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -327,6 +327,7 @@ public class MMapDirectory extends FSDirectory {
     final Arena arena = confined ? Arena.ofConfined() : getSharedArena(name, arenas);
     try (var fc = FileChannel.open(path, StandardOpenOption.READ)) {
       final long fileSize = fc.size();
+      final ReadAdvice readAdvice = toReadAdvice.apply(context);
       return MemorySegmentIndexInput.newInstance(
           resourceDescription,
           arena,
@@ -334,14 +335,15 @@ public class MMapDirectory extends FSDirectory {
               arena,
               resourceDescription,
               fc,
-              toReadAdvice.apply(context),
+              readAdvice,
               chunkSizePower,
               preload.test(name, context),
               fileSize),
           fileSize,
           chunkSizePower,
           confined,
-          toReadAdvice);
+          toReadAdvice,
+          readAdvice == ReadAdvice.RANDOM);
     } catch (Throwable t) {
       arena.close();
       throw t;

--- a/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -338,7 +338,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
 
     ensureOpen();
 
-    if (isRandom == false
+    final boolean skipPrefetchBackoff = this.isRandom;
+    if (skipPrefetchBackoff == false
         && BitUtil.isZeroOrPowerOfTwo(sharedPrefetchCounter.getAndIncrement()) == false) {
       // We've had enough consecutive hits on the page cache that this number is neither zero nor a
       // power of two. There is a good chance that a good chunk of this index input is cached in
@@ -353,8 +354,12 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
         length,
         segment -> {
           if (segment.isLoaded() == false) {
-            // We have a cache miss on at least one page, let's reset the counter.
-            sharedPrefetchCounter.set(0);
+            // We have a cache miss on at least one page. Reset the counter so that the next
+            // NORMAL-mode prefetch fires immediately. Skipped in RANDOM mode since the counter
+            // is not used there.
+            if (skipPrefetchBackoff == false) {
+              sharedPrefetchCounter.set(0);
+            }
             nativeAccess.madviseWillNeed(segment);
             return true;
           }

--- a/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -358,13 +358,15 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
         offset,
         length,
         segment -> {
+          if (skipPrefetchBackoff) {
+            // RANDOM mode: always fire madvise, skip isLoaded() overhead (mincore on every
+            // segment).
+            nativeAccess.madviseWillNeed(segment);
+            return true;
+          }
           if (segment.isLoaded() == false) {
-            // We have a cache miss on at least one page. Reset the counter so that the next
-            // NORMAL-mode prefetch fires immediately. Skipped in RANDOM mode since the counter
-            // is not used there.
-            if (skipPrefetchBackoff == false) {
-              sharedPrefetchCounter.set(0);
-            }
+            // Cache miss: reset counter so the next prefetch fires immediately.
+            sharedPrefetchCounter.set(0);
             nativeAccess.madviseWillNeed(segment);
             return true;
           }

--- a/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -60,6 +60,9 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
   final MemorySegment[] segments;
   final Function<IOContext, ReadAdvice> toReadAdvice;
   final AtomicInteger sharedPrefetchCounter;
+  // True when ReadAdvice.RANDOM is active. Checked before the power-of-two throttle in prefetch()
+  // so that random-access patterns always fire madvise regardless of the page-cache hit counter.
+  volatile boolean isRandom;
 
   int curSegmentIndex = -1;
   MemorySegment
@@ -335,7 +338,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
 
     ensureOpen();
 
-    if (BitUtil.isZeroOrPowerOfTwo(sharedPrefetchCounter.getAndIncrement()) == false) {
+    if (isRandom == false
+        && BitUtil.isZeroOrPowerOfTwo(sharedPrefetchCounter.getAndIncrement()) == false) {
       // We've had enough consecutive hits on the page cache that this number is neither zero nor a
       // power of two. There is a good chance that a good chunk of this index input is cached in
       // physical memory. Let's skip the overhead of the madvise system call, we'll be trying again
@@ -380,6 +384,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
           });
       offset += seg.byteSize();
     }
+
+    isRandom = (readAdvice == ReadAdvice.RANDOM);
   }
 
   boolean advise(long offset, long length, IOFunction<MemorySegment, Boolean> advice)
@@ -628,6 +634,7 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
             });
       }
     }
+    slice.isRandom = (advice == ReadAdvice.RANDOM);
     return slice;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -62,7 +62,7 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
   final AtomicInteger sharedPrefetchCounter;
   // True when ReadAdvice.RANDOM is active. Checked before the power-of-two throttle in prefetch()
   // so that random-access patterns always fire madvise regardless of the page-cache hit counter.
-  volatile boolean isRandom;
+  boolean isRandom;
 
   int curSegmentIndex = -1;
   MemorySegment

--- a/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -76,7 +76,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
       long length,
       int chunkSizePower,
       boolean confined,
-      Function<IOContext, ReadAdvice> toReadAdvice) {
+      Function<IOContext, ReadAdvice> toReadAdvice,
+      boolean isRandom) {
     assert Arrays.stream(segments).map(MemorySegment::scope).allMatch(arena.scope()::equals);
     AtomicInteger sharedPrefetchCounter = new AtomicInteger();
     if (segments.length == 1) {
@@ -88,7 +89,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
           chunkSizePower,
           confined,
           toReadAdvice,
-          sharedPrefetchCounter);
+          sharedPrefetchCounter,
+          isRandom);
     } else {
       return new MultiSegmentImpl(
           resourceDescription,
@@ -99,7 +101,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
           chunkSizePower,
           confined,
           toReadAdvice,
-          sharedPrefetchCounter);
+          sharedPrefetchCounter,
+          isRandom);
     }
   }
 
@@ -111,7 +114,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
       int chunkSizePower,
       boolean confined,
       Function<IOContext, ReadAdvice> toReadAdvice,
-      AtomicInteger sharedPrefetchCounter) {
+      AtomicInteger sharedPrefetchCounter,
+      boolean isRandom) {
     super(resourceDescription);
     this.arena = arena;
     this.segments = segments;
@@ -122,6 +126,7 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
     this.curSegment = segments[0];
     this.toReadAdvice = toReadAdvice;
     this.sharedPrefetchCounter = sharedPrefetchCounter;
+    this.isRandom = isRandom;
   }
 
   void ensureOpen() {
@@ -568,7 +573,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
               chunkSizePower,
               confined,
               toReadAdvice,
-              sharedPrefetchCounter);
+              sharedPrefetchCounter,
+              isRandom);
     } else {
       clone =
           new MultiSegmentImpl(
@@ -580,7 +586,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
               chunkSizePower,
               confined,
               toReadAdvice,
-              sharedPrefetchCounter);
+              sharedPrefetchCounter,
+              isRandom);
     }
     try {
       clone.seek(getFilePointer());
@@ -611,14 +618,15 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
               + this);
     }
 
-    return buildSlice(sliceDescription, offset, length);
+    return buildSlice(sliceDescription, offset, length, isRandom);
   }
 
   @Override
   public final MemorySegmentIndexInput slice(
       String sliceDescription, long offset, long length, IOContext context) throws IOException {
-    MemorySegmentIndexInput slice = slice(sliceDescription, offset, length);
     ReadAdvice advice = toReadAdvice.apply(context);
+    MemorySegmentIndexInput slice =
+        buildSlice(sliceDescription, offset, length, advice == ReadAdvice.RANDOM);
     if (NATIVE_ACCESS.isPresent() && advice != ReadAdvice.NORMAL) {
       // No need to madvise with a normal advice, since it's the OS' default.
       final NativeAccess nativeAccess = NATIVE_ACCESS.get();
@@ -638,12 +646,12 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
             });
       }
     }
-    slice.isRandom = (advice == ReadAdvice.RANDOM);
     return slice;
   }
 
   /** Builds the actual sliced IndexInput (may apply extra offset in subclasses). * */
-  MemorySegmentIndexInput buildSlice(String sliceDescription, long offset, long length) {
+  MemorySegmentIndexInput buildSlice(
+      String sliceDescription, long offset, long length, boolean isRandom) {
     ensureOpen();
     ensureAccessible();
     final MemorySegment[] slices;
@@ -674,7 +682,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
           chunkSizePower,
           confined,
           toReadAdvice,
-          sharedPrefetchCounter);
+          sharedPrefetchCounter,
+          isRandom);
     } else {
       return new MultiSegmentImpl(
           newResourceDescription,
@@ -685,7 +694,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
           chunkSizePower,
           confined,
           toReadAdvice,
-          sharedPrefetchCounter);
+          sharedPrefetchCounter,
+          isRandom);
     }
   }
 
@@ -730,7 +740,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
         int chunkSizePower,
         boolean confined,
         Function<IOContext, ReadAdvice> toReadAdvice,
-        AtomicInteger sharedPrefetchCounter) {
+        AtomicInteger sharedPrefetchCounter,
+        boolean isRandom) {
       super(
           resourceDescription,
           arena,
@@ -739,7 +750,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
           chunkSizePower,
           confined,
           toReadAdvice,
-          sharedPrefetchCounter);
+          sharedPrefetchCounter,
+          isRandom);
       this.curSegmentIndex = 0;
     }
 
@@ -844,7 +856,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
         int chunkSizePower,
         boolean confined,
         Function<IOContext, ReadAdvice> toReadAdvice,
-        AtomicInteger sharedPrefetchCounter) {
+        AtomicInteger sharedPrefetchCounter,
+        boolean isRandom) {
       super(
           resourceDescription,
           arena,
@@ -853,7 +866,8 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
           chunkSizePower,
           confined,
           toReadAdvice,
-          sharedPrefetchCounter);
+          sharedPrefetchCounter,
+          isRandom);
       this.offset = offset;
       try {
         seek(0L);
@@ -920,8 +934,9 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
     }
 
     @Override
-    MemorySegmentIndexInput buildSlice(String sliceDescription, long ofs, long length) {
-      return super.buildSlice(sliceDescription, this.offset + ofs, length);
+    MemorySegmentIndexInput buildSlice(
+        String sliceDescription, long ofs, long length, boolean isRandom) {
+      return super.buildSlice(sliceDescription, this.offset + ofs, length, isRandom);
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -373,6 +373,7 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
   }
 
   private void updateReadAdvice(ReadAdvice readAdvice) throws IOException {
+    isRandom = (readAdvice == ReadAdvice.RANDOM);
     if (NATIVE_ACCESS.isEmpty()) {
       return;
     }
@@ -389,8 +390,6 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
           });
       offset += seg.byteSize();
     }
-
-    isRandom = (readAdvice == ReadAdvice.RANDOM);
   }
 
   boolean advise(long offset, long length, IOFunction<MemorySegment, Boolean> advice)

--- a/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
@@ -398,6 +398,89 @@ public class TestMMapDirectory extends BaseDirectoryTestCase {
     assertFalse(func.apply("_51a.si").isPresent());
   }
 
+  // Verifies that isRandom is set/cleared correctly when the read advice changes via
+  // updateIOContext.
+  public void testIsRandomSetByUpdateIOContext() throws IOException {
+    final int size = 8 * 1024;
+    try (MMapDirectory dir = new MMapDirectory(createTempDir("testIsRandomSetByUpdateIOContext"))) {
+      dir.setReadAdvice(MMapDirectory.ADVISE_BY_CONTEXT);
+      try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+        out.writeBytes(new byte[size], 0, size);
+      }
+      try (var in = (MemorySegmentIndexInput) dir.openInput("test", IOContext.DEFAULT)) {
+        assertFalse(in.isRandom);
+        in.updateIOContext(new DefaultIOContext(DataAccessHint.RANDOM));
+        assertTrue(in.isRandom);
+        in.updateIOContext(new DefaultIOContext(DataAccessHint.SEQUENTIAL));
+        assertFalse(in.isRandom);
+      }
+    }
+  }
+
+  // Verifies that isRandom is set on slices created with an IOContext — the primary entry point
+  // for HNSW vector files. Without this, the volatile field would be set correctly by
+  // updateIOContext but missed entirely for slices, leaving prefetch throttled despite RANDOM
+  // advice.
+  public void testIsRandomSetBySliceWithContext() throws IOException {
+    final int size = 8 * 1024;
+    try (MMapDirectory dir =
+        new MMapDirectory(createTempDir("testIsRandomSetBySliceWithContext"))) {
+      dir.setReadAdvice(MMapDirectory.ADVISE_BY_CONTEXT);
+      try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+        out.writeBytes(new byte[size], 0, size);
+      }
+      try (var in = dir.openInput("test", IOContext.DEFAULT)) {
+        var randomSlice =
+            (MemorySegmentIndexInput)
+                in.slice("s", 0, in.length(), new DefaultIOContext(DataAccessHint.RANDOM));
+        assertTrue(randomSlice.isRandom);
+
+        var normalSlice =
+            (MemorySegmentIndexInput)
+                in.slice("s", 0, in.length(), new DefaultIOContext(DataAccessHint.SEQUENTIAL));
+        assertFalse(normalSlice.isRandom);
+      }
+    }
+  }
+
+  // Verifies that the power-of-two throttle (sharedPrefetchCounter) is bypassed in RANDOM mode.
+  // In NORMAL mode the counter increments on every prefetch() call; in RANDOM mode the isRandom
+  // short-circuit prevents getAndIncrement() from running so the counter stays put.
+  public void testPrefetchNotThrottledForRandom() throws IOException {
+    assumeTrue("madvise required for prefetch", MMapDirectory.supportsMadvise());
+    final int size = 8 * 1024;
+    try (MMapDirectory dir =
+        new MMapDirectory(createTempDir("testPrefetchNotThrottledForRandom"))) {
+      dir.setReadAdvice(MMapDirectory.ADVISE_BY_CONTEXT);
+      dir.setPreload(MMapDirectory.PRELOAD_HINT);
+      try (IndexOutput out =
+          dir.createOutput("test", IOContext.DEFAULT.withHints(PreloadHint.INSTANCE))) {
+        out.writeBytes(new byte[size], 0, size);
+      }
+      try (var in =
+          (MemorySegmentIndexInput)
+              dir.openInput("test", IOContext.DEFAULT.withHints(PreloadHint.INSTANCE))) {
+        assertTrue("file should be preloaded", in.isLoaded().orElse(false));
+        assertFalse(in.isRandom);
+
+        // NORMAL mode: counter increments on each call (no misses because pages are warm)
+        for (int i = 0; i < 4; i++) in.prefetch(0, in.length());
+        assertTrue(
+            "counter should have incremented in NORMAL mode", in.sharedPrefetchCounter.get() > 0);
+
+        // RANDOM mode: isRandom short-circuits before getAndIncrement(), counter must not change
+        in.updateIOContext(new DefaultIOContext(DataAccessHint.RANDOM));
+        assertTrue(in.isRandom);
+        int counterSnapshot = in.sharedPrefetchCounter.get();
+        for (int i = 0; i < 4; i++) in.prefetch(0, in.length());
+        assertEquals(
+            "counter must not increment in RANDOM mode",
+            counterSnapshot,
+            in.sharedPrefetchCounter.get());
+      }
+    }
+  }
+
   public void testPrefetchWithSingleSegment() throws IOException {
     testPrefetchWithSegments(64 * 1024);
   }

--- a/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMMapDirectory.java
@@ -398,6 +398,28 @@ public class TestMMapDirectory extends BaseDirectoryTestCase {
     assertFalse(func.apply("_51a.si").isPresent());
   }
 
+  // Verifies that isRandom is set at construction when openInput is called with a RANDOM context.
+  // Fails without the fix that passes readAdvice == ReadAdvice.RANDOM into newInstance().
+  public void testIsRandomSetByOpenInput() throws IOException {
+    final int size = 8 * 1024;
+    try (MMapDirectory dir = new MMapDirectory(createTempDir("testIsRandomSetByOpenInput"))) {
+      dir.setReadAdvice(MMapDirectory.ADVISE_BY_CONTEXT);
+      try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+        out.writeBytes(new byte[size], 0, size);
+      }
+      try (var in =
+          (MemorySegmentIndexInput)
+              dir.openInput("test", new DefaultIOContext(DataAccessHint.RANDOM))) {
+        assertTrue(in.isRandom);
+      }
+      try (var in =
+          (MemorySegmentIndexInput)
+              dir.openInput("test", new DefaultIOContext(DataAccessHint.SEQUENTIAL))) {
+        assertFalse(in.isRandom);
+      }
+    }
+  }
+
   // Verifies that isRandom is set/cleared correctly when the read advice changes via
   // updateIOContext.
   public void testIsRandomSetByUpdateIOContext() throws IOException {
@@ -443,6 +465,32 @@ public class TestMMapDirectory extends BaseDirectoryTestCase {
     }
   }
 
+  // Verifies that slices created without an IOContext inherit isRandom from the parent.
+  // Fails without the fix that passes isRandom (rather than false) into buildSlice().
+  public void testSliceInheritsIsRandom() throws IOException {
+    final int size = 8 * 1024;
+    try (MMapDirectory dir = new MMapDirectory(createTempDir("testSliceInheritsIsRandom"))) {
+      dir.setReadAdvice(MMapDirectory.ADVISE_BY_CONTEXT);
+      try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+        out.writeBytes(new byte[size], 0, size);
+      }
+      try (var in =
+          (MemorySegmentIndexInput)
+              dir.openInput("test", new DefaultIOContext(DataAccessHint.RANDOM))) {
+        assertTrue(in.isRandom);
+        var slice = in.slice("s", 0, in.length());
+        assertTrue("slice must inherit isRandom=true", slice.isRandom);
+      }
+      try (var in =
+          (MemorySegmentIndexInput)
+              dir.openInput("test", new DefaultIOContext(DataAccessHint.SEQUENTIAL))) {
+        assertFalse(in.isRandom);
+        var slice = in.slice("s", 0, in.length());
+        assertFalse("slice must inherit isRandom=false", slice.isRandom);
+      }
+    }
+  }
+
   // Verifies that the power-of-two throttle (sharedPrefetchCounter) is bypassed in RANDOM mode.
   // In NORMAL mode the counter increments on every prefetch() call; in RANDOM mode the isRandom
   // short-circuit prevents getAndIncrement() from running so the counter stays put.
@@ -477,6 +525,38 @@ public class TestMMapDirectory extends BaseDirectoryTestCase {
             "counter must not increment in RANDOM mode",
             counterSnapshot,
             in.sharedPrefetchCounter.get());
+      }
+    }
+  }
+
+  public void testCloneCopiesIsRandomSingleSegment() throws IOException {
+    testCloneCopiesIsRandom(64 * 1024);
+  }
+
+  public void testCloneCopiesIsRandomMultiSegment() throws IOException {
+    testCloneCopiesIsRandom(16);
+  }
+
+  void testCloneCopiesIsRandom(long maxChunkSize) throws IOException {
+    final int size = 64;
+    try (MMapDirectory dir =
+        new MMapDirectory(createTempDir("testCloneCopiesIsRandom"), maxChunkSize)) {
+      dir.setReadAdvice(MMapDirectory.ADVISE_BY_CONTEXT);
+      try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+        out.writeBytes(new byte[size], 0, size);
+      }
+      // isRandom=true: clone must inherit it (fails without the clone fix)
+      try (var in = (MemorySegmentIndexInput) dir.openInput("test", IOContext.DEFAULT)) {
+        in.updateIOContext(new DefaultIOContext(DataAccessHint.RANDOM));
+        assertTrue(in.isRandom);
+        var clone = in.clone();
+        assertTrue("clone must inherit isRandom=true", clone.isRandom);
+      }
+      // isRandom=false: clone must also reflect false
+      try (var in = (MemorySegmentIndexInput) dir.openInput("test", IOContext.DEFAULT)) {
+        assertFalse(in.isRandom);
+        var clone = in.clone();
+        assertFalse("clone must inherit isRandom=false", clone.isRandom);
       }
     }
   }


### PR DESCRIPTION
### Description

The power-of-two back off in MemorySegmentIndexInput.prefetch() assumes consecutive page-cache hits suggest the file is warming up, so madvise overhead can be skipped until the next power-of-two call. That assumption breaks for ReadAdvice.RANDOM, where each request accesses unpredictable pages — a warm page in the past says nothing about whether the next page is warm (e.g. HNSW graph traversal touches a different path per query).

Add a `volatile boolean isRandom` field, set by updateReadAdvice() and also by slice(String, long, long, IOContext), the primary entry point for HNSW vector files, and skip the backoff in prefetch() when it is true and also skip resetting the `sharedPrefetchCounter`.

The one drawback: for RANDOM-advised files that are fully warm in the page cache, isLoaded() is now called on every prefetch rather than being throttled. In practice this seems acceptable because isLoaded() on warm pages should be cheap, and a fully warm RANDOM file means prefetch will now return a more accurate answer than before.

On x86 (TSO) a volatile load before LOCK XADD requires no hardware fence and costs nothing measurable. On ARM the ldar before ldadd adds a small ordering cost, still dwarfed by the atomic itself. The miss-reset lambda returns to a plain set(0) with no special-casing.

I used claude to generate the tests and then I manually reviewed them.

I also considered encoding RANDOM mode as a negative sentinel in the counter itself (Integer.MIN_VALUE) to avoid any new field. Rejected: the counter walks toward zero on every getAndIncrement(), losing RANDOM mode after ~2B calls without a miss; preserving it through misses required a CAS loop (getAndUpdate) in the miss handler, adding complexity that doesn't seem necessary.
