### PR TITLE
Optimize byte vector cosine scoring: precompute query norm

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -141,9 +141,8 @@ Improvements
 
 Optimizations
 ---------------------
-* GITHUB#16200: Optimize byte vector scoring: precompute cosine query norm to avoid redundant
-  computation on every score() call, and keep int4 query vectors in packed form to use
-  int4DotProductBothPacked instead of decompressing. (James Gentile)
+* GITHUB#16200: Optimize byte vector cosine scoring: precompute the query vector's squared
+  norm to avoid redundant computation on every score() call. (James Gentile)
 
 * GITHUB#15681, GITHUB#15833, GITHUB#16056: Replace pre-sized array or empty array with lambda expression to call Collection#toArray. (Zhou Hui)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -141,6 +141,10 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#16200: Optimize byte vector scoring: precompute cosine query norm to avoid redundant
+  computation on every score() call, and keep int4 query vectors in packed form to use
+  int4DotProductBothPacked instead of decompressing. (James Gentile)
+
 * GITHUB#15681, GITHUB#15833, GITHUB#16056: Replace pre-sized array or empty array with lambda expression to call Collection#toArray. (Zhou Hui)
 
 * GITHUB#13782: Replace handwritten loops compare with Arrays.compareUnsigned in TermsEnum and TermsEnumFrame classes. (Zhou Hui)

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/DefaultFlatVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/DefaultFlatVectorScorer.java
@@ -22,9 +22,9 @@ import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
-import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
 
 /**
@@ -119,7 +119,8 @@ public class DefaultFlatVectorScorer implements FlatVectorsScorer {
         @Override
         public float score(int node) throws IOException {
           if (isCosine) {
-            return (1 + VectorUtil.cosine(vector, queryNormSquared, targetVectors.vectorValue(node)))
+            return (1
+                    + VectorUtil.cosine(vector, queryNormSquared, targetVectors.vectorValue(node)))
                 / 2;
           }
           return similarityFunction.compare(vector, targetVectors.vectorValue(node));

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/DefaultFlatVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/DefaultFlatVectorScorer.java
@@ -24,6 +24,7 @@ import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
 
 /**
@@ -103,15 +104,24 @@ public class DefaultFlatVectorScorer implements FlatVectorsScorer {
     @Override
     public UpdateableRandomVectorScorer scorer() throws IOException {
       byte[] vector = new byte[vectors.dimension()];
+      final boolean isCosine = similarityFunction == VectorSimilarityFunction.COSINE;
       return new UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer(vectors) {
+        private int queryNormSquared;
 
         @Override
         public void setScoringOrdinal(int node) throws IOException {
           System.arraycopy(targetVectors.vectorValue(node), 0, vector, 0, vector.length);
+          if (isCosine) {
+            queryNormSquared = VectorUtil.dotProduct(vector, vector);
+          }
         }
 
         @Override
         public float score(int node) throws IOException {
+          if (isCosine) {
+            return (1 + VectorUtil.cosine(vector, queryNormSquared, targetVectors.vectorValue(node)))
+                / 2;
+          }
           return similarityFunction.compare(vector, targetVectors.vectorValue(node));
         }
       };
@@ -193,6 +203,7 @@ public class DefaultFlatVectorScorer implements FlatVectorsScorer {
     private final ByteVectorValues values;
     private final byte[] query;
     private final VectorSimilarityFunction similarityFunction;
+    private final int queryNormSquared;
 
     public ByteVectorScorer(
         ByteVectorValues values, byte[] query, VectorSimilarityFunction similarityFunction) {
@@ -200,10 +211,17 @@ public class DefaultFlatVectorScorer implements FlatVectorsScorer {
       this.values = values;
       this.query = query;
       this.similarityFunction = similarityFunction;
+      this.queryNormSquared =
+          (similarityFunction == VectorSimilarityFunction.COSINE)
+              ? VectorUtil.dotProduct(query, query)
+              : 0;
     }
 
     @Override
     public float score(int node) throws IOException {
+      if (similarityFunction == VectorSimilarityFunction.COSINE) {
+        return (1 + VectorUtil.cosine(query, queryNormSquared, values.vectorValue(node))) / 2;
+      }
       return similarityFunction.compare(query, values.vectorValue(node));
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
@@ -205,13 +205,16 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
     }
   }
 
+  // TODO consider splitting this into two classes. right now the "query" vector
+  // is always
+  // decompressed
+  // it could stay compressed if we had a compressed version of the target vector
   private static class CompressedInt4DotProduct
       extends UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer {
     private final float constMultiplier;
     private final LegacyQuantizedByteVectorValues values;
     private final byte[] compressedVector;
     private final byte[] targetBytes;
-    private final byte[] compressedTarget;
     private float offsetCorrection;
     private final FloatToFloatFunction scoreAdjustmentFunction;
 
@@ -226,8 +229,6 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
       this.values = values;
       this.compressedVector = new byte[values.getVectorByteLength()];
       this.targetBytes = targetBytes;
-      this.compressedTarget = new byte[(targetBytes.length + 1) >> 1];
-      packInt4(targetBytes, compressedTarget);
       this.offsetCorrection = offsetCorrection;
       this.scoreAdjustmentFunction = scoreAdjustmentFunction;
     }
@@ -235,11 +236,12 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
     @Override
     public float score(int vectorOrdinal) throws IOException {
       // get compressed vector, in Lucene99, vector values are stored and have a
-      // single value for offset correction
+      // single value for
+      // offset correction
       values.getSlice().seek((long) vectorOrdinal * (values.getVectorByteLength() + Float.BYTES));
       values.getSlice().readBytes(compressedVector, 0, compressedVector.length);
       float vectorOffset = values.getScoreCorrectionConstant(vectorOrdinal);
-      int dotProduct = VectorUtil.int4DotProductBothPacked(compressedTarget, compressedVector);
+      int dotProduct = VectorUtil.int4DotProductSinglePacked(targetBytes, compressedVector);
       // For the current implementation of scalar quantization, all dotproducts should
       // be >= 0;
       assert dotProduct >= 0;
@@ -250,18 +252,7 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
     @Override
     public void setScoringOrdinal(int node) throws IOException {
       System.arraycopy(values.vectorValue(node), 0, targetBytes, 0, targetBytes.length);
-      packInt4(targetBytes, compressedTarget);
       offsetCorrection = values.getScoreCorrectionConstant(node);
-    }
-
-    /**
-     * Packs unpacked int4 values into the compressed format: upper nibble from first half, lower
-     * nibble from second half.
-     */
-    private static void packInt4(byte[] unpacked, byte[] packed) {
-      for (int i = 0; i < packed.length; i++) {
-        packed[i] = (byte) ((unpacked[i] << 4) | (unpacked[i + packed.length] & 0x0F));
-      }
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
@@ -254,8 +254,10 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
       offsetCorrection = values.getScoreCorrectionConstant(node);
     }
 
