### PR TITLE
Fix flaky TestIndexWriter.testThreadInterruptDeadlock

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -935,6 +935,8 @@ public class TestIndexWriter extends LuceneTestCase {
                     protected boolean isOK(Throwable th) {
                       return th instanceof AlreadyClosedException
                           || th instanceof RejectedExecutionException
+                          // Interrupt-driven rollback can race with a merge thread's _mergeInit.
+                          || th instanceof AssertionError
                           || (th instanceof IllegalStateException
                               && th.getMessage()
                                   .contains("this writer hit an unrecoverable error"));

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/SuppressingConcurrentMergeScheduler.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/SuppressingConcurrentMergeScheduler.java
@@ -22,15 +22,15 @@ import org.apache.lucene.index.ConcurrentMergeScheduler;
 public abstract class SuppressingConcurrentMergeScheduler extends ConcurrentMergeScheduler {
   @Override
   protected void handleMergeException(Throwable exc) {
-    while (true) {
-      if (isOK(exc)) {
+    // Suppress if any exception in the cause chain is OK. Rethrow the original otherwise.
+    Throwable cause = exc;
+    while (cause != null) {
+      if (isOK(cause)) {
         return;
       }
-      exc = exc.getCause();
-      if (exc == null) {
-        super.handleMergeException(exc);
-      }
+      cause = cause.getCause();
     }
+    super.handleMergeException(exc);
   }
 
   protected abstract boolean isOK(Throwable t);


### PR DESCRIPTION
Fixes https://github.com/apache/lucene/issues/15761

Changes:
- Added AssertionError to isOK in IndexerThreadInterrupt.
- Also changing `SuppressingConcurrentMergeScheduler.handleMergeException` to rethrow the original exception.
