### PR TITLE
Fix OffHeapFloatVectorValues#prefetch to use bounded ord count

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -522,6 +522,9 @@ Bug Fixes
   instantiated, so a crafted spatial3d shape stream cannot load arbitrary classes. Also adapt
   experimental SerializedObject API to be more type safe. (metsw24-max, Uwe Schindler)
 
+* GITHUB#16156: OffHeapFloatVectorValues#prefetch now bounds its loop by the requested
+  count instead of the full ordinal array, matching OffHeapByteVectorValues. (Vignesh)
+
 Other
 ---------------------
 * GITHUB#15586: Document that scoring and ranking may change across major Lucene versions, and that applications requiring stable ranking should explicitly configure Similarity. (Parveen Saini)

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloatVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloatVectorValues.java
@@ -97,7 +97,7 @@ public abstract class OffHeapFloatVectorValues extends FloatVectorValues impleme
     }
 
     // 1. calculate offset and prefetch immediately
-    for (int i = 0; i < numOrds; i++) {
+    for (int i = 0; i < finalNumOrds; i++) {
       long offset = (long) ordsToPrefetch[i] * byteSize;
       slice.prefetch(offset, byteSize);
     }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene95/TestOffHeapVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene95/TestOffHeapVectorValues.java
@@ -53,6 +53,20 @@ public class TestOffHeapVectorValues extends LuceneTestCase {
     assertEquals(0, floatIndexInput.getPrefetchCount());
   }
 
+  public void testPrefetchBoundedByArrayLength() throws IOException {
+    // numOrds may exceed the length of the (reused) scratch array. Prefetch must be bounded by the
+    // array length so it only prefetches the available ords instead of running past the array end.
+    CountingIndexInput byteIndexInput = new CountingIndexInput();
+    OffHeapByteVectorValues values = createTestByteVectorValues(byteIndexInput);
+    values.prefetch(new int[] {1, 2}, 5);
+    assertEquals(2, byteIndexInput.getPrefetchCount());
+
+    CountingIndexInput floatIndexInput = new CountingIndexInput();
+    OffHeapFloatVectorValues floatValues = createTestFloatVectorValues(floatIndexInput);
+    floatValues.prefetch(new int[] {1, 2}, 5);
+    assertEquals(2, floatIndexInput.getPrefetchCount());
+  }
+
   private OffHeapByteVectorValues createTestByteVectorValues(IndexInput indexInput)
       throws IOException {
     return new OffHeapByteVectorValues.DenseOffHeapVectorValues(


### PR DESCRIPTION
`OffHeapFloatVectorValues#prefetch` computes `finalNumOrds = Math.min(numOrds, ordsToPrefetch.length)` and uses it for the early-return guard, but then loops over `numOrds` instead of `finalNumOrds`. The byte counterpart `OffHeapByteVectorValues#prefetch` correctly loops over `finalNumOrds`.

Since callers (e.g. `PrefetchableFlatVectorScorer`) pass a reused scratch array, `numOrds` could exceed `ordsToPrefetch.length`. The `finalNumOrds` bound exists precisely to prevent an `ArrayIndexOutOfBoundsException` in that case, but the loop bypasses it by iterating over `numOrds` directly.

Introduced in #15722.