### PR TITLE
Optimize column batch parent field with bulk fill

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -452,6 +452,8 @@ Optimizations
 
 * GITHUB#16141: Optimize constant-score bulk scoring via intoBitSet batching. (Costin Leau)
 
+* GITHUB#16147: Optimize column batch parent field with bulk fill. (Tim Brooks)
+
 Bug Fixes
 ---------------------
 * GITHUB#15754: Fix HTMLStripCharFilter to prevent tags from incorrectly consuming subsequent

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -716,14 +716,14 @@ final class IndexingChain implements Accountable {
 
       ColumnValidation.validateColumnHasIndexingFeature(fieldName, fieldType);
 
-      if (column instanceof BinaryColumn bc) {
-        ColumnValidation.validateBinaryColumn(bc, fieldType);
-      } else if (column instanceof LongColumn lc) {
-        ColumnValidation.validateLongColumn(lc, fieldType);
-      } else if (column instanceof DictionaryColumn dc) {
-        ColumnValidation.validateDictionaryColumn(dc, fieldType);
-      } else if (column instanceof VectorColumn<?> vc) {
-        ColumnValidation.validateVectorColumn(vc, fieldType);
+      switch (column) {
+        case BinaryColumn bc -> ColumnValidation.validateBinaryColumn(bc, fieldType);
+        case LongColumn lc -> ColumnValidation.validateLongColumn(lc, fieldType);
+        case DictionaryColumn dc -> ColumnValidation.validateDictionaryColumn(dc, fieldType);
+        case VectorColumn<?> vc -> ColumnValidation.validateVectorColumn(vc, fieldType);
+        default ->
+            throw new IllegalArgumentException(
+                "Unknown column type: " + column.getClass().getName());
       }
 
       if (fieldType.stored() || fieldType.indexOptions() != IndexOptions.NONE) {
@@ -750,18 +750,8 @@ final class IndexingChain implements Accountable {
       validateColumnSchema(fieldName, pf, fieldType);
     }
 
-    // Index the parent field for every document (each batch doc is an individual document,
-    // not part of a block, so every doc is its own parent).
     if (parentPf != null) {
-      if (parentPf.fieldInfo == null) {
-        initializeFieldInfo(parentPf);
-        parentPf.trySetValidatedFrozenFieldType();
-      }
-      final NumericDocValuesWriter parentWriter = (NumericDocValuesWriter) parentPf.docValuesWriter;
-      final long value = parentField.numericValue().longValue();
-      for (int i = 0; i < numDocs; i++) {
-        parentWriter.addValue(baseDocID + i, value);
-      }
+      processParentFieldForColumnBatch(baseDocID, numDocs);
     }
 
     // Row-oriented pass: stored fields and term inversion only. Uses fresh tuple cursors.
@@ -795,6 +785,17 @@ final class IndexingChain implements Accountable {
                 "Unknown column type: " + column.getClass().getName());
       }
     }
+  }
+
+  private void processParentFieldForColumnBatch(int baseDocID, int numDocs) throws IOException {
+    if (parentPf.fieldInfo == null) {
+      initializeFieldInfo(parentPf);
+      parentPf.trySetValidatedFrozenFieldType();
+    }
+    // Index the parent field for every document (each batch doc is an individual document,
+    // not part of a block, so every doc is its own parent).
+    final NumericDocValuesWriter parentWriter = (NumericDocValuesWriter) parentPf.docValuesWriter;
+    parentWriter.addRepeatValues(baseDocID, parentField.numericValue().longValue(), numDocs);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/NumericDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NumericDocValuesWriter.java
@@ -64,6 +64,20 @@ class NumericDocValuesWriter extends DocValuesWriter<NumericDocValues> {
     lastDocID = docID;
   }
 
+  void addRepeatValues(int firstDocID, long value, int count) {
+    if (count == 0) {
+      return;
+    }
+    assert firstDocID > lastDocID;
+
+    pending.add(value, count);
+    docsWithField.addRange(firstDocID, firstDocID + count);
+
+    updateBytesUsed();
+
+    lastDocID = firstDocID + count - 1;
+  }
+
   void addDenseValues(int firstDocID, LongValuesCursor cursor) {
     int numValues = cursor.size();
     if (numValues == 0) {

--- a/lucene/core/src/java/org/apache/lucene/util/packed/PackedLongValues.java
+++ b/lucene/core/src/java/org/apache/lucene/util/packed/PackedLongValues.java
@@ -18,6 +18,7 @@ package org.apache.lucene.util.packed;
 
 import static org.apache.lucene.util.packed.PackedInts.checkBlockSize;
 
+import java.util.Arrays;
 import org.apache.lucene.document.column.LongValuesCursor;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.ArrayUtil;
@@ -238,6 +239,22 @@ public class PackedLongValues extends LongValues implements Accountable {
       packIfFull();
       pending[pendingOff++] = l;
       size += 1;
+      return this;
+    }
+
+    /** Add {@code count} copies of {@code value} in bulk. */
+    public Builder add(long value, int count) {
+      if (pending == null) {
+        throw new IllegalStateException("Cannot be reused after build()");
+      }
+      while (count > 0) {
+        packIfFull();
+        int toFill = Math.min(count, pending.length - pendingOff);
+        Arrays.fill(pending, pendingOff, pendingOff + toFill, value);
+        pendingOff += toFill;
+        count -= toFill;
+        size += toFill;
+      }
       return this;
     }
 

--- a/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
+++ b/lucene/core/src/test/org/apache/lucene/util/packed/TestPackedInts.java
@@ -1073,6 +1073,67 @@ public class TestPackedInts extends LuceneTestCase {
     }
   }
 
+  public void testPackedLongValuesAddRepeat() {
+    for (DataType dataType : DataType.values()) {
+      final int pageSize = 1 << TestUtil.nextInt(random(), 6, 12);
+      final float acceptableOverheadRatio = random().nextFloat();
+      final PackedLongValues.Builder buf;
+      switch (dataType) {
+        case PACKED:
+          buf = PackedLongValues.packedBuilder(pageSize, acceptableOverheadRatio);
+          break;
+        case DELTA_PACKED:
+          buf = PackedLongValues.deltaPackedBuilder(pageSize, acceptableOverheadRatio);
+          break;
+        case MONOTONIC:
+          buf = PackedLongValues.monotonicBuilder(pageSize, acceptableOverheadRatio);
+          break;
+        default:
+          throw new RuntimeException("added a type and forgot to add it here?");
+      }
+
+      final List<Long> expected = new ArrayList<>();
+      final int numOps = atLeast(20);
+      for (int op = 0; op < numOps; ++op) {
+        switch (random().nextInt(3)) {
+          case 0:
+            final long single = random().nextLong();
+            buf.add(single);
+            expected.add(single);
+            break;
+          case 1:
+            // count == 0 must be a no-op.
+            buf.add(random().nextLong(), 0);
+            break;
+          default:
+            final long value = random().nextLong();
+            final int count = TestUtil.nextInt(random(), 1, pageSize * 3);
+            buf.add(value, count);
+            for (int i = 0; i < count; ++i) {
+              expected.add(value);
+            }
+            break;
+        }
+        assertEquals(expected.size(), buf.size());
+      }
+
+      final PackedLongValues values = buf.build();
+      assertEquals(expected.size(), values.size());
+      for (int i = 0; i < expected.size(); ++i) {
+        assertEquals((long) expected.get(i), values.get(i));
+      }
+
+      final PackedLongValues.Iterator it = values.iterator();
+      for (int i = 0; i < expected.size(); ++i) {
+        assertTrue(it.hasNext());
+        assertEquals((long) expected.get(i), it.next());
+      }
+      assertFalse(it.hasNext());
+
+      expectThrows(IllegalStateException.class, () -> buf.add(random().nextLong(), 5));
+    }
+  }
+
   public void testPackedInputOutput() throws IOException {
     final long[] longs = new long[random().nextInt(8192)];
     final int[] bitsPerValues = new int[longs.length];


### PR DESCRIPTION
When processing a column batch, the parent field previously wrote each
document's value individually via a per-document loop over addValue(),
which incurred N packed-buffer appends, N bit-set updates, and N atomic
counter increments for updateBytesUsed().

Add PackedLongValues.Builder.add(long value, int count) to fill a run of
identical values in bulk using Arrays.fill(). Add
NumericDocValuesWriter.addRepeatValues(), which also batches the
DocsWithFieldSet range and collapses updateBytesUsed() single call.

Replace the parent-field loop in IndexingChain with a call to
addRepeatValues().