### PR TITLE
Allow multiple addBatch columns per field name

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -610,6 +610,8 @@ Other
 * GITHUB#16178: Simplify how we collect hits in the LRU cache from a DocIdStream into a RoaringDocIdSet.
   (Ignacio Vera)
 
+* GITHUB#16219: Allow multiple addBatch columns per field name. (Tim Brooks)
+
 ======================= Lucene 10.4.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/document/column/ColumnBatch.java
+++ b/lucene/core/src/java/org/apache/lucene/document/column/ColumnBatch.java
@@ -32,15 +32,13 @@ public abstract class ColumnBatch {
   public abstract int numDocs();
 
   /**
-   * Returns the columns in this batch. Each column represents a single field across the documents
-   * in the batch.
+   * Returns the columns in this batch. Each column covers one indexing aspect (inversion, stored,
+   * doc values, points, or vectors) of a field across all documents in the batch.
    *
-   * <p>Multi-valued fields must be expressed as a single column whose tuple cursor emits multiple
-   * values per batch doc-id; the same value (e.g. a doc value) must not be split across columns.
-   * Several columns <em>may</em> share a field name to combine distinct indexing aspects — for
-   * example a stored {@link BinaryColumn} alongside a separate inverted column for the same field —
-   * but each aspect (inversion, stored, doc values, points, vectors) must be carried by a single
-   * column.
+   * <p>Multiple columns may share a field name to combine distinct aspects — for example, a stored
+   * {@link BinaryColumn} alongside a separate inverted column for the same field — but each aspect
+   * must be carried by exactly one column. Multi-valued fields must use a single column whose tuple
+   * cursor emits multiple values per doc-id; an aspect must not be split across columns.
    */
   public abstract Iterable<Column> columns();
 }

--- a/lucene/core/src/java/org/apache/lucene/document/column/ColumnBatch.java
+++ b/lucene/core/src/java/org/apache/lucene/document/column/ColumnBatch.java
@@ -33,8 +33,14 @@ public abstract class ColumnBatch {
 
   /**
    * Returns the columns in this batch. Each column represents a single field across the documents
-   * in the batch. Within a batch, column names must be unique: multi-valued fields should be
-   * expressed as a single column whose tuple cursor emits multiple values per batch doc-id.
+   * in the batch.
+   *
+   * <p>Multi-valued fields must be expressed as a single column whose tuple cursor emits multiple
+   * values per batch doc-id; the same value (e.g. a doc value) must not be split across columns.
+   * Several columns <em>may</em> share a field name to combine distinct indexing aspects — for
+   * example a stored {@link BinaryColumn} alongside a separate inverted column for the same field —
+   * but each aspect (inversion, stored, doc values, points, vectors) must be carried by a single
+   * column.
    */
   public abstract Iterable<Column> columns();
 }

--- a/lucene/core/src/java/org/apache/lucene/document/column/ColumnBatch.java
+++ b/lucene/core/src/java/org/apache/lucene/document/column/ColumnBatch.java
@@ -32,13 +32,13 @@ public abstract class ColumnBatch {
   public abstract int numDocs();
 
   /**
-   * Returns the columns in this batch. Each column covers one indexing aspect (inversion, stored,
+   * Returns the columns in this batch. Each column covers one indexing feature (inversion, stored,
    * doc values, points, or vectors) of a field across all documents in the batch.
    *
-   * <p>Multiple columns may share a field name to combine distinct aspects — for example, a stored
-   * {@link BinaryColumn} alongside a separate inverted column for the same field — but each aspect
+   * <p>Multiple columns may share a field name to combine distinct features — for example, a stored
+   * {@link BinaryColumn} alongside a separate inverted column for the same field — but each feature
    * must be carried by exactly one column. Multi-valued fields must use a single column whose tuple
-   * cursor emits multiple values per doc-id; an aspect must not be split across columns.
+   * cursor emits multiple values per doc-id; a feature must not be split across columns.
    */
   public abstract Iterable<Column> columns();
 }

