### PR TITLE
Add query cache randomly in LuceneTestCaseParent

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCaseParent.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCaseParent.java
@@ -2683,7 +2683,7 @@ public abstract sealed class LuceneTestCaseParent extends Assert
         ret = random.nextBoolean() ? new IndexSearcher(r) : new IndexSearcher(r.getContext());
       }
       if (random.nextBoolean()) {
-        ret.setQueryCache(new LRUQueryCache(100, 1024 * 1024, lrc -> true, 1f));
+        ret.setQueryCache(new LRUQueryCache(100, 1024 * 1024, _ -> true, 1f));
         ret.setQueryCachingPolicy(MAYBE_CACHE_POLICY);
       }
       ret.setSimilarity(getTestFrameworkInfra().getClassEnv().similarity);
@@ -2734,7 +2734,7 @@ public abstract sealed class LuceneTestCaseParent extends Assert
       ret.setSimilarity(getTestFrameworkInfra().getClassEnv().similarity);
 
       if (random.nextBoolean()) {
-        ret.setQueryCache(new LRUQueryCache(100, 1024 * 1024, lrc -> true, 1f));
+        ret.setQueryCache(new LRUQueryCache(100, 1024 * 1024,  _ -> true, 1f));
         ret.setQueryCachingPolicy(MAYBE_CACHE_POLICY);
       }
       if (random().nextBoolean()) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCaseParent.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCaseParent.java
@@ -2734,7 +2734,7 @@ public abstract sealed class LuceneTestCaseParent extends Assert
       ret.setSimilarity(getTestFrameworkInfra().getClassEnv().similarity);
 
       if (random.nextBoolean()) {
-        ret.setQueryCache(new LRUQueryCache(100, 1024 * 1024,  _ -> true, 1f));
+        ret.setQueryCache(new LRUQueryCache(100, 1024 * 1024, _ -> true, 1f));
         ret.setQueryCachingPolicy(MAYBE_CACHE_POLICY);
       }
       if (random().nextBoolean()) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCaseParent.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/LuceneTestCaseParent.java
@@ -2682,6 +2682,10 @@ public abstract sealed class LuceneTestCaseParent extends Assert
       } else {
         ret = random.nextBoolean() ? new IndexSearcher(r) : new IndexSearcher(r.getContext());
       }
+      if (random.nextBoolean()) {
+        ret.setQueryCache(new LRUQueryCache(100, 1024 * 1024, lrc -> true, 1f));
+        ret.setQueryCachingPolicy(MAYBE_CACHE_POLICY);
+      }
       ret.setSimilarity(getTestFrameworkInfra().getClassEnv().similarity);
       return ret;
     } else {
@@ -2728,7 +2732,11 @@ public abstract sealed class LuceneTestCaseParent extends Assert
             };
       }
       ret.setSimilarity(getTestFrameworkInfra().getClassEnv().similarity);
-      ret.setQueryCachingPolicy(MAYBE_CACHE_POLICY);
+
+      if (random.nextBoolean()) {
+        ret.setQueryCache(new LRUQueryCache(100, 1024 * 1024, lrc -> true, 1f));
+        ret.setQueryCachingPolicy(MAYBE_CACHE_POLICY);
+      }
       if (random().nextBoolean()) {
         ret.setTimeout(() -> false);
       }


### PR DESCRIPTION
In #14187, we disabled the query cache by default which means most of our test are running now without it in comparison to branch 10.x where the cache is set by default. That means we might be lacking coverage in some code that depends if the query cache is enable or not.

This PR proposes to add a query cache randomly when a new index searcher is created in LuceneTestCaseParent.
