### PR TITLE
Remove deprecated usages of search(Query, Collector) from monitor module

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -602,6 +602,8 @@ Other
 * GITHUB#16178: Simplify how we collect hits in the LRU cache from a DocIdStream into a RoaringDocIdSet.
   (Ignacio Vera)
 
+* GITHUB#16197: Remove deprecated usages of search(Query, Collector) from monitor module. (Luca Cavanna)
+
 ======================= Lucene 10.4.0 =======================
 
 API Changes

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/ReadonlyQueryIndex.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/ReadonlyQueryIndex.java
@@ -18,10 +18,12 @@
 package org.apache.lucene.monitor;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
@@ -79,7 +81,21 @@ class ReadonlyQueryIndex extends QueryIndex {
           queryBuilder.buildQuery(
               termFilters.get(searcher.getIndexReader().getReaderCacheHelper().getKey()));
       buildTime = System.nanoTime() - buildTime;
-      searcher.search(query, collector);
+      searcher.search(
+          query,
+          new CollectorManager<LazyMonitorQueryCollector, Void>() {
+            @Override
+            public LazyMonitorQueryCollector newCollector() {
+              return collector;
+            }
+
+            @Override
+            public Void reduce(Collection<LazyMonitorQueryCollector> collectors) {
+              assert collectors.size() == 1
+                  : "QueryCollector needs to be made thread-safe before an executor can be provided to the index searcher used by monitor";
+              return null;
+            }
+          });
       return buildTime;
     } finally {
       if (searcher != null) {

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/WritableQueryIndex.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/WritableQueryIndex.java
@@ -19,6 +19,7 @@ package org.apache.lucene.monitor;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -38,6 +39,7 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
@@ -220,7 +222,21 @@ class WritableQueryIndex extends QueryIndex {
           queryBuilder.buildQuery(
               termFilters.get(searcher.getIndexReader().getReaderCacheHelper().getKey()));
       buildTime = System.nanoTime() - buildTime;
-      searcher.search(query, collector);
+      searcher.search(
+          query,
+          new CollectorManager<MonitorQueryCollector, Void>() {
+            @Override
+            public MonitorQueryCollector newCollector() {
+              return collector;
+            }
+
+            @Override
+            public Void reduce(Collection<MonitorQueryCollector> collectors) {
+              assert collectors.size() == 1
+                  : "QueryCollector needs to be made thread-safe before an executor can be provided to the index searcher used by monitor";
+              return null;
+            }
+          });
       return buildTime;
     } finally {
       if (searcher != null) {


### PR DESCRIPTION
This is merely removing the deprecated usages, without introducing search concurrency to monitor. 

The searcher creation is all internal to monitor and there is currently no way for users to provide an executor to parallelize searches. Should we want to do that in the future, a larger refactor is needed to support search concurrency.

Created #16198 to follow-up on introducing search concurrency for monitor.

