### PR TITLE
FilterDirectory should delegate copyFrom() to wrapped directory

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -439,6 +439,8 @@ Bug Fixes
   GlobalOrdinalsWithScoreCollector, fixing an intermittent failure caused by
   non-associative float addition that #16378 missed. (Luca Cavanna)
 
+* GITHUB#16173: FilterDirectory now delegates copyFrom() to the wrapped directory. (Prithvi S)
+
 Other
 ---------------------
 * GITHUB#16266: Remove deprecated search(Query, Collector) calls in QueryUtils by replacing

--- a/lucene/core/src/java/org/apache/lucene/store/FilterDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/FilterDirectory.java
@@ -117,6 +117,12 @@ public abstract class FilterDirectory extends Directory {
   }
 
   @Override
+  public void copyFrom(Directory from, String src, String dest, IOContext context)
+      throws IOException {
+    in.copyFrom(from, src, dest, context);
+  }
+
+  @Override
   public Set<String> getPendingDeletions() throws IOException {
     return in.getPendingDeletions();
   }

--- a/lucene/core/src/test/org/apache/lucene/store/TestFilterDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestFilterDirectory.java
@@ -34,13 +34,36 @@ public class TestFilterDirectory extends BaseDirectoryTestCase {
     // verify that all methods of Directory are overridden by FilterDirectory,
     // except those under the 'exclude' list
     Set<Method> exclude = new HashSet<>();
-    exclude.add(
-        Directory.class.getMethod(
-            "copyFrom", Directory.class, String.class, String.class, IOContext.class));
     exclude.add(Directory.class.getMethod("openChecksumInput", String.class));
     for (Method m : FilterDirectory.class.getMethods()) {
       if (m.getDeclaringClass() == Directory.class) {
         assertTrue("method " + m.getName() + " not overridden!", exclude.contains(m));
+      }
+    }
+  }
+
+  public void testCopyFromDelegates() throws IOException {
+    try (Directory srcDir = new ByteBuffersDirectory();
+        Directory destDir = new ByteBuffersDirectory()) {
+      try (IndexOutput out = srcDir.createOutput("test.txt", IOContext.DEFAULT)) {
+        out.writeString("hello");
+      }
+      boolean[] delegated = {false};
+      FilterDirectory wrappedDestDir =
+          new FilterDirectory(destDir) {
+            @Override
+            public void copyFrom(Directory from, String src, String dest, IOContext context)
+                throws IOException {
+              delegated[0] = true;
+              in.copyFrom(from, src, dest, context);
+            }
+          };
+      FilterDirectory filterDestDir = new FilterDirectory(wrappedDestDir) {};
+      filterDestDir.copyFrom(srcDir, "test.txt", "copied.txt", IOContext.DEFAULT);
+      assertTrue("copyFrom should delegate to wrapped directory", delegated[0]);
+      assertTrue(slowFileExists(destDir, "copied.txt"));
+      try (IndexInput in = destDir.openInput("copied.txt", IOContext.DEFAULT)) {
+        assertEquals("hello", in.readString());
       }
     }
   }


### PR DESCRIPTION
FilterDirectory overrides all other Directory methods but was missing copyFrom(). means wrapping a HardlinkCopyDirectoryWrapper with another FilterDirectory would bypass the hardlink optimization entirely, falling back to a slow byte-by-byte copy instead.