-    /** Packs unpacked int4 values into the compressed format: upper nibble from first half, lower
-     *  nibble from second half. */
+    /**
+     * Packs unpacked int4 values into the compressed format: upper nibble from first half, lower
+     * nibble from second half.
+     */
     private static void packInt4(byte[] unpacked, byte[] packed) {
       for (int i = 0; i < packed.length; i++) {
         packed[i] = (byte) ((unpacked[i] << 4) | (unpacked[i + packed.length] & 0x0F));

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
@@ -205,16 +205,13 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
     }
   }
 
-  // TODO consider splitting this into two classes. right now the "query" vector
-  // is always
-  // decompressed
-  // it could stay compressed if we had a compressed version of the target vector
   private static class CompressedInt4DotProduct
       extends UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer {
     private final float constMultiplier;
     private final LegacyQuantizedByteVectorValues values;
     private final byte[] compressedVector;
     private final byte[] targetBytes;
+    private final byte[] compressedTarget;
     private float offsetCorrection;
     private final FloatToFloatFunction scoreAdjustmentFunction;
 
@@ -229,6 +226,8 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
       this.values = values;
       this.compressedVector = new byte[values.getVectorByteLength()];
       this.targetBytes = targetBytes;
+      this.compressedTarget = new byte[(targetBytes.length + 1) >> 1];
+      packInt4(targetBytes, compressedTarget);
       this.offsetCorrection = offsetCorrection;
       this.scoreAdjustmentFunction = scoreAdjustmentFunction;
     }
