### PR TITLE
Fix errorprone by adding supresswarning

### DIFF
--- a/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestSerializableObjectClassFilter.java
+++ b/lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestSerializableObjectClassFilter.java
@@ -26,6 +26,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestSerializableObjectClassFilter extends LuceneTestCase {
 
+  @SuppressWarnings("NonFinalStaticField")
   static volatile boolean nonSerializableConstructed = false,
       nonSerializableClassInitialized = false;
 


### PR DESCRIPTION
Running `./gradlew :lucene:spatial3d:compileTestJava -Pvalidation.errorprone=true` returns an errorprone error in `lucene/spatial3d/src/test/org/apache/lucene/spatial3d/geom/TestSerializableObjectClassFilter.java`

The errorprone version used in main does not throw this error anymore, thus it only needs disabling on branches with older errorprone version.

Note: This is of course up for discussion, but I figured it might be easier to add this line, that to update error prone to the same version as in main, which could be done as well.