### PR TITLE
switched updategraph to TernaryLongHeap

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -377,6 +377,8 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#16153: Use TernaryLongHeap in UpdateGraphsUtils for faster HNSW graph merging. (Prithvi S)
+
 * GITHUB#15861: Optimise PhraseScorer by short circuiting non competitive documents in TOP_SCORES mode. (Prithvi S)
 
 * GITHUB#15868: Optimize DisjunctionMaxBulkScorer by reusing the inner LeafCollector across

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/UpdateGraphsUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/UpdateGraphsUtils.java
@@ -21,7 +21,7 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
 import org.apache.lucene.internal.hppc.IntHashSet;
-import org.apache.lucene.util.LongHeap;
+import org.apache.lucene.util.TernaryLongHeap;
 
 /**
  * Utility class for updating a big graph with smaller graphs. This is used during merging of
@@ -41,7 +41,7 @@ public class UpdateGraphsUtils {
   public static IntHashSet computeJoinSet(HnswGraph graph) throws IOException {
     int k; // coverage for the current node
     int size = graph.size();
-    LongHeap heap = new LongHeap(size);
+    TernaryLongHeap heap = new TernaryLongHeap(size);
     IntHashSet j = new IntHashSet();
     boolean[] stale = new boolean[size];
     short[] counts = new short[size];


### PR DESCRIPTION
UpdateGraphsUtils.computeJoinSet() was still using the binary LongHeap while NeighborQueue and TopScoreDocCollector had already moved to TernaryLongHeap. 

I ran a quick JMH microbenchmark on computeJoinSet itself and saw ~9% improvement at 5,000 nodes, with the gap widening at larger sizes. 
I also ran wikimediumall through luceneutil to make sure nothing regressed on the search side