### PR TITLE
Add BinarySortField: index sorting on BinaryDocValues

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -103,6 +103,11 @@ New Features
 * GITHUB#15505: Upgrade snowball to 2d2e312df56f2ede014a4ffb3e91e6dea43c24be. New stemmer: PolishStemmer (and
   PolishSnowballAnalyzer in the stempel package) (Justas Sakalauskas, Dawid Weiss)
 
+* GITHUB#16202: Add BinarySortField, allowing BinaryDocValues fields to be used as an index sort. Unlike
+  sorting on SortedDocValues (best for low-cardinality fields), it compares the raw bytes directly and is
+  a good fit for high-cardinality fields. The default ordering is unsigned byte order; a custom comparator
+  can be supplied by subclassing. (Jim Ferenczi)
+
 * GITHUB#14097: Binary partitioning merge policy over float-valued vector field. (Mike Sokolov)
 
 * GITHUB#14178: Add a Faiss-based vector format in the sandbox module. (Kaival Parikh)

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/IndexSortDocValuesBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/IndexSortDocValuesBenchmark.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.BinarySortField;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IOUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Measures the cost of building an index sorted on a single-valued bytes field, comparing {@link
+ * BinarySortField} (over {@link org.apache.lucene.index.BinaryDocValues BinaryDocValues}) against a
+ * {@code SortField.Type.STRING} sort (over {@link org.apache.lucene.index.SortedDocValues
+ * SortedDocValues}).
+ *
+ * <p>Indexing uses the default flush and merge configuration, so documents are flushed naturally
+ * and the merge policy schedules merges as the index grows. {@link #indexWithNaturalMerges}
+ * measures the time to index every document and wait for the resulting merges to finish; {@link
+ * #indexThenForceMerge} additionally force-merges down to a single segment.
+ *
+ * <p>The {@code cardinality} parameter controls how many distinct values the field holds, and
+ * {@code valueLength} the length in bytes of each value.
+ */
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@Fork(
+    value = 1,
+    jvmArgsAppend = {"-Xmx8g", "-Xms8g", "-XX:+AlwaysPreTouch"})
+public class IndexSortDocValuesBenchmark {
+
+  @Param({"1000000"})
+  public int docCount;
+
+  @Param({"16"})
+  public int valueLength;
+
+  /** "binary" uses {@link BinarySortField}; "sorted" uses {@code SortField.Type.STRING}. */
+  @Param({"binary", "sorted"})
+  public String dvType;
+
+  /** "low" cycles a small set of distinct values; "high" gives each document a unique value. */
+  @Param({"low", "high"})
+  public String cardinality;
+
+  private byte[][] values;
+  private Path path;
+
+  @Setup(Level.Trial)
+  public void setup() throws IOException {
+    Random random = new Random(42);
+    int distinct = cardinality.equals("low") ? 128 : docCount;
+    byte[][] pool = new byte[distinct][];
+    for (int i = 0; i < distinct; i++) {
+      byte[] b = new byte[valueLength];
+      random.nextBytes(b);
+      pool[i] = b;
+    }
+    // assign one value per doc; shuffle so the field is unsorted on input
+    values = new byte[docCount][];
+    for (int i = 0; i < docCount; i++) {
+      values[i] = pool[cardinality.equals("low") ? random.nextInt(distinct) : i];
+    }
+    for (int i = docCount - 1; i > 0; i--) {
+      int j = random.nextInt(i + 1);
+      byte[] tmp = values[i];
+      values[i] = values[j];
+      values[j] = tmp;
+    }
+    path = Files.createTempDirectory("indexSortDocValuesBenchmark");
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws IOException {
+    IOUtils.rm(path);
+  }
+
+  private Sort indexSort() {
+    if (dvType.equals("binary")) {
+      return new Sort(new BinarySortField("dv", false));
+    } else {
+      return new Sort(new SortField("dv", SortField.Type.STRING, false));
+    }
+  }
+
+  private long index(boolean forceMerge) throws IOException {
+    Path runPath = Files.createTempDirectory(path, dvType);
+    try (Directory dir = new MMapDirectory(runPath)) {
+      IndexWriterConfig iwc = new IndexWriterConfig().setIndexSort(indexSort());
+      long checksum;
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        Document doc = new Document();
+        ReusableField field = dvType.equals("binary") ? new BinaryField() : new SortedField();
+        doc.add(field.field());
+        for (int i = 0; i < docCount; i++) {
+          field.setValue(values[i]);
+          w.addDocument(doc);
+        }
+        if (forceMerge) {
+          w.forceMerge(1);
+        }
+        checksum = w.getDocStats().maxDoc;
+        // Closing the writer (try-with-resources) flushes, runs and awaits the pending merges that
+        // the merge policy scheduled while indexing, and commits, so the close is part of the
+        // measured region.
+      }
+      return checksum;
+    } finally {
+      IOUtils.rm(runPath);
+    }
+  }
+
+  @Benchmark
+  public long indexWithNaturalMerges() throws IOException {
+    return index(false);
+  }
+
+  @Benchmark
+  public long indexThenForceMerge() throws IOException {
+    return index(true);
+  }
+
+  /** Small abstraction over the two reusable doc-values field types. */
+  private interface ReusableField {
+    Field field();
+
+    void setValue(byte[] value);
+  }
+
+  private static final class BinaryField implements ReusableField {
+    private final BinaryDocValuesField field = new BinaryDocValuesField("dv", new BytesRef());
+
+    @Override
+    public Field field() {
+      return field;
+    }
+
+    @Override
+    public void setValue(byte[] value) {
+      field.setBytesValue(value);
+    }
+  }
+
+  private static final class SortedField implements ReusableField {
+    private final SortedDocValuesField field = new SortedDocValuesField("dv", new BytesRef());
+
+    @Override
+    public Field field() {
+      return field;
+    }
+
+    @Override
+    public void setValue(byte[] value) {
+      field.setBytesValue(value);
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/index/BinaryDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BinaryDocValuesWriter.java
@@ -52,6 +52,7 @@ class BinaryDocValuesWriter extends DocValuesWriter<BinaryDocValues> {
   private long bytesUsed;
   private int lastDocID = -1;
   private int maxLength = 0;
+  private boolean frozen;
 
   private PackedLongValues finalLengths;
 
@@ -103,11 +104,22 @@ class BinaryDocValuesWriter extends DocValuesWriter<BinaryDocValues> {
     bytesUsed = newBytesUsed;
   }
 
+  // Freezes the PagedBytes exactly once. getDocValues() may be called before flush() (e.g. when
+  // index sorting on this field reads the in-RAM values), so we cannot rely on flush() being the
+  // first to freeze.
+  private void freezeBytes() {
+    if (frozen == false) {
+      bytes.freeze(false);
+      frozen = true;
+    }
+  }
+
   @Override
   BinaryDocValues getDocValues() {
     if (finalLengths == null) {
       finalLengths = this.lengths.build();
     }
+    freezeBytes();
     return new BufferedBinaryDocValues(
         finalLengths, maxLength, bytes.getDataInput(), docsWithField.iterator());
   }
@@ -115,7 +127,7 @@ class BinaryDocValuesWriter extends DocValuesWriter<BinaryDocValues> {
   @Override
   public void flush(SegmentWriteState state, Sorter.DocMap sortMap, DocValuesConsumer dvConsumer)
       throws IOException {
-    bytes.freeze(false);
+    freezeBytes();
     if (finalLengths == null) {
       finalLengths = this.lengths.build();
     }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexSorter.java
@@ -25,6 +25,10 @@ import java.util.Comparator;
 import java.util.List;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.LongValues;
 import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.packed.PackedInts;
@@ -37,8 +41,10 @@ import org.apache.lucene.util.packed.PackedInts;
  * <ul>
  *   <li>{@link #getDocComparator(LeafReader,int)} - an object that determines how documents within
  *       a segment are to be sorted
- *   <li>{@link #getComparableProviders(List)} - an array of objects that return a sortable long
- *       value per document and segment
+ *   <li>{@link #getComparableValues(List)} - an object that caches and compares the sort value of
+ *       documents across segments, used for merge sorting. The default implementation adapts {@link
+ *       #getComparableProviders(List)}, so sorts whose value can be expressed as a {@code long}
+ *       only need to implement the latter.
  *   <li>{@link #getProviderName()} - the SPI-registered name of a {@link SortFieldProvider} to
  *       serialize the sort
  * </ul>
@@ -57,6 +63,55 @@ public interface IndexSorter {
     long getAsComparableLong(int docID) throws IOException;
   }
 
+  /**
+   * Caches the sort value of the current document of every segment being merged, and compares them.
+   *
+   * <p>This is the merge-sort counterpart of {@link DocComparator}. Most sorts reduce a document to
+   * a single sortable {@code long} and should implement {@link #getComparableProviders(List)}
+   * instead; the {@link #fromComparableProviders} adapter exposes them through this interface with
+   * no change in behaviour. Sorts whose value cannot be represented as a {@code long} (for example
+   * raw bytes) implement {@link #getComparableValues(List)} directly.
+   */
+  interface ComparableValues {
+    /**
+     * Caches the value of the current document of the given segment so that it can later be
+     * compared by {@link #compare(int, int)}.
+     *
+     * <p>The merge sort visits the documents of each segment in increasing docID order, so {@code
+     * docID} is non-decreasing for a given {@code readerIndex} between consecutive calls.
+     *
+     * @param readerIndex the index of the segment in the list passed to {@link
+     *     #getComparableValues(List)}
+     * @param docID the document whose value should be cached
+     */
+    void setTopValue(int readerIndex, int docID) throws IOException;
+
+    /**
+     * Compares the values previously cached by {@link #setTopValue(int, int)} for the two segments.
+     * The returned value follows the same contract as {@link Comparator#compare(Object, Object)},
+     * without applying the {@code reverse} flag (the caller is responsible for that).
+     */
+    int compare(int readerIndexA, int readerIndexB);
+
+    /**
+     * Adapts an array of {@link ComparableProvider} (one per segment) to {@link ComparableValues}
+     */
+    static ComparableValues fromComparableProviders(ComparableProvider[] providers) {
+      final long[] values = new long[providers.length];
+      return new ComparableValues() {
+        @Override
+        public void setTopValue(int readerIndex, int docID) throws IOException {
+          values[readerIndex] = providers[readerIndex].getAsComparableLong(docID);
+        }
+
+        @Override
+        public int compare(int readerIndexA, int readerIndexB) {
+          return Long.compare(values[readerIndexA], values[readerIndexB]);
+        }
+      };
+    }
+  }
+
   /** A comparator of doc IDs, used for sorting documents within a segment */
   interface DocComparator {
     /**
@@ -68,12 +123,32 @@ public interface IndexSorter {
 
   /**
    * Get an array of {@link ComparableProvider}, one per segment, for merge sorting documents in
-   * different segments
+   * different segments.
+   *
+   * <p>Implementations whose sort value is a {@code long} should implement this method; it is
+   * exposed to the merger through the default {@link #getComparableValues(List)}. Implementations
+   * that override {@link #getComparableValues(List)} directly need not implement this method.
    *
    * @param readers the readers to be merged
    */
-  ComparableProvider[] getComparableProviders(List<? extends LeafReader> readers)
-      throws IOException;
+  default ComparableProvider[] getComparableProviders(List<? extends LeafReader> readers)
+      throws IOException {
+    throw new UnsupportedOperationException(
+        getClass().getName() + " does not implement getComparableProviders");
+  }
+
+  /**
+   * Get a {@link ComparableValues}, used for merge sorting documents across the given segments.
+   *
+   * <p>The default implementation adapts {@link #getComparableProviders(List)} and is appropriate
+   * for any sort whose value can be represented as a {@code long}.
+   *
+   * @param readers the readers to be merged
+   */
+  default ComparableValues getComparableValues(List<? extends LeafReader> readers)
+      throws IOException {
+    return ComparableValues.fromComparableProviders(getComparableProviders(readers));
+  }
 
   /**
    * Get a comparator that determines the sort order of docs within a single Reader.
@@ -105,6 +180,12 @@ public interface IndexSorter {
   interface SortedDocValuesProvider {
     /** Returns the SortedDocValues instance for this LeafReader */
     SortedDocValues get(LeafReader reader) throws IOException;
+  }
+
+  /** Provide a BinaryDocValues instance for a LeafReader */
+  interface BinaryDocValuesProvider {
+    /** Returns the BinaryDocValues instance for this LeafReader */
+    BinaryDocValues get(LeafReader reader) throws IOException;
   }
 
   /** Sorts documents based on integer values from a NumericDocValues instance */
@@ -445,6 +526,140 @@ public interface IndexSorter {
       }
 
       return (docID1, docID2) -> reverseMul * Integer.compare(ords[docID1], ords[docID2]);
+    }
+
+    @Override
+    public String getProviderName() {
+      return providerName;
+    }
+  }
+
+  /**
+   * Sorts documents based on the encoded bytes of a {@link BinaryDocValues} instance.
+   *
+   * <p>Unlike {@link StringSorter}, binary values are compared directly, so no global ordinal map
+   * is built when merging: each segment is already sorted, and the merge only needs to compare the
+   * bytes of the current document of each segment. As a result the merge reads every segment
+   * strictly sequentially (via {@link BinaryDocValues#nextDoc()}), which keeps the cost linear and
+   * remains efficient even when the {@link BinaryDocValues} format stores values in compressed
+   * blocks.
+   *
+   * <p>This sorter is naive by default (it orders documents by the unsigned byte order of their
+   * value), but a custom {@link Comparator} can be supplied to implement domain-specific ordering.
+   */
+  final class BinarySorter implements IndexSorter {
+
+    private final String providerName;
+    private final int reverseMul;
+
+    /**
+     * Compares two values. Either argument may be {@code null}, which represents a missing value;
+     * the {@code reverse} flag is <em>not</em> applied by this comparator.
+     */
+    private final Comparator<BytesRef> comparator;
+
+    private final BinaryDocValuesProvider valuesProvider;
+
+    /** Creates a new BinarySorter */
+    public BinarySorter(
+        String providerName,
+        boolean reverse,
+        Comparator<BytesRef> comparator,
+        BinaryDocValuesProvider valuesProvider) {
+      this.providerName = providerName;
+      this.reverseMul = reverse ? -1 : 1;
+      this.comparator = comparator;
+      this.valuesProvider = valuesProvider;
+    }
+
+    @Override
+    public ComparableValues getComparableValues(List<? extends LeafReader> readers)
+        throws IOException {
+      final BinaryDocValues[] values = new BinaryDocValues[readers.size()];
+      final BytesRefBuilder[] cache = new BytesRefBuilder[readers.size()];
+      final boolean[] present = new boolean[readers.size()];
+      for (int i = 0; i < readers.size(); i++) {
+        values[i] = valuesProvider.get(readers.get(i));
+        cache[i] = new BytesRefBuilder();
+      }
+      final int[] lastDoc = new int[readers.size()];
+      Arrays.fill(lastDoc, -1);
+      return new ComparableValues() {
+        @Override
+        public void setTopValue(int readerIndex, int docID) throws IOException {
+          // The merge sort visits each segment in non-decreasing docID order (consecutive documents
+          // of the same block map to the same parent docID); we only ever scan forward, never seek,
+          // so reads stay sequential even for block-compressed formats.
+          assert docID >= lastDoc[readerIndex]
+              : "out of order access: docID=" + docID + " < lastDoc=" + lastDoc[readerIndex];
+          assert (lastDoc[readerIndex] = docID) >= 0;
+          final BinaryDocValues v = values[readerIndex];
+          int doc = v.docID();
+          while (doc < docID) {
+            doc = v.nextDoc();
+          }
+          if (doc == docID) {
+            present[readerIndex] = true;
+            cache[readerIndex].copyBytes(v.binaryValue());
+          } else {
+            present[readerIndex] = false;
+          }
+        }
+
+        @Override
+        public int compare(int readerIndexA, int readerIndexB) {
+          BytesRef a = present[readerIndexA] ? cache[readerIndexA].get() : null;
+          BytesRef b = present[readerIndexB] ? cache[readerIndexB].get() : null;
+          return comparator.compare(a, b);
+        }
+      };
+    }
+
+    @Override
+    public DocComparator getDocComparator(LeafReader reader, int maxDoc) throws IOException {
+      final BinaryDocValues values = valuesProvider.get(reader);
+      // Materialize the values once for random access during the in-memory sort of a single (newly
+      // flushed) segment. Values are concatenated into a single byte[] (read from the in-RAM
+      // segment
+      // buffer) with a monotonic per-document offset array; presence is tracked in a bitset so
+      // missing values can be distinguished from empty ones. Comparisons then view slices of that
+      // buffer in place (no per-comparison copy), keeping the sort cheap and the footprint to one
+      // maxDoc-sized array plus the bytes, on par with the numeric and string sorters.
+      byte[] blob = new byte[Math.max(16, maxDoc)];
+      final int[] offsets = new int[maxDoc + 1];
+      final FixedBitSet present = new FixedBitSet(maxDoc);
+      int pos = 0;
+      int doc = values.nextDoc();
+      for (int i = 0; i < maxDoc; i++) {
+        offsets[i] = pos;
+        if (doc == i) {
+          final BytesRef v = values.binaryValue();
+          blob = ArrayUtil.grow(blob, pos + v.length);
+          System.arraycopy(v.bytes, v.offset, blob, pos, v.length);
+          pos += v.length;
+          present.set(i);
+          doc = values.nextDoc();
+        }
+      }
+      offsets[maxDoc] = pos;
+      final byte[] data = blob;
+      final BytesRef ref1 = new BytesRef(data);
+      final BytesRef ref2 = new BytesRef(data);
+      return (docID1, docID2) -> {
+        BytesRef v1 = null;
+        BytesRef v2 = null;
+        if (present.get(docID1)) {
+          ref1.offset = offsets[docID1];
+          ref1.length = offsets[docID1 + 1] - offsets[docID1];
+          v1 = ref1;
+        }
+        if (present.get(docID2)) {
+          ref2.offset = offsets[docID2];
+          ref2.length = offsets[docID2 + 1] - offsets[docID2];
+          v2 = ref2;
+        }
+        return reverseMul * comparator.compare(v1, v2);
+      };
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/index/IndexSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexSorter.java
@@ -183,6 +183,7 @@ public interface IndexSorter {
   }
 
   /** Provide a BinaryDocValues instance for a LeafReader */
+  @FunctionalInterface
   interface BinaryDocValuesProvider {
     /** Returns the BinaryDocValues instance for this LeafReader */
     BinaryDocValues get(LeafReader reader) throws IOException;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexSorter.java
@@ -27,7 +27,6 @@ import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.LongValues;
 import org.apache.lucene.util.NumericUtils;
@@ -41,7 +40,7 @@ import org.apache.lucene.util.packed.PackedInts;
  * <ul>
  *   <li>{@link #getDocComparator(LeafReader,int)} - an object that determines how documents within
  *       a segment are to be sorted
- *   <li>{@link #getComparableValues(List)} - an object that caches and compares the sort value of
+ *   <li>{@link #getComparableValues(List)} - an object that reads and compares the sort value of
  *       documents across segments, used for merge sorting. The default implementation adapts {@link
  *       #getComparableProviders(List)}, so sorts whose value can be expressed as a {@code long}
  *       only need to implement the latter.
@@ -74,20 +73,20 @@ public interface IndexSorter {
    */
   interface ComparableValues {
     /**
-     * Caches the value of the current document of the given segment so that it can later be
-     * compared by {@link #compare(int, int)}.
+     * Reads the value of the current document of the given segment so that it can later be compared
+     * by {@link #compare(int, int)}.
      *
      * <p>The merge sort visits the documents of each segment in increasing docID order, so {@code
      * docID} is non-decreasing for a given {@code readerIndex} between consecutive calls.
      *
      * @param readerIndex the index of the segment in the list passed to {@link
      *     #getComparableValues(List)}
-     * @param docID the document whose value should be cached
+     * @param docID the document whose value should be read
      */
     void setTopValue(int readerIndex, int docID) throws IOException;
 
     /**
-     * Compares the values previously cached by {@link #setTopValue(int, int)} for the two segments.
+     * Compares the values previously read by {@link #setTopValue(int, int)} for the two segments.
      * The returned value follows the same contract as {@link Comparator#compare(Object, Object)},
      * without applying the {@code reverse} flag (the caller is responsible for that).
      */
@@ -536,17 +535,11 @@ public interface IndexSorter {
   }
 
   /**
-   * Sorts documents based on the encoded bytes of a {@link BinaryDocValues} instance.
+   * Sorts documents by the bytes of a {@link BinaryDocValues} instance, using the given comparator.
    *
-   * <p>Unlike {@link StringSorter}, binary values are compared directly, so no global ordinal map
-   * is built when merging: each segment is already sorted, and the merge only needs to compare the
-   * bytes of the current document of each segment. As a result the merge reads every segment
-   * strictly sequentially (via {@link BinaryDocValues#nextDoc()}), which keeps the cost linear and
-   * remains efficient even when the {@link BinaryDocValues} format stores values in compressed
-   * blocks.
-   *
-   * <p>This sorter is naive by default (it orders documents by the unsigned byte order of their
-   * value), but a custom {@link Comparator} can be supplied to implement domain-specific ordering.
+   * <p>Unlike {@link StringSorter} there is no global ordinal map: values are compared directly, so
+   * the merge reads each (already sorted) segment strictly sequentially via {@link
+   * BinaryDocValues#nextDoc()}, which stays linear and efficient even for block-compressed formats.
    */
   final class BinarySorter implements IndexSorter {
 
@@ -577,11 +570,13 @@ public interface IndexSorter {
     public ComparableValues getComparableValues(List<? extends LeafReader> readers)
         throws IOException {
       final BinaryDocValues[] values = new BinaryDocValues[readers.size()];
-      final BytesRefBuilder[] cache = new BytesRefBuilder[readers.size()];
-      final boolean[] present = new boolean[readers.size()];
+      // The current sort key of each segment's head, or null if the head document has no value. We
+      // keep the BytesRef without copying: it stays valid until this segment's cursor advances
+      // again
+      // (its next setTopValue), which is exactly the window during which the head is compared.
+      final BytesRef[] heads = new BytesRef[readers.size()];
       for (int i = 0; i < readers.size(); i++) {
         values[i] = valuesProvider.get(readers.get(i));
-        cache[i] = new BytesRefBuilder();
       }
       final int[] lastDoc = new int[readers.size()];
       Arrays.fill(lastDoc, -1);
@@ -599,19 +594,12 @@ public interface IndexSorter {
           while (doc < docID) {
             doc = v.nextDoc();
           }
-          if (doc == docID) {
-            present[readerIndex] = true;
-            cache[readerIndex].copyBytes(v.binaryValue());
-          } else {
-            present[readerIndex] = false;
-          }
+          heads[readerIndex] = doc == docID ? v.binaryValue() : null;
         }
 
         @Override
         public int compare(int readerIndexA, int readerIndexB) {
-          BytesRef a = present[readerIndexA] ? cache[readerIndexA].get() : null;
-          BytesRef b = present[readerIndexB] ? cache[readerIndexB].get() : null;
-          return comparator.compare(a, b);
+          return comparator.compare(heads[readerIndexA], heads[readerIndexB]);
         }
       };
     }
@@ -619,13 +607,9 @@ public interface IndexSorter {
     @Override
     public DocComparator getDocComparator(LeafReader reader, int maxDoc) throws IOException {
       final BinaryDocValues values = valuesProvider.get(reader);
-      // Materialize the values once for random access during the in-memory sort of a single (newly
-      // flushed) segment. Values are concatenated into a single byte[] (read from the in-RAM
-      // segment
-      // buffer) with a monotonic per-document offset array; presence is tracked in a bitset so
-      // missing values can be distinguished from empty ones. Comparisons then view slices of that
-      // buffer in place (no per-comparison copy), keeping the sort cheap and the footprint to one
-      // maxDoc-sized array plus the bytes, on par with the numeric and string sorters.
+      // Materialize the values once for random access during the in-memory sort: concatenate them
+      // into a single byte[] with a per-document offset array, tracking presence in a bitset.
+      // Comparisons then view slices of that buffer in place, with no per-comparison copy.
       byte[] blob = new byte[Math.max(16, maxDoc)];
       final int[] offsets = new int[maxDoc + 1];
       final FixedBitSet present = new FixedBitSet(maxDoc);

--- a/lucene/core/src/java/org/apache/lucene/index/MultiSorter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiSorter.java
@@ -43,8 +43,37 @@ final class MultiSorter {
     // TODO: optimize if only 1 reader is incoming, though that's a rare case
 
     SortField[] fields = sort.getSort();
-    final IndexSorter.ComparableProvider[][] comparables =
-        new IndexSorter.ComparableProvider[fields.length][];
+    int leafCount = readers.size();
+
+    // Per-reader parent bitset (used when index sorting with document blocks). Shared across all
+    // sort fields; null when the reader does not use blocks. A document's sort value is the value
+    // of
+    // the parent (last) document of its block.
+    final BitSet[] parents = new BitSet[leafCount];
+    for (int j = 0; j < leafCount; j++) {
+      CodecReader codecReader = readers.get(j);
+      FieldInfos fieldInfos = codecReader.getFieldInfos();
+      LeafMetaData metaData = codecReader.getMetaData();
+      if (metaData.hasBlocks() && fieldInfos.getParentField() != null) {
+        NumericDocValues parentDocs = codecReader.getNumericDocValues(fieldInfos.getParentField());
+        assert parentDocs != null
+            : "parent field: "
+                + fieldInfos.getParentField()
+                + " must be present if index sorting is used with blocks";
+        parents[j] = BitSet.of(parentDocs, codecReader.maxDoc());
+      }
+      if (metaData.hasBlocks()
+          && fieldInfos.getParentField() == null
+          && metaData.createdVersionMajor() >= Version.LUCENE_10_0_0.major) {
+        throw new CorruptIndexException(
+            "parent field is not set but the index has blocks and uses index sorting. indexCreatedVersionMajor: "
+                + metaData.createdVersionMajor(),
+            "IndexingChain");
+      }
+    }
+
+    final IndexSorter.ComparableValues[] comparables =
+        new IndexSorter.ComparableValues[fields.length];
     final int[] reverseMuls = new int[fields.length];
     for (int i = 0; i < fields.length; i++) {
       IndexSorter sorter = fields[i].getIndexSorter();
@@ -52,35 +81,9 @@ final class MultiSorter {
         throw new IllegalArgumentException(
             "Cannot use sort field " + fields[i] + " for index sorting");
       }
-      comparables[i] = sorter.getComparableProviders(readers);
-      for (int j = 0; j < readers.size(); j++) {
-        CodecReader codecReader = readers.get(j);
-        FieldInfos fieldInfos = codecReader.getFieldInfos();
-        LeafMetaData metaData = codecReader.getMetaData();
-        if (metaData.hasBlocks() && fieldInfos.getParentField() != null) {
-          NumericDocValues parentDocs =
-              codecReader.getNumericDocValues(fieldInfos.getParentField());
-          assert parentDocs != null
-              : "parent field: "
-                  + fieldInfos.getParentField()
-                  + " must be present if index sorting is used with blocks";
-          BitSet parents = BitSet.of(parentDocs, codecReader.maxDoc());
-          IndexSorter.ComparableProvider[] providers = comparables[i];
-          IndexSorter.ComparableProvider provider = providers[j];
-          providers[j] = docId -> provider.getAsComparableLong(parents.nextSetBit(docId));
-        }
-        if (metaData.hasBlocks()
-            && fieldInfos.getParentField() == null
-            && metaData.createdVersionMajor() >= Version.LUCENE_10_0_0.major) {
-          throw new CorruptIndexException(
-              "parent field is not set but the index has blocks and uses index sorting. indexCreatedVersionMajor: "
-                  + metaData.createdVersionMajor(),
-              "IndexingChain");
-        }
-      }
+      comparables[i] = sorter.getComparableValues(readers);
       reverseMuls[i] = fields[i].getReverse() ? -1 : 1;
     }
-    int leafCount = readers.size();
 
     PriorityQueue<LeafAndDocID> queue =
         PriorityQueue.usingComparator(
@@ -88,9 +91,7 @@ final class MultiSorter {
             ((Comparator<LeafAndDocID>)
                     (a, b) -> {
                       for (int i = 0; i < comparables.length; i++) {
-                        int cmp =
-                            Long.compare(
-                                a.valuesAsComparableLongs[i], b.valuesAsComparableLongs[i]);
+                        int cmp = comparables[i].compare(a.readerIndex, b.readerIndex);
                         if (cmp != 0) {
                           return reverseMuls[i] * cmp;
                         }
@@ -104,11 +105,8 @@ final class MultiSorter {
 
     for (int i = 0; i < leafCount; i++) {
       CodecReader reader = readers.get(i);
-      LeafAndDocID leaf =
-          new LeafAndDocID(i, reader.getLiveDocs(), reader.maxDoc(), comparables.length);
-      for (int j = 0; j < comparables.length; j++) {
-        leaf.valuesAsComparableLongs[j] = comparables[j][i].getAsComparableLong(leaf.docID);
-      }
+      LeafAndDocID leaf = new LeafAndDocID(i, reader.getLiveDocs(), reader.maxDoc());
+      setComparableValues(comparables, parents[i], i, leaf.docID);
       queue.add(leaf);
       builders[i] = PackedLongValues.monotonicBuilder(PackedInts.COMPACT);
     }
@@ -130,10 +128,7 @@ final class MultiSorter {
       }
       top.docID++;
       if (top.docID < top.maxDoc) {
-        for (int j = 0; j < comparables.length; j++) {
-          top.valuesAsComparableLongs[j] =
-              comparables[j][top.readerIndex].getAsComparableLong(top.docID);
-        }
+        setComparableValues(comparables, parents[top.readerIndex], top.readerIndex, top.docID);
         queue.updateTop();
       } else {
         queue.pop();
@@ -160,18 +155,30 @@ final class MultiSorter {
     return docMaps;
   }
 
+  /**
+   * Caches, for every sort field, the value of the given document of the given segment so that the
+   * priority queue can compare it. When the segment uses document blocks, the value of the parent
+   * (last) document of {@code docID}'s block is used instead.
+   */
+  private static void setComparableValues(
+      IndexSorter.ComparableValues[] comparables, BitSet parents, int readerIndex, int docID)
+      throws IOException {
+    final int effectiveDocID = parents == null ? docID : parents.nextSetBit(docID);
+    for (IndexSorter.ComparableValues comparable : comparables) {
+      comparable.setTopValue(readerIndex, effectiveDocID);
+    }
+  }
+
   private static class LeafAndDocID {
     final int readerIndex;
     final Bits liveDocs;
     final int maxDoc;
-    final long[] valuesAsComparableLongs;
     int docID;
 
-    public LeafAndDocID(int readerIndex, Bits liveDocs, int maxDoc, int numComparables) {
+    public LeafAndDocID(int readerIndex, Bits liveDocs, int maxDoc) {
       this.readerIndex = readerIndex;
       this.liveDocs = liveDocs;
       this.maxDoc = maxDoc;
-      this.valuesAsComparableLongs = new long[numComparables];
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/BinarySortField.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BinarySortField.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.Comparator;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.IndexSorter;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.SortFieldProvider;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.BytesRef;
+
+/**
+ * SortField for {@link BinaryDocValues}, usable as an <b>index sort</b>.
+ *
+ * <p>Unlike {@link SortField.Type#STRING} (backed by {@link org.apache.lucene.index.SortedDocValues
+ * SortedDocValues}) or {@link SortedSetSortField}, which deduplicate values into a term dictionary
+ * and are best suited to low-cardinality fields, this sort compares the raw bytes of a {@link
+ * BinaryDocValues} field directly. It is therefore a good fit for high-cardinality fields where a
+ * term dictionary would be pure overhead.
+ *
+ * <p>By default documents are ordered by the unsigned byte order of their value ({@link
+ * BytesRef#compareTo}). When the stored bytes are not directly comparable — for example when the
+ * value is encoded and only part of it is the sort key — a custom {@link Comparator} that decodes
+ * the value can be supplied by subclassing and passing it to {@link #BinarySortField(String,
+ * boolean, Object, Comparator, String)}. The subclass must register a companion {@link
+ * SortFieldProvider} under {@code META-INF/services} so the comparator is reconstructed when the
+ * index sort is read back, and therefore used on merge.
+ *
+ * <p>Missing values are sorted first or last via {@link SortField#STRING_FIRST} or {@link
+ * SortField#STRING_LAST} (the default, when unset, is to sort missing values first).
+ *
+ * <p>This {@link SortField} can also be used to sort search results, in which case it compares
+ * values with a linear scan of the binary doc values (it does not benefit from the skipping
+ * optimizations available to numeric or {@code SORTED} fields).
+ *
+ * @lucene.experimental
+ */
+public class BinarySortField extends SortField {
+
+  /** The default unsigned byte order comparator. */
+  static final Comparator<BytesRef> DEFAULT_COMPARATOR = Comparator.naturalOrder();
+
+  private final Comparator<BytesRef> bytesComparator;
+  private final String providerName;
+
+  /**
+   * Creates a sort, possibly in reverse, by the unsigned byte order of the field's value.
+   *
+   * @param field Name of field to sort by. Must not be null.
+   * @param reverse True if natural order should be reversed.
+   */
+  public BinarySortField(String field, boolean reverse) {
+    this(field, reverse, null);
+  }
+
+  /**
+   * Creates a sort, possibly in reverse, by the unsigned byte order of the field's value, with the
+   * given handling of missing values.
+   *
+   * @param field Name of field to sort by. Must not be null.
+   * @param reverse True if natural order should be reversed.
+   * @param missingValue {@link SortField#STRING_FIRST}, {@link SortField#STRING_LAST}, or {@code
+   *     null} (missing first).
+   */
+  public BinarySortField(String field, boolean reverse, Object missingValue) {
+    this(field, reverse, missingValue, DEFAULT_COMPARATOR, Provider.NAME);
+  }
+
+  /**
+   * Expert: creates a sort with a custom value comparator.
+   *
+   * <p>Because the comparator cannot be serialized, subclasses using this constructor must supply
+   * the name of a dedicated {@link SortFieldProvider} (registered via SPI) whose {@link
+   * SortFieldProvider#readSortField} reconstructs a {@code BinarySortField} configured with the
+   * same comparator. The comparator is thus identified by the provider name rather than serialized.
+   *
+   * @param field Name of field to sort by. Must not be null.
+   * @param reverse True if natural order should be reversed.
+   * @param missingValue {@link SortField#STRING_FIRST}, {@link SortField#STRING_LAST}, or {@code
+   *     null}.
+   * @param bytesComparator comparator applied to present (non-missing) values.
+   * @param providerName the SPI name of the companion {@link SortFieldProvider}.
+   */
+  protected BinarySortField(
+      String field,
+      boolean reverse,
+      Object missingValue,
+      Comparator<BytesRef> bytesComparator,
+      String providerName) {
+    super(field, SortField.Type.CUSTOM, reverse, missingValue);
+    if (missingValue != null && missingValue != STRING_FIRST && missingValue != STRING_LAST) {
+      throw new IllegalArgumentException(
+          "missing value for BinarySortField must be null, STRING_FIRST or STRING_LAST");
+    }
+    if (bytesComparator == null) {
+      throw new NullPointerException("bytesComparator must not be null");
+    }
+    if (providerName == null) {
+      throw new NullPointerException("providerName must not be null");
+    }
+    this.bytesComparator = bytesComparator;
+    this.providerName = providerName;
+  }
+
+  /** A SortFieldProvider for this sort */
+  public static final class Provider extends SortFieldProvider {
+
+    /** The name this provider is registered under */
+    public static final String NAME = "BinarySortField";
+
+    /** Creates a new Provider */
+    public Provider() {
+      super(NAME);
+    }
+
+    @Override
+    public SortField readSortField(DataInput in) throws IOException {
+      String field = in.readString();
+      boolean reverse = in.readInt() == 1;
+      int missingValue = in.readInt();
+      if (missingValue == 1) {
+        return new BinarySortField(field, reverse, SortField.STRING_FIRST);
+      } else if (missingValue == 2) {
+        return new BinarySortField(field, reverse, SortField.STRING_LAST);
+      }
+      return new BinarySortField(field, reverse);
+    }
+
+    @Override
+    public void writeSortField(SortField sf, DataOutput out) throws IOException {
+      assert sf instanceof BinarySortField;
+      ((BinarySortField) sf).serialize(out);
+    }
+  }
+
+  private void serialize(DataOutput out) throws IOException {
+    out.writeString(getField());
+    out.writeInt(reverse ? 1 : 0);
+    if (missingValue == SortField.STRING_FIRST) {
+      out.writeInt(1);
+    } else if (missingValue == SortField.STRING_LAST) {
+      out.writeInt(2);
+    } else {
+      out.writeInt(0);
+    }
+  }
+
+  private BinaryDocValues getValues(LeafReader reader) throws IOException {
+    return DocValues.getBinary(reader, getField());
+  }
+
+  /**
+   * The value comparator extended to treat a {@code null} argument as a missing value, ordered
+   * first or last according to {@link #missingValue}. The {@code reverse} flag is applied by the
+   * caller (so that, like {@link SortField.Type#STRING}, missing values follow {@code reverse}),
+   * never here.
+   */
+  private Comparator<BytesRef> comparator() {
+    final boolean missingLast = missingValue == SortField.STRING_LAST;
+    final Comparator<BytesRef> valueComparator = bytesComparator;
+    return (a, b) -> {
+      if (a == null || b == null) {
+        if (a == b) {
+          return 0;
+        }
+        int c = (a == null) ? -1 : 1;
+        return missingLast ? -c : c;
+      }
+      return valueComparator.compare(a, b);
+    };
+  }
+
+  @Override
+  public IndexSorter getIndexSorter() {
+    return new IndexSorter.BinarySorter(providerName, reverse, comparator(), this::getValues);
+  }
+
+  @Override
+  public FieldComparator<?> getComparator(int numHits, Pruning pruning) {
+    final Comparator<BytesRef> comparator = comparator();
+    // Reuse the generic binary-doc-values comparator, plugging in the same comparison used by the
+    // index sorter so the two orderings stay consistent.
+    return new FieldComparator.TermValComparator(
+        numHits, getField(), missingValue == SortField.STRING_LAST) {
+      @Override
+      public int compareValues(BytesRef val1, BytesRef val2) {
+        return comparator.compare(val1, val2);
+      }
+    };
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * super.hashCode() + providerName.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!super.equals(obj)) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    BinarySortField other = (BinarySortField) obj;
+    return providerName.equals(other.providerName);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buffer = new StringBuilder();
+    buffer.append("<binary: \"").append(getField()).append("\">");
+    if (getReverse()) {
+      buffer.append('!');
+    }
+    if (missingValue != null) {
+      buffer.append(" missingValue=");
+      buffer.append(missingValue);
+    }
+    return buffer.toString();
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/BinarySortField.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BinarySortField.java
@@ -22,6 +22,7 @@ import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.IndexSorter;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortFieldProvider;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
@@ -30,35 +31,26 @@ import org.apache.lucene.util.BytesRef;
 /**
  * SortField for {@link BinaryDocValues}, usable as an <b>index sort</b>.
  *
- * <p>Unlike {@link SortField.Type#STRING} (backed by {@link org.apache.lucene.index.SortedDocValues
- * SortedDocValues}) or {@link SortedSetSortField}, which deduplicate values into a term dictionary
- * and are best suited to low-cardinality fields, this sort compares the raw bytes of a {@link
- * BinaryDocValues} field directly. It is therefore a good fit for high-cardinality fields where a
- * term dictionary would be pure overhead.
+ * <p>Unlike a {@link SortField.Type#STRING} sort (backed by {@link
+ * org.apache.lucene.index.SortedDocValues SortedDocValues}), values are compared directly rather
+ * than through a term dictionary, making this a good fit for high-cardinality fields where a
+ * dictionary would be pure overhead. Documents are ordered by the unsigned byte order of their sort
+ * key ({@link BytesRef#compareTo}), optionally reversed, with missing values sorted first or last
+ * via {@link SortField#STRING_FIRST} / {@link SortField#STRING_LAST} (first by default).
  *
- * <p>By default documents are ordered by the unsigned byte order of their value ({@link
- * BytesRef#compareTo}). When the stored bytes are not directly comparable — for example when the
- * value is encoded and only part of it is the sort key — a custom {@link Comparator} that decodes
- * the value can be supplied by subclassing and passing it to {@link #BinarySortField(String,
- * boolean, Object, Comparator, String)}. The subclass must register a companion {@link
- * SortFieldProvider} under {@code META-INF/services} so the comparator is reconstructed when the
- * index sort is read back, and therefore used on merge.
+ * <p>By default the sort key is the stored value. A subclass may override {@link
+ * #getSortKeyDocValues(LeafReader)} to derive an order-preserving key from the stored bytes and/or
+ * other doc-values fields of the segment (for example to select the minimum of a multi-valued
+ * field). Such a subclass must register a {@link SortFieldProvider} via SPI so the sort can be read
+ * back and used on merge.
  *
- * <p>Missing values are sorted first or last via {@link SortField#STRING_FIRST} or {@link
- * SortField#STRING_LAST} (the default, when unset, is to sort missing values first).
- *
- * <p>This {@link SortField} can also be used to sort search results, in which case it compares
- * values with a linear scan of the binary doc values (it does not benefit from the skipping
- * optimizations available to numeric or {@code SORTED} fields).
+ * <p>This field can also sort search results, comparing values with a linear scan of the binary doc
+ * values (without the skipping optimizations available to numeric or {@code SORTED} fields).
  *
  * @lucene.experimental
  */
 public class BinarySortField extends SortField {
 
-  /** The default unsigned byte order comparator. */
-  static final Comparator<BytesRef> DEFAULT_COMPARATOR = Comparator.naturalOrder();
-
-  private final Comparator<BytesRef> bytesComparator;
   private final String providerName;
 
   /**
@@ -81,42 +73,32 @@ public class BinarySortField extends SortField {
    *     null} (missing first).
    */
   public BinarySortField(String field, boolean reverse, Object missingValue) {
-    this(field, reverse, missingValue, DEFAULT_COMPARATOR, Provider.NAME);
+    this(field, reverse, missingValue, Provider.NAME);
   }
 
   /**
-   * Expert: creates a sort with a custom value comparator.
+   * Creates a sort for a subclass that overrides {@link #getSortKeyDocValues(LeafReader)}.
    *
-   * <p>Because the comparator cannot be serialized, subclasses using this constructor must supply
-   * the name of a dedicated {@link SortFieldProvider} (registered via SPI) whose {@link
-   * SortFieldProvider#readSortField} reconstructs a {@code BinarySortField} configured with the
-   * same comparator. The comparator is thus identified by the provider name rather than serialized.
+   * <p>The subclass must supply the name of a dedicated {@link SortFieldProvider} (registered via
+   * SPI) whose {@link SortFieldProvider#readSortField} reconstructs the subclass, so that the same
+   * sort-key derivation is used when the index sort is read back and on merge.
    *
    * @param field Name of field to sort by. Must not be null.
    * @param reverse True if natural order should be reversed.
    * @param missingValue {@link SortField#STRING_FIRST}, {@link SortField#STRING_LAST}, or {@code
    *     null}.
-   * @param bytesComparator comparator applied to present (non-missing) values.
    * @param providerName the SPI name of the companion {@link SortFieldProvider}.
    */
   protected BinarySortField(
-      String field,
-      boolean reverse,
-      Object missingValue,
-      Comparator<BytesRef> bytesComparator,
-      String providerName) {
+      String field, boolean reverse, Object missingValue, String providerName) {
     super(field, SortField.Type.CUSTOM, reverse, missingValue);
     if (missingValue != null && missingValue != STRING_FIRST && missingValue != STRING_LAST) {
       throw new IllegalArgumentException(
           "missing value for BinarySortField must be null, STRING_FIRST or STRING_LAST");
     }
-    if (bytesComparator == null) {
-      throw new NullPointerException("bytesComparator must not be null");
-    }
     if (providerName == null) {
       throw new NullPointerException("providerName must not be null");
     }
-    this.bytesComparator = bytesComparator;
     this.providerName = providerName;
   }
 
@@ -163,19 +145,24 @@ public class BinarySortField extends SortField {
     }
   }
 
-  private BinaryDocValues getValues(LeafReader reader) throws IOException {
+  /**
+   * Returns the per-document sort key, as a {@link BinaryDocValues} whose {@link
+   * BinaryDocValues#binaryValue()} is the bytes to sort on. The default returns the field's values
+   * unchanged; override to derive a key from the stored bytes and/or other doc-values fields of the
+   * segment.
+   *
+   * <p>Values are read in increasing docID order; advance any underlying doc values with {@link
+   * DocIdSetIterator#nextDoc()} only, since at flush time the in-memory doc values do not support
+   * {@code advanceExact}. The returned key has the same lifetime as {@link
+   * BinaryDocValues#binaryValue()} (valid until the next call) and need not be a copy.
+   */
+  protected BinaryDocValues getSortKeyDocValues(LeafReader reader) throws IOException {
     return DocValues.getBinary(reader, getField());
   }
 
-  /**
-   * The value comparator extended to treat a {@code null} argument as a missing value, ordered
-   * first or last according to {@link #missingValue}. The {@code reverse} flag is applied by the
-   * caller (so that, like {@link SortField.Type#STRING}, missing values follow {@code reverse}),
-   * never here.
-   */
+  /** Unsigned byte order comparator that treats a {@code null} argument as a missing value. */
   private Comparator<BytesRef> comparator() {
     final boolean missingLast = missingValue == SortField.STRING_LAST;
-    final Comparator<BytesRef> valueComparator = bytesComparator;
     return (a, b) -> {
       if (a == null || b == null) {
         if (a == b) {
@@ -184,25 +171,24 @@ public class BinarySortField extends SortField {
         int c = (a == null) ? -1 : 1;
         return missingLast ? -c : c;
       }
-      return valueComparator.compare(a, b);
+      return a.compareTo(b);
     };
   }
 
   @Override
   public IndexSorter getIndexSorter() {
-    return new IndexSorter.BinarySorter(providerName, reverse, comparator(), this::getValues);
+    return new IndexSorter.BinarySorter(
+        providerName, reverse, comparator(), this::getSortKeyDocValues);
   }
 
   @Override
   public FieldComparator<?> getComparator(int numHits, Pruning pruning) {
-    final Comparator<BytesRef> comparator = comparator();
-    // Reuse the generic binary-doc-values comparator, plugging in the same comparison used by the
-    // index sorter so the two orderings stay consistent.
     return new FieldComparator.TermValComparator(
         numHits, getField(), missingValue == SortField.STRING_LAST) {
       @Override
-      public int compareValues(BytesRef val1, BytesRef val2) {
-        return comparator.compare(val1, val2);
+      protected BinaryDocValues getBinaryDocValues(LeafReaderContext context, String field)
+          throws IOException {
+        return getSortKeyDocValues(context.reader());
       }
     };
   }

--- a/lucene/core/src/test/META-INF/services/org.apache.lucene.index.SortFieldProvider
+++ b/lucene/core/src/test/META-INF/services/org.apache.lucene.index.SortFieldProvider
@@ -16,3 +16,4 @@
 #
 
 org.apache.lucene.search.TestBinarySortField$FirstValueSortField$Provider
+org.apache.lucene.search.TestBinarySortField$MinValueSortField$Provider

--- a/lucene/core/src/test/META-INF/services/org.apache.lucene.index.SortFieldProvider
+++ b/lucene/core/src/test/META-INF/services/org.apache.lucene.index.SortFieldProvider
@@ -15,7 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.lucene.search.SortField$Provider
-org.apache.lucene.search.SortedNumericSortField$Provider
-org.apache.lucene.search.SortedSetSortField$Provider
-org.apache.lucene.search.BinarySortField$Provider
+org.apache.lucene.search.TestBinarySortField$FirstValueSortField$Provider

--- a/lucene/core/src/test/org/apache/lucene/search/TestBinarySortField.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBinarySortField.java
@@ -1,0 +1,912 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.CodecReader;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.IndexSorter;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SlowCodecReaderWrapper;
+import org.apache.lucene.index.SortFieldProvider;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.store.ByteArrayDataInput;
+import org.apache.lucene.store.ByteBuffersDataInput;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
+
+/** Tests for {@link BinarySortField} used as an index sort (and as a search sort). */
+public class TestBinarySortField extends LuceneTestCase {
+
+  @SuppressWarnings({"unlikely-arg-type", "SelfAssertion"})
+  public void testEquals() {
+    SortField sf = new BinarySortField("a", false);
+    assertFalse(sf.equals(null));
+    assertEquals(sf, sf);
+
+    SortField sf2 = new BinarySortField("a", false);
+    assertEquals(sf, sf2);
+    assertEquals(sf.hashCode(), sf2.hashCode());
+
+    assertFalse(sf.equals(new BinarySortField("a", true)));
+    assertFalse(sf.equals(new BinarySortField("b", false)));
+    assertFalse(sf.equals(new BinarySortField("a", false, SortField.STRING_LAST)));
+    assertFalse(sf.equals("foo"));
+  }
+
+  public void testToString() {
+    assertEquals("<binary: \"a\">", new BinarySortField("a", false).toString());
+    assertEquals("<binary: \"a\">!", new BinarySortField("a", true).toString());
+    assertTrue(
+        new BinarySortField("a", false, SortField.STRING_LAST).toString().contains("missingValue"));
+  }
+
+  public void testIllegalMissingValue() {
+    expectThrows(
+        IllegalArgumentException.class, () -> new BinarySortField("a", false, SortField.FIELD_DOC));
+  }
+
+  /** Round-trips through the registered {@link SortFieldProvider} (verifies SPI registration). */
+  public void testSerialization() throws Exception {
+    assertSerializes(new BinarySortField("field", false));
+    assertSerializes(new BinarySortField("field", true));
+    assertSerializes(new BinarySortField("field", false, SortField.STRING_FIRST));
+    assertSerializes(new BinarySortField("field", true, SortField.STRING_LAST));
+  }
+
+  private static void assertSerializes(BinarySortField sf) throws IOException {
+    ByteBuffersDataOutput out = new ByteBuffersDataOutput();
+    SortFieldProvider.write(sf, out);
+    ByteBuffersDataInput in = out.toDataInput();
+    SortField read = SortFieldProvider.forName(BinarySortField.Provider.NAME).readSortField(in);
+    assertEquals(sf, read);
+  }
+
+  public void testEmptyIndex() throws Exception {
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = newIndexWriterConfig();
+      iwc.setIndexSort(new Sort(new BinarySortField("dv", random().nextBoolean())));
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        w.commit();
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        assertEquals(0, reader.maxDoc());
+      }
+    }
+  }
+
+  public void testSingleDocument() throws Exception {
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = newIndexWriterConfig();
+      iwc.setIndexSort(new Sort(new BinarySortField("dv", random().nextBoolean())));
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        Document doc = new Document();
+        doc.add(new BinaryDocValuesField("dv", new BytesRef("only")));
+        w.addDocument(doc);
+        w.forceMerge(1);
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        assertEquals(1, reader.maxDoc());
+        BinaryDocValues dv = reader.leaves().get(0).reader().getBinaryDocValues("dv");
+        assertTrue(dv.advanceExact(0));
+        assertEquals(new BytesRef("only"), dv.binaryValue());
+      }
+    }
+  }
+
+  /** Index sorting on a field that no document has: sort must be a no-op, index stays valid. */
+  public void testAllMissing() throws Exception {
+    final boolean reverse = random().nextBoolean();
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = newIndexWriterConfig();
+      iwc.setIndexSort(
+          new Sort(
+              new BinarySortField(
+                  "dv", reverse, random().nextBoolean() ? SortField.STRING_FIRST : null)));
+      iwc.setMaxBufferedDocs(TestUtil.nextInt(random(), 10, 30));
+      int numDocs = atLeast(50);
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          doc.add(new StoredField("ord", i));
+          w.addDocument(doc);
+        }
+        if (random().nextBoolean()) {
+          w.forceMerge(1);
+        }
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        assertEquals(numDocs, reader.maxDoc());
+      }
+    }
+  }
+
+  /**
+   * The index sort is immutable: a binary sort can only be set on a new index, and cannot be added
+   * to, or changed on, an existing one.
+   */
+  public void testIndexSortOnlyOnNewIndex() throws Exception {
+    try (Directory dir = newDirectory()) {
+      // a plain (unsorted) index
+      try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+        Document doc = new Document();
+        doc.add(new BinaryDocValuesField("dv", new BytesRef("a")));
+        w.addDocument(doc);
+        w.commit();
+      }
+      // a binary index sort cannot be retrofitted onto the existing unsorted index
+      IndexWriterConfig sortedConfig =
+          newIndexWriterConfig().setIndexSort(new Sort(new BinarySortField("dv", false)));
+      expectThrows(IllegalArgumentException.class, () -> new IndexWriter(dir, sortedConfig));
+    }
+
+    try (Directory dir = newDirectory()) {
+      // a new index created with the binary sort
+      try (IndexWriter w =
+          new IndexWriter(
+              dir,
+              newIndexWriterConfig().setIndexSort(new Sort(new BinarySortField("dv", false))))) {
+        Document doc = new Document();
+        doc.add(new BinaryDocValuesField("dv", new BytesRef("a")));
+        w.addDocument(doc);
+        w.commit();
+      }
+      // reopening with the same sort is fine
+      try (IndexWriter w =
+          new IndexWriter(
+              dir,
+              newIndexWriterConfig().setIndexSort(new Sort(new BinarySortField("dv", false))))) {
+        assertEquals(1, w.getDocStats().maxDoc);
+      }
+      // reopening with a different binary sort is rejected
+      IndexWriterConfig changed =
+          newIndexWriterConfig().setIndexSort(new Sort(new BinarySortField("dv", true)));
+      expectThrows(IllegalArgumentException.class, () -> new IndexWriter(dir, changed));
+    }
+  }
+
+  public void testSingleSegment() throws Exception {
+    assertIndexSorted(false, false, false);
+  }
+
+  public void testReverse() throws Exception {
+    assertIndexSorted(false, true, false);
+  }
+
+  public void testMultiSegmentMerge() throws Exception {
+    assertIndexSorted(true, false, false);
+    assertIndexSorted(true, true, false);
+  }
+
+  public void testWithMissingValues() throws Exception {
+    assertIndexSorted(false, false, true);
+    assertIndexSorted(true, false, true);
+    assertIndexSorted(true, true, true);
+  }
+
+  /** Mixes empty (zero-length) values with non-empty ones and missing values. */
+  public void testEmptyByteValues() throws Exception {
+    final boolean reverse = random().nextBoolean();
+    final Object missingValue =
+        random().nextBoolean() ? SortField.STRING_FIRST : SortField.STRING_LAST;
+    final boolean missingLast = missingValue == SortField.STRING_LAST;
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = newIndexWriterConfig();
+      iwc.setIndexSort(new Sort(new BinarySortField("dv", reverse, missingValue)));
+      iwc.setMaxBufferedDocs(TestUtil.nextInt(random(), 10, 30));
+      int numDocs = atLeast(100);
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          int r = random().nextInt(3);
+          if (r == 0) {
+            // missing
+          } else if (r == 1) {
+            doc.add(new BinaryDocValuesField("dv", new BytesRef(BytesRef.EMPTY_BYTES)));
+          } else {
+            byte[] b = new byte[TestUtil.nextInt(random(), 1, 5)];
+            random().nextBytes(b);
+            doc.add(new BinaryDocValuesField("dv", new BytesRef(b)));
+          }
+          w.addDocument(doc);
+        }
+        w.forceMerge(1);
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        assertLeavesSorted(reader, reverse, missingLast);
+      }
+    }
+  }
+
+  /**
+   * Index sorting with document blocks (nested documents): the sort value lives on the parent
+   * document, and blocks must stay intact and ordered by their parent's value.
+   */
+  public void testNestedBlocks() throws Exception {
+    final boolean reverse = random().nextBoolean();
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = newIndexWriterConfig();
+      iwc.setIndexSort(new Sort(new BinarySortField("sort", reverse)));
+      iwc.setParentField("parent");
+      iwc.setMergePolicy(newLogMergePolicy());
+      final int numBlocks = atLeast(80);
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        for (int b = 0; b < numBlocks; b++) {
+          List<Document> block = new ArrayList<>();
+          int numChildren = random().nextInt(3);
+          for (int c = 0; c < numChildren; c++) {
+            Document child = new Document();
+            child.add(new StoredField("block", b));
+            child.add(new StoredField("role", "child"));
+            block.add(child);
+          }
+          Document parent = new Document();
+          byte[] val = new byte[TestUtil.nextInt(random(), 1, 10)];
+          random().nextBytes(val);
+          parent.add(new BinaryDocValuesField("sort", new BytesRef(val)));
+          parent.add(new StoredField("block", b));
+          parent.add(new StoredField("role", "parent"));
+          block.add(parent);
+          w.addDocuments(block);
+          if (rarely()) {
+            w.commit();
+          }
+        }
+        if (random().nextBoolean()) {
+          w.forceMerge(1);
+        }
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        for (LeafReaderContext ctx : reader.leaves()) {
+          LeafReader leaf = ctx.reader();
+          NumericDocValues parents = leaf.getNumericDocValues("parent");
+          BinaryDocValues sort = leaf.getBinaryDocValues("sort");
+          StoredFields storedFields = leaf.storedFields();
+          BytesRef previous = null;
+          int previousDoc = -1;
+          int doc;
+          while ((doc = parents.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+            assertTrue("parent must have the sort value", sort.advanceExact(doc));
+            BytesRef current = BytesRef.deepCopyOf(sort.binaryValue());
+            assertEquals("parent", storedFields.document(doc).get("role"));
+            int block = Integer.parseInt(storedFields.document(doc).get("block"));
+            // every doc preceding this parent (back to the previous parent) is one of its children
+            // and belongs to the same block: the block stayed intact through sort + merge.
+            for (int d = previousDoc + 1; d < doc; d++) {
+              assertEquals("child", storedFields.document(d).get("role"));
+              assertEquals(block, Integer.parseInt(storedFields.document(d).get("block")));
+            }
+            if (previous != null) {
+              int cmp = previous.compareTo(current);
+              if (reverse) {
+                cmp = -cmp;
+              }
+              assertTrue(
+                  "parent sort values out of order: " + previous + " vs " + current, cmp <= 0);
+            }
+            previous = current;
+            previousDoc = doc;
+          }
+        }
+      }
+    }
+  }
+
+  /** Deleting documents and then merging must keep the surviving documents sorted. */
+  public void testDeletes() throws Exception {
+    final boolean reverse = random().nextBoolean();
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = newIndexWriterConfig();
+      iwc.setIndexSort(new Sort(new BinarySortField("dv", reverse)));
+      iwc.setMaxBufferedDocs(TestUtil.nextInt(random(), 20, 50));
+      int numDocs = atLeast(200);
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          doc.add(new StringField("id", Integer.toString(i), Field.Store.NO));
+          byte[] b = new byte[TestUtil.nextInt(random(), 1, 8)];
+          random().nextBytes(b);
+          doc.add(new BinaryDocValuesField("dv", new BytesRef(b)));
+          w.addDocument(doc);
+        }
+        for (int i = 0; i < numDocs; i++) {
+          if (random().nextInt(3) == 0) {
+            w.deleteDocuments(new Term("id", Integer.toString(i)));
+          }
+        }
+        w.forceMerge(1);
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        assertLeavesSorted(reader, reverse, false);
+      }
+    }
+  }
+
+  /** Binary sort combined with a numeric sort, as primary and as secondary. */
+  public void testMultipleSortFields() throws Exception {
+    for (boolean binaryFirst : new boolean[] {true, false}) {
+      try (Directory dir = newDirectory()) {
+        SortField binary = new BinarySortField("bin", false);
+        SortField numeric = new SortField("num", SortField.Type.LONG, false);
+        Sort sort = binaryFirst ? new Sort(binary, numeric) : new Sort(numeric, binary);
+        IndexWriterConfig iwc = newIndexWriterConfig();
+        iwc.setIndexSort(sort);
+        iwc.setMaxBufferedDocs(TestUtil.nextInt(random(), 20, 50));
+        int numDocs = atLeast(200);
+        try (IndexWriter w = new IndexWriter(dir, iwc)) {
+          for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            // low cardinality on both so ties on the primary are common, exercising the secondary
+            byte[] b = {(byte) random().nextInt(4)};
+            doc.add(new BinaryDocValuesField("bin", new BytesRef(b)));
+            doc.add(new NumericDocValuesField("num", random().nextInt(4)));
+            w.addDocument(doc);
+          }
+          w.forceMerge(1);
+        }
+        try (DirectoryReader reader = DirectoryReader.open(dir)) {
+          LeafReader leaf = getOnlyLeafReader(reader);
+          BinaryDocValues bin = leaf.getBinaryDocValues("bin");
+          NumericDocValues num = leaf.getNumericDocValues("num");
+          BytesRef prevBin = null;
+          long prevNum = 0;
+          for (int doc = 0; doc < leaf.maxDoc(); doc++) {
+            assertTrue(bin.advanceExact(doc));
+            assertTrue(num.advanceExact(doc));
+            BytesRef curBin = BytesRef.deepCopyOf(bin.binaryValue());
+            long curNum = num.longValue();
+            if (doc > 0) {
+              if (binaryFirst) {
+                int c = prevBin.compareTo(curBin);
+                assertTrue(c <= 0);
+                if (c == 0) {
+                  assertTrue(prevNum <= curNum);
+                }
+              } else {
+                assertTrue(prevNum <= curNum);
+                if (prevNum == curNum) {
+                  assertTrue(prevBin.compareTo(curBin) <= 0);
+                }
+              }
+            }
+            prevBin = curBin;
+            prevNum = curNum;
+          }
+        }
+      }
+    }
+  }
+
+  /** addIndexes(CodecReader...) merges already-sorted segments into a sorted index. */
+  public void testAddIndexes() throws Exception {
+    final boolean reverse = random().nextBoolean();
+    Sort sort = new Sort(new BinarySortField("dv", reverse));
+    try (Directory src1 = newDirectory();
+        Directory src2 = newDirectory();
+        Directory dest = newDirectory()) {
+      indexRandom(src1, sort, atLeast(100));
+      indexRandom(src2, sort, atLeast(100));
+
+      IndexWriterConfig iwc = newIndexWriterConfig();
+      iwc.setIndexSort(sort);
+      try (IndexWriter w = new IndexWriter(dest, iwc);
+          DirectoryReader r1 = DirectoryReader.open(src1);
+          DirectoryReader r2 = DirectoryReader.open(src2)) {
+        List<CodecReader> readers = new ArrayList<>();
+        for (LeafReaderContext ctx : r1.leaves()) {
+          readers.add(SlowCodecReaderWrapper.wrap(ctx.reader()));
+        }
+        for (LeafReaderContext ctx : r2.leaves()) {
+          readers.add(SlowCodecReaderWrapper.wrap(ctx.reader()));
+        }
+        w.addIndexes(readers.toArray(new CodecReader[0]));
+        w.forceMerge(1);
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dest)) {
+        assertLeavesSorted(reader, reverse, false);
+      }
+    }
+  }
+
+  /** Verifies parity of the produced order with sorting the same values as SortedDocValues. */
+  public void testParityWithSortedDocValues() throws Exception {
+    final int numDocs = atLeast(300);
+    final boolean reverse = random().nextBoolean();
+    List<byte[]> values = new ArrayList<>();
+    for (int i = 0; i < numDocs; i++) {
+      // low cardinality so SortedDocValues is a fair comparison
+      byte[] b = new byte[TestUtil.nextInt(random(), 1, 6)];
+      random().nextBytes(b);
+      values.add(b);
+    }
+
+    int[] binaryOrder = indexAndReadStoredOrder(values, new BinarySortField("dv", reverse), true);
+    int[] sortedOrder =
+        indexAndReadStoredOrder(values, new SortField("dv", SortField.Type.STRING, reverse), false);
+
+    // Ties between equal byte[] values may be broken differently; compare the sequence of values
+    // rather than the original ords.
+    for (int i = 0; i < numDocs; i++) {
+      assertArrayEquals(
+          "mismatch at position " + i, values.get(binaryOrder[i]), values.get(sortedOrder[i]));
+    }
+  }
+
+  /** Uses {@link BinarySortField} to sort search results (the {@code getComparator} path). */
+  public void testSearchSort() throws Exception {
+    final boolean reverse = random().nextBoolean();
+    final Object missingValue =
+        random().nextBoolean() ? SortField.STRING_FIRST : SortField.STRING_LAST;
+    final boolean missingLast = missingValue == SortField.STRING_LAST;
+    try (Directory dir = newDirectory()) {
+      int numDocs = atLeast(100);
+      try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          if (random().nextInt(5) != 0) {
+            byte[] b = new byte[TestUtil.nextInt(random(), 0, 8)];
+            random().nextBytes(b);
+            doc.add(new BinaryDocValuesField("dv", new BytesRef(b)));
+          }
+          w.addDocument(doc);
+        }
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        IndexSearcher searcher = newSearcher(reader);
+        TopFieldDocs td =
+            searcher.search(
+                new MatchAllDocsQuery(),
+                reader.maxDoc(),
+                new Sort(new BinarySortField("dv", reverse, missingValue)));
+        BytesRef previous = null;
+        boolean previousMissing = false;
+        boolean first = true;
+        for (ScoreDoc sd : td.scoreDocs) {
+          BytesRef current = (BytesRef) ((FieldDoc) sd).fields[0];
+          boolean missing = current == null;
+          if (first == false) {
+            int cmp = compareForSort(previous, previousMissing, current, missing, missingLast);
+            if (reverse) {
+              cmp = -cmp;
+            }
+            assertTrue("search results out of order", cmp <= 0);
+          }
+          previous = current;
+          previousMissing = missing;
+          first = false;
+        }
+      }
+    }
+  }
+
+  /**
+   * End-to-end test of the custom-comparator extension point with a comparator that must
+   * <em>decode</em> the binary value before comparing (the raw bytes are not sortable as-is).
+   * {@link FirstValueSortField} sorts on the first of several length-prefixed values, mirroring how
+   * a multi-valued field is encoded. The sort is persisted, reopened (which deserializes it through
+   * the custom {@link SortFieldProvider} and runs {@code CheckIndex}) and merged, then the stored
+   * order is verified against the decoding comparator — proving the custom comparator survives
+   * serialization and is used on merge.
+   */
+  public void testCustomComparatorIndexSort() throws Exception {
+    final boolean reverse = random().nextBoolean();
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = newIndexWriterConfig();
+      iwc.setIndexSort(new Sort(new FirstValueSortField("dv", reverse)));
+      iwc.setMaxBufferedDocs(TestUtil.nextInt(random(), 20, 50));
+      iwc.setMergePolicy(newLogMergePolicy());
+      int numDocs = atLeast(200);
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          doc.add(new BinaryDocValuesField("dv", encodeValues(randomValues())));
+          w.addDocument(doc);
+          if (random().nextInt(30) == 0) {
+            w.commit();
+          }
+        }
+        if (random().nextBoolean()) {
+          w.forceMerge(1);
+        }
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        for (LeafReaderContext ctx : reader.leaves()) {
+          // the persisted sort was deserialized through FirstValueSortField.Provider
+          assertEquals(
+              new Sort(new FirstValueSortField("dv", reverse)), ctx.reader().getMetaData().sort());
+          BinaryDocValues dv = ctx.reader().getBinaryDocValues("dv");
+          BytesRef previous = null;
+          for (int doc = 0; doc < ctx.reader().maxDoc(); doc++) {
+            assertTrue(dv.advanceExact(doc));
+            BytesRef current = BytesRef.deepCopyOf(dv.binaryValue());
+            if (previous != null) {
+              int cmp = FirstValueSortField.COMPARATOR.compare(previous, current);
+              if (reverse) {
+                cmp = -cmp;
+              }
+              assertTrue("custom order violated", cmp <= 0);
+            }
+            previous = current;
+          }
+        }
+      }
+    }
+  }
+
+  private List<byte[]> randomValues() {
+    int count = TestUtil.nextInt(random(), 1, 3);
+    List<byte[]> values = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      byte[] b = new byte[TestUtil.nextInt(random(), 1, 8)];
+      random().nextBytes(b);
+      values.add(b);
+    }
+    return values;
+  }
+
+  /** Encodes values as {@code [vInt length][bytes]} pairs, like a multi-valued binary field. */
+  private static BytesRef encodeValues(List<byte[]> values) {
+    ByteBuffersDataOutput out = new ByteBuffersDataOutput();
+    try {
+      for (byte[] v : values) {
+        out.writeVInt(v.length);
+        out.writeBytes(v, 0, v.length);
+      }
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+    return new BytesRef(out.toArrayCopy());
+  }
+
+  /**
+   * Exercises a non-natural {@link Comparator} through both the flush ({@link
+   * IndexSorter#getDocComparator}) and merge ({@link IndexSorter#getComparableValues}) comparison
+   * paths.
+   */
+  public void testCustomComparator() throws Exception {
+    // order by length first, then by unsigned bytes
+    Comparator<BytesRef> cmp =
+        Comparator.comparingInt((BytesRef b) -> b.length).thenComparing(Comparator.naturalOrder());
+    IndexSorter.BinarySorter sorter =
+        new IndexSorter.BinarySorter("test", false, cmp, r -> DocValues.getBinary(r, "dv"));
+
+    try (Directory dir = newDirectory()) {
+      int numDocs = atLeast(100);
+      // keep segments separate so the merge-path check below sees more than one leaf
+      try (IndexWriter w =
+          new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          byte[] b = new byte[TestUtil.nextInt(random(), 1, 8)];
+          random().nextBytes(b);
+          doc.add(new BinaryDocValuesField("dv", new BytesRef(b)));
+          w.addDocument(doc);
+          if (i == numDocs / 2) {
+            w.commit();
+          }
+        }
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        // flush path: random pairs within a leaf must follow the comparator
+        for (LeafReaderContext ctx : reader.leaves()) {
+          LeafReader leaf = ctx.reader();
+          IndexSorter.DocComparator dc = sorter.getDocComparator(leaf, leaf.maxDoc());
+          List<BytesRef> docValues = readAll(leaf, "dv");
+          for (int iter = 0; iter < 200; iter++) {
+            int a = random().nextInt(leaf.maxDoc());
+            int b = random().nextInt(leaf.maxDoc());
+            assertEquals(
+                Integer.signum(cmp.compare(docValues.get(a), docValues.get(b))),
+                Integer.signum(dc.compare(a, b)));
+          }
+        }
+
+        // merge path: advancing every segment in lock-step, cross-segment compares must follow the
+        // comparator
+        if (reader.leaves().size() >= 2) {
+          List<LeafReader> leaves = new ArrayList<>();
+          for (LeafReaderContext ctx : reader.leaves()) {
+            leaves.add(ctx.reader());
+          }
+          IndexSorter.ComparableValues cv = sorter.getComparableValues(leaves);
+          List<List<BytesRef>> values = new ArrayList<>();
+          for (LeafReader leaf : leaves) {
+            values.add(readAll(leaf, "dv"));
+          }
+          int n = leaves.size();
+          int maxCommon = leaves.get(0).maxDoc();
+          for (LeafReader leaf : leaves) {
+            maxCommon = Math.min(maxCommon, leaf.maxDoc());
+          }
+          for (int doc = 0; doc < maxCommon; doc++) {
+            for (int r = 0; r < n; r++) {
+              cv.setTopValue(r, doc);
+            }
+            for (int a = 0; a < n; a++) {
+              for (int b = 0; b < n; b++) {
+                assertEquals(
+                    Integer.signum(cmp.compare(values.get(a).get(doc), values.get(b).get(doc))),
+                    Integer.signum(cv.compare(a, b)));
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /** Randomized stress test over values, missing, duplicates, commits, deletes and merges. */
+  public void testRandom() throws Exception {
+    final boolean reverse = random().nextBoolean();
+    final Object missingValue =
+        random().nextBoolean()
+            ? null
+            : (random().nextBoolean() ? SortField.STRING_FIRST : SortField.STRING_LAST);
+    final boolean missingLast = missingValue == SortField.STRING_LAST;
+    final int cardinality = TestUtil.nextInt(random(), 1, 1000);
+    byte[][] pool = new byte[cardinality][];
+    for (int i = 0; i < cardinality; i++) {
+      byte[] b = new byte[TestUtil.nextInt(random(), 0, 12)];
+      random().nextBytes(b);
+      pool[i] = b;
+    }
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = newIndexWriterConfig();
+      iwc.setIndexSort(new Sort(new BinarySortField("dv", reverse, missingValue)));
+      if (random().nextBoolean()) {
+        iwc.setMaxBufferedDocs(TestUtil.nextInt(random(), 20, 80));
+      }
+      iwc.setMergePolicy(newLogMergePolicy());
+      int numDocs = atLeast(500);
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          doc.add(new StringField("id", Integer.toString(i), Field.Store.NO));
+          if (random().nextInt(8) != 0) {
+            doc.add(
+                new BinaryDocValuesField("dv", new BytesRef(pool[random().nextInt(cardinality)])));
+          }
+          w.addDocument(doc);
+          if (random().nextInt(100) == 0) {
+            w.commit();
+          }
+          if (random().nextInt(100) == 0) {
+            w.deleteDocuments(new Term("id", Integer.toString(random().nextInt(i + 1))));
+          }
+        }
+        if (random().nextBoolean()) {
+          w.forceMerge(TestUtil.nextInt(random(), 1, 3));
+        }
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        assertLeavesSorted(reader, reverse, missingLast);
+      }
+    }
+  }
+
+  // ---- helpers ----
+
+  private void indexRandom(Directory dir, Sort sort, int numDocs) throws IOException {
+    IndexWriterConfig iwc = newIndexWriterConfig();
+    iwc.setIndexSort(sort);
+    iwc.setMaxBufferedDocs(TestUtil.nextInt(random(), 20, 50));
+    try (IndexWriter w = new IndexWriter(dir, iwc)) {
+      for (int i = 0; i < numDocs; i++) {
+        Document doc = new Document();
+        byte[] b = new byte[TestUtil.nextInt(random(), 1, 8)];
+        random().nextBytes(b);
+        doc.add(new BinaryDocValuesField("dv", new BytesRef(b)));
+        w.addDocument(doc);
+      }
+    }
+  }
+
+  private static List<BytesRef> readAll(LeafReader leaf, String field) throws IOException {
+    List<BytesRef> values = new ArrayList<>();
+    BinaryDocValues dv = leaf.getBinaryDocValues(field);
+    for (int doc = 0; doc < leaf.maxDoc(); doc++) {
+      assertTrue("test assumes a value on every document", dv.advanceExact(doc));
+      values.add(BytesRef.deepCopyOf(dv.binaryValue()));
+    }
+    return values;
+  }
+
+  /** Asserts every leaf is sorted by "dv" according to the given reverse / missing policy. */
+  private static void assertLeavesSorted(
+      DirectoryReader reader, boolean reverse, boolean missingLast) throws IOException {
+    for (LeafReaderContext ctx : reader.leaves()) {
+      BinaryDocValues dv = ctx.reader().getBinaryDocValues("dv");
+      BytesRef previous = null;
+      boolean previousMissing = false;
+      boolean first = true;
+      for (int doc = 0; doc < ctx.reader().maxDoc(); doc++) {
+        boolean hasValue = dv != null && dv.advanceExact(doc);
+        BytesRef current = hasValue ? BytesRef.deepCopyOf(dv.binaryValue()) : null;
+        if (first == false) {
+          int cmp = compareForSort(previous, previousMissing, current, !hasValue, missingLast);
+          if (reverse) {
+            cmp = -cmp;
+          }
+          assertTrue(
+              "values out of order at doc " + doc + ": prev=" + previous + " cur=" + current,
+              cmp <= 0);
+        }
+        previous = current;
+        previousMissing = !hasValue;
+        first = false;
+      }
+    }
+  }
+
+  /** Indexes random byte[] values, sorts the index, and verifies the order within each leaf. */
+  private void assertIndexSorted(boolean multiSegment, boolean reverse, boolean missing)
+      throws Exception {
+    final int numDocs = atLeast(200);
+    Object missingValue =
+        missing ? (random().nextBoolean() ? SortField.STRING_FIRST : SortField.STRING_LAST) : null;
+    final boolean missingLast = missingValue == SortField.STRING_LAST;
+
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = newIndexWriterConfig();
+      iwc.setIndexSort(new Sort(new BinarySortField("dv", reverse, missingValue)));
+      if (multiSegment) {
+        iwc.setMaxBufferedDocs(TestUtil.nextInt(random(), 20, 50));
+        iwc.setMergePolicy(newLogMergePolicy());
+      }
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          if (missing == false || random().nextInt(5) != 0) {
+            byte[] b = new byte[TestUtil.nextInt(random(), 0, 12)];
+            random().nextBytes(b);
+            doc.add(new BinaryDocValuesField("dv", new BytesRef(b)));
+          }
+          doc.add(new StoredField("ord", i));
+          w.addDocument(doc);
+          if (multiSegment && random().nextInt(50) == 0) {
+            w.commit();
+          }
+        }
+        if (multiSegment && random().nextBoolean()) {
+          w.forceMerge(1);
+        }
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        // Each segment is independently sorted; segments are not globally ordered relative to one
+        // another unless merged, so we verify the order within each leaf.
+        assertLeavesSorted(reader, reverse, missingLast);
+        for (LeafReaderContext ctx : reader.leaves()) {
+          assertNotNull("index sort not persisted", ctx.reader().getMetaData().sort());
+        }
+      }
+    }
+  }
+
+  /**
+   * Compares two (possibly missing) values the way the index sort would, before applying reverse.
+   */
+  private static int compareForSort(
+      BytesRef a, boolean aMissing, BytesRef b, boolean bMissing, boolean missingLast) {
+    if (aMissing || bMissing) {
+      if (aMissing == bMissing) {
+        return 0;
+      }
+      int c = aMissing ? -1 : 1;
+      return missingLast ? -c : c;
+    }
+    return a.compareTo(b);
+  }
+
+  private int[] indexAndReadStoredOrder(List<byte[]> values, SortField sortField, boolean binary)
+      throws Exception {
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = newIndexWriterConfig();
+      iwc.setIndexSort(new Sort(sortField));
+      iwc.setMaxBufferedDocs(TestUtil.nextInt(random(), 20, 60));
+      iwc.setMergePolicy(newLogMergePolicy());
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        for (int i = 0; i < values.size(); i++) {
+          Document doc = new Document();
+          BytesRef v = new BytesRef(values.get(i));
+          if (binary) {
+            doc.add(new BinaryDocValuesField("dv", v));
+          } else {
+            doc.add(new SortedDocValuesField("dv", v));
+          }
+          doc.add(new StoredField("ord", i));
+          w.addDocument(doc);
+        }
+        w.forceMerge(1);
+      }
+      List<Integer> order = new ArrayList<>();
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        LeafReader leaf = getOnlyLeafReader(reader);
+        StoredFields storedFields = leaf.storedFields();
+        for (int doc = 0; doc < leaf.maxDoc(); doc++) {
+          order.add(Integer.parseInt(storedFields.document(doc).get("ord")));
+        }
+      }
+      return order.stream().mapToInt(Integer::intValue).toArray();
+    }
+  }
+
+  /**
+   * Example custom-comparator extension: the binary value holds one or more {@code [vInt
+   * length][bytes]} values, and the sort key is the <em>first</em> value (so the raw bytes are not
+   * sortable as-is, they must be decoded). The companion {@link Provider} reconstructs the field —
+   * and hence its comparator — when the index sort is deserialized, so the same decoding is used on
+   * merge. It is registered via {@code META-INF/services/org.apache.lucene.index.SortFieldProvider}
+   * under the test resources.
+   */
+  public static final class FirstValueSortField extends BinarySortField {
+    static final String NAME = "FirstValueSortField";
+    static final Comparator<BytesRef> COMPARATOR = (a, b) -> firstValue(a).compareTo(firstValue(b));
+
+    public FirstValueSortField(String field, boolean reverse) {
+      super(field, reverse, null, COMPARATOR, NAME);
+    }
+
+    private static BytesRef firstValue(BytesRef raw) {
+      ByteArrayDataInput in = new ByteArrayDataInput(raw.bytes, raw.offset, raw.length);
+      int length = in.readVInt();
+      return new BytesRef(raw.bytes, in.getPosition(), length);
+    }
+
+    /** Serializes/deserializes a {@link FirstValueSortField} (and thus its decoding comparator). */
+    public static final class Provider extends SortFieldProvider {
+      public Provider() {
+        super(NAME);
+      }
+
+      @Override
+      public SortField readSortField(DataInput in) throws IOException {
+        return new FirstValueSortField(in.readString(), in.readInt() == 1);
+      }
+
+      @Override
+      public void writeSortField(SortField sf, DataOutput out) throws IOException {
+        out.writeString(sf.getField());
+        out.writeInt(sf.getReverse() ? 1 : 0);
+      }
+    }
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/search/TestBinarySortField.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBinarySortField.java
@@ -415,6 +415,128 @@ public class TestBinarySortField extends LuceneTestCase {
     }
   }
 
+  /** Two binary doc-values fields in the same segment, used together as a two-level index sort. */
+  public void testMultipleBinaryFields() throws Exception {
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = newIndexWriterConfig();
+      iwc.setIndexSort(new Sort(new BinarySortField("a", false), new BinarySortField("b", false)));
+      iwc.setMaxBufferedDocs(25);
+      iwc.setMergePolicy(NoMergePolicy.INSTANCE); // keep the flush-sorted segments separate
+      int numDocs = 300;
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          byte[] a = {(byte) random().nextInt(3)}; // low cardinality so ties on 'a' exercise 'b'
+          byte[] b = new byte[TestUtil.nextInt(random(), 1, 6)];
+          random().nextBytes(b);
+          doc.add(new BinaryDocValuesField("a", new BytesRef(a)));
+          doc.add(new BinaryDocValuesField("b", new BytesRef(b)));
+          w.addDocument(doc);
+        }
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        assertTrue("expected multiple flush-sorted segments", reader.leaves().size() > 1);
+        for (LeafReaderContext ctx : reader.leaves()) {
+          BinaryDocValues da = ctx.reader().getBinaryDocValues("a");
+          BinaryDocValues db = ctx.reader().getBinaryDocValues("b");
+          BytesRef prevA = null;
+          BytesRef prevB = null;
+          for (int doc = 0; doc < ctx.reader().maxDoc(); doc++) {
+            assertTrue(da.advanceExact(doc));
+            assertTrue(db.advanceExact(doc));
+            BytesRef a = BytesRef.deepCopyOf(da.binaryValue());
+            BytesRef b = BytesRef.deepCopyOf(db.binaryValue());
+            if (prevA != null) {
+              int c = prevA.compareTo(a);
+              assertTrue("primary binary field out of order", c <= 0);
+              if (c == 0) {
+                assertTrue("secondary binary field out of order", prevB.compareTo(b) <= 0);
+              }
+            }
+            prevA = a;
+            prevB = b;
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Mixes a custom {@link BinarySortField} subclass ({@link FirstValueSortField}, which decodes its
+   * value) with a default binary sort field and a numeric sort field in a single index sort. Also
+   * exercises two binary doc-values fields in the same segment, through flush, merge and reopen.
+   */
+  public void testMixCustomAndDefaultSortFields() throws Exception {
+    try (Directory dir = newDirectory()) {
+      Sort sort =
+          new Sort(
+              new FirstValueSortField("a", false), // custom binary (decoding comparator)
+              new BinarySortField("b", false), // default binary
+              new SortField("n", SortField.Type.LONG, false)); // numeric
+      IndexWriterConfig iwc = newIndexWriterConfig();
+      iwc.setIndexSort(sort);
+      iwc.setMaxBufferedDocs(25);
+      iwc.setMergePolicy(random().nextBoolean() ? NoMergePolicy.INSTANCE : newLogMergePolicy());
+      int numDocs = atLeast(300);
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          List<byte[]> aValues = new ArrayList<>();
+          aValues.add(new byte[] {(byte) random().nextInt(3)}); // low-card first value -> ties
+          if (random().nextBoolean()) {
+            byte[] extra = new byte[TestUtil.nextInt(random(), 1, 4)];
+            random().nextBytes(extra);
+            aValues.add(extra);
+          }
+          doc.add(new BinaryDocValuesField("a", encodeValues(aValues)));
+          doc.add(
+              new BinaryDocValuesField("b", new BytesRef(new byte[] {(byte) random().nextInt(3)})));
+          doc.add(new NumericDocValuesField("n", random().nextInt(5)));
+          w.addDocument(doc);
+        }
+        if (random().nextBoolean()) {
+          w.forceMerge(1);
+        }
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        // the persisted sort deserializes through three different providers
+        for (LeafReaderContext ctx : reader.leaves()) {
+          assertEquals(sort, ctx.reader().getMetaData().sort());
+          BinaryDocValues da = ctx.reader().getBinaryDocValues("a");
+          BinaryDocValues db = ctx.reader().getBinaryDocValues("b");
+          NumericDocValues dn = ctx.reader().getNumericDocValues("n");
+          BytesRef prevA = null;
+          BytesRef prevB = null;
+          long prevN = 0;
+          for (int doc = 0; doc < ctx.reader().maxDoc(); doc++) {
+            assertTrue(da.advanceExact(doc));
+            assertTrue(db.advanceExact(doc));
+            assertTrue(dn.advanceExact(doc));
+            BytesRef a = BytesRef.deepCopyOf(da.binaryValue());
+            BytesRef b = BytesRef.deepCopyOf(db.binaryValue());
+            long n = dn.longValue();
+            if (prevA != null) {
+              int ca =
+                  FirstValueSortField.firstValue(prevA)
+                      .compareTo(FirstValueSortField.firstValue(a)); // decodes the first value
+              assertTrue("custom primary out of order", ca <= 0);
+              if (ca == 0) {
+                int cb = prevB.compareTo(b);
+                assertTrue("default binary secondary out of order", cb <= 0);
+                if (cb == 0) {
+                  assertTrue("numeric tertiary out of order", prevN <= n);
+                }
+              }
+            }
+            prevA = a;
+            prevB = b;
+            prevN = n;
+          }
+        }
+      }
+    }
+  }
+
   /** addIndexes(CodecReader...) merges already-sorted segments into a sorted index. */
   public void testAddIndexes() throws Exception {
     final boolean reverse = random().nextBoolean();
@@ -518,15 +640,14 @@ public class TestBinarySortField extends LuceneTestCase {
   }
 
   /**
-   * End-to-end test of the custom-comparator extension point with a comparator that must
-   * <em>decode</em> the binary value before comparing (the raw bytes are not sortable as-is).
-   * {@link FirstValueSortField} sorts on the first of several length-prefixed values, mirroring how
-   * a multi-valued field is encoded. The sort is persisted, reopened (which deserializes it through
-   * the custom {@link SortFieldProvider} and runs {@code CheckIndex}) and merged, then the stored
-   * order is verified against the decoding comparator — proving the custom comparator survives
-   * serialization and is used on merge.
+   * End-to-end test of the value-source extension point with a key that must be <em>decoded</em>
+   * from the binary value (the raw bytes are not sortable as-is). {@link FirstValueSortField} sorts
+   * on the first of several length-prefixed values, mirroring how a multi-valued field is encoded.
+   * The sort is persisted, reopened (which deserializes it through the custom {@link
+   * SortFieldProvider} and runs {@code CheckIndex}) and merged, then the stored order is verified
+   * against the decoded key — proving the derived key survives serialization and is used on merge.
    */
-  public void testCustomComparatorIndexSort() throws Exception {
+  public void testFirstValueSortKeyIndexSort() throws Exception {
     final boolean reverse = random().nextBoolean();
     try (Directory dir = newDirectory()) {
       IndexWriterConfig iwc = newIndexWriterConfig();
@@ -558,7 +679,9 @@ public class TestBinarySortField extends LuceneTestCase {
             assertTrue(dv.advanceExact(doc));
             BytesRef current = BytesRef.deepCopyOf(dv.binaryValue());
             if (previous != null) {
-              int cmp = FirstValueSortField.COMPARATOR.compare(previous, current);
+              int cmp =
+                  FirstValueSortField.firstValue(previous)
+                      .compareTo(FirstValueSortField.firstValue(current));
               if (reverse) {
                 cmp = -cmp;
               }
@@ -594,6 +717,64 @@ public class TestBinarySortField extends LuceneTestCase {
       throw new AssertionError(e);
     }
     return new BytesRef(out.toArrayCopy());
+  }
+
+  /**
+   * Selecting the MIN value of a multi-valued, self-describing binary field ({@link
+   * MinValueSortField}). Forces many small flushed segments (no force-merge) so each is sorted at
+   * flush using the value source, and also covers the merge case; the order is verified against the
+   * per-document minimum value.
+   */
+  public void testMinValueSortKey() throws Exception {
+    final boolean reverse = random().nextBoolean();
+    final boolean merge = random().nextBoolean();
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = newIndexWriterConfig();
+      iwc.setIndexSort(new Sort(new MinValueSortField("dv", reverse)));
+      iwc.setMaxBufferedDocs(25); // force frequent flushes
+      iwc.setMergePolicy(merge ? newLogMergePolicy() : NoMergePolicy.INSTANCE);
+      int numDocs = 400;
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          int count = TestUtil.nextInt(random(), 1, 4);
+          List<byte[]> values = new ArrayList<>();
+          for (int v = 0; v < count; v++) {
+            byte[] b = new byte[TestUtil.nextInt(random(), 1, 6)];
+            random().nextBytes(b);
+            values.add(b);
+          }
+          doc.add(new BinaryDocValuesField("dv", encodeValues(values)));
+          w.addDocument(doc);
+        }
+        if (merge && random().nextBoolean()) {
+          w.forceMerge(1);
+        }
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        if (merge == false) {
+          assertTrue("expected multiple flush-sorted segments", reader.leaves().size() > 1);
+        }
+        for (LeafReaderContext ctx : reader.leaves()) {
+          assertEquals(
+              new Sort(new MinValueSortField("dv", reverse)), ctx.reader().getMetaData().sort());
+          BinaryDocValues dv = ctx.reader().getBinaryDocValues("dv");
+          BytesRef previous = null;
+          for (int doc = 0; doc < ctx.reader().maxDoc(); doc++) {
+            assertTrue(dv.advanceExact(doc));
+            BytesRef key = BytesRef.deepCopyOf(MinValueSortField.min(dv.binaryValue()));
+            if (previous != null) {
+              int cmp = previous.compareTo(key);
+              if (reverse) {
+                cmp = -cmp;
+              }
+              assertTrue("min-value order violated", cmp <= 0);
+            }
+            previous = key;
+          }
+        }
+      }
+    }
   }
 
   /**
@@ -870,28 +1051,63 @@ public class TestBinarySortField extends LuceneTestCase {
   }
 
   /**
-   * Example custom-comparator extension: the binary value holds one or more {@code [vInt
-   * length][bytes]} values, and the sort key is the <em>first</em> value (so the raw bytes are not
-   * sortable as-is, they must be decoded). The companion {@link Provider} reconstructs the field —
-   * and hence its comparator — when the index sort is deserialized, so the same decoding is used on
-   * merge. It is registered via {@code META-INF/services/org.apache.lucene.index.SortFieldProvider}
-   * under the test resources.
+   * Example value-source extension: the binary value holds one or more {@code [vInt length][bytes]}
+   * values (so the raw bytes are not sortable as-is); the sort key is the <em>first</em> value,
+   * extracted once per document in {@link #getSortKeyDocValues}. The {@link Provider} reconstructs
+   * the field when the index sort is read back, so the same key is produced on merge. It is
+   * registered via {@code META-INF/services/org.apache.lucene.index.SortFieldProvider} under the
+   * test resources.
    */
   public static final class FirstValueSortField extends BinarySortField {
     static final String NAME = "FirstValueSortField";
-    static final Comparator<BytesRef> COMPARATOR = (a, b) -> firstValue(a).compareTo(firstValue(b));
 
     public FirstValueSortField(String field, boolean reverse) {
-      super(field, reverse, null, COMPARATOR, NAME);
+      super(field, reverse, null, NAME);
     }
 
-    private static BytesRef firstValue(BytesRef raw) {
+    @Override
+    protected BinaryDocValues getSortKeyDocValues(LeafReader reader) throws IOException {
+      BinaryDocValues binary = DocValues.getBinary(reader, getField());
+      return new BinaryDocValues() {
+        @Override
+        public BytesRef binaryValue() throws IOException {
+          return firstValue(binary.binaryValue());
+        }
+
+        @Override
+        public int docID() {
+          return binary.docID();
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+          return binary.nextDoc();
+        }
+
+        @Override
+        public int advance(int t) throws IOException {
+          return binary.advance(t);
+        }
+
+        @Override
+        public boolean advanceExact(int t) throws IOException {
+          return binary.advanceExact(t);
+        }
+
+        @Override
+        public long cost() {
+          return binary.cost();
+        }
+      };
+    }
+
+    static BytesRef firstValue(BytesRef raw) {
       ByteArrayDataInput in = new ByteArrayDataInput(raw.bytes, raw.offset, raw.length);
       int length = in.readVInt();
       return new BytesRef(raw.bytes, in.getPosition(), length);
     }
 
-    /** Serializes/deserializes a {@link FirstValueSortField} (and thus its decoding comparator). */
+    /** Serializes/deserializes a {@link FirstValueSortField}. */
     public static final class Provider extends SortFieldProvider {
       public Provider() {
         super(NAME);
@@ -900,6 +1116,93 @@ public class TestBinarySortField extends LuceneTestCase {
       @Override
       public SortField readSortField(DataInput in) throws IOException {
         return new FirstValueSortField(in.readString(), in.readInt() == 1);
+      }
+
+      @Override
+      public void writeSortField(SortField sf, DataOutput out) throws IOException {
+        out.writeString(sf.getField());
+        out.writeInt(sf.getReverse() ? 1 : 0);
+      }
+    }
+  }
+
+  /**
+   * Example value source that selects the <em>minimum</em> value of a multi-valued binary field.
+   * The value is self-describing — a sequence of {@code [vInt length][bytes]} pairs — so the values
+   * are scanned to the end of the {@link BytesRef} and the smallest is returned as the sort key; no
+   * companion field is needed. The {@link Provider} reconstructs the field when the index sort is
+   * read back, so the same key is produced on merge.
+   */
+  public static final class MinValueSortField extends BinarySortField {
+    static final String NAME = "MinValueSortField";
+
+    public MinValueSortField(String field, boolean reverse) {
+      super(field, reverse, null, NAME);
+    }
+
+    @Override
+    protected BinaryDocValues getSortKeyDocValues(LeafReader reader) throws IOException {
+      BinaryDocValues binary = DocValues.getBinary(reader, getField());
+      return new BinaryDocValues() {
+        @Override
+        public BytesRef binaryValue() throws IOException {
+          return min(binary.binaryValue());
+        }
+
+        @Override
+        public int docID() {
+          return binary.docID();
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+          return binary.nextDoc();
+        }
+
+        @Override
+        public int advance(int t) throws IOException {
+          return binary.advance(t);
+        }
+
+        @Override
+        public boolean advanceExact(int t) throws IOException {
+          return binary.advanceExact(t);
+        }
+
+        @Override
+        public long cost() {
+          return binary.cost();
+        }
+      };
+    }
+
+    /**
+     * Returns the minimum of the {@code [vInt length][bytes]} values packed in {@code raw}, as a
+     * view into {@code raw} (no copy — the value is only used for comparison, per the contract).
+     */
+    static BytesRef min(BytesRef raw) {
+      ByteArrayDataInput in = new ByteArrayDataInput(raw.bytes, raw.offset, raw.length);
+      BytesRef best = null;
+      while (in.eof() == false) {
+        int length = in.readVInt();
+        BytesRef value = new BytesRef(raw.bytes, in.getPosition(), length);
+        in.setPosition(in.getPosition() + length);
+        if (best == null || value.compareTo(best) < 0) {
+          best = value;
+        }
+      }
+      return best;
+    }
+
+    /** Serializes/deserializes a {@link MinValueSortField}. */
+    public static final class Provider extends SortFieldProvider {
+      public Provider() {
+        super(NAME);
+      }
+
+      @Override
+      public SortField readSortField(DataInput in) throws IOException {
+        return new MinValueSortField(in.readString(), in.readInt() == 1);
       }
 
       @Override


### PR DESCRIPTION
Adds `BinarySortField`, letting a single-valued `BinaryDocValues` field be used as an index sort (and search sort). Values are compared directly in unsigned byte order instead of through a term dictionary and ordinal map, so it suits high-cardinality fields where a dictionary is pure overhead. By default the sort key is the stored value; a subclass may override `getSortKeyDocValues` to supply a custom order-preserving key (a `BinaryDocValues` iterator) derived from the stored bytes and/or other doc-values fields. Because nothing is dictionary-encoded or compressed, it is expected to be faster at high cardinality, most visibly on the compaction (force) merge, which avoids rebuilding the global ordinal map.

Implementation notes:
- `IndexSorter` gains a `ComparableValues` abstraction for the cross-segment order so it no longer has to be a `long`; the default adapts the existing `ComparableProvider` with no behaviour change, leaving numeric and string sorts untouched.
- `BinarySorter` reads each segment's sort key strictly sequentially (`nextDoc` only) during merge — efficient even for block-compressed binary formats — and compares slices in place at flush.
- Fixes `BinaryDocValuesWriter` to freeze its `PagedBytes` lazily, since index sorting reads the in-RAM values before `flush()`.

The change is additive and non-breaking: no existing method signature changes (`getComparableProviders` becomes a `default`, which is binary- and source-compatible), the index-sort serialization format is unchanged, and the index sort remains immutable.

## Benchmark

`IndexSortDocValuesBenchmark` (JMH, `SingleShotTime`) builds a sorted index of 1M documents with 16-byte values, comparing `BinarySortField` (`BinaryDocValues`) against a `STRING` sort (`SortedDocValues`). `indexWithNaturalMerges` waits for naturally scheduled merges; `indexThenForceMerge` additionally force-merges to a single segment.

| cardinality | operation | binary (ms) | sorted (ms) |
|---|---|---|---|
| low | index + natural merges | 397 ± 24 | 260 ± 69 |
| low | index + forceMerge(1) | 390 ± 20 | 249 ± 33 |
| high | index + natural merges | 708 ± 91 | 595 ± 58 |
| high | index + forceMerge(1) | 728 ± 130 | 884 ± 90 |

At low cardinality the ordinal-based `SortedDocValues` sort wins, as expected. At high cardinality the force-merge step adds ~20 ms for binary versus ~290 ms for sorted, because the compaction merge does not rebuild the global ordinal map. The same shape holds at 10M documents.

## Tests

Cover flush/merge order, reverse, missing first/last, empty values, nested document blocks, deletes, multi-field sorts, `addIndexes`, search sorting, a custom sort key, serialization round-trip, index-sort immutability, and a randomized stress test. Search-time sort uses a linear scan (no skipping optimization).
