### PR TITLE
Fix flaky TestLRUQueryCache.testUnifiedCacheEntryCallbacks by using non-randomized IndexWriterConfig

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -501,6 +501,8 @@ Bug Fixes
 * GITHUB#15836: Use exact search in VectorSimilarityQuery when traversalSimilarity is -infinity to
   guarantee completeness. (Sagar Upadhyaya)
 
+* GITHUB#16169: Fix flaky TestLRUQueryCache.testUnifiedCacheEntryCallbacks by using a non-randomized IndexWriterConfig. (Prithvi S)
+
 * GITHUB#12419, GITHUB#15119, GITHUB#15864: Fix circular dependency deadlock in
   TestSecrets initialization (Namgyu Kim, Uwe Schindler)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -501,8 +501,6 @@ Bug Fixes
 * GITHUB#15836: Use exact search in VectorSimilarityQuery when traversalSimilarity is -infinity to
   guarantee completeness. (Sagar Upadhyaya)
 
-* GITHUB#16169: Fix flaky TestLRUQueryCache.testUnifiedCacheEntryCallbacks by using a non-randomized IndexWriterConfig. (Prithvi S)
-
 * GITHUB#12419, GITHUB#15119, GITHUB#15864: Fix circular dependency deadlock in
   TestSecrets initialization (Namgyu Kim, Uwe Schindler)
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -2669,9 +2669,11 @@ public class TestLRUQueryCache extends LuceneTestCase {
           }
         };
 
-    // Force exactly 1 segment so cache behavior is deterministic
+    // Force exactly 1 segment so cache behavior is deterministic.
+    // Use a non-randomized IndexWriterConfig to prevent randomized flush thresholds
+    // (e.g., tiny RAM buffer) from splitting 3 docs into multiple segments.
     Directory dir = newDirectory();
-    IndexWriterConfig iwc = newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE);
+    IndexWriterConfig iwc = new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE);
     IndexWriter iw = new IndexWriter(dir, iwc);
     Document doc = new Document();
     doc.add(new StringField("color", "red", Store.NO));


### PR DESCRIPTION
newIndexWriterConfig() uses randomized settings from LuceneTestCase which can create tiny RAM buffers which causes 3 documents to be flushed into multiple segments, breaking the test's assumption of exactly 1 segment