### PR TITLE
SkipBlockRangeIterator: Don't extend docIdRunEnd into sparse blocks

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/SkipBlockRangeIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SkipBlockRangeIterator.java
@@ -130,7 +130,9 @@ public class SkipBlockRangeIterator extends AbstractDocIdSetIterator {
     int nextLevel = 1;
     while (nextLevel < skipper.numLevels()
         && skipper.minValue(nextLevel) >= minValue
-        && skipper.maxValue(nextLevel) <= maxValue) {
+        && skipper.maxValue(nextLevel) <= maxValue
+        && skipper.maxDocID(nextLevel) - skipper.minDocID(nextLevel)
+            == skipper.docCount(nextLevel) - 1) {
       maxDoc = skipper.maxDocID(nextLevel);
       nextLevel++;
     }

--- a/lucene/core/src/test/org/apache/lucene/search/BaseDocValuesSkipperTests.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseDocValuesSkipperTests.java
@@ -23,11 +23,16 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 
 public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
 
+  // Dense up to 1024+64=1088, sparse (even docs only) from 1088 onward.
+  // This means block [1024,1087] is dense YES while [1088,1151] is sparse YES_IF_PRESENT,
+  // both in the same level-1 block [1024,1151] — exercising the docIDRunEnd density check.
+  static final int DENSE_END = 1088;
+
   /**
-   * Fake numeric doc values so that: - docs 0-127 all match - docs in 128-255 are all greater than
-   * queryMax - docs in 256-511 are all less than queryMin - docs in 512-1023 have some docs that
-   * match the range, others not - docs in 1024-2047 follow a similar pattern as docs in 0-1023
-   * except that not all docs have a value (only even docs)
+   * Fake numeric doc values: value pattern repeats every 1024 docs (d%1024 in [0,128) matches,
+   * [128,256) is above queryMax, [256,512) is below queryMin, [512,1024) is a mix). Docs 0 through
+   * {@link #DENSE_END}-1 are dense (all have values); docs from {@link #DENSE_END} onward are
+   * sparse (only even docs have a value).
    */
   protected static NumericDocValues docValues(long queryMin, long queryMax) {
     return new NumericDocValues() {
@@ -52,14 +57,14 @@ public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
 
       @Override
       public int advance(int target) throws IOException {
-        if (target < 1024) {
-          // dense up to 1024
-          return doc = target;
-        } else if (doc < 2047) {
-          // 50% docs have a value up to 2048
-          return doc = target + (target & 1);
-        } else {
+        if (target >= 2048) {
           return doc = DocIdSetIterator.NO_MORE_DOCS;
+        } else if (target < DENSE_END) {
+          return doc = target;
+        } else {
+          // sparse: round up to even
+          int d = target + (target & 1);
+          return doc = (d >= 2048) ? DocIdSetIterator.NO_MORE_DOCS : d;
         }
       }
 
@@ -91,7 +96,9 @@ public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
 
   /**
    * Fake skipper over a NumericDocValues field built by an equivalent call to {@link
-   * #docValues(long, long)}
+   * #docValues(long, long)}. Dense up to doc {@link #DENSE_END}, sparse (even docs only) after
+   * that. This means block [1024,1087] is dense YES while [1088,1151] is sparse YES_IF_PRESENT,
+   * both in the same level-1 block — exercising the docIDRunEnd density check.
    */
   protected static DocValuesSkipper docValuesSkipper(
       long queryMin, long queryMax, boolean doLevels) {
@@ -164,13 +171,18 @@ public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
       @Override
       public int docCount(int level) {
         int rangeLog = 9 - numLevels() + level;
-
-        if (doc < 1024) {
-          return 1 << rangeLog;
-        } else {
-          // half docs have a value
-          return 1 << rangeLog >> 1;
+        int blockSize = 1 << rangeLog;
+        int minDoc = minDocID(level);
+        if (minDoc < 0 || minDoc >= 2048) {
+          return 0;
         }
+        if (minDoc >= DENSE_END) {
+          return blockSize / 2;
+        }
+        // Block starts in dense region — count dense + sparse portions
+        int denseCount = Math.min(blockSize, DENSE_END - minDoc);
+        int sparseCount = (blockSize - denseCount) / 2;
+        return denseCount + sparseCount;
       }
 
       @Override
@@ -185,7 +197,7 @@ public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
 
       @Override
       public int docCount() {
-        return 1024 + 1024 / 2;
+        return DENSE_END + (2048 - DENSE_END) / 2; // 1088 + 480 = 1568
       }
 
       @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalRangeIterator.java
@@ -37,7 +37,7 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
   // ---- Shared helpers ----
 
   private static boolean docHasValue(int doc) {
-    return doc < 1024 || (doc < 2048 && (doc & 1) == 0);
+    return doc < DENSE_END || (doc < 2048 && (doc & 1) == 0);
   }
 
   private static List<Integer> collectMatches(DocValuesRangeIterator iter) throws IOException {
@@ -124,13 +124,13 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
 
       @Override
       public int advance(int target) {
-        if (target < 1024) {
-          return doc = target;
-        } else if (target < 2048) {
-          doc = target + (target & 1);
-          return doc < 2048 ? doc : (doc = DocIdSetIterator.NO_MORE_DOCS);
-        } else {
+        if (target >= 2048) {
           return doc = DocIdSetIterator.NO_MORE_DOCS;
+        } else if (target < DENSE_END) {
+          return doc = target;
+        } else {
+          int d = target + (target & 1);
+          return doc = (d >= 2048) ? DocIdSetIterator.NO_MORE_DOCS : d;
         }
       }
 
@@ -202,11 +202,11 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     DocValuesRangeIterator iter = createSortedDocValuesIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
-    approx.advance(1024);
+    approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertTrue(iter.matches());
 
-    approx.advance(1025);
+    approx.advance(1089);
     assertFalse(iter.matches());
   }
 
@@ -225,8 +225,15 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     approx.advance(512);
     assertEquals(513, iter.docIDRunEnd());
 
+    // YES block in second repetition (dense up to DENSE_END=1088)
     approx.advance(1024);
-    assertEquals(1025, iter.docIDRunEnd());
+    assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
+    assertEquals(1088, iter.docIDRunEnd());
+
+    // YES_IF_PRESENT block
+    approx.advance(1088);
+    assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertEquals(1089, iter.docIDRunEnd());
   }
 
   // ==========================================================================
@@ -326,13 +333,13 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
       @Override
       public int advance(int target) {
         ordIdx = 0;
-        if (target < 1024) {
-          return doc = target;
-        } else if (target < 2048) {
-          doc = target + (target & 1);
-          return doc < 2048 ? doc : (doc = DocIdSetIterator.NO_MORE_DOCS);
-        } else {
+        if (target >= 2048) {
           return doc = DocIdSetIterator.NO_MORE_DOCS;
+        } else if (target < DENSE_END) {
+          return doc = target;
+        } else {
+          int d = target + (target & 1);
+          return doc = (d >= 2048) ? DocIdSetIterator.NO_MORE_DOCS : d;
         }
       }
 
@@ -461,11 +468,11 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     DocValuesRangeIterator iter = createSortedSetDocValuesIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
-    approx.advance(1024);
+    approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertTrue(iter.matches());
 
-    approx.advance(1025);
+    approx.advance(1089);
     assertFalse(iter.matches());
   }
 
@@ -486,8 +493,14 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
     assertEquals(513, iter.docIDRunEnd());
 
+    // YES block in second repetition (dense up to DENSE_END=1088)
     approx.advance(1024);
+    assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
+    assertEquals(1088, iter.docIDRunEnd());
+
+    // YES_IF_PRESENT block
+    approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
-    assertEquals(1025, iter.docIDRunEnd());
+    assertEquals(1089, iter.docIDRunEnd());
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
@@ -326,10 +326,15 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
     assertEquals(513, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block: also doc+1
+    // YES block in second repetition (dense up to DENSE_END=1088): also doc+1
     approx.advance(1024);
-    assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
     assertEquals(1025, iter.docIDRunEnd());
+
+    // YES_IF_PRESENT block: also doc+1
+    approx.advance(1088);
+    assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertEquals(1089, iter.docIDRunEnd());
   }
 
   // ==========================================================================
@@ -546,9 +551,15 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
     assertEquals(513, iter.docIDRunEnd());
 
+    // YES block in second repetition (dense up to DENSE_END=1088)
     approx.advance(1024);
-    assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
     assertEquals(1025, iter.docIDRunEnd());
+
+    // YES_IF_PRESENT block
+    approx.advance(1088);
+    assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertEquals(1089, iter.docIDRunEnd());
   }
 
   // --- SortedSetDocValues: YES_IF_PRESENT ---
@@ -558,12 +569,12 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
     // Sparse region: even doc has value, odd doc does not
-    approx.advance(1024);
+    approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     // Ords [10, 20], 10 in set → match
     assertTrue(iter.matches());
 
-    approx.advance(1025);
+    approx.advance(1089);
     // Odd doc has no value → no match
     assertFalse(iter.matches());
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRangeIterator.java
@@ -49,7 +49,7 @@ public class TestDocValuesRangeIterator extends BaseDocValuesSkipperTests {
   }
 
   private static boolean docHasValue(int doc) {
-    return doc < 1024 || (doc < 2048 && (doc & 1) == 0);
+    return doc < DENSE_END || (doc < 2048 && (doc & 1) == 0);
   }
 
   /**
@@ -209,12 +209,12 @@ public class TestDocValuesRangeIterator extends BaseDocValuesSkipperTests {
 
     // Sparse block with values in range: all values match but not all docs
     // have a value, so the block is classified YES_IF_PRESENT.
-    approx.advance(1024);
+    approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     // Even doc has a value -> match
     assertTrue(iter.matches());
 
-    approx.advance(1025);
+    approx.advance(1089);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     // Odd doc has no value -> no match
     assertFalse(iter.matches());
@@ -286,8 +286,8 @@ public class TestDocValuesRangeIterator extends BaseDocValuesSkipperTests {
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
     // YES_IF_PRESENT blocks have gaps, so docIdRunEnd = doc + 1
-    approx.advance(1024);
+    approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
-    assertEquals(1025, iter.docIDRunEnd());
+    assertEquals(1089, iter.docIDRunEnd());
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSkipBlockRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSkipBlockRangeIterator.java
@@ -27,10 +27,14 @@ public class TestSkipBlockRangeIterator extends BaseDocValuesSkipperTests {
     SkipBlockRangeIterator it = new SkipBlockRangeIterator(skipper, 10, 20);
 
     assertEquals(0, it.nextDoc());
+    // Level-1 block [0,127] is dense and in range: docIDRunEnd expands
     assertEquals(128, it.docIDRunEnd());
     assertEquals(100, it.advance(100));
     assertEquals(512, it.advance(300));
     assertEquals(513, it.docIDRunEnd());
+    // Block [1024,1087] is dense YES, but level-1 [1024,1151] is sparse: can't expand
+    assertEquals(1024, it.advance(1024));
+    assertEquals(1088, it.docIDRunEnd());
     assertEquals(1100, it.advance(1100));
     assertEquals(1101, it.docIDRunEnd());
     assertEquals(1536, it.advance(1500));

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortedNumericDocValuesRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortedNumericDocValuesRangeIterator.java
@@ -75,7 +75,7 @@ public class TestSortedNumericDocValuesRangeIterator extends BaseDocValuesSkippe
   }
 
   private static boolean docHasValue(int doc) {
-    return doc < 1024 || (doc < 2048 && (doc & 1) == 0);
+    return doc < DENSE_END || (doc < 2048 && (doc & 1) == 0);
   }
 
   private static List<Integer> expectedMatches() {
@@ -111,13 +111,13 @@ public class TestSortedNumericDocValuesRangeIterator extends BaseDocValuesSkippe
       @Override
       public int advance(int target) throws IOException {
         valueIdx = 0;
-        if (target < 1024) {
-          return doc = target;
-        } else if (target < 2048) {
-          doc = target + (target & 1);
-          return doc < 2048 ? doc : (doc = DocIdSetIterator.NO_MORE_DOCS);
-        } else {
+        if (target >= 2048) {
           return doc = DocIdSetIterator.NO_MORE_DOCS;
+        } else if (target < DENSE_END) {
+          return doc = target;
+        } else {
+          int d = target + (target & 1);
+          return doc = (d >= 2048) ? DocIdSetIterator.NO_MORE_DOCS : d;
         }
       }
 
@@ -294,12 +294,12 @@ public class TestSortedNumericDocValuesRangeIterator extends BaseDocValuesSkippe
     DocValuesRangeIterator iter = createIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
-    approx.advance(1024);
+    approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     // Even doc has a value → match
     assertTrue(iter.matches());
 
-    approx.advance(1025);
+    approx.advance(1089);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     // Odd doc has no value → no match
     assertFalse(iter.matches());
@@ -359,8 +359,14 @@ public class TestSortedNumericDocValuesRangeIterator extends BaseDocValuesSkippe
     DocValuesRangeIterator iter = createIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
+    // YES block in second repetition (dense up to DENSE_END=1088)
     approx.advance(1024);
+    assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
+    assertEquals(1088, iter.docIDRunEnd());
+
+    // YES_IF_PRESENT blocks have gaps, so docIdRunEnd = doc + 1
+    approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
-    assertEquals(1025, iter.docIDRunEnd());
+    assertEquals(1089, iter.docIDRunEnd());
   }
 }


### PR DESCRIPTION
When docIdRunEnd is called when positioned in a YES block, we climb through the levels to see how far we can extend the run end, but were failing to check that the higher-level blocks contained values for all documents.

This adds that check and updates BaseDocValuesSkipperTests to include ranges that exercise the bug.