### PR TITLE
Restore WANDScorer for TOP_SCORES + minShouldMatch > 1

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -158,6 +158,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
+* GITHUB#16176: Restore WANDScroer for TOP_SCORES + minShouldMatch > 1. (Tianxiao Wei)
+
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
   when all values are identical. (Mike Sokolov)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -158,8 +158,6 @@ Optimizations
 
 Bug Fixes
 ---------------------
-* GITHUB#16176: Restore WANDScroer for TOP_SCORES + minShouldMatch > 1. (Tianxiao Wei)
-
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
   when all values are identical. (Mike Sokolov)
 
@@ -385,6 +383,8 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#16176: Restore WANDScorer for TOP_SCORES + minShouldMatch > 1. (Tianxiao Wei)
+
 * GITHUB#16153: Use TernaryLongHeap in UpdateGraphsUtils for faster HNSW graph merging. (Prithvi S)
 
 * GITHUB#15861: Optimise PhraseScorer by short circuiting non competitive documents in TOP_SCORES mode. (Prithvi S)

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
@@ -295,7 +295,7 @@ final class BooleanScorerSupplier extends ScorerSupplier {
     if (scoreMode == ScoreMode.TOP_SCORES) {
       if (minShouldMatch > 1) {
         // Fall back to BS2/WANDScorer: it supports both block-max impact
-        // pruning and minShouldMatch >= 2. BooleanScorer (the fall-through
+        // pruning and minShouldMatch > 1. BooleanScorer (the fall-through
         // below) does not consult score upper bounds and would score every
         // doc in the 2048-doc window, defeating top-K pruning.
         return null;

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanScorerSupplier.java
@@ -292,7 +292,14 @@ final class BooleanScorerSupplier extends ScorerSupplier {
       return subs.get(Occur.SHOULD).iterator().next().bulkScorer();
     }
 
-    if (scoreMode == ScoreMode.TOP_SCORES && minShouldMatch <= 1) {
+    if (scoreMode == ScoreMode.TOP_SCORES) {
+      if (minShouldMatch > 1) {
+        // Fall back to BS2/WANDScorer: it supports both block-max impact
+        // pruning and minShouldMatch >= 2. BooleanScorer (the fall-through
+        // below) does not consult score upper bounds and would score every
+        // doc in the 2048-doc window, defeating top-K pruning.
+        return null;
+      }
       List<Scorer> optionalScorers = new ArrayList<>();
       for (ScorerSupplier ss : subs.get(Occur.SHOULD)) {
         optionalScorers.add(ss.get(Long.MAX_VALUE));

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanScorer.java
@@ -617,4 +617,51 @@ public class TestBooleanScorer extends LuceneTestCase {
     w.close();
     dir.close();
   }
+
+  /** Make sure a SHOULD-only BooleanQuery with TOP_SCORES and minShouldMatch > 1 is dispatched to WandScorer */
+  public void testTopScoresWithMinShouldMatchFallsBackToWand() throws IOException {
+    Directory dir = newDirectory();
+    RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+    for (int i = 0; i < 100; i++) {
+      Document doc = new Document();
+      doc.add(new StringField("foo", "bar", Store.NO));
+      doc.add(new StringField("foo", "baz", Store.NO));
+      doc.add(new StringField("foo", "qux", Store.NO));
+      w.addDocument(doc);
+    }
+    IndexReader reader = w.getReader();
+    IndexSearcher searcher = new IndexSearcher(reader);
+    searcher.setQueryCache(null); // so that weights are not wrapped
+    final LeafReaderContext ctx = reader.leaves().get(0);
+
+    Query query =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("foo", "bar")), Occur.SHOULD)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.SHOULD)
+            .add(new TermQuery(new Term("foo", "qux")), Occur.SHOULD)
+            .setMinimumNumberShouldMatch(2)
+            .build();
+
+    Weight weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.TOP_SCORES, 1);
+    ScorerSupplier ss = weight.scorerSupplier(ctx);
+    assertNull(
+        "TOP_SCORES + minShouldMatch > 1 must skip BooleanScorer and fall back to BS2/WAND",
+        ((BooleanScorerSupplier) ss).booleanScorer());
+
+    // Sanity: bulkScorer() itself returns a non-null BS2 (DefaultBulkScorer
+    // wrapping WANDScorer).
+    assertTrue(ss.bulkScorer() instanceof DefaultBulkScorer);
+
+    // Non-TOP_SCORES with minShouldMatch > 1 still uses BooleanScorer when
+    // matches are dense.
+    weight = searcher.createWeight(searcher.rewrite(query), ScoreMode.COMPLETE, 1);
+    ss = weight.scorerSupplier(ctx);
+    assertTrue(
+        "COMPLETE + minShouldMatch > 1 (dense) should still use BooleanScorer",
+        ((BooleanScorerSupplier) ss).booleanScorer() instanceof BooleanScorer);
+
+    reader.close();
+    w.close();
+    dir.close();
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanScorer.java
@@ -618,7 +618,10 @@ public class TestBooleanScorer extends LuceneTestCase {
     dir.close();
   }
 
-  /** Make sure a SHOULD-only BooleanQuery with TOP_SCORES and minShouldMatch > 1 is dispatched to WandScorer */
+  /**
+   * Make sure a SHOULD-only BooleanQuery with TOP_SCORES and minShouldMatch > 1 is dispatched to
+   * WandScorer
+   */
   public void testTopScoresWithMinShouldMatchFallsBackToWand() throws IOException {
     Directory dir = newDirectory();
     RandomIndexWriter w = new RandomIndexWriter(random(), dir);


### PR DESCRIPTION
### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->

Lucene https://github.com/apache/lucene/pull/13408 (released in 10.0) dropped a guard in `BooleanScorerSupplier.optionalBulkScorer` that previously kept `TOP_SCORES + minShouldMatch > 1` queries on `WANDScorer`. As a side effect, when matches are dense, dispatch now lands on BooleanScorer, which has no top-K impact pruning — causing 10–100× latency regressions on pure-should compound queries with minimumShouldMatch > 1.