### PR TITLE
skip the per-bit loop in MergingHnswGraphBuilder

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -379,8 +379,6 @@ Improvements
 
 Optimizations
 ---------------------
-* GITHUB#16155: Use BitSet#nextClearBit to iterate uninitialized nodes in MergingHnswGraphBuilder. (Sasilekha R)
-
 * GITHUB#15861: Optimise PhraseScorer by short circuiting non competitive documents in TOP_SCORES mode. (Prithvi S)
 
 * GITHUB#15868: Optimize DisjunctionMaxBulkScorer by reusing the inner LeafCollector across
@@ -466,6 +464,8 @@ Optimizations
 * GITHUB#16147: Optimize column batch parent field with bulk fill. (Tim Brooks)
 
 * GITHUB#15991: Load dense filters into bitset in MaxScoreBulkScorer. (Prithvi S)
+
+* GITHUB#16155: Use BitSet#nextClearBit to iterate uninitialized nodes in MergingHnswGraphBuilder. (Sasilekha R)
 
 Bug Fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -379,6 +379,8 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#16155: Use BitSet#nextClearBit to iterate uninitialized nodes in MergingHnswGraphBuilder. (Sasilekha R)
+
 * GITHUB#15861: Optimise PhraseScorer by short circuiting non competitive documents in TOP_SCORES mode. (Prithvi S)
 
 * GITHUB#15868: Optimize DisjunctionMaxBulkScorer by reusing the inner LeafCollector across

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/MergingHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/MergingHnswGraphBuilder.java
@@ -128,12 +128,14 @@ public final class MergingHnswGraphBuilder extends HnswGraphBuilder {
       updateGraph(graphs[i], ordMaps[i]);
     }
 
-    // TODO: optimize to iterate only over unset bits in initializedNodes
-    if (initializedNodes != null) {
-      for (int node = 0; node < maxOrd; node++) {
-        if (initializedNodes.get(node) == false) {
-          addGraphNode(node);
-        }
+    if (initializedNodes != null && maxOrd > 0) {
+      for (int node = initializedNodes.nextClearBit(0, maxOrd);
+          node != NO_MORE_DOCS;
+          node =
+              (node + 1 < maxOrd)
+                  ? initializedNodes.nextClearBit(node + 1, maxOrd)
+                  : NO_MORE_DOCS) {
+        addGraphNode(node);
       }
     }
 


### PR DESCRIPTION
old loop checked every bit one by one to find uninitialized nodes. swapped it to use nextClearBit, which skips over set bits much faster. guarded the empty case and the last-bit case so we don't trip the BitSet asserts.