### PR TITLE
Fix ControlledRealTimeReopenThread.close() to wake waiters on interrupt

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -347,6 +347,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
+* GITHUB#16210: Fix `ControlledRealTimeReopenThread.close()` to wake waiters on interrupt. (Prithvi S)
+
 * GITHUB#16350: Disable bulk-scoring in monitor queries. (Alan Woodward)
 
 * GITHUB#16295: SingletonSortedNumericDocValues now delegates rangeIntoBitSet

--- a/lucene/core/src/java/org/apache/lucene/search/ControlledRealTimeReopenThread.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ControlledRealTimeReopenThread.java
@@ -118,14 +118,6 @@ public class ControlledRealTimeReopenThread<T> extends Thread implements Closeab
     } catch (InterruptedException ie) {
       throw new ThreadInterruptedException(ie);
     }
-
-    // Max it out so any waiting search threads will return:
-    searchingGen = Long.MAX_VALUE;
-
-    // Wake up waiters.
-    synchronized (waitingRoom) {
-      waitingRoom.notifyAll();
-    }
   }
 
   /**
@@ -188,32 +180,39 @@ public class ControlledRealTimeReopenThread<T> extends Thread implements Closeab
 
   @Override
   public void run() {
-    long lastReopenStartNS = System.nanoTime();
+    try {
+      long lastReopenStartNS = System.nanoTime();
 
-    while (!finish) {
+      while (!finish) {
 
-      // TODO: try to guesstimate how long reopen might take based on past data?
+        // TODO: try to guesstimate how long reopen might take based on past data?
 
-      // True if we have someone waiting for reopened searcher:
-      boolean hasWaiting = waitingGen.get() > searchingGen;
-      final long nextReopenStartNS =
-          lastReopenStartNS + (hasWaiting ? targetMinStaleNS : targetMaxStaleNS);
+        // True if we have someone waiting for reopened searcher:
+        boolean hasWaiting = waitingGen.get() > searchingGen;
+        final long nextReopenStartNS =
+            lastReopenStartNS + (hasWaiting ? targetMinStaleNS : targetMaxStaleNS);
 
-      final long sleepNS = nextReopenStartNS - System.nanoTime();
-      if (sleepNS > 0) {
-        try {
-          reloadRequests.tryAcquire(sleepNS, NANOSECONDS);
-          reloadRequests.drainPermits();
-        } catch (InterruptedException e) {
-          throw new ThreadInterruptedException(e);
+        final long sleepNS = nextReopenStartNS - System.nanoTime();
+        if (sleepNS > 0) {
+          try {
+            reloadRequests.tryAcquire(sleepNS, NANOSECONDS);
+            reloadRequests.drainPermits();
+          } catch (InterruptedException e) {
+            throw new ThreadInterruptedException(e);
+          }
+        } else {
+          lastReopenStartNS = System.nanoTime();
+          try {
+            manager.maybeRefreshBlocking();
+          } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+          }
         }
-      } else {
-        lastReopenStartNS = System.nanoTime();
-        try {
-          manager.maybeRefreshBlocking();
-        } catch (IOException ioe) {
-          throw new RuntimeException(ioe);
-        }
+      }
+    } finally {
+      synchronized (waitingRoom) {
+        searchingGen = Long.MAX_VALUE;
+        waitingRoom.notifyAll();
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestControlledRealTimeReopenThread.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestControlledRealTimeReopenThread.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -593,5 +594,78 @@ public class TestControlledRealTimeReopenThread extends ThreadedIndexingAndSearc
     long gen2 = w.deleteAll();
     nrtDeletesThread.waitForGeneration(gen2);
     IOUtils.close(nrtDeletesThread, nrtDeletes, w, dir);
+  }
+
+  /**
+   * Tests that close() releases waitForGeneration() waiters even if the thread calling close() is
+   * interrupted during join(). The reopen thread's run() finally block must still wake waiters.
+   */
+  public void testCloseInterruptWakesWaiters() throws Exception {
+    Directory dir = newDirectory();
+    IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+    conf.setMergePolicy(NoMergePolicy.INSTANCE);
+    IndexWriter w = new IndexWriter(dir, conf);
+    SearcherManager mgr = new SearcherManager(w, false, false, null);
+
+    ControlledRealTimeReopenThread<IndexSearcher> thread =
+        new ControlledRealTimeReopenThread<>(
+            w, mgr, Duration.ofSeconds(60), Duration.ofSeconds(60));
+    thread.setDaemon(true);
+    thread.start();
+
+    long targetGen = w.addDocument(new Document());
+
+    CountDownLatch waiterReady = new CountDownLatch(1);
+    final AtomicBoolean waiterFinished = new AtomicBoolean(false);
+    Thread waiter =
+        new Thread() {
+          @Override
+          public void run() {
+            try {
+              waiterReady.countDown();
+              thread.waitForGeneration(targetGen); // will block forever
+              waiterFinished.set(true);
+            } catch (InterruptedException ie) {
+              Thread.currentThread().interrupt();
+              throw new RuntimeException(ie);
+            }
+          }
+        };
+    waiter.start();
+
+    waiterReady.await();
+    for (int i = 0; i < 20000; i++) { // best effort wait for WAITING state
+      if (waiter.getState() == Thread.State.WAITING) break;
+      Thread.yield();
+    }
+
+    Thread closer =
+        new Thread(
+            () -> {
+              Thread.currentThread().interrupt();
+              try {
+                thread.close();
+              } catch (ThreadInterruptedException _) {
+                // optional: hit the interrupted-join path
+              }
+            });
+    closer.start();
+    closer.join();
+
+    thread.join(30_000);
+    assertFalse(thread.isAlive());
+    assertEquals(Long.MAX_VALUE, thread.getSearchingGen());
+
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(60);
+    while (!waiterFinished.get() && System.nanoTime() < deadline) {
+      Thread.yield();
+    }
+    waiter.join(30_000);
+    assertFalse(waiter.isAlive());
+    assertTrue(waiterFinished.get());
+
+    mgr.close();
+    w.close();
+    dir.close();
   }
 }


### PR DESCRIPTION
`close()` calls `join()` on the background thread, then bumps `searchingGen` to Long.MAX_VALUE and notifyAll()'s waiters. If `join()` throws `InterruptedException`, the rethrow happened before the bump + notify, so threads in `waitForGeneration(targetGen, -1)` with `targetGen > searchingGen` hung forever.

so moved the cleanup into a `finally` block around `join()`.
