### PR TITLE
Fix minor lock/unlock acquisition order in DocumentsWriterDeleteQueue

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -551,6 +551,8 @@ Bug Fixes
 * GITHUB#16156: OffHeapFloatVectorValues#prefetch now bounds its loop by the requested
   count instead of the full ordinal array, matching OffHeapByteVectorValues. (Vignesh)
 
+* GITHUB#16179: Fix minor lock/unlock acquisition order in DocumentsWriterDeleteQueue (Chris Hegarty)
+
 Other
 ---------------------
 * GITHUB#15586: Document that scoring and ranking may change across major Lucene versions, and that applications requiring stable ranking should explicitly configure Similarity. (Parveen Saini)

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterDeleteQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterDeleteQueue.java
@@ -197,14 +197,14 @@ final class DocumentsWriterDeleteQueue implements Accountable, Closeable {
 
   void tryApplyGlobalSlice() {
     if (globalBufferLock.tryLock()) {
-      ensureOpen();
-      /*
-       * The global buffer must be locked but we don't need to update them if
-       * there is an update going on right now. It is sufficient to apply the
-       * deletes that have been added after the current in-flight global slices
-       * tail the next time we can get the lock!
-       */
       try {
+        ensureOpen();
+        /*
+         * The global buffer must be locked but we don't need to update them if
+         * there is an update going on right now. It is sufficient to apply the
+         * deletes that have been added after the current in-flight global slices
+         * tail the next time we can get the lock!
+         */
         if (updateSliceNoSeqNo(globalSlice)) {
           globalSlice.apply(globalBufferedUpdates, BufferedUpdates.MAX_INT);
         }


### PR DESCRIPTION
Fix minor lock/unlock acquisition order in DocumentsWriterDeleteQueue.

Ensures that the acquired lock is always released, even if ensureOpen throws.

Minor issue identified by a code analyser.