### PR TITLE
add bulk off-heap scoring for uint8 quantized vectors using panama vector api

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -296,6 +296,8 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#16203: Add bulk off-heap scoring for uint8 quantized vectors using Panama Vector API. (Prithvi S)
+
 * GITHUG#16280: Single-pass writeString fast path for short strings in ByteBuffersDataOutput (neoremind)
 
 Bug Fixes

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene99/TestLucene99ScalarQuantizedVectorScorer.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene99/TestLucene99ScalarQuantizedVectorScorer.java
@@ -26,6 +26,7 @@ import java.nio.ByteOrder;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.hnsw.DefaultFlatVectorScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader;
 import org.apache.lucene.codecs.lucene99.Lucene99ScalarQuantizedVectorScorer;
@@ -48,6 +49,8 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
 import org.apache.lucene.util.quantization.LegacyQuantizedByteVectorValues;
 import org.apache.lucene.util.quantization.ScalarQuantizer;
 
@@ -166,6 +169,373 @@ public class TestLucene99ScalarQuantizedVectorScorer extends LuceneTestCase {
     vectorScoringTest(7, false);
   }
 
+  public void testBulkScoringInt7() throws Exception {
+    // Use dimension 64 to ensure SIMD loop is exercised on all platforms
+    bulkScoringTest(7, false, 64);
+  }
+
+  public void testBulkScoringLargeDimensionsUint8() throws Exception {
+    bulkScoringTest(7, false, 128);
+  }
+
+  public void testBulkScoringOddDimensionsUint8() throws Exception {
+    bulkScoringTest(7, false, 97);
+  }
+
+  public void testBulkScoringTailPathsUint8() throws Exception {
+    bulkScoringTailTest(7, false, 128);
+  }
+
+  public void testBulkScoringSimdBoundaryUint8() throws Exception {
+    // Test dimensions at 128-bit SIMD width boundary (15, 16, 17)
+    bulkScoringTest(7, false, 15);
+    bulkScoringTest(7, false, 16);
+    bulkScoringTest(7, false, 17);
+  }
+
+  public void testBulkScoringUpdateableUint8() throws Exception {
+    bulkScoringUpdateableTest(7, false, 128);
+  }
+
+  /**
+   * Verifies that int4 vectors fall back to single-vector scoring via super.bulkScore() instead of
+   * hitting the uint8 bulk path. This guards against accidental removal of the !isUint8() guard in
+   * bulkScoreBody.
+   */
+  public void testBulkScoringInt4Fallback() throws Exception {
+    bulkScoringInt4FallbackTest(4, true, 128);
+    bulkScoringInt4FallbackTest(4, false, 128);
+  }
+
+  public void testBulkScoringShuffledOrdinalsUint8() throws Exception {
+    bulkScoringShuffledTest(7, false, 128);
+  }
+
+  private void bulkScoringInt4FallbackTest(int bits, boolean compress, int dimensionOverride)
+      throws IOException {
+    float[][] storedVectors = new float[10][];
+    int numVectors = 10;
+    int vectorDimensions = dimensionOverride;
+    if (bits == 4 && vectorDimensions % 2 == 1) {
+      vectorDimensions++;
+    }
+    for (int i = 0; i < numVectors; i++) {
+      float[] vector = new float[vectorDimensions];
+      for (int j = 0; j < vectorDimensions; j++) {
+        vector[j] = i + j;
+      }
+      VectorUtil.l2normalize(vector);
+      storedVectors[i] = vector;
+    }
+
+    for (VectorSimilarityFunction similarityFunction :
+        new VectorSimilarityFunction[] {
+          VectorSimilarityFunction.DOT_PRODUCT,
+          VectorSimilarityFunction.COSINE,
+          VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
+          VectorSimilarityFunction.EUCLIDEAN
+        }) {
+      try (Directory dir = newDirectory()) {
+        indexVectors(dir, storedVectors, similarityFunction, bits, compress);
+        try (DirectoryReader reader = DirectoryReader.open(dir)) {
+          LeafReader leafReader = reader.leaves().get(0).reader();
+          float[] vector = new float[vectorDimensions];
+          for (int i = 0; i < vectorDimensions; i++) {
+            vector[i] = i + 1;
+          }
+          VectorUtil.l2normalize(vector);
+          RandomVectorScorer randomScorer =
+              getBulkRandomVectorScorer(similarityFunction, leafReader, vector);
+
+          // Score individually
+          float[] singleScores = new float[numVectors];
+          for (int i = 0; i < numVectors; i++) {
+            singleScores[i] = randomScorer.score(i);
+          }
+
+          // Score in bulk — should fall back to single-vector loop for int4
+          float[] bulkScores = new float[numVectors];
+          int[] nodes = new int[numVectors];
+          for (int i = 0; i < numVectors; i++) {
+            nodes[i] = i;
+          }
+          randomScorer.bulkScore(nodes, bulkScores, numVectors);
+
+          // Verify fallback produces identical results to single-vector scoring
+          for (int i = 0; i < numVectors; i++) {
+            assertEquals(
+                similarityFunction.toString() + " ord=" + i, singleScores[i], bulkScores[i], 0f);
+          }
+        }
+      }
+    }
+  }
+
+  private void bulkScoringShuffledTest(int bits, boolean compress, int dimensionOverride)
+      throws IOException {
+    float[][] storedVectors = new float[10][];
+    int numVectors = 10;
+    int vectorDimensions = dimensionOverride;
+    if (bits == 4 && vectorDimensions % 2 == 1) {
+      vectorDimensions++;
+    }
+    for (int i = 0; i < numVectors; i++) {
+      float[] vector = new float[vectorDimensions];
+      for (int j = 0; j < vectorDimensions; j++) {
+        vector[j] = i + j;
+      }
+      VectorUtil.l2normalize(vector);
+      storedVectors[i] = vector;
+    }
+
+    for (VectorSimilarityFunction similarityFunction :
+        new VectorSimilarityFunction[] {
+          VectorSimilarityFunction.DOT_PRODUCT,
+          VectorSimilarityFunction.COSINE,
+          VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
+          VectorSimilarityFunction.EUCLIDEAN
+        }) {
+      try (Directory dir = newDirectory()) {
+        indexVectors(dir, storedVectors, similarityFunction, bits, compress);
+        try (DirectoryReader reader = DirectoryReader.open(dir)) {
+          LeafReader leafReader = reader.leaves().get(0).reader();
+          float[] vector = new float[vectorDimensions];
+          for (int i = 0; i < vectorDimensions; i++) {
+            vector[i] = i + 1;
+          }
+          VectorUtil.l2normalize(vector);
+          RandomVectorScorer randomScorer =
+              getBulkRandomVectorScorer(similarityFunction, leafReader, vector);
+
+          // Score individually
+          float[] singleScores = new float[numVectors];
+          for (int i = 0; i < numVectors; i++) {
+            singleScores[i] = randomScorer.score(i);
+          }
+
+          // Score in bulk with shuffled non-contiguous ordinals
+          float[] bulkScores = new float[numVectors];
+          int[] nodes = new int[numVectors];
+          for (int i = 0; i < numVectors; i++) {
+            nodes[i] = i;
+          }
+          // Shuffle ordinals to test non-contiguous access
+          for (int i = numVectors - 1; i > 0; i--) {
+            int j = random().nextInt(i + 1);
+            int tmp = nodes[i];
+            nodes[i] = nodes[j];
+            nodes[j] = tmp;
+          }
+          randomScorer.bulkScore(nodes, bulkScores, numVectors);
+
+          // Verify bulk matches single-vector exactly
+          for (int i = 0; i < numVectors; i++) {
+            assertEquals(
+                similarityFunction.toString() + " ord=" + nodes[i],
+                singleScores[nodes[i]],
+                bulkScores[i],
+                0f);
+          }
+        }
+      }
+    }
+  }
+
+  private void bulkScoringTest(int bits, boolean compress, int dimensionOverride)
+      throws IOException {
+    float[][] storedVectors = new float[10][];
+    int numVectors = 10;
+    int vectorDimensions = dimensionOverride > 0 ? dimensionOverride : random().nextInt(10) + 4;
+    if (bits == 4 && vectorDimensions % 2 == 1) {
+      vectorDimensions++;
+    }
+    for (int i = 0; i < numVectors; i++) {
+      float[] vector = new float[vectorDimensions];
+      for (int j = 0; j < vectorDimensions; j++) {
+        vector[j] = i + j;
+      }
+      VectorUtil.l2normalize(vector);
+      storedVectors[i] = vector;
+    }
+
+    for (VectorSimilarityFunction similarityFunction :
+        new VectorSimilarityFunction[] {
+          VectorSimilarityFunction.DOT_PRODUCT,
+          VectorSimilarityFunction.COSINE,
+          VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
+          VectorSimilarityFunction.EUCLIDEAN
+        }) {
+      try (Directory dir = newDirectory()) {
+        indexVectors(dir, storedVectors, similarityFunction, bits, compress);
+        try (DirectoryReader reader = DirectoryReader.open(dir)) {
+          LeafReader leafReader = reader.leaves().get(0).reader();
+          float[] vector = new float[vectorDimensions];
+          for (int i = 0; i < vectorDimensions; i++) {
+            vector[i] = i + 1;
+          }
+          VectorUtil.l2normalize(vector);
+          RandomVectorScorer randomScorer =
+              getBulkRandomVectorScorer(similarityFunction, leafReader, vector);
+
+          // Score individually
+          float[] singleScores = new float[numVectors];
+          for (int i = 0; i < numVectors; i++) {
+            singleScores[i] = randomScorer.score(i);
+          }
+
+          // Score in bulk
+          float[] bulkScores = new float[numVectors];
+          int[] nodes = new int[numVectors];
+          for (int i = 0; i < numVectors; i++) {
+            nodes[i] = i;
+          }
+          randomScorer.bulkScore(nodes, bulkScores, numVectors);
+
+          // Verify bulk matches single-vector exactly (integer ops should be identical)
+          for (int i = 0; i < numVectors; i++) {
+            assertEquals(
+                similarityFunction.toString() + " ord=" + i, singleScores[i], bulkScores[i], 0f);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Tests tail handling in bulkScore by scoring subsets of vectors that exercise 0, 1, 2, and 3
+   * remaining nodes after the 4-wide main loop.
+   */
+  private void bulkScoringTailTest(int bits, boolean compress, int dimensionOverride)
+      throws IOException {
+    int numVectors = 10;
+    int vectorDimensions = dimensionOverride;
+    if (bits == 4 && vectorDimensions % 2 == 1) {
+      vectorDimensions++;
+    }
+    float[][] storedVectors = new float[numVectors][];
+    for (int i = 0; i < numVectors; i++) {
+      float[] vector = new float[vectorDimensions];
+      for (int j = 0; j < vectorDimensions; j++) {
+        vector[j] = i + j;
+      }
+      VectorUtil.l2normalize(vector);
+      storedVectors[i] = vector;
+    }
+
+    for (VectorSimilarityFunction similarityFunction :
+        new VectorSimilarityFunction[] {
+          VectorSimilarityFunction.DOT_PRODUCT,
+          VectorSimilarityFunction.COSINE,
+          VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
+          VectorSimilarityFunction.EUCLIDEAN
+        }) {
+      try (Directory dir = newDirectory()) {
+        indexVectors(dir, storedVectors, similarityFunction, bits, compress);
+        try (DirectoryReader reader = DirectoryReader.open(dir)) {
+          LeafReader leafReader = reader.leaves().get(0).reader();
+          float[] vector = new float[vectorDimensions];
+          for (int i = 0; i < vectorDimensions; i++) {
+            vector[i] = i + 1;
+          }
+          VectorUtil.l2normalize(vector);
+          RandomVectorScorer randomScorer =
+              getBulkRandomVectorScorer(similarityFunction, leafReader, vector);
+
+          // Test numNodes = 0 (edge case)
+          float[] bulkScores0 = new float[0];
+          int[] nodes0 = new int[0];
+          float max0 = randomScorer.bulkScore(nodes0, bulkScores0, 0);
+          assertEquals("numNodes=0 maxScore", Float.NEGATIVE_INFINITY, max0, 0f);
+
+          // Test numNodes = 1, 2, 3 (tail paths)
+          for (int tailCount = 1; tailCount <= 3; tailCount++) {
+            float[] singleScores = new float[tailCount];
+            for (int i = 0; i < tailCount; i++) {
+              singleScores[i] = randomScorer.score(i);
+            }
+
+            float[] bulkScores = new float[tailCount];
+            int[] nodes = new int[tailCount];
+            for (int i = 0; i < tailCount; i++) {
+              nodes[i] = i;
+            }
+            randomScorer.bulkScore(nodes, bulkScores, tailCount);
+
+            for (int i = 0; i < tailCount; i++) {
+              assertEquals(
+                  similarityFunction.toString() + " tailCount=" + tailCount + " ord=" + i,
+                  singleScores[i],
+                  bulkScores[i],
+                  0f);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private void bulkScoringUpdateableTest(int bits, boolean compress, int dimensionOverride)
+      throws IOException {
+    float[][] storedVectors = new float[10][];
+    int numVectors = 10;
+    int vectorDimensions = dimensionOverride > 0 ? dimensionOverride : random().nextInt(10) + 4;
+    if (bits == 4 && vectorDimensions % 2 == 1) {
+      vectorDimensions++;
+    }
+    for (int i = 0; i < numVectors; i++) {
+      float[] vector = new float[vectorDimensions];
+      for (int j = 0; j < vectorDimensions; j++) {
+        vector[j] = i + j;
+      }
+      VectorUtil.l2normalize(vector);
+      storedVectors[i] = vector;
+    }
+
+    for (VectorSimilarityFunction similarityFunction :
+        new VectorSimilarityFunction[] {
+          VectorSimilarityFunction.DOT_PRODUCT,
+          VectorSimilarityFunction.COSINE,
+          VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
+          VectorSimilarityFunction.EUCLIDEAN
+        }) {
+      try (Directory dir = newDirectory()) {
+        indexVectors(dir, storedVectors, similarityFunction, bits, compress);
+        try (DirectoryReader reader = DirectoryReader.open(dir)) {
+          LeafReader leafReader = reader.leaves().get(0).reader();
+
+          for (int scoringOrd = 0; scoringOrd < numVectors; scoringOrd++) {
+            UpdateableRandomVectorScorer singleScorer =
+                getBulkUpdateableRandomVectorScorer(similarityFunction, leafReader, scoringOrd);
+
+            // Score individually
+            float[] singleScores = new float[numVectors];
+            for (int i = 0; i < numVectors; i++) {
+              singleScores[i] = singleScorer.score(i);
+            }
+
+            // Score in bulk using a fresh scorer with same scoring ordinal
+            UpdateableRandomVectorScorer bulkScorer =
+                getBulkUpdateableRandomVectorScorer(similarityFunction, leafReader, scoringOrd);
+            float[] bulkScores = new float[numVectors];
+            int[] nodes = new int[numVectors];
+            for (int i = 0; i < numVectors; i++) {
+              nodes[i] = i;
+            }
+            bulkScorer.bulkScore(nodes, bulkScores, numVectors);
+
+            for (int i = 0; i < numVectors; i++) {
+              assertEquals(
+                  similarityFunction.toString() + " scoringOrd=" + scoringOrd + " ord=" + i,
+                  singleScores[i],
+                  bulkScores[i],
+                  0f);
+            }
+          }
+        }
+      }
+    }
+  }
+
   private void vectorScoringTest(int bits, boolean compress) throws IOException {
     float[][] storedVectors = new float[10][];
     int numVectors = 10;
@@ -222,6 +592,40 @@ public class TestLucene99ScalarQuantizedVectorScorer extends LuceneTestCase {
             (OffHeapQuantizedByteVectorValues) hnswFormat.getQuantizedVectorValues("field");
         return new Lucene99ScalarQuantizedVectorScorer(new DefaultFlatVectorScorer())
             .getRandomVectorScorer(function, quantizedByteVectorReader, vector);
+      }
+    }
+    throw new IllegalArgumentException("Unsupported reader");
+  }
+
+  private RandomVectorScorer getBulkRandomVectorScorer(
+      VectorSimilarityFunction function, LeafReader leafReader, float[] vector) throws IOException {
+    if (leafReader instanceof CodecReader codecReader) {
+      KnnVectorsReader format = codecReader.getVectorReader();
+      format = format.unwrapReaderForField("field");
+      if (format instanceof Lucene99HnswVectorsReader hnswFormat) {
+        OffHeapQuantizedByteVectorValues quantizedByteVectorReader =
+            (OffHeapQuantizedByteVectorValues) hnswFormat.getQuantizedVectorValues("field");
+        return FlatVectorScorerUtil.getLucene99ScalarQuantizedVectorsScorer()
+            .getRandomVectorScorer(function, quantizedByteVectorReader, vector);
+      }
+    }
+    throw new IllegalArgumentException("Unsupported reader");
+  }
+
+  private UpdateableRandomVectorScorer getBulkUpdateableRandomVectorScorer(
+      VectorSimilarityFunction function, LeafReader leafReader, int scoringOrd) throws IOException {
+    if (leafReader instanceof CodecReader codecReader) {
+      KnnVectorsReader format = codecReader.getVectorReader();
+      format = format.unwrapReaderForField("field");
+      if (format instanceof Lucene99HnswVectorsReader hnswFormat) {
+        OffHeapQuantizedByteVectorValues quantizedByteVectorReader =
+            (OffHeapQuantizedByteVectorValues) hnswFormat.getQuantizedVectorValues("field");
+        RandomVectorScorerSupplier supplier =
+            FlatVectorScorerUtil.getLucene99ScalarQuantizedVectorsScorer()
+                .getRandomVectorScorerSupplier(function, quantizedByteVectorReader);
+        UpdateableRandomVectorScorer scorer = supplier.scorer();
+        scorer.setScoringOrdinal(scoringOrd);
+        return scorer;
       }
     }
     throw new IllegalArgumentException("Unsupported reader");

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorScorerQuantizedBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorScorerQuantizedBenchmark.java
@@ -1,0 +1,409 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import static org.apache.lucene.index.VectorSimilarityFunction.COSINE;
+import static org.apache.lucene.index.VectorSimilarityFunction.DOT_PRODUCT;
+import static org.apache.lucene.index.VectorSimilarityFunction.EUCLIDEAN;
+import static org.apache.lucene.index.VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.lucene.codecs.hnsw.DefaultFlatVectorScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
+import org.apache.lucene.codecs.lucene99.Lucene99ScalarQuantizedVectorScorer;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
+import org.apache.lucene.util.quantization.LegacyQuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.ScalarQuantizer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmark to compare the performance of quantized (uint8) vector scoring using the default and
+ * optimized (MemorySegment bulk) scorers.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 4, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(
+    value = 3,
+    jvmArgsAppend = {
+      "-Xmx2g",
+      "-Xms2g",
+      "-XX:+AlwaysPreTouch",
+      "--add-modules=jdk.incubator.vector"
+    })
+public class VectorScorerQuantizedBenchmark {
+
+  @Param({"1024"})
+  public int size;
+
+  @Param({"true", "false"})
+  public boolean pollute = false;
+
+  public int numVectors = 128_000;
+  public int numVectorsToScore = 20_000;
+
+  float[] scores;
+  int[] indices;
+  Path path;
+  Directory dir;
+  IndexInput in;
+  KnnVectorValues values;
+  UpdateableRandomVectorScorer defDotScorer, defCosScorer, defEucScorer, defMipScorer;
+  UpdateableRandomVectorScorer optDotScorer, optCosScorer, optEucScorer, optMipScorer;
+
+  @Setup(Level.Trial)
+  public void setup() throws IOException {
+    var random = ThreadLocalRandom.current();
+    path = Files.createTempDirectory("VectorScorerQuantizedBenchmark");
+    dir = new MMapDirectory(path);
+
+    // Create quantized uint8 vectors with score correction offsets
+    // Format per vector: [byte0..byteN-1][float_offset]
+    int nodeSize = size + Float.BYTES;
+    byte[] nodeBytes = new byte[nodeSize];
+    ByteBuffer nodeBuf = ByteBuffer.wrap(nodeBytes).order(ByteOrder.LITTLE_ENDIAN);
+
+    try (IndexOutput out = dir.createOutput("vector.data", IOContext.DEFAULT)) {
+      for (int v = 0; v < numVectors; v++) {
+        nodeBuf.clear();
+        byte[] vec = randomVectorBytes(size, random);
+        nodeBuf.put(vec);
+        nodeBuf.putFloat(random.nextFloat() * 0.01f); // small offset
+        out.writeBytes(nodeBytes, 0, nodeSize);
+      }
+    }
+  }
+
+  @Setup(Level.Iteration)
+  public void perIterationInit() throws IOException {
+    var random = ThreadLocalRandom.current();
+    scores = new float[numVectorsToScore];
+    if (in != null) {
+      in.close();
+    }
+    in = dir.openInput("vector.data", IOContext.DEFAULT);
+    int targetOrd = random.nextInt(numVectors);
+
+    // default scorer
+    values = quantizedVectorValues(size, numVectors, in);
+    var def = new Lucene99ScalarQuantizedVectorScorer(DefaultFlatVectorScorer.INSTANCE);
+    defDotScorer = def.getRandomVectorScorerSupplier(DOT_PRODUCT, values.copy()).scorer();
+    defCosScorer = def.getRandomVectorScorerSupplier(COSINE, values.copy()).scorer();
+    defEucScorer = def.getRandomVectorScorerSupplier(EUCLIDEAN, values.copy()).scorer();
+    defMipScorer = def.getRandomVectorScorerSupplier(MAXIMUM_INNER_PRODUCT, values.copy()).scorer();
+    defDotScorer.setScoringOrdinal(targetOrd);
+    defCosScorer.setScoringOrdinal(targetOrd);
+    defEucScorer.setScoringOrdinal(targetOrd);
+    defMipScorer.setScoringOrdinal(targetOrd);
+
+    // optimized scorer (MemorySegment path)
+    var opt = FlatVectorScorerUtil.getLucene99ScalarQuantizedVectorsScorer();
+    optDotScorer = opt.getRandomVectorScorerSupplier(DOT_PRODUCT, values.copy()).scorer();
+    optCosScorer = opt.getRandomVectorScorerSupplier(COSINE, values.copy()).scorer();
+    optEucScorer = opt.getRandomVectorScorerSupplier(EUCLIDEAN, values.copy()).scorer();
+    optMipScorer = opt.getRandomVectorScorerSupplier(MAXIMUM_INNER_PRODUCT, values.copy()).scorer();
+    optDotScorer.setScoringOrdinal(targetOrd);
+    optCosScorer.setScoringOrdinal(targetOrd);
+    optEucScorer.setScoringOrdinal(targetOrd);
+    optMipScorer.setScoringOrdinal(targetOrd);
+
+    List<Integer> list = IntStream.range(0, numVectors).boxed().collect(Collectors.toList());
+    Collections.shuffle(list, random);
+    indices = list.stream().limit(numVectorsToScore).mapToInt(i -> i).toArray();
+
+    if (pollute) {
+      pollute(random);
+    }
+  }
+
+  @TearDown
+  public void teardown() throws IOException {
+    IOUtils.close(in);
+    dir.deleteFile("vector.data");
+    IOUtils.close(dir);
+    Files.delete(path);
+  }
+
+  public void pollute(Random random) throws IOException {
+    float[] vec = randomVectorFloats(size, random);
+    var opt = FlatVectorScorerUtil.getLucene99ScalarQuantizedVectorsScorer();
+
+    for (int i = 0; i < 2; i++) {
+      dotProductOptScorer();
+      dotProductOptBulkScore();
+      cosineOptScorer();
+      cosineDefaultBulk();
+      euclideanOptScorer();
+      euclideanOptBulkScore();
+      mipOptScorer();
+      mipOptBulkScore();
+      for (var sim : List.of(COSINE, DOT_PRODUCT, EUCLIDEAN, MAXIMUM_INNER_PRODUCT)) {
+        var scorer = opt.getRandomVectorScorer(sim, values.copy(), vec);
+        for (int v = 0; v < numVectorsToScore; v++) {
+          scores[v] = scorer.score(indices[v]);
+        }
+      }
+    }
+  }
+
+  // -- dot product
+
+  @Benchmark
+  public float[] dotProductDefault() throws IOException {
+    for (int v = 0; v < numVectorsToScore; v++) {
+      scores[v] = defDotScorer.score(indices[v]);
+    }
+    return scores;
+  }
+
+  @Benchmark
+  public float[] dotProductDefaultBulk() throws IOException {
+    defDotScorer.bulkScore(indices, scores, indices.length);
+    return scores;
+  }
+
+  @Benchmark
+  public float[] dotProductOptScorer() throws IOException {
+    for (int v = 0; v < numVectorsToScore; v++) {
+      scores[v] = optDotScorer.score(indices[v]);
+    }
+    return scores;
+  }
+
+  @Benchmark
+  public float[] dotProductOptBulkScore() throws IOException {
+    optDotScorer.bulkScore(indices, scores, indices.length);
+    return scores;
+  }
+
+  // -- euclidean
+
+  @Benchmark
+  public float[] euclideanDefault() throws IOException {
+    for (int v = 0; v < numVectorsToScore; v++) {
+      scores[v] = defEucScorer.score(indices[v]);
+    }
+    return scores;
+  }
+
+  @Benchmark
+  public float[] euclideanDefaultBulk() throws IOException {
+    defEucScorer.bulkScore(indices, scores, indices.length);
+    return scores;
+  }
+
+  @Benchmark
+  public float[] euclideanOptScorer() throws IOException {
+    for (int v = 0; v < numVectorsToScore; v++) {
+      scores[v] = optEucScorer.score(indices[v]);
+    }
+    return scores;
+  }
+
+  @Benchmark
+  public float[] euclideanOptBulkScore() throws IOException {
+    optEucScorer.bulkScore(indices, scores, indices.length);
+    return scores;
+  }
+
+  // -- cosine
+
+  @Benchmark
+  public float[] cosineDefault() throws IOException {
+    for (int v = 0; v < numVectorsToScore; v++) {
+      scores[v] = defCosScorer.score(indices[v]);
+    }
+    return scores;
+  }
+
+  @Benchmark
+  public float[] cosineDefaultBulk() throws IOException {
+    defCosScorer.bulkScore(indices, scores, indices.length);
+    return scores;
+  }
+
+  @Benchmark
+  public float[] cosineOptScorer() throws IOException {
+    for (int v = 0; v < numVectorsToScore; v++) {
+      scores[v] = optCosScorer.score(indices[v]);
+    }
+    return scores;
+  }
+
+  @Benchmark
+  public float[] cosineOptBulkScore() throws IOException {
+    optCosScorer.bulkScore(indices, scores, indices.length);
+    return scores;
+  }
+
+  // -- max inner product
+
+  @Benchmark
+  public float[] mipDefault() throws IOException {
+    for (int v = 0; v < numVectorsToScore; v++) {
+      scores[v] = defMipScorer.score(indices[v]);
+    }
+    return scores;
+  }
+
+  @Benchmark
+  public float[] mipDefaultBulk() throws IOException {
+    defMipScorer.bulkScore(indices, scores, indices.length);
+    return scores;
+  }
+
+  @Benchmark
+  public float[] mipOptScorer() throws IOException {
+    for (int v = 0; v < numVectorsToScore; v++) {
+      scores[v] = optMipScorer.score(indices[v]);
+    }
+    return scores;
+  }
+
+  @Benchmark
+  public float[] mipOptBulkScore() throws IOException {
+    optMipScorer.bulkScore(indices, scores, indices.length);
+    return scores;
+  }
+
+  static byte[] randomVectorBytes(int dims, Random random) {
+    byte[] ba = new byte[dims];
+    random.nextBytes(ba);
+    // Make unsigned by clearing the sign bit, so values are 0-127
+    // This matches the uint8 quantization range
+    for (int i = 0; i < dims; i++) {
+      ba[i] = (byte) ((ba[i] & 0xFF) % 128);
+    }
+    return ba;
+  }
+
+  static float[] randomVectorFloats(int dims, Random random) {
+    float[] fa = new float[dims];
+    for (int i = 0; i < dims; ++i) {
+      fa[i] = random.nextFloat();
+    }
+    return fa;
+  }
+
+  static KnnVectorValues quantizedVectorValues(int dims, int size, IndexInput in)
+      throws IOException {
+    int nodeSize = dims + Float.BYTES;
+    return new SimpleLegacyQuantizedByteVectorValues(dims, size, in, nodeSize);
+  }
+
+  /**
+   * A minimal LegacyQuantizedByteVectorValues for benchmarking. Each "node" is [vector bytes][float
+   * offset].
+   */
+  static final class SimpleLegacyQuantizedByteVectorValues extends LegacyQuantizedByteVectorValues {
+    private final int dims;
+    private final int size;
+    private final IndexInput in;
+    private final int nodeSize;
+    private final byte[] scratch;
+    private int ord = -1;
+
+    SimpleLegacyQuantizedByteVectorValues(int dims, int size, IndexInput in, int nodeSize)
+        throws IOException {
+      this.dims = dims;
+      this.size = size;
+      this.in = in.slice("test", 0, in.length());
+      this.nodeSize = nodeSize;
+      this.scratch = new byte[dims];
+    }
+
+    @Override
+    public int dimension() {
+      return dims;
+    }
+
+    @Override
+    public int size() {
+      return size;
+    }
+
+    @Override
+    public byte[] vectorValue(int ord) throws IOException {
+      this.ord = ord;
+      ((RandomAccessInput) in).readBytes((long) ord * nodeSize, scratch, 0, dims);
+      return scratch;
+    }
+
+    public byte[] vectorValue() throws IOException {
+      return vectorValue(ord);
+    }
+
+    @Override
+    public int ordToDoc(int ord) {
+      return ord;
+    }
+
+    @Override
+    public SimpleLegacyQuantizedByteVectorValues copy() throws IOException {
+      return new SimpleLegacyQuantizedByteVectorValues(dims, size, in, nodeSize);
+    }
+
+    @Override
+    public IndexInput getSlice() {
+      return in;
+    }
+
+    @Override
+    public ScalarQuantizer getScalarQuantizer() {
+      // Return a simple 7-bit quantizer (bits > 4, so uint8 path is used)
+      return new ScalarQuantizer(0f, 1f, (byte) 7);
+    }
+
+    @Override
+    public float getScoreCorrectionConstant(int ord) throws IOException {
+      return Float.intBitsToFloat(((RandomAccessInput) in).readInt((long) ord * nodeSize + dims));
+    }
+  }
+}

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentScalarQuantizedVectorScorer.java
@@ -38,6 +38,17 @@ import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
 import org.apache.lucene.util.quantization.LegacyQuantizedByteVectorValues;
 import org.apache.lucene.util.quantization.ScalarQuantizer;
 
+/**
+ * MemorySegment-based optimized scorer for Lucene99 scalar quantized vectors. Uses the Panama
+ * Vector API for bulk off-heap scoring when the underlying index input supports direct
+ * MemorySegment access.
+ *
+ * <p>Bulk scoring activation: The bulk path requires the vector data to be accessible as a
+ * contiguous MemorySegment via {@link MemorySegmentAccessInput#segmentSliceOrNull(long, long)}. If
+ * the index spans multiple segments (e.g., files larger than the platform's mmap limit), the slice
+ * may be unavailable and bulk scoring falls back to the default single-vector loop. This fallback
+ * is silent and correct.
+ */
 class Lucene99MemorySegmentScalarQuantizedVectorScorer implements FlatVectorsScorer {
   static final Lucene99MemorySegmentScalarQuantizedVectorScorer INSTANCE =
       new Lucene99MemorySegmentScalarQuantizedVectorScorer();
@@ -90,11 +101,15 @@ class Lucene99MemorySegmentScalarQuantizedVectorScorer implements FlatVectorsSco
     private final ScalarQuantizer quantizer;
     private final float constMultiplier;
     private final MemorySegmentAccessInput input;
-    private final int vectorByteSize;
-    private final int nodeSize;
+    final int vectorByteSize;
+    final int nodeSize;
     private final Scorer scorer;
     private final FloatToFloatFunction scaler;
+    private final boolean isUint8;
+    final boolean isEuclidean;
+    final MemorySegment dataSeg;
     private byte[] scratch;
+    private final int[] scratchIntScores = new int[4];
 
     RandomVectorScorerBase(
         VectorSimilarityFunction similarityFunction,
@@ -108,10 +123,14 @@ class Lucene99MemorySegmentScalarQuantizedVectorScorer implements FlatVectorsSco
       this.vectorByteSize = values.getVectorByteLength();
       this.nodeSize = this.vectorByteSize + Float.BYTES;
 
+      boolean bitsLe4 = this.quantizer.getBits() <= 4;
+      this.isUint8 = !bitsLe4;
+      this.isEuclidean = similarityFunction == VectorSimilarityFunction.EUCLIDEAN;
+
       this.scorer =
           switch (similarityFunction) {
             case EUCLIDEAN -> {
-              if (this.quantizer.getBits() <= 4) {
+              if (bitsLe4) {
                 if (this.vectorByteSize != values.dimension()) {
                   yield this::compressedInt4Euclidean;
                 }
@@ -120,7 +139,7 @@ class Lucene99MemorySegmentScalarQuantizedVectorScorer implements FlatVectorsSco
               yield this::euclidean;
             }
             case DOT_PRODUCT, COSINE, MAXIMUM_INNER_PRODUCT -> {
-              if (this.quantizer.getBits() <= 4) {
+              if (bitsLe4) {
                 if (this.vectorByteSize != values.dimension()) {
                   yield this::compressedInt4DotProduct;
                 }
@@ -136,6 +155,15 @@ class Lucene99MemorySegmentScalarQuantizedVectorScorer implements FlatVectorsSco
             case DOT_PRODUCT, COSINE -> VectorUtil::normalizeToUnitInterval;
             case MAXIMUM_INNER_PRODUCT -> VectorUtil::scaleMaxInnerProductScore;
           };
+
+      // Cache the MemorySegment for bulk operations; fall back to null if unavailable
+      MemorySegment seg = null;
+      try {
+        seg = input.segmentSliceOrNull(0L, input.length());
+      } catch (IOException e) {
+        // ignore, bulkScore will fall back to default loop
+      }
+      this.dataSeg = seg;
 
       checkInvariants();
     }
@@ -182,6 +210,103 @@ class Lucene99MemorySegmentScalarQuantizedVectorScorer implements FlatVectorsSco
       return scaler.apply(scorer.score(node.vector) * constMultiplier + node.offset + queryOffset);
     }
 
+    float bulkScoreBody(int[] nodes, float[] scores, int numNodes, float queryOffset)
+        throws IOException {
+      if (dataSeg == null || !isUint8) {
+        // Fallback to default single-vector scoring loop for non-uint8 formats
+        // (int4 bulk scoring is not implemented) or when MemorySegment is unavailable
+        return super.bulkScore(nodes, scores, numNodes);
+      }
+      if (numNodes > nodes.length || numNodes > scores.length) {
+        throw new IllegalArgumentException(
+            "numNodes ("
+                + numNodes
+                + ") exceeds nodes.length ("
+                + nodes.length
+                + ") or scores.length ("
+                + scores.length
+                + ")");
+      }
+      int i = 0;
+      float maxScore = Float.NEGATIVE_INFINITY;
+      final int limit = numNodes & ~3;
+      for (; i < limit; i += 4) {
+        checkOrdinal(nodes[i]);
+        checkOrdinal(nodes[i + 1]);
+        checkOrdinal(nodes[i + 2]);
+        checkOrdinal(nodes[i + 3]);
+        long addr1 = (long) nodes[i] * nodeSize;
+        long addr2 = (long) nodes[i + 1] * nodeSize;
+        long addr3 = (long) nodes[i + 2] * nodeSize;
+        long addr4 = (long) nodes[i + 3] * nodeSize;
+        // Read offsets directly from dataSeg (avoids input.readInt overhead)
+        float off1 = Float.intBitsToFloat(dataSeg.get(INT_UNALIGNED_LE, addr1 + vectorByteSize));
+        float off2 = Float.intBitsToFloat(dataSeg.get(INT_UNALIGNED_LE, addr2 + vectorByteSize));
+        float off3 = Float.intBitsToFloat(dataSeg.get(INT_UNALIGNED_LE, addr3 + vectorByteSize));
+        float off4 = Float.intBitsToFloat(dataSeg.get(INT_UNALIGNED_LE, addr4 + vectorByteSize));
+        bulkVectorOp(addr1, addr2, addr3, addr4, scratchIntScores);
+        scores[i] = scaler.apply(scratchIntScores[0] * constMultiplier + off1 + queryOffset);
+        maxScore = Math.max(maxScore, scores[i]);
+        scores[i + 1] = scaler.apply(scratchIntScores[1] * constMultiplier + off2 + queryOffset);
+        maxScore = Math.max(maxScore, scores[i + 1]);
+        scores[i + 2] = scaler.apply(scratchIntScores[2] * constMultiplier + off3 + queryOffset);
+        maxScore = Math.max(maxScore, scores[i + 2]);
+        scores[i + 3] = scaler.apply(scratchIntScores[3] * constMultiplier + off4 + queryOffset);
+        maxScore = Math.max(maxScore, scores[i + 3]);
+      }
+      int remaining = numNodes - i;
+      if (remaining > 0) {
+        // Tail handling: process 1-3 remaining nodes. Unused slots are padded by
+        // aliasing to addr1, so bulkVectorOp computes a dummy score that is ignored.
+        checkOrdinal(nodes[i]);
+        long addr1 = (long) nodes[i] * nodeSize;
+        long addr2 = addr1;
+        long addr3 = addr1;
+        if (remaining > 1) {
+          checkOrdinal(nodes[i + 1]);
+          addr2 = (long) nodes[i + 1] * nodeSize;
+        }
+        if (remaining > 2) {
+          checkOrdinal(nodes[i + 2]);
+          addr3 = (long) nodes[i + 2] * nodeSize;
+        }
+        // Read offsets directly from dataSeg
+        float off1 = Float.intBitsToFloat(dataSeg.get(INT_UNALIGNED_LE, addr1 + vectorByteSize));
+        float off2 = Float.intBitsToFloat(dataSeg.get(INT_UNALIGNED_LE, addr2 + vectorByteSize));
+        float off3 = Float.intBitsToFloat(dataSeg.get(INT_UNALIGNED_LE, addr3 + vectorByteSize));
+        bulkVectorOp(addr1, addr2, addr3, addr1, scratchIntScores);
+        scores[i] = scaler.apply(scratchIntScores[0] * constMultiplier + off1 + queryOffset);
+        maxScore = Math.max(maxScore, scores[i]);
+        if (remaining > 1) {
+          scores[i + 1] = scaler.apply(scratchIntScores[1] * constMultiplier + off2 + queryOffset);
+          maxScore = Math.max(maxScore, scores[i + 1]);
+        }
+        if (remaining > 2) {
+          scores[i + 2] = scaler.apply(scratchIntScores[2] * constMultiplier + off3 + queryOffset);
+          maxScore = Math.max(maxScore, scores[i + 2]);
+        }
+      }
+      return maxScore;
+    }
+
+    void bulkVectorOp(long d1, long d2, long d3, long d4, int[] scores) {
+      MemorySegment s1 = dataSeg.asSlice(d1, vectorByteSize);
+      MemorySegment s2 = dataSeg.asSlice(d2, vectorByteSize);
+      MemorySegment s3 = dataSeg.asSlice(d3, vectorByteSize);
+      MemorySegment s4 = dataSeg.asSlice(d4, vectorByteSize);
+      if (isEuclidean) {
+        scores[0] = euclidean(s1);
+        scores[1] = euclidean(s2);
+        scores[2] = euclidean(s3);
+        scores[3] = euclidean(s4);
+      } else {
+        scores[0] = dotProduct(s1);
+        scores[1] = dotProduct(s2);
+        scores[2] = dotProduct(s3);
+        scores[3] = dotProduct(s4);
+      }
+    }
+
     abstract int euclidean(MemorySegment doc);
 
     abstract int int4Euclidean(MemorySegment doc);
@@ -222,6 +347,11 @@ class Lucene99MemorySegmentScalarQuantizedVectorScorer implements FlatVectorsSco
     }
 
     @Override
+    public float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+      return bulkScoreBody(nodes, scores, numNodes, queryOffset);
+    }
+
+    @Override
     int euclidean(MemorySegment doc) {
       return PanamaVectorUtilSupport.uint8SquareDistance(targetBytes, doc);
     }
@@ -252,6 +382,11 @@ class Lucene99MemorySegmentScalarQuantizedVectorScorer implements FlatVectorsSco
     }
   }
 
+  /**
+   * Native implementation of RandomVectorScorer. Uses JNI for single-vector ops but inherits bulk
+   * scoring from the parent (which uses Panama Vector API). Native bulk kernels are not yet
+   * implemented.
+   */
   private static class NativeRandomVectorScorerImpl extends RandomVectorScorerImpl {
     NativeRandomVectorScorerImpl(
         VectorSimilarityFunction similarityFunction,
@@ -338,6 +473,11 @@ class Lucene99MemorySegmentScalarQuantizedVectorScorer implements FlatVectorsSco
     }
 
     @Override
+    public float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+      return bulkScoreBody(nodes, scores, numNodes, queryOffset);
+    }
+
+    @Override
     int euclidean(MemorySegment doc) {
       return PanamaVectorUtilSupport.uint8SquareDistance(query, doc);
     }
@@ -368,6 +508,11 @@ class Lucene99MemorySegmentScalarQuantizedVectorScorer implements FlatVectorsSco
     }
   }
 
+  /**
+   * Native implementation of UpdateableRandomVectorScorer. Uses JNI for single-vector ops but
+   * inherits bulk scoring from the parent (which uses Panama Vector API). Native bulk kernels are
+   * not yet implemented.
+   */
   private static class NativeUpdateableRandomVectorScorerImpl
       extends UpdateableRandomVectorScorerImpl {
 

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/MemorySegmentBulkVectorOps.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/MemorySegmentBulkVectorOps.java
@@ -27,25 +27,25 @@ import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorShape;
 import jdk.incubator.vector.VectorSpecies;
 
-/** Implementations of bulk vector comparison operations. Currently only supports float32. */
-public final class MemorySegmentBulkVectorOps {
+/** Implementations of bulk float32 vector comparison operations. */
+final class MemorySegmentBulkVectorOps {
 
   static final VectorSpecies<Float> FLOAT_SPECIES =
       VectorSpecies.of(float.class, VectorShape.forBitSize(PREFERRED_VECTOR_BITSIZE));
   static final ByteOrder LE = ByteOrder.LITTLE_ENDIAN;
   static final ValueLayout.OfFloat LAYOUT_LE_FLOAT = ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(LE);
 
-  public static final DotProduct DOT_INSTANCE = new DotProduct();
-  public static final Cosine COS_INSTANCE = new Cosine();
-  public static final SqrDistance SQR_INSTANCE = new SqrDistance();
+  static final DotProduct DOT_INSTANCE = new DotProduct();
+  static final Cosine COS_INSTANCE = new Cosine();
+  static final SqrDistance SQR_INSTANCE = new SqrDistance();
 
   private MemorySegmentBulkVectorOps() {}
 
-  public static final class DotProduct {
+  static final class DotProduct {
 
     private DotProduct() {}
 
-    public void dotProductBulk(
+    void dotProductBulk(
         MemorySegment dataSeg,
         float[] scores,
         float[] q,
@@ -57,7 +57,7 @@ public final class MemorySegmentBulkVectorOps {
       dotProductBulkImpl(dataSeg, scores, q, -1L, d1, d2, d3, d4, elementCount);
     }
 
-    public void dotProductBulk(
+    void dotProductBulk(
         MemorySegment seg,
         float[] scores,
         long q,
@@ -149,11 +149,11 @@ public final class MemorySegmentBulkVectorOps {
 
   // -- cosine
 
-  public static final class Cosine {
+  static final class Cosine {
 
     private Cosine() {}
 
-    public void cosineBulk(
+    void cosineBulk(
         MemorySegment dataSeg,
         float[] scores,
         float[] q,
@@ -165,7 +165,7 @@ public final class MemorySegmentBulkVectorOps {
       cosineBulkImpl(dataSeg, scores, q, -1L, d1, d2, d3, d4, elementCount);
     }
 
-    public void cosineBulk(
+    void cosineBulk(
         MemorySegment seg,
         float[] scores,
         long q,
@@ -292,11 +292,11 @@ public final class MemorySegmentBulkVectorOps {
 
   // -- square distance
 
-  public static final class SqrDistance {
+  static final class SqrDistance {
 
     private SqrDistance() {}
 
-    public void sqrDistanceBulk(
+    void sqrDistanceBulk(
         MemorySegment dataSeg,
         float[] scores,
         float[] q,
@@ -308,7 +308,7 @@ public final class MemorySegmentBulkVectorOps {
       sqrDistanceBulkImpl(dataSeg, scores, q, -1L, d1, d2, d3, d4, elementCount);
     }
 
-    public void sqrDistanceBulk(
+    void sqrDistanceBulk(
         MemorySegment seg,
         float[] scores,
         long q,


### PR DESCRIPTION
add off-heap bulk scoring support for uint8 quantized vectors (via MemorySegment direct access in the Lucene99 scorer). processes neighbor batches from HNSW with direct offset reads and falls back for int4 / non-contiguous cases.

benchmarks (amd ryzen 7 7800x3d, avx-512):
- float32 bulk: ~1.5x speedup
- uint8 bulk (clean icache): ~5-7% slower
- uint8 bulk (polluted icache): ~2x faster

related: https://github.com/apache/lucene/issues/15155 #15257 #14980 
also I tried this for int4 bulk but saw ~2.3x slower on avx-512 due to nibble unpacking overhead..