### PR TITLE
Add tests for int4DibitDotProduct

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
@@ -271,6 +271,27 @@ public class TestVectorUtilSupport extends BaseVectorizationTestCase {
     assertLongReturningProviders(p -> p.int4BitDotProduct(int4Quantized, binaryQuantized));
   }
 
+  public void testInt4DibitDotProduct() {
+    var dibitQuantized = new byte[size];
+    var int4Quantized = new byte[size * 2];
+    random().nextBytes(dibitQuantized);
+    random().nextBytes(int4Quantized);
+    assertLongReturningProviders(p -> p.int4DibitDotProduct(int4Quantized, dibitQuantized));
+  }
+
+  public void testInt4DibitDotProductBoundaries() {
+    var dibitQuantized = new byte[size];
+    var int4Quantized = new byte[size * 2];
+
+    Arrays.fill(dibitQuantized, Byte.MAX_VALUE);
+    Arrays.fill(int4Quantized, Byte.MAX_VALUE);
+    assertLongReturningProviders(p -> p.int4DibitDotProduct(int4Quantized, dibitQuantized));
+
+    Arrays.fill(dibitQuantized, Byte.MIN_VALUE);
+    Arrays.fill(int4Quantized, Byte.MIN_VALUE);
+    assertLongReturningProviders(p -> p.int4DibitDotProduct(int4Quantized, dibitQuantized));
+  }
+
   static byte[] pack(byte[] unpacked) {
     int len = (unpacked.length + 1) / 2;
     var packed = new byte[len];

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -600,7 +600,8 @@ public class TestVectorUtil extends LuceneTestCase {
   public void testBasicInt4DibitDotProduct() {
     testBasicInt4DibitDotProductImpl(VectorUtil::int4DibitDotProduct);
     testBasicInt4DibitDotProductImpl(defaultedProvider.getVectorUtilSupport()::int4DibitDotProduct);
-    testBasicInt4DibitDotProductImpl(defOrPanamaProvider.getVectorUtilSupport()::int4DibitDotProduct);
+    testBasicInt4DibitDotProductImpl(
+        defOrPanamaProvider.getVectorUtilSupport()::int4DibitDotProduct);
   }
 
   interface Int4DibitDotProduct {
@@ -612,7 +613,7 @@ public class TestVectorUtil extends LuceneTestCase {
     assertEquals(45L, int4DibitDotProductFunc.apply(new byte[] {1, 1, 1, 1}, new byte[] {1, 1}));
     assertEquals(90L, int4DibitDotProductFunc.apply(new byte[] {3, 3, 3, 3}, new byte[] {3, 3}));
     assertEquals(1L, int4DibitDotProductFunc.apply(new byte[] {1, 2, 4, 8}, new byte[] {1, 0}));
-    
+
     // Multi-stripe deterministic cases (stripe sizes 2 and 3)
     assertEquals(
         90L,

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -486,6 +486,16 @@ public class TestVectorUtil extends LuceneTestCase {
     }
   }
 
+  public void testInt4DibitDotProductInvariants() {
+    int iterations = atLeast(10);
+    for (int i = 0; i < iterations; i++) {
+      int size = randomIntBetween(random(), 1, 10);
+      var d = new byte[size];
+      var q = new byte[size * 2 - 1];
+      expectThrows(IllegalArgumentException.class, () -> VectorUtil.int4DibitDotProduct(q, d));
+    }
+  }
+
   static final VectorizationProvider defaultedProvider =
       BaseVectorizationTestCase.defaultProvider();
   static final VectorizationProvider defOrPanamaProvider =
@@ -583,6 +593,80 @@ public class TestVectorUtil extends LuceneTestCase {
     int res = 0;
     for (int i = 0; i < 4; i++) {
       res += (popcount(q, i * d.length, d, d.length) << i);
+    }
+    return res;
+  }
+
+  public void testBasicInt4DibitDotProduct() {
+    testBasicInt4DibitDotProductImpl(VectorUtil::int4DibitDotProduct);
+    testBasicInt4DibitDotProductImpl(defaultedProvider.getVectorUtilSupport()::int4DibitDotProduct);
+    testBasicInt4DibitDotProductImpl(defOrPanamaProvider.getVectorUtilSupport()::int4DibitDotProduct);
+  }
+
+  interface Int4DibitDotProduct {
+    long apply(byte[] q, byte[] d);
+  }
+
+  void testBasicInt4DibitDotProductImpl(Int4DibitDotProduct int4DibitDotProductFunc) {
+    // q is 4 stripes, d is 2 stripes (lower bits first, then upper bits)
+    assertEquals(45L, int4DibitDotProductFunc.apply(new byte[] {1, 1, 1, 1}, new byte[] {1, 1}));
+    assertEquals(90L, int4DibitDotProductFunc.apply(new byte[] {3, 3, 3, 3}, new byte[] {3, 3}));
+    assertEquals(1L, int4DibitDotProductFunc.apply(new byte[] {1, 2, 4, 8}, new byte[] {1, 0}));
+    
+    // Multi-stripe deterministic cases (stripe sizes 2 and 3)
+    assertEquals(
+        90L,
+        int4DibitDotProductFunc.apply(
+            new byte[] {1, 2, 1, 2, 1, 2, 1, 2}, new byte[] {1, 2, 1, 2}));
+    assertEquals(
+        180L,
+        int4DibitDotProductFunc.apply(
+            new byte[] {1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3}, new byte[] {1, 2, 3, 1, 2, 3}));
+  }
+
+  public void testInt4DibitDotProduct() {
+    testInt4DibitDotProductImpl(VectorUtil::int4DibitDotProduct);
+    testInt4DibitDotProductImpl(defaultedProvider.getVectorUtilSupport()::int4DibitDotProduct);
+    testInt4DibitDotProductImpl(defOrPanamaProvider.getVectorUtilSupport()::int4DibitDotProduct);
+  }
+
+  void testInt4DibitDotProductImpl(Int4DibitDotProduct int4DibitDotProductFunc) {
+    int iterations = atLeast(50);
+    for (int i = 0; i < iterations; i++) {
+      int size = random().nextInt(5000);
+      var d = new byte[size];
+      var q = new byte[size * 2];
+      random().nextBytes(d);
+      random().nextBytes(q);
+      assertEquals(scalarInt4DibitDotProduct(q, d), int4DibitDotProductFunc.apply(q, d));
+
+      Arrays.fill(d, Byte.MAX_VALUE);
+      Arrays.fill(q, Byte.MAX_VALUE);
+      assertEquals(scalarInt4DibitDotProduct(q, d), int4DibitDotProductFunc.apply(q, d));
+
+      Arrays.fill(d, Byte.MIN_VALUE);
+      Arrays.fill(q, Byte.MIN_VALUE);
+      assertEquals(scalarInt4DibitDotProduct(q, d), int4DibitDotProductFunc.apply(q, d));
+    }
+  }
+
+  // Independent reference: int4 query (4 bit-plane stripes) dot dibit doc (2 bit-plane stripes).
+  // value = sum over query plane i and doc plane j of popcount(q_i AND d_j) << (i + j).
+  static long scalarInt4DibitDotProduct(byte[] q, byte[] d) {
+    int stripeSize = d.length / 2;
+    long res = 0;
+    for (int i = 0; i < 4; i++) {
+      for (int j = 0; j < 2; j++) {
+        res += ((long) dibitPopcount(q, i * stripeSize, d, j * stripeSize, stripeSize)) << (i + j);
+      }
+    }
+    return res;
+  }
+
+  static int dibitPopcount(byte[] a, int aOffset, byte[] b, int bOffset, int length) {
+    int res = 0;
+    for (int k = 0; k < length; k++) {
+      res += Integer.bitCount((a[aOffset + k] & b[bOffset + k]) & 0xFF);
     }
     return res;
   }


### PR DESCRIPTION
`int4DibitDotProduct` (used by the DIBIT_QUERY_NIBBLE scalar-quantized encoding) has scalar, Panama, and native implementations but no dedicated tests, unlike its sibling `int4BitDotProduct`.

This PR adds mirroring coverage for the dibit dot product:
- scalar/Panama parity tests (random + boundary) in TestVectorUtilSupport
- invariants, deterministic, and independent-reference tests in TestVectorUtil