### PR TITLE
Simplify how we collect hits in the LRU cache from a DocIdStream

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -586,6 +586,9 @@ Other
 
 * GITHUB##16135: Disable external entities in hyphenation PatternParser. (metsw24-max, Uwe Schindler)
 
+* GITHUB#16178: Simplify how we collect hits in the LRU cache from a DocIdStream into a RoaringDocIdSet.
+  (Ignacio Vera)
+
 ======================= Lucene 10.4.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
@@ -607,6 +607,8 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
     scorer.score(
         new LeafCollector() {
 
+          private int[] buffer;
+
           @Override
           public void setScorer(Scorable scorer) {}
 
@@ -623,9 +625,16 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
           }
 
           @Override
-          public void collect(DocIdStream stream) throws IOException {
-              count[0] += stream.count();
-              stream.forEach(bitSet::set);
+          public void collect(DocIdStream stream) {
+            if (buffer == null) {
+              buffer = new int[128];
+            }
+            for (int c = stream.intoArray(buffer); c != 0; c = stream.intoArray(buffer)) {
+              for (int i = 0; i < c; ++i) {
+                bitSet.set(buffer[i]);
+              }
+              count[0] += c;
+            }
           }
         },
         null,

--- a/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
@@ -607,8 +607,6 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
     scorer.score(
         new LeafCollector() {
 
-          private int[] buffer;
-
           @Override
           public void setScorer(Scorable scorer) {}
 
@@ -625,16 +623,9 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
           }
 
           @Override
-          public void collect(DocIdStream stream) {
-            if (buffer == null) {
-              buffer = new int[128];
-            }
-            for (int c = stream.intoArray(buffer); c != 0; c = stream.intoArray(buffer)) {
-              for (int i = 0; i < c; ++i) {
-                bitSet.set(buffer[i]);
-              }
-              count[0] += c;
-            }
+          public void collect(DocIdStream stream) throws IOException {
+              count[0] += stream.count();
+              stream.forEach(bitSet::set);
           }
         },
         null,
@@ -648,8 +639,6 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
     RoaringDocIdSet.Builder builder = new RoaringDocIdSet.Builder(maxDoc);
     scorer.score(
         new LeafCollector() {
-
-          private int[] buffer = null;
 
           @Override
           public void setScorer(Scorable scorer) {}
@@ -665,15 +654,8 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
           }
 
           @Override
-          public void collect(DocIdStream stream) {
-            if (buffer == null) {
-              buffer = new int[128];
-            }
-            for (int c = stream.intoArray(buffer); c != 0; c = stream.intoArray(buffer)) {
-              for (int i = 0; i < c; ++i) {
-                builder.add(buffer[i]);
-              }
-            }
+          public void collect(DocIdStream stream) throws IOException {
+            stream.forEach(builder::add);
           }
         },
         null,


### PR DESCRIPTION
We are currently using an intermediate buffer to collect those hits but it feels more natural to use the method DocIdStream#forEach to collect those. I actually asked an AI agent to check the performance of this change and it claims this way of collecting hits is faster, even when polluting the consumer with different implementations.

EDIT: change is only when populating RoaringDocIdSet

Here are the summary of the results:

```
Results (polymorphic consumer)

  ┌────────┬─────────┬─────────────┬───────────┬─────────┬───────────────────┐
  │ Stream │ Density │ Target      │ intoArray │ forEach │ forEach advantage │
  ├────────┼─────────┼─────────────┼───────────┼─────────┼───────────────────┤
  │ BITSET │ 1%      │ Roaring     │ 19.2 µs   │ 5.4 µs  │ ~3.6×             │
  │ BITSET │ 10%     │ Roaring     │ 212 µs    │ 48 µs   │ ~4.4×             │
  │ BITSET │ 50%     │ Roaring     │ 982 µs    │ 202 µs  │ ~4.9×             │
  │ RANGE  │ 50%     │ Roaring     │ 235 µs    │ 193 µs  │ ~1.2×             │
  └────────┴─────────┴─────────────┴───────────┴─────────┴───────────────────┘

```