### PR TITLE
Add JMH benchmarks for int4Bit and int4Dibit dot products

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -269,6 +269,8 @@ Other
 
 * GITHUB#16082: Added a new JMH microbenchmark for DiversifyingChildrenFloatKnnVectorQuery. (Anna Ruggero via Alessandro Benedetti)
 
+* GITHUB#16170: Add JMH benchmarks for int4BitDotProduct and int4DibitDotProduct. (Vignesh)
+
 ======================= Lucene 10.5.0 =======================
 
 API Changes

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
@@ -57,6 +57,10 @@ public class VectorUtilBenchmark {
   private byte[] halfBytesAPacked;
   private byte[] halfBytesB;
   private byte[] halfBytesBPacked;
+  private byte[] int4QuantizedBit;
+  private byte[] binaryQuantized;
+  private byte[] int4QuantizedDibit;
+  private byte[] dibitQuantized;
   private float[] floatsA;
   private float[] floatsB;
   private int expectedHalfByteDotProduct;
@@ -104,6 +108,17 @@ public class VectorUtilBenchmark {
       floatsA[i] = random.nextFloat();
       floatsB[i] = random.nextFloat();
     }
+
+    // arrays for BBQ int4-bit and int4-dibit dot product benchmarks
+    int4QuantizedBit = new byte[size * 4];
+    random.nextBytes(int4QuantizedBit);
+    binaryQuantized = new byte[size];
+    random.nextBytes(binaryQuantized);
+
+    int4QuantizedDibit = new byte[size * 2];
+    random.nextBytes(int4QuantizedDibit);
+    dibitQuantized = new byte[size];
+    random.nextBytes(dibitQuantized);
   }
 
   @Benchmark
@@ -242,6 +257,28 @@ public class VectorUtilBenchmark {
   @Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
   public int binarySquareUint8Vector() {
     return VectorUtil.uint8SquareDistance(bytesA, bytesB);
+  }
+
+  @Benchmark
+  public long int4BitDotProductScalar() {
+    return VectorUtil.int4BitDotProduct(int4QuantizedBit, binaryQuantized);
+  }
+
+  @Benchmark
+  @Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+  public long int4BitDotProductVector() {
+    return VectorUtil.int4BitDotProduct(int4QuantizedBit, binaryQuantized);
+  }
+
+  @Benchmark
+  public long int4DibitDotProductScalar() {
+    return VectorUtil.int4DibitDotProduct(int4QuantizedDibit, dibitQuantized);
+  }
+
+  @Benchmark
+  @Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+  public long int4DibitDotProductVector() {
+    return VectorUtil.int4DibitDotProduct(int4QuantizedDibit, dibitQuantized);
   }
 
   @Benchmark


### PR DESCRIPTION
This PR adds JMH benchmarks for `int4BitDotProduct` and `int4DibitDotProduct`, mirroring the existing `binaryDotProductUint8Scalar/Vector` pattern (scalar benchmark + vector `@Fork` with `--add-modules=jdk.incubator.vector`).

These BBQ scoring kernels previously had no JMH coverage despite having dedicated Panama implementations.