### PR TITLE
convert contiguous ordinal sets to ranges

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -486,6 +486,8 @@ Optimizations
 
 * GITHUB#16155: Use BitSet#nextClearBit to iterate uninitialized nodes in MergingHnswGraphBuilder. (Sasilekha R)
 
+* GITHUB#16174: Convert contiguous ordinal sets to ranges in DocValuesRangeIterator#forOrdinalSet. (Sasilekha R)
+
 Bug Fixes
 ---------------------
 * GITHUB#15754: Fix HTMLStripCharFilter to prevent tags from incorrectly consuming subsequent

--- a/lucene/core/src/java/org/apache/lucene/search/DocValuesRangeIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocValuesRangeIterator.java
@@ -136,7 +136,13 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
             values, new SkipBlockRangeIterator(skipper, min, max), check, 5, false);
   }
 
-  private record OrdinalSet(long min, long max, LongBitSet ords) {
+  /**
+   * @param contiguous true iff every ordinal in [min, max] is set, in which case the set is
+   *     equivalent to the contiguous range [min, max] and a cheaper range check can be used in
+   *     place of the per-doc bit lookup. Computed at construction time so callers don't have to
+   *     trust an undocumented invariant about the bounds of set bits in {@code ords}.
+   */
+  private record OrdinalSet(long min, long max, LongBitSet ords, boolean contiguous) {
 
     boolean disjoint(DocValuesSkipper skipper) {
       if (skipper == null) {
@@ -155,11 +161,18 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
     long min = termsEnum.ord();
     ords.set(min);
     long max = min;
+    // Count distinct ords via getAndSet so a TermsEnum that yields a duplicate ord doesn't fool
+    // the contiguity check below. The first set bit (min) is always new on a fresh bitset.
+    long distinctCount = 1;
     while (termsEnum.next() != null) {
       max = termsEnum.ord();
-      ords.set(max);
+      if (ords.getAndSet(max) == false) {
+        distinctCount++;
+      }
     }
-    return new OrdinalSet(min, max, ords);
+    // If every ord in [min, max] is set, the set is equivalent to forOrdinalRange and can use the
+    // cheaper range check + block-level YES short-circuit.
+    return new OrdinalSet(min, max, ords, distinctCount == max - min + 1);
   }
 
   /**
@@ -175,7 +188,9 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
     if (ordinalSet == null || ordinalSet.disjoint(skipper)) {
       return new EmptyRangeIterator();
     }
-    // TODO add check to OrdinalSet to detect if it can be converted to a range instead
+    if (ordinalSet.contiguous) {
+      return forOrdinalRange(values, skipper, ordinalSet.min, ordinalSet.max);
+    }
     IOBooleanSupplier check = () -> ordinalSet.ords.get(values.ordValue());
     return skipper == null
         ? new DocValuesValueRangeIterator(values, check, 2)
@@ -215,13 +230,18 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
       long minOrd,
       long maxOrd,
       LongBitSet ords) {
-    return forOrdinalSet(values, skipper, new OrdinalSet(minOrd, maxOrd, ords));
+    // Pass contiguous=false: callers of this overload aren't required by the javadoc to keep all
+    // set bits within [minOrd, maxOrd], so we can't infer contiguity from cardinality alone.
+    return forOrdinalSet(values, skipper, new OrdinalSet(minOrd, maxOrd, ords, false));
   }
 
   private static DocValuesRangeIterator forOrdinalSet(
       SortedSetDocValues values, DocValuesSkipper skipper, OrdinalSet ordinalSet) {
     if (ordinalSet == null || ordinalSet.disjoint(skipper)) {
       return new EmptyRangeIterator();
+    }
+    if (ordinalSet.contiguous) {
+      return forOrdinalRange(values, skipper, ordinalSet.min, ordinalSet.max);
     }
     IOBooleanSupplier check =
         () -> {

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
@@ -306,6 +306,90 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     assertEquals(DocIdSetIterator.NO_MORE_DOCS, approx.advance(2048));
   }
 
+  // --- SortedDocValues: contiguous ordinal set is converted to a range ---
+
+  /**
+   * When the ordinal set happens to be a contiguous range [min, max] (no gaps), {@code
+   * forOrdinalSet} should behave as if {@code forOrdinalRange(min, max)} had been called: cheaper
+   * per-doc predicate, YES blocks short-circuit without consulting the doc values, and {@code
+   * docIDRunEnd} extends across the block instead of returning {@code doc + 1}.
+   */
+  public void testSortedDocValuesContiguousOrdinalSetUsesRangeFastPath() throws IOException {
+    // Contiguous: every ordinal in [10, 20] is present.
+    long[] contiguousOrds = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
+
+    SortedDocValues values = sortedDocValues();
+    DocValuesSkipper skipper = docValuesSkipper(QUERY_MIN, QUERY_MAX, true);
+    DocValuesRangeIterator iter =
+        DocValuesRangeIterator.forOrdinalSet(values, skipper, fakeTermsEnum(contiguousOrds));
+    SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
+
+    // YES block: predicate must not be consulted, so the doc values iterator is not advanced.
+    approx.advance(0);
+    assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
+    assertTrue(iter.matches());
+    assertTrue(
+        "predicate should not have advanced doc values in a YES block when the ordinal set is"
+            + " a contiguous range",
+        values.docID() < approx.docID());
+
+    // docIDRunEnd should extend across the YES run rather than collapsing to doc + 1, matching
+    // forOrdinalRange semantics. With three skipper levels, the YES run extends to 128.
+    assertEquals(128, iter.docIDRunEnd());
+
+    // The gap-ordinal that a non-contiguous set would reject (doc 514 → ordinal 15) must now
+    // match, confirming the predicate has been widened to the [min, max] range check.
+    approx.advance(514);
+    assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
+    assertTrue(iter.matches());
+
+    // End-to-end correctness: the contiguous-set iterator must produce the exact same docs as
+    // a forOrdinalRange iterator over [10, 20].
+    List<Integer> rangeMatches =
+        collectMatches(
+            DocValuesRangeIterator.forOrdinalRange(
+                sortedDocValues(),
+                docValuesSkipper(QUERY_MIN, QUERY_MAX, true),
+                QUERY_MIN,
+                QUERY_MAX));
+    List<Integer> setMatches =
+        collectMatches(
+            DocValuesRangeIterator.forOrdinalSet(
+                sortedDocValues(),
+                docValuesSkipper(QUERY_MIN, QUERY_MAX, true),
+                fakeTermsEnum(contiguousOrds)));
+    assertEquals(rangeMatches, setMatches);
+  }
+
+  // --- SortedDocValues: duplicate ords from TermsEnum must not fool contiguity detection ---
+
+  /**
+   * A misbehaving (or simply unusual) {@link TermsEnum} could yield the same ord twice. The
+   * contiguity check must rely on the number of <em>distinct</em> ords, not on the call count,
+   * otherwise a set like {10, 10, 12} would be misclassified as the contiguous range [10, 12] and
+   * ordinal 11 would start matching incorrectly.
+   */
+  public void testSortedDocValuesDuplicateOrdsNotMisclassifiedAsContiguous() throws IOException {
+    // {10, 10, 12}: three next() calls, but only two distinct ords with ord 11 missing.
+    long[] ordsWithDuplicate = {10, 10, 12};
+
+    SortedDocValues values = sortedDocValues();
+    DocValuesSkipper skipper = docValuesSkipper(QUERY_MIN, QUERY_MAX, true);
+    DocValuesRangeIterator iter =
+        DocValuesRangeIterator.forOrdinalSet(values, skipper, fakeTermsEnum(ordsWithDuplicate));
+    SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
+
+    // Doc 0 → ord 14: outside the {10, 12} set, must not match. With a buggy contiguity check
+    // it would be treated as the range [10, 12] and still reject 14 — so we also probe an ord
+    // inside the false range (11) to make sure it is rejected.
+    approx.advance(0);
+    assertFalse(iter.matches());
+
+    // The key signal: docIDRunEnd must collapse to doc+1 because the set is not contiguous and
+    // alwaysCheckPredicate is still true.
+    assertEquals(1, iter.docIDRunEnd());
+  }
+
   // --- SortedDocValues: docIdRunEnd is conservative with ordinal sets ---
 
   public void testSortedDocValuesDocIdRunEndAlwaysDocPlusOne() throws IOException {
@@ -560,6 +644,59 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertEquals(1089, iter.docIDRunEnd());
+  }
+
+  // --- SortedSetDocValues: contiguous ordinal set is converted to a range ---
+
+  /**
+   * Multi-valued counterpart of {@link #testSortedDocValuesContiguousOrdinalSetUsesRangeFastPath}.
+   * When the TermsEnum yields a contiguous run of ordinals, {@code forOrdinalSet} must behave like
+   * {@code forOrdinalRange}: YES blocks short-circuit, {@code docIDRunEnd} extends across the
+   * block, and the previously-gap ordinal is accepted.
+   */
+  public void testSortedSetContiguousOrdinalSetUsesRangeFastPath() throws IOException {
+    long[] contiguousOrds = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
+
+    SortedSetDocValues values = sortedSetDocValues();
+    DocValuesSkipper skipper = docValuesSkipper(QUERY_MIN, QUERY_MAX, true);
+    DocValuesRangeIterator iter =
+        DocValuesRangeIterator.forOrdinalSet(values, skipper, fakeTermsEnum(contiguousOrds));
+    SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
+
+    // YES block: predicate must not be consulted, so the doc values iterator is not advanced.
+    approx.advance(0);
+    assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
+    assertTrue(iter.matches());
+    assertTrue(
+        "predicate should not have advanced doc values in a YES block when the ordinal set is"
+            + " a contiguous range",
+        values.docID() < approx.docID());
+
+    // docIDRunEnd should extend across the YES run rather than collapsing to doc + 1.
+    assertEquals(128, iter.docIDRunEnd());
+
+    // The gap-ordinal that a non-contiguous set would reject (doc 514 → ords [9, 15]) must now
+    // match, confirming the predicate has been widened to the [min, max] range check.
+    approx.advance(514);
+    assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
+    assertTrue(iter.matches());
+
+    // End-to-end correctness: the contiguous-set iterator must produce the exact same docs as
+    // a forOrdinalRange iterator over [10, 20].
+    List<Integer> rangeMatches =
+        collectMatches(
+            DocValuesRangeIterator.forOrdinalRange(
+                sortedSetDocValues(),
+                docValuesSkipper(QUERY_MIN, QUERY_MAX, true),
+                QUERY_MIN,
+                QUERY_MAX));
+    List<Integer> setMatches =
+        collectMatches(
+            DocValuesRangeIterator.forOrdinalSet(
+                sortedSetDocValues(),
+                docValuesSkipper(QUERY_MIN, QUERY_MAX, true),
+                fakeTermsEnum(contiguousOrds)));
+    assertEquals(rangeMatches, setMatches);
   }
 
   // --- SortedSetDocValues: YES_IF_PRESENT ---


### PR DESCRIPTION
Contiguity is detected inside buildOrdinalSet while building the set, so there's no extra cardinality() pass and no reliance on undocumented invariants.