### PR TITLE
Improve the test introduced by #16135 to not create any files

### DIFF
--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/compound/hyphenation/TestPatternParser.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/compound/hyphenation/TestPatternParser.java
@@ -18,7 +18,6 @@ package org.apache.lucene.analysis.compound.hyphenation;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.ArrayList;
 import java.util.Locale;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.xml.sax.InputSource;
@@ -26,28 +25,8 @@ import org.xml.sax.SAXException;
 
 public class TestPatternParser extends LuceneTestCase {
 
-  /** Collects everything the parser hands to the consumer so we can inspect it. */
-  private static class CollectingConsumer implements PatternConsumer {
-    final StringBuilder collected = new StringBuilder();
-
-    @Override
-    public void addClass(String chargroup) {
-      collected.append(chargroup);
-    }
-
-    @Override
-    public void addException(String word, ArrayList<Object> hyphenatedword) {
-      collected.append(word);
-    }
-
-    @Override
-    public void addPattern(String pattern, String values) {
-      collected.append(pattern);
-    }
-  }
-
   public void testExternalEntityIsNotExpanded() throws Exception {
-    String externalRef = this.getClass().getResource("TestPatternParser.class").toString();
+    String externalRef = this.getClass().getResource("../compoundDictionary.txt").toExternalForm();
     String evil =
         String.format(
             Locale.ROOT,
@@ -63,8 +42,7 @@ public class TestPatternParser extends LuceneTestCase {
             """,
             externalRef);
 
-    CollectingConsumer consumer = new CollectingConsumer();
-    PatternParser parser = new PatternParser(consumer);
+    PatternParser parser = new PatternParser(new HyphenationTree());
     var e =
         expectThrows(
             IOException.class, () -> parser.parse(new InputSource(new StringReader(evil))));

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/compound/hyphenation/TestPatternParser.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/compound/hyphenation/TestPatternParser.java
@@ -17,10 +17,12 @@
 package org.apache.lucene.analysis.compound.hyphenation;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Locale;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -53,28 +55,29 @@ public class TestPatternParser extends LuceneTestCase {
     String marker = "SUPERSECRETMARKER";
     Files.write(secret, marker.getBytes(StandardCharsets.UTF_8));
 
-    Path evil = dir.resolve("evil.xml");
-    Files.write(
-        evil,
-        ("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-                + "<!DOCTYPE hyphenation-info [\n"
-                + "  <!ENTITY xxe SYSTEM \""
-                + secret.toUri()
-                + "\">\n"
-                + "]>\n"
-                + "<hyphenation-info>\n"
-                + "<classes>aA</classes>\n"
-                + "<patterns>&xxe;</patterns>\n"
-                + "</hyphenation-info>\n")
-            .getBytes(StandardCharsets.UTF_8));
+    String externalRef = this.getClass().getResource("TestPatternParser.class").toString();
+    String evil =
+        String.format(
+            Locale.ROOT,
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE hyphenation-info [
+              <!ENTITY xxe SYSTEM "%s">
+            ]>
+            <hyphenation-info>
+              <classes>aA</classes>
+              <patterns>&xxe;</patterns>
+            </hyphenation-info>
+            """,
+            externalRef);
 
     CollectingConsumer consumer = new CollectingConsumer();
     PatternParser parser = new PatternParser(consumer);
     var e =
         expectThrows(
-            IOException.class, () -> parser.parse(new InputSource(evil.toUri().toString())));
+            IOException.class, () -> parser.parse(new InputSource(new StringReader(evil))));
     assertTrue(e.getCause() instanceof SAXException);
     assertTrue(e.getMessage().contains("External Entity resolving unsupported"));
-    assertTrue(e.getMessage().contains("secret.txt"));
+    assertTrue(e.getMessage().contains(externalRef));
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/compound/hyphenation/TestPatternParser.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/compound/hyphenation/TestPatternParser.java
@@ -18,9 +18,6 @@ package org.apache.lucene.analysis.compound.hyphenation;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Locale;
 import org.apache.lucene.tests.util.LuceneTestCase;
@@ -50,11 +47,6 @@ public class TestPatternParser extends LuceneTestCase {
   }
 
   public void testExternalEntityIsNotExpanded() throws Exception {
-    Path dir = createTempDir();
-    Path secret = dir.resolve("secret.txt");
-    String marker = "SUPERSECRETMARKER";
-    Files.write(secret, marker.getBytes(StandardCharsets.UTF_8));
-
     String externalRef = this.getClass().getResource("TestPatternParser.class").toString();
     String evil =
         String.format(


### PR DESCRIPTION
see original PR #16135

I hate tests that create files without need. The whole thing can be tested without creating any file.