--- a/lucene/core/src/java/org/apache/lucene/document/column/ColumnValidation.java
+++ b/lucene/core/src/java/org/apache/lucene/document/column/ColumnValidation.java
@@ -33,64 +33,64 @@ public final class ColumnValidation {
   private ColumnValidation() {}
 
   /** Inverted-index aspect ({@code indexOptions() != NONE}). */
-  static final int FEATURE_INVERSION = 1 << 0;
+  static final int ASPECT_INVERSION = 1 << 0;
 
   /** Stored-fields aspect ({@code stored()}). */
-  static final int FEATURE_STORED = 1 << 1;
+  static final int ASPECT_STORED = 1 << 1;
 
   /** Doc-values aspect ({@code docValuesType() != NONE}). */
-  static final int FEATURE_DOCVALUES = 1 << 2;
+  static final int ASPECT_DOCVALUES = 1 << 2;
 
   /** Points aspect ({@code pointDimensionCount() != 0}). */
-  static final int FEATURE_POINTS = 1 << 3;
+  static final int ASPECT_POINTS = 1 << 3;
 
   /** KNN-vector aspect ({@code vectorDimension() != 0}). */
-  static final int FEATURE_VECTOR = 1 << 4;
+  static final int ASPECT_VECTOR = 1 << 4;
 
   /**
-   * Returns a bitmask of the indexing aspects ({@code FEATURE_*}) declared by {@code fieldType}.
+   * Returns a bitmask of the indexing aspects ({@code ASPECT_*}) declared by {@code fieldType}.
    * Used by the column-batch path to enforce that, when several columns share a field name, each
    * aspect is carried by at most one column.
    */
-  public static int featureMask(IndexableFieldType fieldType) {
+  public static int aspectMask(IndexableFieldType fieldType) {
     int mask = 0;
     if (fieldType.indexOptions() != IndexOptions.NONE) {
-      mask |= FEATURE_INVERSION;
+      mask |= ASPECT_INVERSION;
     }
     if (fieldType.stored()) {
-      mask |= FEATURE_STORED;
+      mask |= ASPECT_STORED;
     }
     if (fieldType.docValuesType() != DocValuesType.NONE) {
-      mask |= FEATURE_DOCVALUES;
+      mask |= ASPECT_DOCVALUES;
     }
     if (fieldType.pointDimensionCount() != 0) {
-      mask |= FEATURE_POINTS;
+      mask |= ASPECT_POINTS;
     }
     if (fieldType.vectorDimension() != 0) {
-      mask |= FEATURE_VECTOR;
+      mask |= ASPECT_VECTOR;
     }
     return mask;
   }
 
   /** Returns a human-readable comma-separated list of the aspect names set in {@code mask}. */
-  public static String featureNames(int mask) {
+  public static String aspectNames(int mask) {
     StringBuilder sb = new StringBuilder();
-    if ((mask & FEATURE_INVERSION) != 0) {
+    if ((mask & ASPECT_INVERSION) != 0) {
       sb.append("inversion");
     }
-    if ((mask & FEATURE_STORED) != 0) {
+    if ((mask & ASPECT_STORED) != 0) {
       if (!sb.isEmpty()) sb.append(", ");
       sb.append("stored");
     }
-    if ((mask & FEATURE_DOCVALUES) != 0) {
+    if ((mask & ASPECT_DOCVALUES) != 0) {
       if (!sb.isEmpty()) sb.append(", ");
       sb.append("doc values");
     }
-    if ((mask & FEATURE_POINTS) != 0) {
+    if ((mask & ASPECT_POINTS) != 0) {
       if (!sb.isEmpty()) sb.append(", ");
       sb.append("points");
     }
-    if ((mask & FEATURE_VECTOR) != 0) {
+    if ((mask & ASPECT_VECTOR) != 0) {
       if (!sb.isEmpty()) sb.append(", ");
       sb.append("vectors");
     }
@@ -98,10 +98,10 @@ public final class ColumnValidation {
   }
 
   /**
-   * Throws {@link IllegalArgumentException} if {@code fieldType} declares no indexing feature (no
+   * Throws {@link IllegalArgumentException} if {@code fieldType} declares no indexing aspect (no
    * doc values, no points, not stored, no index options, no vectors).
    */
-  public static void validateColumnHasIndexingFeature(
+  public static void validateColumnHasIndexingAspect(
       String fieldName, IndexableFieldType fieldType) {
     if (fieldType.docValuesType() == DocValuesType.NONE
         && fieldType.pointDimensionCount() == 0

--- a/lucene/core/src/java/org/apache/lucene/document/column/ColumnValidation.java
+++ b/lucene/core/src/java/org/apache/lucene/document/column/ColumnValidation.java
@@ -32,6 +32,71 @@ public final class ColumnValidation {
 
   private ColumnValidation() {}
 
+  /** Inverted-index aspect ({@code indexOptions() != NONE}). */
+  static final int FEATURE_INVERSION = 1 << 0;
+
+  /** Stored-fields aspect ({@code stored()}). */
+  static final int FEATURE_STORED = 1 << 1;
+
+  /** Doc-values aspect ({@code docValuesType() != NONE}). */
+  static final int FEATURE_DOCVALUES = 1 << 2;
+
+  /** Points aspect ({@code pointDimensionCount() != 0}). */
+  static final int FEATURE_POINTS = 1 << 3;
+
+  /** KNN-vector aspect ({@code vectorDimension() != 0}). */
+  static final int FEATURE_VECTOR = 1 << 4;
+
+  /**
+   * Returns a bitmask of the indexing aspects ({@code FEATURE_*}) declared by {@code fieldType}.
+   * Used by the column-batch path to enforce that, when several columns share a field name, each
+   * aspect is carried by at most one column.
+   */
+  public static int featureMask(IndexableFieldType fieldType) {
+    int mask = 0;
+    if (fieldType.indexOptions() != IndexOptions.NONE) {
+      mask |= FEATURE_INVERSION;
+    }
+    if (fieldType.stored()) {
+      mask |= FEATURE_STORED;
+    }
+    if (fieldType.docValuesType() != DocValuesType.NONE) {
+      mask |= FEATURE_DOCVALUES;
+    }
+    if (fieldType.pointDimensionCount() != 0) {
+      mask |= FEATURE_POINTS;
+    }
+    if (fieldType.vectorDimension() != 0) {
+      mask |= FEATURE_VECTOR;
+    }
+    return mask;
+  }
+
+  /** Returns a human-readable comma-separated list of the aspect names set in {@code mask}. */
+  public static String featureNames(int mask) {
+    StringBuilder sb = new StringBuilder();
+    if ((mask & FEATURE_INVERSION) != 0) {
+      sb.append("inversion");
+    }
+    if ((mask & FEATURE_STORED) != 0) {
+      if (!sb.isEmpty()) sb.append(", ");
+      sb.append("stored");
+    }
+    if ((mask & FEATURE_DOCVALUES) != 0) {
+      if (!sb.isEmpty()) sb.append(", ");
+      sb.append("doc values");
+    }
+    if ((mask & FEATURE_POINTS) != 0) {
+      if (!sb.isEmpty()) sb.append(", ");
+      sb.append("points");
+    }
+    if ((mask & FEATURE_VECTOR) != 0) {
+      if (!sb.isEmpty()) sb.append(", ");
+      sb.append("vectors");
+    }
+    return "[" + sb + "]";
+  }
+
   /**
    * Throws {@link IllegalArgumentException} if {@code fieldType} declares no indexing feature (no
    * doc values, no points, not stored, no index options, no vectors).

--- a/lucene/core/src/java/org/apache/lucene/document/column/ColumnValidation.java
+++ b/lucene/core/src/java/org/apache/lucene/document/column/ColumnValidation.java
@@ -32,65 +32,65 @@ public final class ColumnValidation {
 
   private ColumnValidation() {}
 
-  /** Inverted-index aspect ({@code indexOptions() != NONE}). */
-  static final int ASPECT_INVERSION = 1 << 0;
+  /** Inverted-index feature ({@code indexOptions() != NONE}). */
+  static final int FEATURE_INVERSION = 1 << 0;
 
-  /** Stored-fields aspect ({@code stored()}). */
-  static final int ASPECT_STORED = 1 << 1;
+  /** Stored-fields feature ({@code stored()}). */
+  static final int FEATURE_STORED = 1 << 1;
 
-  /** Doc-values aspect ({@code docValuesType() != NONE}). */
-  static final int ASPECT_DOCVALUES = 1 << 2;
+  /** Doc-values feature ({@code docValuesType() != NONE}). */
+  static final int FEATURE_DOCVALUES = 1 << 2;
 
-  /** Points aspect ({@code pointDimensionCount() != 0}). */
-  static final int ASPECT_POINTS = 1 << 3;
+  /** Points feature ({@code pointDimensionCount() != 0}). */
+  static final int FEATURE_POINTS = 1 << 3;
 
-  /** KNN-vector aspect ({@code vectorDimension() != 0}). */
-  static final int ASPECT_VECTOR = 1 << 4;
+  /** KNN-vector feature ({@code vectorDimension() != 0}). */
+  static final int FEATURE_VECTOR = 1 << 4;
 
   /**
-   * Returns a bitmask of the indexing aspects ({@code ASPECT_*}) declared by {@code fieldType}.
+   * Returns a bitmask of the indexing features ({@code FEATURE_*}) declared by {@code fieldType}.
    * Used by the column-batch path to enforce that, when several columns share a field name, each
-   * aspect is carried by at most one column.
+   * feature is carried by at most one column.
    */
-  public static int aspectMask(IndexableFieldType fieldType) {
+  public static int featureMask(IndexableFieldType fieldType) {
     int mask = 0;
     if (fieldType.indexOptions() != IndexOptions.NONE) {
-      mask |= ASPECT_INVERSION;
+      mask |= FEATURE_INVERSION;
     }
     if (fieldType.stored()) {
-      mask |= ASPECT_STORED;
+      mask |= FEATURE_STORED;
     }
     if (fieldType.docValuesType() != DocValuesType.NONE) {
-      mask |= ASPECT_DOCVALUES;
+      mask |= FEATURE_DOCVALUES;
     }
     if (fieldType.pointDimensionCount() != 0) {
-      mask |= ASPECT_POINTS;
+      mask |= FEATURE_POINTS;
     }
     if (fieldType.vectorDimension() != 0) {
-      mask |= ASPECT_VECTOR;
+      mask |= FEATURE_VECTOR;
     }
     return mask;
   }
 
-  /** Returns a human-readable comma-separated list of the aspect names set in {@code mask}. */
-  public static String aspectNames(int mask) {
+  /** Returns a human-readable comma-separated list of the feature names set in {@code mask}. */
+  public static String featureNames(int mask) {
     StringBuilder sb = new StringBuilder();
-    if ((mask & ASPECT_INVERSION) != 0) {
+    if ((mask & FEATURE_INVERSION) != 0) {
       sb.append("inversion");
     }
-    if ((mask & ASPECT_STORED) != 0) {
+    if ((mask & FEATURE_STORED) != 0) {
       if (!sb.isEmpty()) sb.append(", ");
       sb.append("stored");
     }
-    if ((mask & ASPECT_DOCVALUES) != 0) {
+    if ((mask & FEATURE_DOCVALUES) != 0) {
       if (!sb.isEmpty()) sb.append(", ");
       sb.append("doc values");
     }
-    if ((mask & ASPECT_POINTS) != 0) {
+    if ((mask & FEATURE_POINTS) != 0) {
       if (!sb.isEmpty()) sb.append(", ");
       sb.append("points");
     }
-    if ((mask & ASPECT_VECTOR) != 0) {
+    if ((mask & FEATURE_VECTOR) != 0) {
       if (!sb.isEmpty()) sb.append(", ");
       sb.append("vectors");
     }
@@ -98,10 +98,10 @@ public final class ColumnValidation {
   }
 
   /**
-   * Throws {@link IllegalArgumentException} if {@code fieldType} declares no indexing aspect (no
+   * Throws {@link IllegalArgumentException} if {@code fieldType} declares no indexing feature (no
    * doc values, no points, not stored, no index options, no vectors).
    */
-  public static void validateColumnHasIndexingAspect(
+  public static void validateColumnHasIndexingFeature(
       String fieldName, IndexableFieldType fieldType) {
     if (fieldType.docValuesType() == DocValuesType.NONE
         && fieldType.pointDimensionCount() == 0

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -708,8 +708,10 @@ final class IndexingChain implements Accountable {
     boolean hasRowColumns = false;
     long batchGen = nextFieldGen++;
 
-    // First pass: validate all column schemas and initialize field infos
+    // First pass: validate all columns and accumulate each field's schema. A batch may carry more
+    // than one column for a field name to combine distinct aspects (see featureMask).
     int columnIdx = 0;
+    int uniqueFieldCount = 0;
     for (Column column : columnBatch.columns()) {
       final String fieldName = column.name();
       final IndexableFieldType fieldType = column.fieldType();
@@ -740,14 +742,34 @@ final class IndexingChain implements Accountable {
       }
       docFields[columnIdx++] = pf;
 
-      if (pf.fieldGen == batchGen) {
-        throw new IllegalArgumentException(
-            "ColumnBatch contains more than one column for field \""
-                + fieldName
-                + "\"; multi-valued fields must use a single column with a sparse cursor");
+      if (pf.fieldGen != batchGen) {
+        // First column for this field name in this batch: start a fresh schema and aspect set, and
+        // collect the field once so its FieldInfo is initialized/validated after the loop.
+        pf.fieldGen = batchGen;
+        pf.columnFeatures = 0;
+        pf.schema.reset(baseDocID);
+        fields[uniqueFieldCount++] = pf;
       }
-      pf.fieldGen = batchGen;
-      validateColumnSchema(fieldName, pf, fieldType);
+
+      // Each indexing aspect must come from a single column for a given field name.
+      int columnFeatures = ColumnValidation.featureMask(fieldType);
+      int overlap = pf.columnFeatures & columnFeatures;
+      if (overlap != 0) {
+        throw new IllegalArgumentException(
+            "ColumnBatch has multiple columns for field \""
+                + fieldName
+                + "\" claiming the same indexing aspect "
+                + ColumnValidation.featureNames(overlap)
+                + "; each aspect must come from a single column.");
+      }
+      pf.columnFeatures |= (byte) columnFeatures;
+
+      updateDocFieldSchema(fieldName, pf.schema, fieldType);
+    }
+
+    // Initialize field infos / validate schemas once per unique field name in the batch.
+    if (uniqueFieldCount > 0) {
+      initAndValidateFields(uniqueFieldCount);
     }
 
     if (parentPf != null) {
@@ -919,17 +941,6 @@ final class IndexingChain implements Accountable {
                 + numDocs
                 + ")");
       }
-    }
-  }
-
-  private void validateColumnSchema(String fieldName, PerField pf, IndexableFieldType fieldType)
-      throws IOException {
-    updateDocFieldSchema(fieldName, pf.schema, fieldType);
-    if (pf.fieldInfo == null) {
-      initializeFieldInfo(pf);
-      pf.trySetValidatedFrozenFieldType();
-    } else {
-      pf.schema.assertSameSchema(pf.fieldInfo);
     }
   }
 
@@ -1675,6 +1686,17 @@ final class IndexingChain implements Accountable {
 
     /** We use this to know when a PerField is seen for the first time in the current document. */
     long fieldGen = -1;
+
+    /**
+     * Bit set of indexing aspects (as returned by {@link ColumnValidation#featureMask}) already
+     * claimed for this field name within the current {@code addBatch} call. A column batch may
+     * carry several columns for one field name to combine distinct aspects (e.g. a stored column
+     * plus an inverted column), but each aspect — inversion, stored, doc values, points, vectors —
+     * must come from a single column. Reset to 0 on the first sighting of the name in a batch
+     * (keyed off {@code fieldGen}), so it self-invalidates per batch and is untouched by {@code
+     * addDocument}.
+     */
+    byte columnFeatures;
 
     // Used by the hash table
     PerField next;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -709,14 +709,14 @@ final class IndexingChain implements Accountable {
     long batchGen = nextFieldGen++;
 
     // First pass: validate all columns and accumulate each field's schema. A batch may carry more
-    // than one column for a field name to combine distinct aspects (see featureMask).
+    // than one column for a field name to combine distinct aspects (see aspectMask).
     int columnIdx = 0;
     int uniqueFieldCount = 0;
     for (Column column : columnBatch.columns()) {
       final String fieldName = column.name();
       final IndexableFieldType fieldType = column.fieldType();
 
-      ColumnValidation.validateColumnHasIndexingFeature(fieldName, fieldType);
+      ColumnValidation.validateColumnHasIndexingAspect(fieldName, fieldType);
 
       switch (column) {
         case BinaryColumn bc -> ColumnValidation.validateBinaryColumn(bc, fieldType);
@@ -746,23 +746,23 @@ final class IndexingChain implements Accountable {
         // First column for this field name in this batch: start a fresh schema and aspect set, and
         // collect the field once so its FieldInfo is initialized/validated after the loop.
         pf.fieldGen = batchGen;
-        pf.columnFeatures = 0;
+        pf.columnAspects = 0;
         pf.schema.reset(baseDocID);
         fields[uniqueFieldCount++] = pf;
       }
 
       // Each indexing aspect must come from a single column for a given field name.
-      int columnFeatures = ColumnValidation.featureMask(fieldType);
-      int overlap = pf.columnFeatures & columnFeatures;
+      int columnAspects = ColumnValidation.aspectMask(fieldType);
+      int overlap = pf.columnAspects & columnAspects;
       if (overlap != 0) {
         throw new IllegalArgumentException(
             "ColumnBatch has multiple columns for field \""
                 + fieldName
                 + "\" claiming the same indexing aspect "
-                + ColumnValidation.featureNames(overlap)
+                + ColumnValidation.aspectNames(overlap)
                 + "; each aspect must come from a single column.");
       }
-      pf.columnFeatures |= (byte) columnFeatures;
+      pf.columnAspects |= (byte) columnAspects;
 
       updateDocFieldSchema(fieldName, pf.schema, fieldType);
     }
@@ -1688,15 +1688,14 @@ final class IndexingChain implements Accountable {
     long fieldGen = -1;
 
     /**
-     * Bit set of indexing aspects (as returned by {@link ColumnValidation#featureMask}) already
+     * Bit set of indexing aspects (as returned by {@link ColumnValidation#aspectMask}) already
      * claimed for this field name within the current {@code addBatch} call. A column batch may
      * carry several columns for one field name to combine distinct aspects (e.g. a stored column
      * plus an inverted column), but each aspect — inversion, stored, doc values, points, vectors —
      * must come from a single column. Reset to 0 on the first sighting of the name in a batch
-     * (keyed off {@code fieldGen}), so it self-invalidates per batch and is untouched by {@code
-     * addDocument}.
+     * (keyed off {@code fieldGen}).
      */
-    byte columnFeatures;
+    byte columnAspects;
 
     // Used by the hash table
     PerField next;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -746,27 +746,27 @@ final class IndexingChain implements Accountable {
       }
       docFields[columnIdx++] = pf;
 
+      int columnFeatures = ColumnValidation.featureMask(fieldType);
       if (pf.fieldGen != batchGen) {
         // First column for this field name in this batch: start a fresh schema and feature set, and
         // collect the field once so its FieldInfo is initialized/validated after the loop.
         pf.fieldGen = batchGen;
-        pf.columnFeatures = 0;
+        pf.columnFeatures = (byte) columnFeatures;
         pf.schema.reset(baseDocID);
         fields[uniqueFieldCount++] = pf;
+      } else {
+        // Each indexing feature must come from a single column for a given field name.
+        int overlap = pf.columnFeatures & columnFeatures;
+        if (overlap != 0) {
+          throw new IllegalArgumentException(
+              "ColumnBatch has multiple columns for field \""
+                  + fieldName
+                  + "\" claiming the same indexing feature "
+                  + ColumnValidation.featureNames(overlap)
+                  + "; each feature may appear in at most one column.");
+        }
+        pf.columnFeatures |= (byte) columnFeatures;
       }
-
-      // Each indexing feature must come from a single column for a given field name.
-      int columnFeatures = ColumnValidation.featureMask(fieldType);
-      int overlap = pf.columnFeatures & columnFeatures;
-      if (overlap != 0) {
-        throw new IllegalArgumentException(
-            "ColumnBatch has multiple columns for field \""
-                + fieldName
-                + "\" claiming the same indexing feature "
-                + ColumnValidation.featureNames(overlap)
-                + "; each feature may appear in at most one column.");
-      }
-      pf.columnFeatures |= (byte) columnFeatures;
 
       updateDocFieldSchema(fieldName, pf.schema, fieldType);
     }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -713,14 +713,14 @@ final class IndexingChain implements Accountable {
     long batchGen = nextFieldGen++;
 
     // First pass: validate all columns and accumulate each field's schema. A batch may carry more
-    // than one column for a field name to combine distinct aspects (see aspectMask).
+    // than one column for a field name to combine distinct features (see featureMask).
     int columnIdx = 0;
     int uniqueFieldCount = 0;
     for (Column column : columnBatch.columns()) {
       final String fieldName = column.name();
       final IndexableFieldType fieldType = column.fieldType();
 
-      ColumnValidation.validateColumnHasIndexingAspect(fieldName, fieldType);
+      ColumnValidation.validateColumnHasIndexingFeature(fieldName, fieldType);
 
       switch (column) {
         case BinaryColumn bc -> ColumnValidation.validateBinaryColumn(bc, fieldType);
@@ -747,26 +747,26 @@ final class IndexingChain implements Accountable {
       docFields[columnIdx++] = pf;
 
       if (pf.fieldGen != batchGen) {
-        // First column for this field name in this batch: start a fresh schema and aspect set, and
+        // First column for this field name in this batch: start a fresh schema and feature set, and
         // collect the field once so its FieldInfo is initialized/validated after the loop.
         pf.fieldGen = batchGen;
-        pf.columnAspects = 0;
+        pf.columnFeatures = 0;
         pf.schema.reset(baseDocID);
         fields[uniqueFieldCount++] = pf;
       }
 
-      // Each indexing aspect must come from a single column for a given field name.
-      int columnAspects = ColumnValidation.aspectMask(fieldType);
-      int overlap = pf.columnAspects & columnAspects;
+      // Each indexing feature must come from a single column for a given field name.
+      int columnFeatures = ColumnValidation.featureMask(fieldType);
+      int overlap = pf.columnFeatures & columnFeatures;
       if (overlap != 0) {
         throw new IllegalArgumentException(
             "ColumnBatch has multiple columns for field \""
                 + fieldName
-                + "\" claiming the same indexing aspect "
-                + ColumnValidation.aspectNames(overlap)
-                + "; each aspect must come from a single column.");
+                + "\" claiming the same indexing feature "
+                + ColumnValidation.featureNames(overlap)
+                + "; each feature must come from exactly one column.");
       }
-      pf.columnAspects |= (byte) columnAspects;
+      pf.columnFeatures |= (byte) columnFeatures;
 
       updateDocFieldSchema(fieldName, pf.schema, fieldType);
     }
@@ -1743,14 +1743,14 @@ final class IndexingChain implements Accountable {
     long fieldGen = -1;
 
     /**
-     * Bit set of indexing aspects (as returned by {@link ColumnValidation#aspectMask}) already
+     * Bit set of indexing features (as returned by {@link ColumnValidation#featureMask}) already
      * claimed for this field name within the current {@code addBatch} call. A column batch may
-     * carry several columns for one field name to combine distinct aspects (e.g. a stored column
-     * plus an inverted column), but each aspect — inversion, stored, doc values, points, vectors —
+     * carry several columns for one field name to combine distinct features (e.g. a stored column
+     * plus an inverted column), but each feature — inversion, stored, doc values, points, vectors —
      * must come from a single column. Reset to 0 on the first sighting of the name in a batch
      * (keyed off {@code fieldGen}).
      */
-    byte columnAspects;
+    byte columnFeatures;
 
     // Used by the hash table
     PerField next;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -764,7 +764,7 @@ final class IndexingChain implements Accountable {
                 + fieldName
                 + "\" claiming the same indexing feature "
                 + ColumnValidation.featureNames(overlap)
-                + "; each feature must come from exactly one column.");
+                + "; each feature may appear in at most one column.");
       }
       pf.columnFeatures |= (byte) columnFeatures;
 

--- a/lucene/core/src/test/org/apache/lucene/document/column/TestColumnBatchMultiColumnField.java
+++ b/lucene/core/src/test/org/apache/lucene/document/column/TestColumnBatchMultiColumnField.java
@@ -367,7 +367,7 @@ public class TestColumnBatchMultiColumnField extends LuceneTestCase {
     dir.close();
   }
 
-  public void testRejectsDuplicateInversionAspect() throws IOException {
+  public void testRejectsDuplicateInversionFeature() throws IOException {
     Directory dir = newDirectory();
     IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
     expectThrows(
@@ -387,7 +387,7 @@ public class TestColumnBatchMultiColumnField extends LuceneTestCase {
     dir.close();
   }
 
-  public void testRejectsDuplicateStoredAspect() throws IOException {
+  public void testRejectsDuplicateStoredFeature() throws IOException {
     Directory dir = newDirectory();
     IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
     expectThrows(
@@ -410,7 +410,7 @@ public class TestColumnBatchMultiColumnField extends LuceneTestCase {
     dir.close();
   }
 
-  public void testRejectsDuplicateDocValuesAspect() throws IOException {
+  public void testRejectsDuplicateDocValuesFeature() throws IOException {
     Directory dir = newDirectory();
     IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
     expectThrows(
@@ -427,7 +427,7 @@ public class TestColumnBatchMultiColumnField extends LuceneTestCase {
     dir.close();
   }
 
-  public void testRejectsDuplicatePointsAspect() throws IOException {
+  public void testRejectsDuplicatePointsFeature() throws IOException {
     Directory dir = newDirectory();
     IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
     FieldType pointType = new FieldType();
@@ -451,7 +451,7 @@ public class TestColumnBatchMultiColumnField extends LuceneTestCase {
     dir.close();
   }
 
-  public void testRejectsDuplicateVectorAspect() throws IOException {
+  public void testRejectsDuplicateVectorFeature() throws IOException {
     Directory dir = newDirectory();
     IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
     FieldType vectorType = floatVectorType(2, VectorSimilarityFunction.EUCLIDEAN);

--- a/lucene/core/src/test/org/apache/lucene/document/column/TestColumnBatchMultiColumnField.java
+++ b/lucene/core/src/test/org/apache/lucene/document/column/TestColumnBatchMultiColumnField.java
@@ -1,0 +1,471 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.document.column;
+
+import static org.apache.lucene.document.column.ColumnBatchTestUtil.ArrayBinaryColumn;
+import static org.apache.lucene.document.column.ColumnBatchTestUtil.ArrayFloatVectorColumn;
+import static org.apache.lucene.document.column.ColumnBatchTestUtil.ArrayLongColumn;
+import static org.apache.lucene.document.column.ColumnBatchTestUtil.floatVectorType;
+import static org.apache.lucene.document.column.ColumnBatchTestUtil.simpleBatch;
+
+import java.io.IOException;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TieredMergePolicy;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.BytesRef;
+
+/**
+ * Tests for composing multiple columns under a single field name in {@link ColumnBatch#columns()}.
+ */
+public class TestColumnBatchMultiColumnField extends LuceneTestCase {
+
+  /** Returns a frozen {@link FieldType} for an untokenized inverted-only field. */
+  private static FieldType invertedType() {
+    FieldType type = new FieldType();
+    type.setIndexOptions(IndexOptions.DOCS);
+    type.setTokenized(false);
+    type.setOmitNorms(true);
+    type.freeze();
+    return type;
+  }
+
+  /** Returns a frozen {@link FieldType} for a stored-only (non-indexed) field. */
+  private static FieldType storedBinaryType() {
+    FieldType type = new FieldType();
+    type.setStored(true);
+    type.freeze();
+    return type;
+  }
+
+  private IndexWriterConfig stableIwc() {
+    IndexWriterConfig iwc =
+        newIndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(new TieredMergePolicy());
+    iwc.setRAMBufferSizeMB(16);
+    iwc.setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH);
+    return iwc;
+  }
+
+  public void testComposeStoredAndInverted() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+
+    BytesRef[] stored = {newBytesRef("Hello World"), newBytesRef("Goodbye World")};
+    // Index the lower-cased tokens so the stored and indexed representations differ.
+    BytesRef[] indexed = {newBytesRef("hello"), newBytesRef("goodbye")};
+
+    w.addBatch(
+        simpleBatch(
+            2,
+            new ArrayBinaryColumn("body", storedBinaryType(), new int[] {0, 1}, stored),
+            new ArrayBinaryColumn("body", invertedType(), new int[] {0, 1}, indexed)));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+    IndexSearcher s = new IndexSearcher(r);
+
+    // Inverted postings come from the inverted column.
+    assertEquals(1, s.count(new TermQuery(new Term("body", "hello"))));
+    assertEquals(1, s.count(new TermQuery(new Term("body", "goodbye"))));
+    // The upper-cased original is not indexed.
+    assertEquals(0, s.count(new TermQuery(new Term("body", "Hello"))));
+
+    // Stored values come from the stored column.
+    StoredFields storedFields = leaf.storedFields();
+    assertEquals(stored[0], storedFields.document(0).getField("body").binaryValue());
+    assertEquals(stored[1], storedFields.document(1).getField("body").binaryValue());
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  public void testComposeDocValuesAndInverted() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+
+    BytesRef[] tokens = {newBytesRef("alpha"), newBytesRef("beta")};
+    w.addBatch(
+        simpleBatch(
+            2,
+            new ArrayLongColumn(
+                "x", NumericDocValuesField.TYPE, new int[] {0, 1}, new long[] {42L, 99L}),
+            new ArrayBinaryColumn("x", invertedType(), new int[] {0, 1}, tokens)));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+    IndexSearcher s = new IndexSearcher(r);
+
+    // Inverted postings come from the binary column.
+    assertEquals(1, s.count(new TermQuery(new Term("x", "alpha"))));
+    assertEquals(1, s.count(new TermQuery(new Term("x", "beta"))));
+
+    // Numeric doc values come from the long column.
+    NumericDocValues dv = leaf.getNumericDocValues("x");
+    assertNotNull(dv);
+    assertEquals(0, dv.nextDoc());
+    assertEquals(42L, dv.longValue());
+    assertEquals(1, dv.nextDoc());
+    assertEquals(99L, dv.longValue());
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  public void testComposeOrderIndependent() throws IOException {
+    BytesRef stored = newBytesRef("Hello World");
+    BytesRef indexed = newBytesRef("hello");
+
+    Directory storedFirst = indexComposedBinaryColumns(true, stored, indexed);
+    Directory invertedFirst = indexComposedBinaryColumns(false, stored, indexed);
+
+    for (Directory d : new Directory[] {storedFirst, invertedFirst}) {
+      DirectoryReader r = DirectoryReader.open(d);
+      LeafReader leaf = getOnlyLeafReader(r);
+      IndexSearcher s = new IndexSearcher(r);
+      assertEquals(1, s.count(new TermQuery(new Term("body", "hello"))));
+      assertEquals(0, s.count(new TermQuery(new Term("body", "Hello"))));
+      assertEquals(stored, leaf.storedFields().document(0).getField("body").binaryValue());
+      r.close();
+      d.close();
+    }
+  }
+
+  private Directory indexComposedBinaryColumns(
+      boolean storedFirst, BytesRef stored, BytesRef indexed) throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+    Column storedCol =
+        new ArrayBinaryColumn("body", storedBinaryType(), new int[] {0}, new BytesRef[] {stored});
+    Column invertedCol =
+        new ArrayBinaryColumn("body", invertedType(), new int[] {0}, new BytesRef[] {indexed});
+    w.addBatch(
+        storedFirst
+            ? simpleBatch(1, storedCol, invertedCol)
+            : simpleBatch(1, invertedCol, storedCol));
+    w.close();
+    return dir;
+  }
+
+  public void testComposeDocValuesAndPoints() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+
+    FieldType pointType = new FieldType();
+    pointType.setDimensions(1, Integer.BYTES);
+    pointType.freeze();
+
+    w.addBatch(
+        simpleBatch(
+            2,
+            new ArrayLongColumn(
+                "n", NumericDocValuesField.TYPE, new int[] {0, 1}, new long[] {7L, 8L}),
+            new ArrayLongColumn(
+                "n",
+                pointType,
+                LongColumn.NumericKind.INT,
+                new int[] {0, 1},
+                new long[] {7L, 8L})));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+    IndexSearcher s = new IndexSearcher(r);
+
+    // Points come from the point column.
+    assertEquals(1, s.count(IntPoint.newExactQuery("n", 7)));
+    assertEquals(2, s.count(IntPoint.newRangeQuery("n", 7, 8)));
+
+    // NUMERIC doc values come from the doc-values column.
+    NumericDocValues dv = leaf.getNumericDocValues("n");
+    assertNotNull(dv);
+    assertEquals(0, dv.nextDoc());
+    assertEquals(7L, dv.longValue());
+    assertEquals(1, dv.nextDoc());
+    assertEquals(8L, dv.longValue());
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  public void testComposeDocValuesAndVector() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+
+    FieldType vectorType = floatVectorType(2, VectorSimilarityFunction.EUCLIDEAN);
+    float[][] vectors = {{1f, 2f}, {3f, 4f}};
+
+    w.addBatch(
+        simpleBatch(
+            2,
+            new ArrayLongColumn(
+                "v", NumericDocValuesField.TYPE, new int[] {0, 1}, new long[] {11L, 22L}),
+            new ArrayFloatVectorColumn("v", vectorType, new int[] {0, 1}, vectors)));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+
+    NumericDocValues dv = leaf.getNumericDocValues("v");
+    assertNotNull(dv);
+    assertEquals(0, dv.nextDoc());
+    assertEquals(11L, dv.longValue());
+    assertEquals(1, dv.nextDoc());
+    assertEquals(22L, dv.longValue());
+
+    FloatVectorValues fvv = leaf.getFloatVectorValues("v");
+    assertNotNull(fvv);
+    KnnVectorValues.DocIndexIterator it = fvv.iterator();
+    for (int i = 0; i < 2; i++) {
+      assertEquals(i, it.nextDoc());
+      assertArrayEquals(vectors[i], fvv.vectorValue(it.index()), 0f);
+    }
+    assertEquals(DocIdSetIterator.NO_MORE_DOCS, it.nextDoc());
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  public void testComposeSparseDisjointDocIds() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+
+    w.addBatch(
+        simpleBatch(
+            2,
+            new ArrayBinaryColumn(
+                "body", storedBinaryType(), new int[] {0}, new BytesRef[] {newBytesRef("kept")}),
+            new ArrayBinaryColumn(
+                "body", invertedType(), new int[] {1}, new BytesRef[] {newBytesRef("token")})));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+    IndexSearcher s = new IndexSearcher(r);
+
+    // The token is indexed on doc 1 only.
+    assertEquals(1, s.count(new TermQuery(new Term("body", "token"))));
+
+    StoredFields storedFields = leaf.storedFields();
+    // doc 0 carries the stored value; doc 1 has no stored "body".
+    assertEquals(newBytesRef("kept"), storedFields.document(0).getField("body").binaryValue());
+    assertNull(storedFields.document(1).getField("body"));
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  public void testComposeAcrossBatches() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, stableIwc());
+
+    w.addBatch(
+        simpleBatch(
+            1,
+            new ArrayBinaryColumn(
+                "body", storedBinaryType(), new int[] {0}, new BytesRef[] {newBytesRef("Hello")}),
+            new ArrayBinaryColumn(
+                "body", invertedType(), new int[] {0}, new BytesRef[] {newBytesRef("hello")})));
+    w.addBatch(
+        simpleBatch(
+            1,
+            new ArrayBinaryColumn(
+                "body", storedBinaryType(), new int[] {0}, new BytesRef[] {newBytesRef("World")}),
+            new ArrayBinaryColumn(
+                "body", invertedType(), new int[] {0}, new BytesRef[] {newBytesRef("world")})));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+    IndexSearcher s = new IndexSearcher(r);
+
+    assertEquals(1, s.count(new TermQuery(new Term("body", "hello"))));
+    assertEquals(1, s.count(new TermQuery(new Term("body", "world"))));
+
+    StoredFields storedFields = leaf.storedFields();
+    assertEquals(newBytesRef("Hello"), storedFields.document(0).getField("body").binaryValue());
+    assertEquals(newBytesRef("World"), storedFields.document(1).getField("body").binaryValue());
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  public void testComposeMixedWithAddDocument() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, stableIwc());
+
+    // A field type that is both stored and inverted, matching the merged schema produced by
+    // composing storedBinaryType() + invertedType() in a batch.
+    FieldType combined = new FieldType();
+    combined.setStored(true);
+    combined.setIndexOptions(IndexOptions.DOCS);
+    combined.setTokenized(false);
+    combined.setOmitNorms(true);
+    combined.freeze();
+
+    // doc 0 via addDocument establishes the FieldInfo (and the frozen-field fast path).
+    Document doc = new Document();
+    doc.add(new Field("body", "alpha", combined));
+    w.addDocument(doc);
+
+    // doc 1 via a composed batch for the same field name, in the same segment.
+    w.addBatch(
+        simpleBatch(
+            1,
+            new ArrayBinaryColumn(
+                "body", storedBinaryType(), new int[] {0}, new BytesRef[] {newBytesRef("Beta")}),
+            new ArrayBinaryColumn(
+                "body", invertedType(), new int[] {0}, new BytesRef[] {newBytesRef("beta")})));
+
+    DirectoryReader r = DirectoryReader.open(w);
+    LeafReader leaf = getOnlyLeafReader(r);
+    IndexSearcher s = new IndexSearcher(r);
+
+    assertEquals(1, s.count(new TermQuery(new Term("body", "alpha"))));
+    assertEquals(1, s.count(new TermQuery(new Term("body", "beta"))));
+
+    StoredFields storedFields = leaf.storedFields();
+    assertEquals("alpha", storedFields.document(0).getField("body").stringValue());
+    assertEquals(newBytesRef("Beta"), storedFields.document(1).getField("body").binaryValue());
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  public void testRejectsDuplicateInversionAspect() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+    expectThrows(
+        IllegalArgumentException.class,
+        () ->
+            w.addBatch(
+                simpleBatch(
+                    1,
+                    new ArrayBinaryColumn(
+                        "body", invertedType(), new int[] {0}, new BytesRef[] {newBytesRef("a")}),
+                    new ArrayBinaryColumn(
+                        "body",
+                        invertedType(),
+                        new int[] {0},
+                        new BytesRef[] {newBytesRef("b")}))));
+    w.close();
+    dir.close();
+  }
+
+  public void testRejectsDuplicateStoredAspect() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+    expectThrows(
+        IllegalArgumentException.class,
+        () ->
+            w.addBatch(
+                simpleBatch(
+                    1,
+                    new ArrayBinaryColumn(
+                        "body",
+                        storedBinaryType(),
+                        new int[] {0},
+                        new BytesRef[] {newBytesRef("a")}),
+                    new ArrayBinaryColumn(
+                        "body",
+                        storedBinaryType(),
+                        new int[] {0},
+                        new BytesRef[] {newBytesRef("b")}))));
+    w.close();
+    dir.close();
+  }
+
+  public void testRejectsDuplicateDocValuesAspect() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+    expectThrows(
+        IllegalArgumentException.class,
+        () ->
+            w.addBatch(
+                simpleBatch(
+                    1,
+                    new ArrayLongColumn(
+                        "x", NumericDocValuesField.TYPE, new int[] {0}, new long[] {1L}),
+                    new ArrayLongColumn(
+                        "x", NumericDocValuesField.TYPE, new int[] {0}, new long[] {2L}))));
+    w.close();
+    dir.close();
+  }
+
+  public void testRejectsDuplicatePointsAspect() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+    FieldType pointType = new FieldType();
+    pointType.setDimensions(1, Integer.BYTES);
+    pointType.freeze();
+    expectThrows(
+        IllegalArgumentException.class,
+        () ->
+            w.addBatch(
+                simpleBatch(
+                    1,
+                    new ArrayLongColumn(
+                        "p", pointType, LongColumn.NumericKind.INT, new int[] {0}, new long[] {1L}),
+                    new ArrayLongColumn(
+                        "p",
+                        pointType,
+                        LongColumn.NumericKind.INT,
+                        new int[] {0},
+                        new long[] {2L}))));
+    w.close();
+    dir.close();
+  }
+
+  public void testRejectsDuplicateVectorAspect() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+    FieldType vectorType = floatVectorType(2, VectorSimilarityFunction.EUCLIDEAN);
+    expectThrows(
+        IllegalArgumentException.class,
+        () ->
+            w.addBatch(
+                simpleBatch(
+                    1,
+                    new ArrayFloatVectorColumn(
+                        "v", vectorType, new int[] {0}, new float[][] {{1f, 2f}}),
+                    new ArrayFloatVectorColumn(
+                        "v", vectorType, new int[] {0}, new float[][] {{3f, 4f}}))));
+    w.close();
+    dir.close();
+  }
+}


### PR DESCRIPTION
Relaxes the one-column-per-field-name rule in addBatch so a field can be
built from several columns contributing distinct indexing features — for
example a stored BinaryColumn alongside an inverted BinaryColumn.

processBatch now mirrors processDocument: schemas accumulate across
same-named columns and FieldInfo is frozen once after the loop. Each
feature (inversion, stored, doc values, points, vectors) must still come
from a single column, enforced via a per-field byte bitset of claimed
features keyed off fieldGen.