### PR TITLE
Address frozen FieldType cache never recovering after type switch

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -511,6 +511,8 @@ Optimizations
 
 * GITHUB#16166: Add bulk range evaluation for multi-valued sorted numeric doc values. (Costin Leau)
 
+* GITHUB#16171: Address frozen FieldType cache never recovering after type switch. (neoremind)
+
 Bug Fixes
 ---------------------
 * GITHUB#15754: Fix HTMLStripCharFilter to prevent tags from incorrectly consuming subsequent

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -680,10 +680,10 @@ final class IndexingChain implements Accountable {
       PerField pf = fields[i];
       if (pf.fieldInfo == null) {
         initializeFieldInfo(pf);
-        pf.trySetValidatedFrozenFieldType();
       } else {
         pf.schema.assertSameSchema(pf.fieldInfo);
       }
+      pf.trySetValidatedFrozenFieldType();
     }
   }
 
@@ -1713,12 +1713,7 @@ final class IndexingChain implements Accountable {
 
     void reset(int docId, IndexableFieldType fieldType) {
       first = true;
-      if (fieldInfo == null) {
-        // The first time we encounter this field in a segment propose a frozen field to optimize
-        // the validation step. This will be promoted in trySetValidatedFrozenFieldType if it is
-        // frozen and valid.
-        candidateFieldType = fieldType;
-      }
+      candidateFieldType = fieldType;
       if (fieldType == validatedFrozenFieldType) {
         schema.resetJustDocId(docId);
       } else {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexOptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexOptions.java
@@ -235,6 +235,7 @@ public class TestIndexOptions extends LuceneTestCase {
     Document doc = new Document();
     doc.add(new Field("foo", "bar1", frozenFt));
     doc.add(new Field("foo", "bar2", differentFt));
+    // throw exception because of intra-document inconsistency
     IllegalArgumentException e =
         expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc));
     assertTrue(e.getMessage(), e.getMessage().contains("index options"));
@@ -327,6 +328,41 @@ public class TestIndexOptions extends LuceneTestCase {
             IllegalArgumentException.class,
             () -> w.addDocument(Collections.singleton(new Field("foo", "bar", ft2))));
     assertTrue(e.getMessage(), e.getMessage().contains("index options"));
+    w.close();
+    dir.close();
+  }
+
+  public void testMultiValuedFieldDeoptimizesWhenCacheActive() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+    FieldType ftA = new FieldType(TextField.TYPE_STORED);
+    ftA.freeze();
+    FieldType ftB = new FieldType(TextField.TYPE_STORED); // same schema, different instance
+    ftB.freeze();
+    // Doc 0
+    w.addDocument(Collections.singleton(new Field("foo", "val0", ftA)));
+    // Doc 1
+    Document doc = new Document();
+    doc.add(new Field("foo", "val1a", ftA));
+    doc.add(new Field("foo", "val1b", ftB));
+    w.addDocument(doc);
+    // Doc 2
+    w.addDocument(Collections.singleton(new Field("foo", "val2", ftB)));
+    // Doc 3
+    w.addDocument(Collections.singleton(new Field("foo", "val3", ftB)));
+    try (LeafReader r = getOnlyLeafReader(DirectoryReader.open(w))) {
+      assertEquals(4, r.maxDoc());
+    }
+    // Doc 4: multi-valued with incompatible frozen type — must fail
+    FieldType ftC = new FieldType(TextField.TYPE_STORED);
+    ftC.setStoreTermVectors(true);
+    ftC.freeze();
+    Document doc4 = new Document();
+    doc4.add(new Field("foo", "val4a", ftB));
+    doc4.add(new Field("foo", "val4b", ftC));
+    IllegalArgumentException e =
+        expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc4));
+    assertTrue(e.getMessage(), e.getMessage().contains("store term vector"));
     w.close();
     dir.close();
   }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexOptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexOptions.java
@@ -332,7 +332,7 @@ public class TestIndexOptions extends LuceneTestCase {
     dir.close();
   }
 
-  public void testMultiValuedFieldDeoptimizes() throws IOException {
+  public void testMultiValueForcesDeoptimization() throws IOException {
     Directory dir = newDirectory();
     IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
     FieldType ftA = new FieldType(TextField.TYPE_STORED);

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexOptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexOptions.java
@@ -332,7 +332,7 @@ public class TestIndexOptions extends LuceneTestCase {
     dir.close();
   }
 
-  public void testMultiValuedFieldDeoptimizesWhenCacheActive() throws IOException {
+  public void testMultiValuedFieldDeoptimizes() throws IOException {
     Directory dir = newDirectory();
     IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
     FieldType ftA = new FieldType(TextField.TYPE_STORED);


### PR DESCRIPTION
#15886 is a nice optimization, when a field keeps using the same frozen FieldType instance inter-documents, we can skip the whole `schema.reset() + updateDocFieldSchema() + assertSameSchema()` validation path.

I found a corner case, the validatedFrozenFieldType cache never recovers after switching between two different frozen FieldType instances that share the same schema.

Once we switch from fieldTypeA to fieldTypeB (same schema, different instance), the validatedFrozenFieldType cache gets nulled and stays null for the rest of the segment, then every subsequent document still pays the cost of `schema.reset() + updateDocFieldSchema() + assertSameSchema()` as before.

I verified this by adding an `InfoStream` log in the assertion schema slow path and counting how many times invoked, see [test link](https://github.com/neoremind/lucene/commit/4ab6832fe8ecd8facbaa261ad1c14636334b8da9#diff-e4a05dae452b3cb44726589d1cec355df5c43f02d2f4c63c8a7699a68d9e6427R24-R315
), I don't want to introduce the heavy `InfoStream` just for this simple logic here. The existing test `testFrozenFieldTypeCacheRestabilizes` reproduces the problem, but since it doesn't assert how many times we hit the slow path, it still passes.

To illustrate:

```
FieldType ftA = new FieldType(TextField.TYPE_STORED);
ftA.freeze();
// insert Doc 0 - 9 with ftA
FieldType ftB = new FieldType(TextField.TYPE_STORED); // same schema
ftB.freeze();
// insert Doc 10 - 20 with ftB

// Doc 0: INIT path → cache = ftA
// Docs 1–9: ftA == cache → fast path, no duplication on schema.reset() + updateDocFieldSchema() + assertSameSchema()
// Doc 10: ftB != ftA → cache = null, validate path, assertSameSchema passes
//         BUT nobody re-promotes ftB → cache stays null
// Docs 11–20: cache is null → slow path assert schema for all subsequent calls 
```

In detail, two issues:

1. In `PerField.reset()`, `candidateFieldType` is only set when `fieldInfo == null`, which is the very first document for that field in the segment. After that first doc, no matter what frozen type comes in, it's never recorded as a candidate. So there's simply nothing available to promote into the cache later.

2. `trySetValidatedFrozenFieldType()`, the method that actually promotes a candidate into `validatedFrozenFieldType` cache only runs inside the `fieldInfo == null` branch of `initAndValidateFields()`. It's never called in the else-branch where we already have a `fieldInfo` and just run `assertSameSchema()`.

Also adds test coverage for `multiValueForcesDeoptimize`.
