### PR TITLE
Add advisory QueryReadHint and wire QueryAccessHint.POINT into HNSW prefetch

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/PrefetchableFlatVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/PrefetchableFlatVectorScorer.java
@@ -50,6 +50,20 @@ public class PrefetchableFlatVectorScorer implements FlatVectorsScorer {
     this.flatVectorsScorer = flatVectorsScorer;
   }
 
+  /**
+   * Wrap {@code base} so {@link RandomVectorScorer#bulkScore} prefetches the batch's vectors before
+   * scoring, when {@code base} exposes its {@link KnnVectorValues}; otherwise return it unchanged.
+   * The prefetch is purely advisory: it never changes scores or doc mapping, and is itself a no-op
+   * when the values do not override {@link KnnVectorValues#prefetch} or the pages are resident.
+   *
+   * @lucene.experimental
+   */
+  public static RandomVectorScorer wrapWithPrefetch(RandomVectorScorer base) {
+    return base instanceof RandomVectorScorer.AbstractRandomVectorScorer arvs
+        ? new PrefetchableRandomVectorScorer(arvs)
+        : base;
+  }
+
   @Override
   public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
       VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues)

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/OffHeapScalarQuantizedVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/OffHeapScalarQuantizedVectorValues.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.codecs.lucene90.IndexedDISI;
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -160,6 +161,13 @@ public abstract class OffHeapScalarQuantizedVectorValues extends QuantizedByteVe
   @Override
   public OptimizedScalarQuantizer getQuantizer() {
     return quantizer;
+  }
+
+  @Override
+  public void prefetch(final int[] ordsToPrefetch, int numOrds) throws IOException {
+    // Lets per-query consumers (e.g. Lucene99HnswVectorsReader honouring QueryAccessHint.POINT)
+    // issue a prefetch for each upcoming quantised vector record before bulkScore reads it.
+    HasIndexSlice.prefetchOrdinals(slice, byteSize, ordsToPrefetch, numOrds);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/HasIndexSlice.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/HasIndexSlice.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.codecs.lucene95;
 
+import java.io.IOException;
 import org.apache.lucene.store.IndexInput;
 
 /**
@@ -26,4 +27,31 @@ public interface HasIndexSlice {
 
   /** Returns an IndexInput from which to read this instance's values, or null if not available. */
   IndexInput getSlice();
+
+  /**
+   * Shared helper for off-heap vector value implementations that store fixed-size records on a
+   * slice: issue a read-ahead {@link IndexInput#prefetch} for each of the given vector ordinals.
+   *
+   * <p>Zero or one ordinal is intentionally left to fault in on the immediately-following read,
+   * since prefetching a record that is about to be read offers no overlap.
+   *
+   * @param slice the slice the records live on (one record every {@code byteSize} bytes); a {@code
+   *     null} slice (e.g. an empty values instance) is tolerated and prefetches nothing
+   * @param byteSize the on-disk size of one record
+   * @param ordsToPrefetch ordinals to prefetch (only the first {@code numOrds} are used)
+   * @param numOrds number of valid entries in {@code ordsToPrefetch}
+   */
+  static void prefetchOrdinals(IndexInput slice, int byteSize, int[] ordsToPrefetch, int numOrds)
+      throws IOException {
+    // n <= 1 also covers the empty (n == 0) and null-ordinals cases; nothing is prefetched when
+    // there is no slice or at most one record (which faults in on the immediately-following read).
+    final int n = (ordsToPrefetch == null) ? 0 : Math.min(numOrds, ordsToPrefetch.length);
+    if (slice == null || n <= 1) {
+      return;
+    }
+    for (int i = 0; i < n; i++) {
+      final long offset = (long) ordsToPrefetch[i] * byteSize;
+      slice.prefetch(offset, byteSize);
+    }
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapByteVectorValues.java
@@ -83,19 +83,7 @@ public abstract class OffHeapByteVectorValues extends ByteVectorValues implement
 
   @Override
   public void prefetch(final int[] ordsToPrefetch, int numOrds) throws IOException {
-    if (ordsToPrefetch == null) {
-      return;
-    }
-    int finalNumOrds = Math.min(numOrds, ordsToPrefetch.length);
-    if (finalNumOrds <= 1) {
-      return;
-    }
-
-    // 1. calculate offset and prefetch immediately
-    for (int i = 0; i < finalNumOrds; i++) {
-      long offset = (long) ordsToPrefetch[i] * byteSize;
-      slice.prefetch(offset, byteSize);
-    }
+    HasIndexSlice.prefetchOrdinals(slice, byteSize, ordsToPrefetch, numOrds);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloatVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloatVectorValues.java
@@ -87,20 +87,7 @@ public abstract class OffHeapFloatVectorValues extends FloatVectorValues impleme
 
   @Override
   public void prefetch(final int[] ordsToPrefetch, int numOrds) throws IOException {
-    if (ordsToPrefetch == null) {
-      return;
-    }
-
-    int finalNumOrds = Math.min(numOrds, ordsToPrefetch.length);
-    if (finalNumOrds <= 1) {
-      return;
-    }
-
-    // 1. calculate offset and prefetch immediately
-    for (int i = 0; i < finalNumOrds; i++) {
-      long offset = (long) ordsToPrefetch[i] * byteSize;
-      slice.prefetch(offset, byteSize);
-    }
+    HasIndexSlice.prefetchOrdinals(slice, byteSize, ordsToPrefetch, numOrds);
   }
 
   public static OffHeapFloatVectorValues load(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
@@ -28,6 +28,7 @@ import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.HnswGraphProvider;
+import org.apache.lucene.codecs.hnsw.PrefetchableFlatVectorScorer;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.FieldInfo;
@@ -41,6 +42,7 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.internal.hppc.IntObjectHashMap;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.QueryAccessHint;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataAccessHint;
 import org.apache.lucene.store.DataInput;
@@ -331,7 +333,15 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
     if (fieldEntry.size() == 0 || knnCollector.k() == 0) {
       return;
     }
-    final RandomVectorScorer scorer = scorerSupplier.get();
+    final RandomVectorScorer rawScorer = scorerSupplier.get();
+    // QueryAccessHint.POINT consumer: when the collector advertises POINT, wrap the scorer so each
+    // batch of neighbor vectors is prefetched before bulkScore() reads them (wrapWithPrefetch is a
+    // no-op when prefetch is unsupported or the pages are resident). Absent the hint nothing wraps,
+    // so default behaviour is unchanged.
+    final RandomVectorScorer scorer =
+        knnCollector.readHints().contains(QueryAccessHint.POINT)
+            ? PrefetchableFlatVectorScorer.wrapWithPrefetch(rawScorer)
+            : rawScorer;
     final KnnCollector collector =
         new OrdinalTranslatedKnnCollector(knnCollector, scorer::ordToDoc);
     // Take into account if quantized? E.g. some scorer cost?

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.lucene90.IndexedDISI;
@@ -60,8 +61,22 @@ abstract class AbstractKnnVectorQuery extends Query {
   protected final int k;
   protected final Query filter;
   protected final KnnSearchStrategy searchStrategy;
+  // Per-query read hints carried by the query itself (default empty). Genuinely per-query: unlike
+  // IndexSearcher#setReadHints these ride on the immutable query, so a shared searcher can run
+  // hinted and un-hinted queries at once. Consulted at rewrite time, where only the query and the
+  // searcher are available (the KNN I/O happens during rewrite, before any Weight/ScorerSupplier).
+  protected final Set<QueryReadHint> readHints;
 
   AbstractKnnVectorQuery(String field, int k, Query filter, KnnSearchStrategy searchStrategy) {
+    this(field, k, filter, searchStrategy, Set.of());
+  }
+
+  AbstractKnnVectorQuery(
+      String field,
+      int k,
+      Query filter,
+      KnnSearchStrategy searchStrategy,
+      Set<QueryReadHint> readHints) {
     this.field = Objects.requireNonNull(field, "field");
     this.k = k;
     if (k < 1) {
@@ -69,6 +84,7 @@ abstract class AbstractKnnVectorQuery extends Query {
     }
     this.filter = filter;
     this.searchStrategy = searchStrategy;
+    this.readHints = Set.copyOf(Objects.requireNonNull(readHints, "readHints"));
   }
 
   @Override
@@ -245,7 +261,7 @@ abstract class AbstractKnnVectorQuery extends Query {
   }
 
   protected KnnCollectorManager getKnnCollectorManager(int k, IndexSearcher searcher) {
-    return new TopKnnCollectorManager(k, searcher);
+    return new TopKnnCollectorManager(k, searcher, readHints);
   }
 
   static class OptimisticKnnCollectorManager implements KnnCollectorManager {
@@ -432,12 +448,17 @@ abstract class AbstractKnnVectorQuery extends Query {
     return k == that.k
         && Objects.equals(field, that.field)
         && Objects.equals(filter, that.filter)
-        && Objects.equals(searchStrategy, that.searchStrategy);
+        && Objects.equals(searchStrategy, that.searchStrategy)
+        && Objects.equals(readHints, that.readHints);
   }
 
+  // readHints is advisory (I/O strategy only, never affects results) but is intentionally part of
+  // query identity, consistent with searchStrategy here and with IndexOrDocValuesQuery treating its
+  // execution-strategy field as identity: a hinted and an un-hinted query produce different
+  // KnnCollectorManagers, so they are distinct cache keys.
   @Override
   public int hashCode() {
-    return Objects.hash(field, k, filter);
+    return Objects.hash(field, k, filter, searchStrategy, readHints);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractVectorSimilarityQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractVectorSimilarityQuery.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.QueryTimeout;
@@ -56,6 +57,9 @@ abstract class AbstractVectorSimilarityQuery extends Query {
   protected final float decay;
   protected final Query filter;
   protected final KnnSearchStrategy searchStrategy;
+  // Per-query read hints carried by the query itself (default empty); override the searcher's when
+  // non-empty. See KnnFloatVectorQuery#withReadHints for the rationale.
+  protected final Set<QueryReadHint> readHints;
 
   /**
    * Search for all (approximate) vectors above a similarity threshold using {@link
@@ -92,6 +96,16 @@ abstract class AbstractVectorSimilarityQuery extends Query {
       float decay,
       Query filter,
       KnnSearchStrategy searchStrategy) {
+    this(field, resultSimilarity, decay, filter, searchStrategy, Set.of());
+  }
+
+  AbstractVectorSimilarityQuery(
+      String field,
+      float resultSimilarity,
+      float decay,
+      Query filter,
+      KnnSearchStrategy searchStrategy,
+      Set<QueryReadHint> readHints) {
     if (Float.isNaN(resultSimilarity)) {
       throw new IllegalArgumentException(
           "resultSimilarity must have a valid value; got " + resultSimilarity);
@@ -110,6 +124,7 @@ abstract class AbstractVectorSimilarityQuery extends Query {
     this.decay = decay;
     this.filter = filter;
     this.searchStrategy = searchStrategy == null ? DEFAULT_STRATEGY : searchStrategy;
+    this.readHints = Set.copyOf(Objects.requireNonNull(readHints, "readHints"));
   }
 
   /**
@@ -152,8 +167,16 @@ abstract class AbstractVectorSimilarityQuery extends Query {
               : searcher.createWeight(searcher.rewrite(filter), ScoreMode.COMPLETE_NO_SCORES, 1);
 
       final QueryTimeout queryTimeout = searcher.getTimeout();
+      // Surface the effective read hints (the per-query override when set, otherwise the
+      // searcher's) on the approximate-search collectors so codec readers can consult
+      // KnnCollector#readHints(). The exact-search fallback paths below build their own
+      // VectorScorer via createVectorScorer and ignore hints, so they are unaffected.
       final TimeLimitingKnnCollectorManager timeLimitingKnnCollectorManager =
-          new TimeLimitingKnnCollectorManager(getKnnCollectorManager(), queryTimeout);
+          new TimeLimitingKnnCollectorManager(
+              KnnCollectorManager.withReadHints(
+                  getKnnCollectorManager(),
+                  QueryReadHint.resolve(readHints, searcher.getReadHints())),
+              queryTimeout);
 
       @Override
       public Explanation explain(LeafReaderContext context, int doc) throws IOException {
@@ -271,12 +294,13 @@ abstract class AbstractVectorSimilarityQuery extends Query {
             == 0
         && Float.compare(((AbstractVectorSimilarityQuery) o).decay, decay) == 0
         && Objects.equals(filter, ((AbstractVectorSimilarityQuery) o).filter)
-        && Objects.equals(searchStrategy, ((AbstractVectorSimilarityQuery) o).searchStrategy);
+        && Objects.equals(searchStrategy, ((AbstractVectorSimilarityQuery) o).searchStrategy)
+        && Objects.equals(readHints, ((AbstractVectorSimilarityQuery) o).readHints);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(field, resultSimilarity, decay, filter, searchStrategy);
+    return Objects.hash(field, resultSimilarity, decay, filter, searchStrategy, readHints);
   }
 
   private static class VectorSimilarityScorerSupplier extends ScorerSupplier {

--- a/lucene/core/src/java/org/apache/lucene/search/ByteVectorSimilarityQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ByteVectorSimilarityQuery.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.LeafReaderContext;
@@ -61,6 +62,30 @@ public class ByteVectorSimilarityQuery extends AbstractVectorSimilarityQuery {
       KnnSearchStrategy searchStrategy) {
     super(field, resultSimilarity, decay, filter, searchStrategy);
     this.target = Objects.requireNonNull(target, "target");
+  }
+
+  private ByteVectorSimilarityQuery(
+      String field,
+      byte[] target,
+      float resultSimilarity,
+      float decay,
+      Query filter,
+      KnnSearchStrategy searchStrategy,
+      Set<QueryReadHint> readHints) {
+    super(field, resultSimilarity, decay, filter, searchStrategy, readHints);
+    this.target = Objects.requireNonNull(target, "target");
+  }
+
+  /**
+   * Return a copy of this query that advertises the given {@link QueryReadHint}s. Unlike {@link
+   * IndexSearcher#setReadHints} (searcher-wide), these ride on the query itself and override the
+   * searcher's, so one shared {@link IndexSearcher} can run hinted and un-hinted queries at once.
+   *
+   * @lucene.experimental
+   */
+  public ByteVectorSimilarityQuery withReadHints(Set<QueryReadHint> readHints) {
+    return new ByteVectorSimilarityQuery(
+        field, target, resultSimilarity, decay, filter, searchStrategy, readHints);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/FloatVectorSimilarityQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FloatVectorSimilarityQuery.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.LeafReaderContext;
@@ -62,6 +63,30 @@ public class FloatVectorSimilarityQuery extends AbstractVectorSimilarityQuery {
       KnnSearchStrategy searchStrategy) {
     super(field, resultSimilarity, decay, filter, searchStrategy);
     this.target = VectorUtil.checkFinite(Objects.requireNonNull(target, "target"));
+  }
+
+  private FloatVectorSimilarityQuery(
+      String field,
+      float[] target,
+      float resultSimilarity,
+      float decay,
+      Query filter,
+      KnnSearchStrategy searchStrategy,
+      Set<QueryReadHint> readHints) {
+    super(field, resultSimilarity, decay, filter, searchStrategy, readHints);
+    this.target = VectorUtil.checkFinite(Objects.requireNonNull(target, "target"));
+  }
+
+  /**
+   * Return a copy of this query that advertises the given {@link QueryReadHint}s. Unlike {@link
+   * IndexSearcher#setReadHints} (searcher-wide), these ride on the query itself and override the
+   * searcher's, so one shared {@link IndexSearcher} can run hinted and un-hinted queries at once.
+   *
+   * @lucene.experimental
+   */
+  public FloatVectorSimilarityQuery withReadHints(Set<QueryReadHint> readHints) {
+    return new FloatVectorSimilarityQuery(
+        field, target, resultSimilarity, decay, filter, searchStrategy, readHints);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -124,6 +124,7 @@ public class IndexSearcher {
 
   private QueryCache queryCache = DEFAULT_QUERY_CACHE;
   private QueryCachingPolicy queryCachingPolicy = DEFAULT_CACHING_POLICY;
+  private volatile Set<QueryReadHint> readHints = Set.of();
 
   /**
    * Expert: returns a default Similarity instance. In general, this method is only called to
@@ -307,6 +308,37 @@ public class IndexSearcher {
    */
   public QueryCachingPolicy getQueryCachingPolicy() {
     return queryCachingPolicy;
+  }
+
+  /**
+   * Set advisory read hints that this searcher attaches to the KNN collectors it creates, so codec
+   * readers can consult them when wiring up per-query iteration. This is the query-time companion
+   * to {@link org.apache.lucene.store.IOContext.FileOpenHint open-time file hints}. The hints reach
+   * KNN readers via {@link org.apache.lucene.search.knn.TopKnnCollectorManager} -&gt; {@link
+   * KnnCollector#readHints()}, which the HNSW vectors reader consults to decide whether to
+   * prefetch. Hints never affect correctness.
+   *
+   * <p><b>Scope:</b> hints are stored on this {@code IndexSearcher} and apply to <em>every</em>
+   * search through it until changed -- they are searcher-scoped, not per-{@link #search} call, and
+   * are visible to concurrent searches on a shared instance. For single-query hints use {@link
+   * KnnFloatVectorQuery#withReadHints} or a dedicated searcher. Changes take effect for collectors
+   * created after the call; in-flight scorers are unaffected. An empty set restores the default of
+   * no hints.
+   *
+   * @lucene.experimental
+   */
+  public void setReadHints(Set<QueryReadHint> hints) {
+    this.readHints = Set.copyOf(Objects.requireNonNull(hints));
+  }
+
+  /**
+   * Return the read hints attached to this searcher, or an empty set if none have been set via
+   * {@link #setReadHints(Set)}.
+   *
+   * @lucene.experimental
+   */
+  public Set<QueryReadHint> getReadHints() {
+    return readHints;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnByteVectorQuery.java
@@ -21,6 +21,7 @@ import static org.apache.lucene.search.knn.KnnSearchStrategy.Hnsw.DEFAULT;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.index.ByteVectorValues;
@@ -94,6 +95,28 @@ public class KnnByteVectorQuery extends AbstractKnnVectorQuery {
       String field, byte[] target, int k, Query filter, KnnSearchStrategy searchStrategy) {
     super(field, k, filter, searchStrategy);
     this.target = Objects.requireNonNull(target, "target");
+  }
+
+  private KnnByteVectorQuery(
+      String field,
+      byte[] target,
+      int k,
+      Query filter,
+      KnnSearchStrategy searchStrategy,
+      Set<QueryReadHint> readHints) {
+    super(field, k, filter, searchStrategy, readHints);
+    this.target = Objects.requireNonNull(target, "target");
+  }
+
+  /**
+   * Return a copy of this query that advertises the given {@link QueryReadHint}s. Unlike {@link
+   * IndexSearcher#setReadHints} (searcher-wide), these ride on the query itself and override the
+   * searcher's, so one shared {@link IndexSearcher} can run hinted and un-hinted queries at once.
+   *
+   * @lucene.experimental
+   */
+  public KnnByteVectorQuery withReadHints(Set<QueryReadHint> readHints) {
+    return new KnnByteVectorQuery(field, target, k, filter, searchStrategy, readHints);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/KnnCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnCollector.java
@@ -17,6 +17,7 @@
 
 package org.apache.lucene.search;
 
+import java.util.Set;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 
 /**
@@ -94,6 +95,38 @@ public interface KnnCollector {
   KnnSearchStrategy getSearchStrategy();
 
   /**
+   * Per-query read hints attached to this collector. Default is an empty set. Vector readers may
+   * consult these hints to choose an I/O strategy (e.g. whether to issue extra prefetch calls).
+   * Hints never affect correctness.
+   *
+   * @lucene.experimental
+   */
+  default Set<QueryReadHint> readHints() {
+    return Set.of();
+  }
+
+  /**
+   * Wrap {@code collector} so {@link #readHints()} returns a defensive, immutable copy of {@code
+   * readHints}, delegating everything else. Returns {@code collector} unchanged (allocating
+   * nothing) when it is {@code null}, or when {@code readHints} is {@code null} or empty, so the
+   * no-hint path is free.
+   *
+   * @lucene.experimental
+   */
+  static KnnCollector withReadHints(KnnCollector collector, Set<QueryReadHint> readHints) {
+    if (collector == null || readHints == null || readHints.isEmpty()) {
+      return collector;
+    }
+    final Set<QueryReadHint> copy = Set.copyOf(readHints);
+    return new Decorator(collector) {
+      @Override
+      public Set<QueryReadHint> readHints() {
+        return copy;
+      }
+    };
+  }
+
+  /**
    * KnnCollector.Decorator is the base class for decorators of KnnCollector objects, which extend
    * the object with new behaviors.
    *
@@ -149,6 +182,11 @@ public interface KnnCollector {
     @Override
     public KnnSearchStrategy getSearchStrategy() {
       return collector.getSearchStrategy();
+    }
+
+    @Override
+    public Set<QueryReadHint> readHints() {
+      return collector.readHints();
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnFloatVectorQuery.java
@@ -21,6 +21,7 @@ import static org.apache.lucene.search.knn.KnnSearchStrategy.Hnsw.DEFAULT;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.FieldInfo;
@@ -95,6 +96,28 @@ public class KnnFloatVectorQuery extends AbstractKnnVectorQuery {
       String field, float[] target, int k, Query filter, KnnSearchStrategy searchStrategy) {
     super(field, k, filter, searchStrategy);
     this.target = VectorUtil.checkFinite(Objects.requireNonNull(target, "target"));
+  }
+
+  private KnnFloatVectorQuery(
+      String field,
+      float[] target,
+      int k,
+      Query filter,
+      KnnSearchStrategy searchStrategy,
+      Set<QueryReadHint> readHints) {
+    super(field, k, filter, searchStrategy, readHints);
+    this.target = VectorUtil.checkFinite(Objects.requireNonNull(target, "target"));
+  }
+
+  /**
+   * Return a copy of this query that advertises the given {@link QueryReadHint}s. Unlike {@link
+   * IndexSearcher#setReadHints} (searcher-wide), these ride on the query itself and override the
+   * searcher's, so one shared {@link IndexSearcher} can run hinted and un-hinted queries at once.
+   *
+   * @lucene.experimental
+   */
+  public KnnFloatVectorQuery withReadHints(Set<QueryReadHint> readHints) {
+    return new KnnFloatVectorQuery(field, target, k, filter, searchStrategy, readHints);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/PatienceKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PatienceKnnVectorQuery.java
@@ -130,6 +130,9 @@ public class PatienceKnnVectorQuery extends AbstractKnnVectorQuery {
       KnnSearchStrategy searchStrategy,
       double saturationThreshold,
       int patience) {
+    // The wrapper carries no independent read-hint state: getKnnCollectorManager() delegates to the
+    // inner query, which owns the hints (see #withReadHints on the concrete KNN queries). Passing
+    // them up to super too would double-count them in equals/hashCode (the delegate already does).
     super(field, k, filter, searchStrategy);
     this.delegate = knnQuery;
     this.saturationThreshold = saturationThreshold;

--- a/lucene/core/src/java/org/apache/lucene/search/QueryAccessHint.java
+++ b/lucene/core/src/java/org/apache/lucene/search/QueryAccessHint.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+/**
+ * Hint describing the access pattern of a query, intended to be consulted by readers when wiring up
+ * per-query iteration.
+ *
+ * <p>This intentionally mirrors {@link org.apache.lucene.store.DataAccessHint} in spirit: it
+ * describes <em>what is likely to happen</em>, not what mechanism should be used to satisfy it.
+ * Readers may consult this hint to choose between, e.g., aggressive prefetch vs. cache-friendly
+ * traversal, but they are not required to.
+ *
+ * @lucene.experimental
+ */
+public enum QueryAccessHint implements QueryReadHint {
+  /**
+   * The query expects to perform a small number of accesses and is latency-sensitive. Readers may
+   * favor strategies that reduce per-access latency, such as prefetching the blocks a single
+   * traversal is about to touch.
+   *
+   * <p>This is advisory and best-effort: a reader with no cheaper-latency strategy simply ignores
+   * it. Among the built-in formats it is consumed by {@link
+   * org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader} on the HNSW graph-search path for
+   * full-precision float32, byte, and scalar-quantised vectors (each batch of neighbour vectors is
+   * prefetched before scoring). Other vector encodings — e.g. bit vectors, or off-heap values whose
+   * representation does not override {@code prefetch} — currently ignore it, so setting POINT over
+   * those fields is a silent no-op rather than an error.
+   */
+  POINT
+}

--- a/lucene/core/src/java/org/apache/lucene/search/QueryReadHint.java
+++ b/lucene/core/src/java/org/apache/lucene/search/QueryReadHint.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.util.Set;
+
+/**
+ * Marker interface for hints a query or collector can attach to influence how per-query reader
+ * access is performed.
+ *
+ * <p>Hints describe the access pattern of the query itself (for example, whether a query expects to
+ * issue many accesses or just a few). They are deliberately decoupled from any specific I/O
+ * implementation detail: readers are free to ignore them, or to combine them with their own
+ * knowledge of segment layout to decide on a strategy (prefetch depth, cache budget, etc.).
+ *
+ * <p>Hints never affect correctness; they only influence I/O strategy.
+ *
+ * <p>This is the query-time analogue of {@link org.apache.lucene.store.IOContext.FileOpenHint},
+ * which describes how a file is opened. {@code QueryReadHint} instead describes how a query intends
+ * to use already-open readers. It is carried from {@link IndexSearcher#getReadHints()} (or a
+ * per-query override on a supporting query) down to {@link KnnCollector#readHints()}, which codec
+ * readers such as the HNSW vectors reader consult, rather than from {@link
+ * org.apache.lucene.store.Directory#openInput}.
+ *
+ * <p>Implementations MUST be immutable and safe to share across threads. Enums are the expected
+ * shape; ad-hoc bag-like implementations are discouraged.
+ *
+ * @lucene.experimental
+ */
+public interface QueryReadHint {
+
+  /**
+   * Resolve the effective read hints for a search. A non-empty per-query hint set takes precedence
+   * over (overrides) the searcher-wide hints; an empty or {@code null} per-query set inherits the
+   * searcher's. This centralizes the one precedence rule shared by {@link
+   * org.apache.lucene.search.knn.TopKnnCollectorManager} and the vector-similarity queries so it
+   * cannot drift between call sites.
+   *
+   * @param queryHints hints carried by the query itself (may be {@code null} or empty)
+   * @param searcherHints hints set on the {@link IndexSearcher} (may be {@code null} or empty)
+   * @return the effective, never-{@code null} hint set
+   * @lucene.experimental
+   */
+  static Set<QueryReadHint> resolve(
+      Set<QueryReadHint> queryHints, Set<QueryReadHint> searcherHints) {
+    if (queryHints == null || queryHints.isEmpty()) {
+      return searcherHints == null ? Set.of() : searcherHints;
+    }
+    return queryHints;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/SeededKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SeededKnnVectorQuery.java
@@ -76,6 +76,9 @@ public class SeededKnnVectorQuery extends AbstractKnnVectorQuery {
       int k,
       Query filter,
       KnnSearchStrategy searchStrategy) {
+    // The wrapper carries no independent read-hint state: getKnnCollectorManager() delegates to the
+    // inner query, which owns the hints (see #withReadHints on the concrete KNN queries). Passing
+    // them up to super too would double-count them in equals/hashCode (the delegate already does).
     super(field, k, filter, searchStrategy);
     this.delegate = knnQuery;
     this.seed = Objects.requireNonNull(seed);

--- a/lucene/core/src/java/org/apache/lucene/search/knn/KnnCollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/knn/KnnCollectorManager.java
@@ -18,8 +18,10 @@
 package org.apache.lucene.search.knn;
 
 import java.io.IOException;
+import java.util.Set;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.QueryReadHint;
 
 /**
  * KnnCollectorManager responsible for creating {@link KnnCollector} instances. Useful to create
@@ -58,5 +60,43 @@ public interface KnnCollectorManager {
 
   default boolean isOptimistic() {
     return false;
+  }
+
+  /**
+   * Wrap {@code delegate} so the collectors it produces advertise {@code readHints} via {@link
+   * KnnCollector#readHints()}, delegating everything else. Returns {@code delegate} unchanged when
+   * {@code readHints} is {@code null} or empty, so the no-hint path allocates nothing extra. This
+   * is the single delegate-wrapping implementation shared by the KNN queries that surface
+   * per-query/searcher read hints to codec readers.
+   *
+   * @lucene.experimental
+   */
+  static KnnCollectorManager withReadHints(
+      KnnCollectorManager delegate, Set<QueryReadHint> readHints) {
+    if (readHints == null || readHints.isEmpty()) {
+      return delegate;
+    }
+    return new KnnCollectorManager() {
+      @Override
+      public KnnCollector newCollector(
+          int visitedLimit, KnnSearchStrategy searchStrategy, LeafReaderContext context)
+          throws IOException {
+        return KnnCollector.withReadHints(
+            delegate.newCollector(visitedLimit, searchStrategy, context), readHints);
+      }
+
+      @Override
+      public KnnCollector newOptimisticCollector(
+          int visitedLimit, KnnSearchStrategy searchStrategy, LeafReaderContext context, int k)
+          throws IOException {
+        return KnnCollector.withReadHints(
+            delegate.newOptimisticCollector(visitedLimit, searchStrategy, context, k), readHints);
+      }
+
+      @Override
+      public boolean isOptimistic() {
+        return delegate.isOptimistic();
+      }
+    };
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/knn/TopKnnCollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/knn/TopKnnCollectorManager.java
@@ -18,9 +18,11 @@
 package org.apache.lucene.search.knn;
 
 import java.io.IOException;
+import java.util.Set;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.QueryReadHint;
 import org.apache.lucene.search.TopKnnCollector;
 
 /** TopKnnCollectorManager responsible for creating {@link TopKnnCollector} instances. */
@@ -28,9 +30,26 @@ public class TopKnnCollectorManager implements KnnCollectorManager {
 
   // the number of docs to collect
   private final int k;
+  // Per-query read hints carried from the IndexSearcher, surfaced to codec readers via
+  // KnnCollector#readHints(). Empty (the default) means no hint and no extra allocation.
+  private final Set<QueryReadHint> readHints;
 
   public TopKnnCollectorManager(int k, IndexSearcher indexSearcher) {
+    this(k, indexSearcher, Set.of());
+  }
+
+  /**
+   * @param queryReadHints per-query read hints carried by the query itself (may be {@code null} or
+   *     empty). When non-empty these take precedence over the searcher's {@link
+   *     IndexSearcher#getReadHints()}, giving genuine per-query control even when a single {@link
+   *     IndexSearcher} is shared across threads; {@code null}/empty inherits the searcher's hints.
+   */
+  public TopKnnCollectorManager(
+      int k, IndexSearcher indexSearcher, Set<QueryReadHint> queryReadHints) {
     this.k = k;
+    Set<QueryReadHint> searcherHints =
+        indexSearcher == null ? Set.of() : indexSearcher.getReadHints();
+    this.readHints = QueryReadHint.resolve(queryReadHints, searcherHints);
   }
 
   /**
@@ -43,13 +62,15 @@ public class TopKnnCollectorManager implements KnnCollectorManager {
   public KnnCollector newCollector(
       int visitedLimit, KnnSearchStrategy searchStrategy, LeafReaderContext context)
       throws IOException {
-    return new TopKnnCollector(k, visitedLimit, searchStrategy);
+    return KnnCollector.withReadHints(
+        new TopKnnCollector(k, visitedLimit, searchStrategy), readHints);
   }
 
   @Override
   public KnnCollector newOptimisticCollector(
       int visitedLimit, KnnSearchStrategy searchStrategy, LeafReaderContext context, int k) {
-    return new TopKnnCollector(k, visitedLimit, searchStrategy);
+    return KnnCollector.withReadHints(
+        new TopKnnCollector(k, visitedLimit, searchStrategy), readHints);
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestHnswVectorReaderPrefetchHint.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestHnswVectorReaderPrefetchHint.java
@@ -1,0 +1,459 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene99;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
+import org.apache.lucene.codecs.lucene104.Lucene104HnswScalarQuantizedVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.search.FloatVectorSimilarityQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.PatienceKnnVectorQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryAccessHint;
+import org.apache.lucene.search.QueryReadHint;
+import org.apache.lucene.search.SeededKnnVectorQuery;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopKnnCollector;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.tests.store.MockDirectoryWrapper;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+/**
+ * Verifies that {@link Lucene99HnswVectorsReader} consumes {@link QueryAccessHint#POINT} by
+ * wrapping the vector scorer so prefetch is called per neighbour batch before bulkScore.
+ *
+ * <p>The signal is observed via a counting {@link IndexInput} wrapper on the directory: with the
+ * hint absent, the reader makes zero {@code prefetch} calls; with the hint present, it makes at
+ * least one. Results are also compared to confirm correctness is unaffected.
+ */
+public class TestHnswVectorReaderPrefetchHint extends LuceneTestCase {
+
+  private static final int DIM = 16;
+  private static final int NUM_DOCS = 256;
+
+  public void testPrefetchHintFloat32() throws Exception {
+    // float32 HNSW: the graph scorer reads full-precision vectors from the .vec slice.
+    assertPrefetchHintRespected(new Lucene99HnswVectorsFormat(), ".vec");
+  }
+
+  public void testPrefetchHintScalarQuantized() throws Exception {
+    // int7 scalar-quantised HNSW: the graph scorer reads quantised vectors from the .veq slice.
+    // Exercises OffHeapScalarQuantizedVectorValues#prefetch.
+    assertPrefetchHintRespected(new Lucene104HnswScalarQuantizedVectorsFormat(), ".veq");
+  }
+
+  private void assertPrefetchHintRespected(KnnVectorsFormat format, String countedExt)
+      throws Exception {
+    final AtomicLong prefetchCount = new AtomicLong();
+
+    try (Directory raw = newMMapDirectory();
+        Directory dir = new PrefetchCountingDirectory(raw, prefetchCount, countedExt)) {
+      buildIndex(dir, format, 42);
+      try (IndexReader reader = DirectoryReader.open(dir)) {
+        LeafReaderContext ctx = reader.leaves().get(0);
+        Random rng = new Random(0xC0FFEE);
+        float[] q = unit(DIM, rng);
+
+        prefetchCount.set(0);
+        TopDocs nohint = runSearch(ctx, q, /* hints= */ Set.of());
+        long countNoHint = prefetchCount.get();
+
+        prefetchCount.set(0);
+        TopDocs hinted = runSearch(ctx, q, Set.of(QueryAccessHint.POINT));
+        long countWithHint = prefetchCount.get();
+
+        // Correctness: identical results regardless of hint (prefetch is read-only).
+        assertEquals(nohint.scoreDocs.length, hinted.scoreDocs.length);
+        for (int i = 0; i < nohint.scoreDocs.length; i++) {
+          assertEquals(nohint.scoreDocs[i].doc, hinted.scoreDocs[i].doc);
+          assertEquals(nohint.scoreDocs[i].score, hinted.scoreDocs[i].score, 0f);
+        }
+        // Consumer behaviour: no hint => no prefetch; POINT => at least one prefetch.
+        assertEquals("no-hint baseline must not invoke prefetch", 0L, countNoHint);
+        assertTrue(
+            "POINT hint must invoke prefetch on the " + countedExt + " file; got=" + countWithHint,
+            countWithHint > 0);
+      }
+    }
+  }
+
+  /**
+   * End-to-end through the public API: {@link IndexSearcher#setReadHints} must reach the reader via
+   * the production {@link org.apache.lucene.search.knn.TopKnnCollectorManager} (no hand-rolled
+   * collector). With the hint set, a {@link KnnFloatVectorQuery} prefetches; without it, it does
+   * not.
+   */
+  public void testReadHintReachesReaderThroughIndexSearcher() throws Exception {
+    assertReadHintReachesReaderThroughIndexSearcher(new Lucene99HnswVectorsFormat(), ".vec");
+  }
+
+  /** Same end-to-end production path as above, but for the scalar-quantised format (.veq). */
+  public void testReadHintReachesReaderThroughIndexSearcherScalarQuantized() throws Exception {
+    assertReadHintReachesReaderThroughIndexSearcher(
+        new Lucene104HnswScalarQuantizedVectorsFormat(), ".veq");
+  }
+
+  private void assertReadHintReachesReaderThroughIndexSearcher(
+      KnnVectorsFormat format, String countedExt) throws Exception {
+    final AtomicLong prefetchCount = new AtomicLong();
+
+    try (Directory raw = newMMapDirectory();
+        Directory dir = new PrefetchCountingDirectory(raw, prefetchCount, countedExt)) {
+      buildIndex(dir, format, 7);
+      try (IndexReader reader = DirectoryReader.open(dir)) {
+        Random rng = new Random(0xBEEF);
+        float[] q = unit(DIM, rng);
+        KnnFloatVectorQuery query = new KnnFloatVectorQuery("vec", q, 10);
+
+        // No hint on the searcher: production path must not prefetch.
+        IndexSearcher s1 = new IndexSearcher(reader);
+        s1.setQueryCache(null);
+        prefetchCount.set(0);
+        s1.search(query, 10);
+        assertEquals("no read hint on the searcher must not prefetch", 0L, prefetchCount.get());
+
+        // POINT hint on the searcher: TopKnnCollectorManager must carry it to the collector,
+        // and Lucene99HnswVectorsReader must prefetch.
+        IndexSearcher s2 = new IndexSearcher(reader);
+        s2.setQueryCache(null);
+        s2.setReadHints(Set.of(QueryAccessHint.POINT));
+        prefetchCount.set(0);
+        s2.search(query, 10);
+        assertTrue(
+            "IndexSearcher.setReadHints(POINT) must reach the reader and prefetch; got="
+                + prefetchCount.get(),
+            prefetchCount.get() > 0);
+      }
+    }
+  }
+
+  /**
+   * Genuine per-query control: with a single shared {@link IndexSearcher} that has NO
+   * searcher-level hint, a query built with {@link KnnFloatVectorQuery#withReadHints} prefetches
+   * while a plain query on the same searcher does not. This proves the hint rides on the query, not
+   * the searcher.
+   */
+  public void testReadHintIsPerQueryOnSharedSearcher() throws Exception {
+    final AtomicLong prefetchCount = new AtomicLong();
+
+    try (Directory raw = newMMapDirectory();
+        Directory dir = new PrefetchCountingDirectory(raw, prefetchCount, ".vec")) {
+      buildIndex(dir, new Lucene99HnswVectorsFormat(), 13);
+      try (IndexReader reader = DirectoryReader.open(dir)) {
+        float[] q = unit(DIM, new Random(0xCAFE));
+
+        // ONE shared searcher, NO searcher-level hint.
+        IndexSearcher searcher = new IndexSearcher(reader);
+        searcher.setQueryCache(null);
+        assertEquals(Set.of(), searcher.getReadHints());
+
+        KnnFloatVectorQuery plain = new KnnFloatVectorQuery("vec", q, 10);
+        KnnFloatVectorQuery hinted = plain.withReadHints(Set.of(QueryAccessHint.POINT));
+
+        // Plain query on the shared searcher: no prefetch.
+        prefetchCount.set(0);
+        searcher.search(plain, 10);
+        assertEquals(
+            "plain query on a searcher with no hint must not prefetch", 0L, prefetchCount.get());
+
+        // Per-query hinted query on the SAME searcher: prefetch happens.
+        prefetchCount.set(0);
+        searcher.search(hinted, 10);
+        assertTrue(
+            "withReadHints(POINT) must prefetch even though the searcher has no hint; got="
+                + prefetchCount.get(),
+            prefetchCount.get() > 0);
+
+        // The two queries are distinct (different hints => not equal, distinct cache keys).
+        assertNotEquals(plain, hinted);
+
+        // Same proof for the similarity-query family (different base/wiring): decay < 1 and no
+        // filter select the approximate path. withReadHints on the SAME un-hinted searcher must
+        // prefetch while the plain similarity query must not.
+        FloatVectorSimilarityQuery simPlain =
+            new FloatVectorSimilarityQuery(
+                "vec", q, /* resultSimilarity= */ 0f, /* decay= */ 0.5f, /* filter= */ null);
+        FloatVectorSimilarityQuery simHinted =
+            simPlain.withReadHints(Set.of(QueryAccessHint.POINT));
+
+        prefetchCount.set(0);
+        searcher.search(simPlain, 50);
+        assertEquals(
+            "plain similarity query on a searcher with no hint must not prefetch",
+            0L,
+            prefetchCount.get());
+
+        prefetchCount.set(0);
+        searcher.search(simHinted, 50);
+        assertTrue(
+            "FloatVectorSimilarityQuery.withReadHints(POINT) must prefetch on an un-hinted searcher;"
+                + " got="
+                + prefetchCount.get(),
+            prefetchCount.get() > 0);
+        assertNotEquals(simPlain, simHinted);
+      }
+    }
+  }
+
+  /**
+   * End-to-end through the public API for the similarity-threshold query family: {@link
+   * FloatVectorSimilarityQuery}'s approximate (graph) search path runs through the reader's {@code
+   * searchNearestVectors}, so {@link IndexSearcher#setReadHints} must reach the reader via {@code
+   * AbstractVectorSimilarityQuery}'s collector wiring. (decay &lt; 1 and no filter select the
+   * approximate path, not the exact-scan fallback.)
+   */
+  public void testReadHintReachesReaderThroughVectorSimilarityQuery() throws Exception {
+    final AtomicLong prefetchCount = new AtomicLong();
+
+    try (Directory raw = newMMapDirectory();
+        Directory dir = new PrefetchCountingDirectory(raw, prefetchCount, ".vec")) {
+      buildIndex(dir, new Lucene99HnswVectorsFormat(), 11);
+      try (IndexReader reader = DirectoryReader.open(dir)) {
+        float[] q = unit(DIM, new Random(0xABCD));
+        // decay = 0.5 (< 1) and no filter => approximate graph search; low resultSimilarity so the
+        // search actually traverses and reads vectors.
+        Query query =
+            new FloatVectorSimilarityQuery(
+                "vec", q, /* resultSimilarity= */ 0f, /* decay= */ 0.5f, /* filter= */ null);
+
+        IndexSearcher s1 = new IndexSearcher(reader);
+        s1.setQueryCache(null);
+        prefetchCount.set(0);
+        s1.search(query, 50);
+        assertEquals("no read hint on the searcher must not prefetch", 0L, prefetchCount.get());
+
+        IndexSearcher s2 = new IndexSearcher(reader);
+        s2.setQueryCache(null);
+        s2.setReadHints(Set.of(QueryAccessHint.POINT));
+        prefetchCount.set(0);
+        s2.search(query, 50);
+        assertTrue(
+            "FloatVectorSimilarityQuery + setReadHints(POINT) must reach the reader and prefetch;"
+                + " got="
+                + prefetchCount.get(),
+            prefetchCount.get() > 0);
+      }
+    }
+  }
+
+  /**
+   * The hint must survive query wrapping. {@link SeededKnnVectorQuery} and {@link
+   * PatienceKnnVectorQuery} both delegate collector creation to the inner query, so a per-query
+   * hint attached to the inner {@link KnnFloatVectorQuery} via {@link
+   * KnnFloatVectorQuery#withReadHints} must still reach the reader through the wrappers — including
+   * when {@link PatienceKnnVectorQuery#rewrite} reconstructs its {@code Seeded} delegate. A plain
+   * (un-hinted) inner query through the same wrappers must not prefetch. The searcher itself
+   * carries no hint, so any prefetch observed here came through the wrapped query.
+   */
+  public void testReadHintPropagatesThroughSeededAndPatience() throws Exception {
+    final AtomicLong prefetchCount = new AtomicLong();
+
+    try (Directory raw = newMMapDirectory();
+        Directory dir = new PrefetchCountingDirectory(raw, prefetchCount, ".vec")) {
+      buildIndex(dir, new Lucene99HnswVectorsFormat(), 23);
+      try (IndexReader reader = DirectoryReader.open(dir)) {
+        float[] q = unit(DIM, new Random(0xD00D));
+        IndexSearcher searcher = new IndexSearcher(reader);
+        searcher.setQueryCache(null);
+        assertEquals(Set.of(), searcher.getReadHints());
+
+        KnnFloatVectorQuery plain = new KnnFloatVectorQuery("vec", q, 10);
+        KnnFloatVectorQuery hinted = plain.withReadHints(Set.of(QueryAccessHint.POINT));
+        Query seed = new MatchAllDocsQuery();
+
+        // Seeded wrapper: hint rides on the inner query.
+        assertPrefetch(
+            searcher, SeededKnnVectorQuery.fromFloatQuery(plain, seed), prefetchCount, false);
+        assertPrefetch(
+            searcher, SeededKnnVectorQuery.fromFloatQuery(hinted, seed), prefetchCount, true);
+
+        // Patience over a float query.
+        assertPrefetch(
+            searcher, PatienceKnnVectorQuery.fromFloatQuery(plain), prefetchCount, false);
+        assertPrefetch(
+            searcher, PatienceKnnVectorQuery.fromFloatQuery(hinted), prefetchCount, true);
+
+        // Patience over a Seeded query (exercises Patience.rewrite rebuilding the Seeded delegate).
+        assertPrefetch(
+            searcher,
+            PatienceKnnVectorQuery.fromSeededQuery(
+                SeededKnnVectorQuery.fromFloatQuery(plain, seed)),
+            prefetchCount,
+            false);
+        assertPrefetch(
+            searcher,
+            PatienceKnnVectorQuery.fromSeededQuery(
+                SeededKnnVectorQuery.fromFloatQuery(hinted, seed)),
+            prefetchCount,
+            true);
+      }
+    }
+  }
+
+  private static void assertPrefetch(
+      IndexSearcher searcher, Query query, AtomicLong counter, boolean expectPrefetch)
+      throws IOException {
+    counter.set(0);
+    searcher.search(query, 10);
+    if (expectPrefetch) {
+      assertTrue(
+          "expected POINT prefetch for " + query + "; got=" + counter.get(), counter.get() > 0);
+    } else {
+      assertEquals("expected no prefetch for un-hinted " + query, 0L, counter.get());
+    }
+  }
+
+  private static void buildIndex(Directory dir, KnnVectorsFormat format, long seed)
+      throws IOException {
+    try (IndexWriter w =
+        new IndexWriter(
+            dir,
+            new IndexWriterConfig()
+                .setUseCompoundFile(false)
+                .setCodec(
+                    new Lucene104Codec() {
+                      @Override
+                      public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+                        return format;
+                      }
+                    }))) {
+      Random rng = new Random(seed);
+      for (int i = 0; i < NUM_DOCS; i++) {
+        Document d = new Document();
+        d.add(new KnnFloatVectorField("vec", unit(DIM, rng), VectorSimilarityFunction.DOT_PRODUCT));
+        w.addDocument(d);
+      }
+      w.forceMerge(1);
+    }
+  }
+
+  private static Directory newMMapDirectory() throws IOException {
+    // Wrap in MockDirectoryWrapper (as TestKnnByteVectorQueryMMap does) so close-time leak
+    // assertions run over the prefetch path's clone()/slice() wrappers. MockIndexInputWrapper
+    // forwards prefetch(), so the CountingPrefetchInput layered on top still observes the calls.
+    return new MockDirectoryWrapper(
+        random(), new MMapDirectory(createTempDir("hnsw-prefetch-hint")));
+  }
+
+  private static TopDocs runSearch(LeafReaderContext ctx, float[] q, Set<QueryReadHint> hints)
+      throws IOException {
+    HintedTopKnnCollector collector = new HintedTopKnnCollector(10, hints);
+    ctx.reader()
+        .searchNearestVectors(
+            "vec",
+            q,
+            collector,
+            AcceptDocs.fromLiveDocs(ctx.reader().getLiveDocs(), ctx.reader().maxDoc()));
+    return collector.topDocs();
+  }
+
+  /** TopKnnCollector that advertises a configurable hint set. */
+  private static final class HintedTopKnnCollector extends TopKnnCollector {
+    private final Set<QueryReadHint> hints;
+
+    HintedTopKnnCollector(int k, Set<QueryReadHint> hints) {
+      super(k, Integer.MAX_VALUE, null);
+      this.hints = hints;
+    }
+
+    @Override
+    public Set<QueryReadHint> readHints() {
+      return hints;
+    }
+  }
+
+  /** Directory wrapper that wraps each opened input with a prefetch-counting filter. */
+  private static final class PrefetchCountingDirectory extends FilterDirectory {
+    private final AtomicLong counter;
+    private final String countedExt;
+
+    PrefetchCountingDirectory(Directory in, AtomicLong counter, String countedExt) {
+      super(in);
+      this.counter = counter;
+      this.countedExt = countedExt;
+    }
+
+    @Override
+    public IndexInput openInput(String name, IOContext context) throws IOException {
+      IndexInput delegate = in.openInput(name, context);
+      // Only count prefetch on the file the consumer targets (the per-neighbour vector data:
+      // .vec for float32, .veq for scalar-quantised). The HNSW graph file (.vex) is not what
+      // this hint targets, and the meta files (.vem*) are small and only read at open time.
+      if (name.endsWith(countedExt)) {
+        return new CountingPrefetchInput(delegate, counter);
+      }
+      return delegate;
+    }
+  }
+
+  private static final class CountingPrefetchInput extends FilterIndexInput {
+    private final AtomicLong counter;
+
+    CountingPrefetchInput(IndexInput in, AtomicLong counter) {
+      super("CountingPrefetchInput(" + in + ")", in);
+      this.counter = counter;
+    }
+
+    @Override
+    public boolean prefetch(long offset, long length) throws IOException {
+      counter.incrementAndGet();
+      return in.prefetch(offset, length);
+    }
+
+    @Override
+    public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+      return new CountingPrefetchInput(in.slice(sliceDescription, offset, length), counter);
+    }
+
+    @Override
+    public IndexInput clone() {
+      return new CountingPrefetchInput(in.clone(), counter);
+    }
+  }
+
+  private static float[] unit(int dim, Random rng) {
+    float[] v = new float[dim];
+    double norm = 0;
+    for (int i = 0; i < dim; i++) {
+      v[i] = rng.nextFloat() * 2f - 1f;
+      norm += v[i] * v[i];
+    }
+    norm = Math.sqrt(norm);
+    for (int i = 0; i < dim; i++) v[i] /= (float) norm;
+    return v;
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/search/TestQueryReadHint.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestQueryReadHint.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+/**
+ * Tests for the {@link QueryReadHint} plumbing on {@link IndexSearcher}. The hint is opt-in and
+ * advisory; this verifies only that {@link IndexSearcher#setReadHints(Set)} stores an immutable,
+ * defensively-copied snapshot and that the default is empty. End-to-end reachability of the hint
+ * into a reader (the only built-in consumer) is covered by {@code
+ * TestHnswVectorReaderPrefetchHint}.
+ */
+public class TestQueryReadHint extends LuceneTestCase {
+
+  public void testIndexSearcherStoresHintsImmutably() throws IOException {
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter iw = new IndexWriter(dir, newIndexWriterConfig())) {
+        Document doc = new Document();
+        doc.add(new StringField("f", "v", Field.Store.NO));
+        iw.addDocument(doc);
+      }
+      try (DirectoryReader r = DirectoryReader.open(dir)) {
+        IndexSearcher s = new IndexSearcher(r);
+        assertEquals(Set.of(), s.getReadHints());
+
+        s.setReadHints(Set.of(QueryAccessHint.POINT));
+        assertEquals(Set.of(QueryAccessHint.POINT), s.getReadHints());
+
+        // returned set must be immutable
+        Set<QueryReadHint> snapshot = s.getReadHints();
+        expectThrows(
+            UnsupportedOperationException.class, () -> snapshot.add(QueryAccessHint.POINT));
+
+        // mutating an externally-passed set after handing it over must NOT affect the searcher
+        HashSet<QueryReadHint> mutable = new HashSet<>();
+        mutable.add(QueryAccessHint.POINT);
+        s.setReadHints(mutable);
+        mutable.clear();
+        assertEquals(Set.of(QueryAccessHint.POINT), s.getReadHints());
+
+        // empty restores default
+        s.setReadHints(Set.of());
+        assertEquals(Set.of(), s.getReadHints());
+
+        expectThrows(NullPointerException.class, () -> s.setReadHints(null));
+      }
+    }
+  }
+
+  // ---- equals/hashCode contract for the per-query withReadHints withers (advisory but part of
+  // query identity, so same-hint copies must be equal AND share a hashCode). ----
+
+  public void testWithReadHintsEqualsAndHashCode() {
+    float[] f = new float[] {1f, 0f, 0f};
+    byte[] b = new byte[] {1, 2, 3};
+    Set<QueryReadHint> point = Set.of(QueryAccessHint.POINT);
+
+    // Two independently-built copies with the same hint are equal and share a hashCode.
+    assertEqualAndHash(
+        new KnnFloatVectorQuery("f", f, 5).withReadHints(point),
+        new KnnFloatVectorQuery("f", f, 5).withReadHints(point));
+    assertEqualAndHash(
+        new KnnByteVectorQuery("f", b, 5).withReadHints(point),
+        new KnnByteVectorQuery("f", b, 5).withReadHints(point));
+    assertEqualAndHash(
+        new FloatVectorSimilarityQuery("f", f, 0f, 0.5f, null).withReadHints(point),
+        new FloatVectorSimilarityQuery("f", f, 0f, 0.5f, null).withReadHints(point));
+    assertEqualAndHash(
+        new ByteVectorSimilarityQuery("f", b, 0f, 0.5f, null).withReadHints(point),
+        new ByteVectorSimilarityQuery("f", b, 0f, 0.5f, null).withReadHints(point));
+
+    // A hinted query differs from its plain origin (distinct cache keys).
+    KnnFloatVectorQuery plain = new KnnFloatVectorQuery("f", f, 5);
+    assertNotEquals(plain, plain.withReadHints(point));
+    // withReadHints(empty) carries no hint, so it equals the plain query.
+    assertEqualAndHash(plain, plain.withReadHints(Set.of()));
+  }
+
+  public void testWithReadHintsEqualityThroughSeededAndPatience() {
+    float[] f = new float[] {1f, 0f, 0f};
+    Set<QueryReadHint> point = Set.of(QueryAccessHint.POINT);
+    Query seed = new MatchAllDocsQuery();
+
+    KnnFloatVectorQuery plain = new KnnFloatVectorQuery("f", f, 5);
+    KnnFloatVectorQuery hinted = plain.withReadHints(point);
+
+    // Seeded/Patience carry no independent hint state; identity flows through the delegate, so a
+    // hinted vs. un-hinted inner query yields distinct wrappers.
+    assertEqualAndHash(
+        SeededKnnVectorQuery.fromFloatQuery(hinted, seed),
+        SeededKnnVectorQuery.fromFloatQuery(hinted, seed));
+    assertNotEquals(
+        SeededKnnVectorQuery.fromFloatQuery(plain, seed),
+        SeededKnnVectorQuery.fromFloatQuery(hinted, seed));
+
+    assertEqualAndHash(
+        PatienceKnnVectorQuery.fromFloatQuery(hinted),
+        PatienceKnnVectorQuery.fromFloatQuery(hinted));
+    assertNotEquals(
+        PatienceKnnVectorQuery.fromFloatQuery(plain),
+        PatienceKnnVectorQuery.fromFloatQuery(hinted));
+  }
+
+  private static void assertEqualAndHash(Query a, Query b) {
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+}

--- a/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingNearestChildrenKnnCollectorManager.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingNearestChildrenKnnCollectorManager.java
@@ -18,9 +18,11 @@
 package org.apache.lucene.search.join;
 
 import java.io.IOException;
+import java.util.Set;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.QueryReadHint;
 import org.apache.lucene.search.knn.KnnCollectorManager;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.util.BitSet;
@@ -35,6 +37,10 @@ public class DiversifyingNearestChildrenKnnCollectorManager implements KnnCollec
   private final int k;
   // filter identifying the parent documents.
   private final BitSetProducer parentsFilter;
+  // Read hints carried from the IndexSearcher, surfaced to codec readers via
+  // KnnCollector#readHints() (e.g. QueryAccessHint.POINT prefetch in Lucene99HnswVectorsReader).
+  // Empty (the default) means no hint and no extra allocation.
+  private final Set<QueryReadHint> readHints;
 
   /**
    * Constructor
@@ -46,6 +52,7 @@ public class DiversifyingNearestChildrenKnnCollectorManager implements KnnCollec
       int k, BitSetProducer parentsFilter, IndexSearcher indexSearcher) {
     this.k = k;
     this.parentsFilter = parentsFilter;
+    this.readHints = indexSearcher == null ? Set.of() : indexSearcher.getReadHints();
   }
 
   /**
@@ -62,8 +69,9 @@ public class DiversifyingNearestChildrenKnnCollectorManager implements KnnCollec
     if (parentBitSet == null) {
       return null;
     }
-    return new DiversifyingNearestChildrenKnnCollector(
-        k, visitedLimit, searchStrategy, parentBitSet);
+    return KnnCollector.withReadHints(
+        new DiversifyingNearestChildrenKnnCollector(k, visitedLimit, searchStrategy, parentBitSet),
+        readHints);
   }
 
   @Override
@@ -74,8 +82,9 @@ public class DiversifyingNearestChildrenKnnCollectorManager implements KnnCollec
     if (parentBitSet == null) {
       return null;
     }
-    return new DiversifyingNearestChildrenKnnCollector(
-        k, visitedLimit, searchStrategy, parentBitSet);
+    return KnnCollector.withReadHints(
+        new DiversifyingNearestChildrenKnnCollector(k, visitedLimit, searchStrategy, parentBitSet),
+        readHints);
   }
 
   @Override


### PR DESCRIPTION
Still just experimental at the moment.

Cold-cache microbenchmark (1M Cohere wikipedia-en 1024-dim vectors, fresh JVM per query, OS page cache dropped before every query, cells interleaved, n=100 unless noted) on Linux (Manjaro x86_64, JDK 26, NVMe)

  float32, single segment, k=10:    168 ms median baseline -> 27 ms POINT (~6.2x)
  float32, single segment, k=100:   655 ms -> 74 ms (~8.9x)
  float32, 9 segments, k=10:        1388 ms -> 124 ms (~11.2x)
  int7 scalar-quantised, k=10:      170 ms -> 30 ms (~5.7x)

macOS (Apple Silicon M2, JDK 25; single-segment float32, n=50): 157 ms -> 80 ms (~2.0x).

Linux warm cache (n=2000 after 200 warmup): candidate-none 0.255 ms median vs POINT 0.258 ms (neutral).

Other similarities, dimensions, filters, partial-cache and concurrent-query scenarios were not measured. I tried whole-file madvise variants and rejected them - results not good at all.