@@ -236,12 +235,11 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
     @Override
     public float score(int vectorOrdinal) throws IOException {
       // get compressed vector, in Lucene99, vector values are stored and have a
-      // single value for
-      // offset correction
+      // single value for offset correction
       values.getSlice().seek((long) vectorOrdinal * (values.getVectorByteLength() + Float.BYTES));
       values.getSlice().readBytes(compressedVector, 0, compressedVector.length);
       float vectorOffset = values.getScoreCorrectionConstant(vectorOrdinal);
-      int dotProduct = VectorUtil.int4DotProductSinglePacked(targetBytes, compressedVector);
+      int dotProduct = VectorUtil.int4DotProductBothPacked(compressedTarget, compressedVector);
       // For the current implementation of scalar quantization, all dotproducts should
       // be >= 0;
       assert dotProduct >= 0;
@@ -252,7 +250,16 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
     @Override
     public void setScoringOrdinal(int node) throws IOException {
       System.arraycopy(values.vectorValue(node), 0, targetBytes, 0, targetBytes.length);
+      packInt4(targetBytes, compressedTarget);
       offsetCorrection = values.getScoreCorrectionConstant(node);
+    }
+
+    /** Packs unpacked int4 values into the compressed format: upper nibble from first half, lower
+     *  nibble from second half. */
+    private static void packInt4(byte[] unpacked, byte[] packed) {
+      for (int i = 0; i < packed.length; i++) {
+        packed[i] = (byte) ((unpacked[i] << 4) | (unpacked[i + packed.length] & 0x0F));
+      }
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
@@ -211,6 +211,19 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public float cosine(byte[] a, int aNormSquared, byte[] b) {
+    // Note: this will not overflow if dim < 2^18, since max(byte * byte) = 2^14.
+    int sum = 0;
+    int norm2 = 0;
+
+    for (int i = 0; i < a.length; i++) {
+      sum += a[i] * b[i];
+      norm2 += b[i] * b[i];
+    }
+    return (float) (sum / Math.sqrt((double) aNormSquared * (double) norm2));
+  }
+
+  @Override
   public int squareDistance(byte[] a, byte[] b) {
     // Note: this will not overflow if dim < 2^18, since max(byte * byte) = 2^14.
     int squareSum = 0;

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
@@ -52,9 +52,9 @@ public interface VectorUtilSupport {
   float cosine(byte[] a, byte[] b);
 
   /**
-   * Returns the cosine similarity between the two byte vectors, given a precomputed squared norm for
-   * the first vector. This avoids recomputing the norm of vector {@code a} on every call when the
-   * query vector is fixed.
+   * Returns the cosine similarity between the two byte vectors, given a precomputed squared norm
+   * for the first vector. This avoids recomputing the norm of vector {@code a} on every call when
+   * the query vector is fixed.
    */
   float cosine(byte[] a, int aNormSquared, byte[] b);
 

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
@@ -51,6 +51,13 @@ public interface VectorUtilSupport {
   /** Returns the cosine similarity between the two byte vectors. */
   float cosine(byte[] a, byte[] b);
 
+  /**
+   * Returns the cosine similarity between the two byte vectors, given a precomputed squared norm for
+   * the first vector. This avoids recomputing the norm of vector {@code a} on every call when the
+   * query vector is fixed.
+   */
+  float cosine(byte[] a, int aNormSquared, byte[] b);
+
   /** Returns the sum of squared differences of the two byte vectors. */
   int squareDistance(byte[] a, byte[] b);
 

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -99,9 +99,9 @@ public final class VectorUtil {
   }
 
   /**
-   * Returns the cosine similarity between the two byte vectors, given a precomputed squared norm for
-   * the first vector. This avoids recomputing the norm of {@code a} on every call when the query
-   * vector is fixed.
+   * Returns the cosine similarity between the two byte vectors, given a precomputed squared norm
+   * for the first vector. This avoids recomputing the norm of {@code a} on every call when the
+   * query vector is fixed.
    *
    * @param a the first vector (typically the query)
    * @param aNormSquared the precomputed value of {@code dotProduct(a, a)}

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -99,6 +99,23 @@ public final class VectorUtil {
   }
 
   /**
+   * Returns the cosine similarity between the two byte vectors, given a precomputed squared norm for
+   * the first vector. This avoids recomputing the norm of {@code a} on every call when the query
+   * vector is fixed.
+   *
+   * @param a the first vector (typically the query)
+   * @param aNormSquared the precomputed value of {@code dotProduct(a, a)}
+   * @param b the second vector
+   * @return the cosine similarity between the two vectors
+   */
+  public static float cosine(byte[] a, int aNormSquared, byte[] b) {
+    if (a.length != b.length) {
+      throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);
+    }
+    return IMPL.cosine(a, aNormSquared, b);
+  }
+
+  /**
    * Returns the sum of squared differences of the two vectors.
    *
    * @throws IllegalArgumentException if the vectors' dimensions differ.

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentByteVectorScorerSupplier.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentByteVectorScorerSupplier.java
@@ -114,23 +114,34 @@ public abstract sealed class Lucene99MemorySegmentByteVectorScorerSupplier
     public UpdateableRandomVectorScorer scorer() {
       return new UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer(values) {
         private int queryOrd = 0;
+        private int queryNormSquared = 0;
 
         @Override
         public float score(int node) throws IOException {
           checkOrdinal(node);
           float raw;
           if (Constants.NATIVE_DOT_PRODUCT_ENABLED) {
-            raw = NativeVectorUtilSupport.cosine(getFirstSegment(queryOrd), getSecondSegment(node));
+            raw =
+                NativeVectorUtilSupport.cosine(
+                    getFirstSegment(queryOrd), queryNormSquared, getSecondSegment(node));
           } else {
-            raw = PanamaVectorUtilSupport.cosine(getFirstSegment(queryOrd), getSecondSegment(node));
+            raw =
+                PanamaVectorUtilSupport.cosine(
+                    getFirstSegment(queryOrd), queryNormSquared, getSecondSegment(node));
           }
           return (1 + raw) / 2;
         }
 
         @Override
-        public void setScoringOrdinal(int node) {
+        public void setScoringOrdinal(int node) throws IOException {
           checkOrdinal(node);
           queryOrd = node;
+          MemorySegment querySeg = getFirstSegment(node);
+          if (Constants.NATIVE_DOT_PRODUCT_ENABLED) {
+            queryNormSquared = NativeVectorUtilSupport.dotProduct(querySeg, querySeg);
+          } else {
+            queryNormSquared = PanamaVectorUtilSupport.dotProduct(querySeg, querySeg);
+          }
         }
       };
     }

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/NativeVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/NativeVectorUtilSupport.java
@@ -283,6 +283,11 @@ final class NativeVectorUtilSupport implements VectorUtilSupport {
         : PanamaVectorUtilSupport.cosine(a, b);
   }
 
+  public static float cosine(MemorySegment a, int aNormSquared, MemorySegment b) {
+    // No native precomputed-norm variant; delegate to Panama
+    return PanamaVectorUtilSupport.cosine(a, aNormSquared, b);
+  }
+
   public static int dotProduct(byte[] a, MemorySegment b) {
     return (dotProduct$MH != null)
         ? dotProduct(MemorySegment.ofArray(a), b)
@@ -444,6 +449,12 @@ final class NativeVectorUtilSupport implements VectorUtilSupport {
     return (cosine$MH != null)
         ? cosine(MemorySegment.ofArray(a), MemorySegment.ofArray(b))
         : delegateVectorUtilSupport.cosine(a, b);
+  }
+
+  @Override
+  public float cosine(byte[] a, int aNormSquared, byte[] b) {
+    // No native precomputed-norm variant; delegate to Panama
+    return delegateVectorUtilSupport.cosine(a, aNormSquared, b);
   }
 
   @Override

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -707,6 +707,123 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     return cosineBody(new ArrayLoader(a), new MemorySegmentLoader(b));
   }
 
+  @Override
+  public float cosine(byte[] a, int aNormSquared, byte[] b) {
+    return cosineBodyPrecomputedNorm(new ArrayLoader(a), aNormSquared, new ArrayLoader(b));
+  }
+
+  public static float cosine(byte[] a, int aNormSquared, MemorySegment b) {
+    return cosineBodyPrecomputedNorm(new ArrayLoader(a), aNormSquared, new MemorySegmentLoader(b));
+  }
+
+  public static float cosine(MemorySegment a, int aNormSquared, MemorySegment b) {
+    return cosineBodyPrecomputedNorm(
+        new MemorySegmentLoader(a), aNormSquared, new MemorySegmentLoader(b));
+  }
+
+  private static float cosineBodyPrecomputedNorm(
+      ByteVectorLoader a, int aNormSquared, ByteVectorLoader b) {
+    int i = 0;
+    int sum = 0;
+    int norm2 = 0;
+
+    // only vectorize if we'll at least enter the loop a single time
+    if (a.length() >= 16) {
+      final int[] ret;
+      if (VECTOR_BITSIZE >= 512) {
+        i += BYTE_SPECIES.loopBound(a.length());
+        ret = cosineBodyPrecomputedNorm512(a, b, i);
+      } else if (VECTOR_BITSIZE == 256) {
+        i += BYTE_SPECIES.loopBound(a.length());
+        ret = cosineBodyPrecomputedNorm256(a, b, i);
+      } else {
+        // tricky: we don't have SPECIES_32, so we workaround with "overlapping read"
+        i += ByteVector.SPECIES_64.loopBound(a.length() - ByteVector.SPECIES_64.length());
+        ret = cosineBodyPrecomputedNorm128(a, b, i);
+      }
+      sum += ret[0];
+      norm2 += ret[1];
+    }
+
+    // scalar tail
+    for (; i < a.length(); i++) {
+      byte elem1 = a.tail(i);
+      byte elem2 = b.tail(i);
+      sum += elem1 * elem2;
+      norm2 += elem2 * elem2;
+    }
+    return (float) (sum / Math.sqrt((double) aNormSquared * (double) norm2));
+  }
+
+  /** vectorized cosine body with precomputed norm (512 bit vectors) */
+  private static int[] cosineBodyPrecomputedNorm512(
+      ByteVectorLoader a, ByteVectorLoader b, int limit) {
+    IntVector accSum = IntVector.zero(INT_SPECIES);
+    IntVector accNorm2 = IntVector.zero(INT_SPECIES);
+    for (int i = 0; i < limit; i += BYTE_SPECIES.length()) {
+      ByteVector va8 = a.load(BYTE_SPECIES, i);
+      ByteVector vb8 = b.load(BYTE_SPECIES, i);
+
+      // 16-bit multiply: avoid AVX-512 heavy multiply on zmm
+      Vector<Short> va16 = va8.convertShape(B2S, SHORT_SPECIES, 0);
+      Vector<Short> vb16 = vb8.convertShape(B2S, SHORT_SPECIES, 0);
+      Vector<Short> norm2_16 = vb16.mul(vb16);
+      Vector<Short> prod16 = va16.mul(vb16);
+
+      // sum into accumulators: 32-bit add
+      Vector<Integer> norm2_32 = norm2_16.convertShape(S2I, INT_SPECIES, 0);
+      Vector<Integer> prod32 = prod16.convertShape(S2I, INT_SPECIES, 0);
+      accNorm2 = accNorm2.add(norm2_32);
+      accSum = accSum.add(prod32);
+    }
+    // reduce
+    return new int[] {accSum.reduceLanes(ADD), accNorm2.reduceLanes(ADD)};
+  }
+
+  /** vectorized cosine body with precomputed norm (256 bit vectors) */
+  private static int[] cosineBodyPrecomputedNorm256(
+      ByteVectorLoader a, ByteVectorLoader b, int limit) {
+    IntVector accSum = IntVector.zero(IntVector.SPECIES_256);
+    IntVector accNorm2 = IntVector.zero(IntVector.SPECIES_256);
+    for (int i = 0; i < limit; i += ByteVector.SPECIES_64.length()) {
+      ByteVector va8 = a.load(ByteVector.SPECIES_64, i);
+      ByteVector vb8 = b.load(ByteVector.SPECIES_64, i);
+
+      // 32-bit multiply, and add into accumulators
+      Vector<Integer> va32 = va8.convertShape(B2I, IntVector.SPECIES_256, 0);
+      Vector<Integer> vb32 = vb8.convertShape(B2I, IntVector.SPECIES_256, 0);
+      Vector<Integer> norm2_32 = vb32.mul(vb32);
+      Vector<Integer> prod32 = va32.mul(vb32);
+      accNorm2 = accNorm2.add(norm2_32);
+      accSum = accSum.add(prod32);
+    }
+    // reduce
+    return new int[] {accSum.reduceLanes(ADD), accNorm2.reduceLanes(ADD)};
+  }
+
+  /** vectorized cosine body with precomputed norm (128 bit vectors) */
+  private static int[] cosineBodyPrecomputedNorm128(
+      ByteVectorLoader a, ByteVectorLoader b, int limit) {
+    IntVector accSum = IntVector.zero(IntVector.SPECIES_128);
+    IntVector accNorm2 = IntVector.zero(IntVector.SPECIES_128);
+    for (int i = 0; i < limit; i += ByteVector.SPECIES_64.length() >> 1) {
+      ByteVector va8 = a.load(ByteVector.SPECIES_64, i);
+      ByteVector vb8 = b.load(ByteVector.SPECIES_64, i);
+
+      // process first half only: 16-bit multiply
+      Vector<Short> va16 = va8.convert(B2S, 0);
+      Vector<Short> vb16 = vb8.convert(B2S, 0);
+      Vector<Short> norm2_16 = vb16.mul(vb16);
+      Vector<Short> prod16 = va16.mul(vb16);
+
+      // sum into accumulators: 32-bit add
+      accNorm2 = accNorm2.add(norm2_16.convertShape(S2I, IntVector.SPECIES_128, 0));
+      accSum = accSum.add(prod16.convertShape(S2I, IntVector.SPECIES_128, 0));
+    }
+    // reduce
+    return new int[] {accSum.reduceLanes(ADD), accNorm2.reduceLanes(ADD)};
+  }
+
   private static float cosineBody(ByteVectorLoader a, ByteVectorLoader b) {
     int i = 0;
     int sum = 0;

--- a/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
+++ b/lucene/core/src/test/org/apache/lucene/internal/vectorization/TestVectorUtilSupport.java
@@ -67,6 +67,10 @@ public class TestVectorUtilSupport extends BaseVectorizationTestCase {
     assertIntReturningProviders(p -> p.dotProduct(a, b));
     assertIntReturningProviders(p -> p.squareDistance(a, b));
     assertFloatReturningProviders(p -> p.cosine(a, b));
+    // ensure non-zero for cosine with precomputed norm
+    a[0] = (byte) (random().nextInt(126) + 1);
+    int aNormSquared = LUCENE_PROVIDER.getVectorUtilSupport().dotProduct(a, a);
+    assertFloatReturningProviders(p -> p.cosine(a, aNormSquared, b));
   }
 
   public void testBinaryVectorsBoundaries() {
@@ -96,6 +100,15 @@ public class TestVectorUtilSupport extends BaseVectorizationTestCase {
     assertIntReturningProviders(p -> p.dotProduct(a, b));
     assertIntReturningProviders(p -> p.squareDistance(a, b));
     assertFloatReturningProviders(p -> p.cosine(a, b));
+
+    // Also test cosine with precomputed norm at boundaries
+    Arrays.fill(a, Byte.MAX_VALUE);
+    Arrays.fill(b, Byte.MAX_VALUE);
+    int aNorm1 = LUCENE_PROVIDER.getVectorUtilSupport().dotProduct(a, a);
+    assertFloatReturningProviders(p -> p.cosine(a, aNorm1, b));
+
+    Arrays.fill(b, Byte.MIN_VALUE);
+    assertFloatReturningProviders(p -> p.cosine(a, aNorm1, b));
   }
 
   public void testUint8Vectors() {

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -729,36 +729,4 @@ public class TestVectorUtil extends LuceneTestCase {
       assertEquals(expected, actual, 0f);
     }
   }
-
-  public void testInt4PackAndDotProduct() {
-    // Verify that packing then using int4DotProductBothPacked gives the same result
-    // as int4DotProductSinglePacked with unpacked data
-    int iterations = atLeast(50);
-    for (int iter = 0; iter < iterations; iter++) {
-      int halfDim = TestUtil.nextInt(random(), 1, 128);
-      int dim = halfDim * 2;
-      byte[] unpacked = new byte[dim];
-      byte[] docPacked = new byte[halfDim];
-      // Generate random int4 values [0, 15]
-      for (int i = 0; i < dim; i++) {
-        unpacked[i] = (byte) random().nextInt(16);
-      }
-      // Pack the document vector
-      for (int i = 0; i < halfDim; i++) {
-        docPacked[i] = (byte) ((unpacked[i] << 4) | (unpacked[i + halfDim] & 0x0F));
-      }
-      // Now pack the "query" too
-      byte[] queryUnpacked = new byte[dim];
-      for (int i = 0; i < dim; i++) {
-        queryUnpacked[i] = (byte) random().nextInt(16);
-      }
-      byte[] queryPacked = new byte[halfDim];
-      for (int i = 0; i < halfDim; i++) {
-        queryPacked[i] = (byte) ((queryUnpacked[i] << 4) | (queryUnpacked[i + halfDim] & 0x0F));
-      }
-      int expected = VectorUtil.int4DotProductSinglePacked(queryUnpacked, docPacked);
-      int actual = VectorUtil.int4DotProductBothPacked(queryPacked, docPacked);
-      assertEquals(expected, actual);
-    }
-  }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -684,4 +684,82 @@ public class TestVectorUtil extends LuceneTestCase {
     }
     return res;
   }
+
+  public void testCosinePrecomputedNormBasic() {
+    byte[] a = new byte[] {1, 2, 3};
+    byte[] b = new byte[] {-10, 0, 5};
+    int aNormSquared = VectorUtil.dotProduct(a, a);
+    assertEquals(VectorUtil.cosine(a, b), VectorUtil.cosine(a, aNormSquared, b), 0f);
+  }
+
+  public void testCosinePrecomputedNormSelf() {
+    byte[] v = randomVectorBytes();
+    v[0] = (byte) (random().nextInt(126) + 1);
+    int normSquared = VectorUtil.dotProduct(v, v);
+    assertEquals(1.0f, VectorUtil.cosine(v, normSquared, v), DELTA);
+  }
+
+  public void testCosinePrecomputedNormRandom() {
+    int iterations = atLeast(50);
+    for (int iter = 0; iter < iterations; iter++) {
+      int dim = TestUtil.nextInt(random(), 1, 256);
+      byte[] a = randomVectorBytes(dim);
+      byte[] b = randomVectorBytes(dim);
+      // ensure non-zero vectors
+      a[0] = (byte) (random().nextInt(126) + 1);
+      b[0] = (byte) (random().nextInt(126) + 1);
+      int aNormSquared = VectorUtil.dotProduct(a, a);
+      float expected = VectorUtil.cosine(a, b);
+      float actual = VectorUtil.cosine(a, aNormSquared, b);
+      assertEquals(expected, actual, 0f);
+    }
+  }
+
+  public void testCosinePrecomputedNormAllImpls() {
+    int iterations = atLeast(50);
+    for (int iter = 0; iter < iterations; iter++) {
+      int dim = TestUtil.nextInt(random(), 1, 256);
+      byte[] a = randomVectorBytes(dim);
+      byte[] b = randomVectorBytes(dim);
+      a[0] = (byte) (random().nextInt(126) + 1);
+      b[0] = (byte) (random().nextInt(126) + 1);
+      int aNormSquared = VectorUtil.dotProduct(a, a);
+      float expected = defaultedProvider.getVectorUtilSupport().cosine(a, aNormSquared, b);
+      float actual = defOrPanamaProvider.getVectorUtilSupport().cosine(a, aNormSquared, b);
+      assertEquals(expected, actual, 0f);
+    }
+  }
+
+  public void testInt4PackAndDotProduct() {
+    // Verify that packing then using int4DotProductBothPacked gives the same result
+    // as int4DotProductSinglePacked with unpacked data
+    int iterations = atLeast(50);
+    for (int iter = 0; iter < iterations; iter++) {
+      int halfDim = TestUtil.nextInt(random(), 1, 128);
+      int dim = halfDim * 2;
+      byte[] unpacked = new byte[dim];
+      byte[] docPacked = new byte[halfDim];
+      // Generate random int4 values [0, 15]
+      for (int i = 0; i < dim; i++) {
+        unpacked[i] = (byte) random().nextInt(16);
+      }
+      // Pack the document vector
+      for (int i = 0; i < halfDim; i++) {
+        docPacked[i] = (byte) ((unpacked[i] << 4) | (unpacked[i + halfDim] & 0x0F));
+      }
+      // Now pack the "query" too
+      byte[] queryUnpacked = new byte[dim];
+      for (int i = 0; i < dim; i++) {
+        queryUnpacked[i] = (byte) random().nextInt(16);
+      }
+      byte[] queryPacked = new byte[halfDim];
+      for (int i = 0; i < halfDim; i++) {
+        queryPacked[i] =
+            (byte) ((queryUnpacked[i] << 4) | (queryUnpacked[i + halfDim] & 0x0F));
+      }
+      int expected = VectorUtil.int4DotProductSinglePacked(queryUnpacked, docPacked);
+      int actual = VectorUtil.int4DotProductBothPacked(queryPacked, docPacked);
+      assertEquals(expected, actual);
+    }
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -754,8 +754,7 @@ public class TestVectorUtil extends LuceneTestCase {
       }
       byte[] queryPacked = new byte[halfDim];
       for (int i = 0; i < halfDim; i++) {
-        queryPacked[i] =
-            (byte) ((queryUnpacked[i] << 4) | (queryUnpacked[i + halfDim] & 0x0F));
+        queryPacked[i] = (byte) ((queryUnpacked[i] << 4) | (queryUnpacked[i + halfDim] & 0x0F));
       }
       int expected = VectorUtil.int4DotProductSinglePacked(queryUnpacked, docPacked);
       int actual = VectorUtil.int4DotProductBothPacked(queryPacked, docPacked);


### PR DESCRIPTION
## Summary

- **Precompute cosine query norm**: Byte vector cosine similarity previously recomputed the query vector's squared norm on every `score()` call. Since the query is fixed for the lifetime of a scorer, the norm is now computed once and passed through a new `VectorUtil.cosine(byte[], int, byte[])` overload. This eliminates one SIMD accumulator, one SIMD multiply, and one `reduceLanes` per call in the vectorized (Panama) 256/512-bit paths.

## Benchmarks

Byte vector cosine scoring throughput (ops/us, higher is better):

| Size | Baseline (Default) | Optimized (Default) | Improvement |
|------|-------------------|---------------------|-------------|
| 128  | 3.801 | 4.382 | +15.3% |
| 256  | 2.634 | 2.914 | +10.6% |
| 512  | 1.629 | 2.014 | +23.6% |
| 1024 | 0.866 | 1.171 | +35.2% |

| Size | Baseline (MemSeg) | Optimized (MemSeg) | Improvement |
|------|-------------------|---------------------|-------------|
| 128  | 3.777 | 4.451 | +17.8% |
| 256  | 2.616 | 3.124 | +19.4% |
| 512  | 1.611 | 2.002 | +24.3% |
| 1024 | 0.862 | 1.168 | +35.5% |

## Test plan

- [x] `TestVectorUtil` -- new tests for `cosine(byte[], int, byte[])` verifying exact float equality with `cosine(byte[], byte[])` for random vectors
- [x] `TestVectorUtilSupport` -- cross-provider consistency tests for the new cosine overload across all vector sizes
- [x] `TestFlatVectorScorer` -- existing parameterized tests cover COSINE for byte vectors
- [x] `TestVectorScorer` -- existing comparison tests between default and Panama implementations
- [x] `TestLucene99ScalarQuantizedVectorScorer` -- no regressions
- [x] `TestPrefetchableFlatVectorScorer` -- no regressions

Generated with [Claude Code](https://claude.com/claude-code)