### PR TITLE
build: prevent duplicate dependabot PRs against /dev-tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,18 +14,6 @@ updates:
     cooldown:
       default-days: 7
 
-  # python dependencies in /dev-tools/scripts
-  - package-ecosystem: pip
-    directory: /dev-tools/scripts/
-    open-pull-requests-limit: 25
-    schedule:
-      interval: monthly
-    commit-message:
-      prefix: build(deps)
-    labels: [dependencies, skip-changelog]
-    cooldown:
-      default-days: 7
-
   # python dependencies in /dev-tools
   - package-ecosystem: uv
     directory: /dev-tools/


### PR DESCRIPTION
We're getting duplicate PRs for anything in /dev-tools/scripts, since we have an entry for dev-tools. This seems to just be how the uv ecosystem dependabot updater works, it finds the stuff in /dev-tools/scripts too.

Remove the /dev-tools/scripts pip ecosystem to tone down the noise
