### PR TITLE
BooleanWeight.explain prints failing optional clauses (when required)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -388,6 +388,8 @@ Improvements
 
 * GITHUB#16144: Clarify LeafCollector batch collection scoring contract. (Costin Leau)
 
+* GITHUB#16229: BooleanWeight.explain prints failing optional clauses when query fails due to insufficient SHOULD matches. (Jakub Slowinski)
+
 Optimizations
 ---------------------
 * GITHUB#16176: Restore WANDScorer for TOP_SCORES + minShouldMatch > 1. (Tianxiao Wei)

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
@@ -65,6 +65,7 @@ final class BooleanWeight extends Weight {
   public Explanation explain(LeafReaderContext context, int doc) throws IOException {
     final int minShouldMatch = query.getMinimumNumberShouldMatch();
     List<Explanation> subs = new ArrayList<>();
+    List<Explanation> failingOptionals = new ArrayList<>();
     boolean fail = false;
     int matchCount = 0;
     int shouldMatchCount = 0;
@@ -97,14 +98,19 @@ final class BooleanWeight extends Weight {
         subs.add(
             Explanation.noMatch("no match on required clause (" + c.query().toString() + ")", e));
         fail = true;
+      } else if (c.occur() == Occur.SHOULD) {
+        failingOptionals.add(
+            Explanation.noMatch("no match on optional clause (" + c.query().toString() + ")", e));
       }
     }
     if (fail) {
       return Explanation.noMatch(
           "Failure to meet condition(s) of required/prohibited clause(s)", subs);
     } else if (matchCount == 0) {
+      subs.addAll(failingOptionals);
       return Explanation.noMatch("No matching clauses", subs);
     } else if (shouldMatchCount < minShouldMatch) {
+      subs.addAll(failingOptionals);
       return Explanation.noMatch(
           "Failure to match minimum number of optional clauses: " + minShouldMatch, subs);
     } else {

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
@@ -112,7 +112,11 @@ final class BooleanWeight extends Weight {
     } else if (shouldMatchCount < minShouldMatch) {
       subs.addAll(failingOptionals);
       return Explanation.noMatch(
-          "Failure to match minimum number of optional clauses: " + minShouldMatch, subs);
+          "Failure to match minimum number of optional clauses: "
+              + minShouldMatch
+              + ", matched: "
+              + shouldMatchCount,
+          subs);
     } else {
       // Replicating the same floating-point errors as the scorer does is quite
       // complex (essentially because of how ReqOptSumScorer casts intermediate

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
@@ -1411,4 +1411,49 @@ public class TestBooleanQuery extends LuceneTestCase {
         UnsupportedOperationException.class,
         () -> bq.clauses().add(new BooleanClause(MatchNoDocsQuery.INSTANCE, Occur.SHOULD)));
   }
+
+  public void testExplainFailingOptionalClauses() throws Exception {
+    Directory dir = newDirectory();
+    RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+    Document doc = new Document();
+    doc.add(new TextField("field", "foo", Store.NO));
+    w.addDocument(doc);
+    IndexReader reader = w.getReader();
+    w.close();
+    IndexSearcher searcher = newSearcher(reader);
+
+    // minShouldMatch not satisfied, show failing SHOULDs.
+    BooleanQuery msm =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("field", "foo")), Occur.SHOULD)
+            .add(new TermQuery(new Term("field", "bar")), Occur.SHOULD)
+            .add(new TermQuery(new Term("field", "baz")), Occur.SHOULD)
+            .setMinimumNumberShouldMatch(2)
+            .build();
+    String msmExpl = searcher.explain(msm, 0).toString();
+    assertTrue(msmExpl.contains("no match on optional clause (field:bar)"));
+    assertTrue(msmExpl.contains("no match on optional clause (field:baz)"));
+    assertFalse(msmExpl.contains("no match on optional clause (field:foo)"));
+
+    // nothing matches in disjunction, show failing SHOULDs.
+    BooleanQuery disj =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("field", "bar")), Occur.SHOULD)
+            .add(new TermQuery(new Term("field", "baz")), Occur.SHOULD)
+            .build();
+    String disjExpl = searcher.explain(disj, 0).toString();
+    assertTrue(disjExpl.contains("no match on optional clause (field:bar)"));
+    assertTrue(disjExpl.contains("no match on optional clause (field:baz)"));
+
+    // MUST clause fails, failing SHOULDs are not shown.
+    BooleanQuery mustFail =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("field", "missing")), Occur.MUST)
+            .add(new TermQuery(new Term("field", "bar")), Occur.SHOULD)
+            .build();
+    assertFalse(searcher.explain(mustFail, 0).toString().contains("no match on optional clause"));
+
+    reader.close();
+    dir.close();
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
@@ -1395,7 +1395,7 @@ public class TestBooleanQuery extends LuceneTestCase {
     bqBuilder.add(new TermQuery(d), Occur.MUST_NOT);
     bqBuilder.add(new TermQuery(d), Occur.MUST_NOT);
     BooleanQuery bq = bqBuilder.build();
-    // should and must are not dedupliacated
+    // should and must are not deduplicated
     assertEquals(2, bq.getClauses(Occur.SHOULD).size());
     assertEquals(2, bq.getClauses(Occur.MUST).size());
     // filter and must not are deduplicated
@@ -1410,50 +1410,5 @@ public class TestBooleanQuery extends LuceneTestCase {
     assertThrows(
         UnsupportedOperationException.class,
         () -> bq.clauses().add(new BooleanClause(MatchNoDocsQuery.INSTANCE, Occur.SHOULD)));
-  }
-
-  public void testExplainFailingOptionalClauses() throws Exception {
-    Directory dir = newDirectory();
-    RandomIndexWriter w = new RandomIndexWriter(random(), dir);
-    Document doc = new Document();
-    doc.add(new TextField("field", "foo", Store.NO));
-    w.addDocument(doc);
-    IndexReader reader = w.getReader();
-    w.close();
-    IndexSearcher searcher = newSearcher(reader);
-
-    // minShouldMatch not satisfied, show failing SHOULDs.
-    BooleanQuery msm =
-        new BooleanQuery.Builder()
-            .add(new TermQuery(new Term("field", "foo")), Occur.SHOULD)
-            .add(new TermQuery(new Term("field", "bar")), Occur.SHOULD)
-            .add(new TermQuery(new Term("field", "baz")), Occur.SHOULD)
-            .setMinimumNumberShouldMatch(2)
-            .build();
-    String msmExpl = searcher.explain(msm, 0).toString();
-    assertTrue(msmExpl.contains("no match on optional clause (field:bar)"));
-    assertTrue(msmExpl.contains("no match on optional clause (field:baz)"));
-    assertFalse(msmExpl.contains("no match on optional clause (field:foo)"));
-
-    // nothing matches in disjunction, show failing SHOULDs.
-    BooleanQuery disj =
-        new BooleanQuery.Builder()
-            .add(new TermQuery(new Term("field", "bar")), Occur.SHOULD)
-            .add(new TermQuery(new Term("field", "baz")), Occur.SHOULD)
-            .build();
-    String disjExpl = searcher.explain(disj, 0).toString();
-    assertTrue(disjExpl.contains("no match on optional clause (field:bar)"));
-    assertTrue(disjExpl.contains("no match on optional clause (field:baz)"));
-
-    // MUST clause fails, failing SHOULDs are not shown.
-    BooleanQuery mustFail =
-        new BooleanQuery.Builder()
-            .add(new TermQuery(new Term("field", "missing")), Occur.MUST)
-            .add(new TermQuery(new Term("field", "bar")), Occur.SHOULD)
-            .build();
-    assertFalse(searcher.explain(mustFail, 0).toString().contains("no match on optional clause"));
-
-    reader.close();
-    dir.close();
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestComplexExplanations.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestComplexExplanations.java
@@ -156,6 +156,8 @@ public class TestComplexExplanations extends BaseExplanationTestCase {
             .setMinimumNumberShouldMatch(2)
             .build();
     String msmExpl = searcher.explain(msm, 0).toString();
+    assertTrue(
+        msmExpl.contains("Failure to match minimum number of optional clauses: 2, matched: 1"));
     assertTrue(msmExpl.contains("no match on optional clause (field:xx)"));
     assertTrue(msmExpl.contains("no match on optional clause (field:zz)"));
     assertFalse(msmExpl.contains("no match on optional clause (field:w1)"));

--- a/lucene/core/src/test/org/apache/lucene/search/TestComplexExplanations.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestComplexExplanations.java
@@ -145,4 +145,37 @@ public class TestComplexExplanations extends BaseExplanationTestCase {
 
     bqtest(new BoostQuery(query, 0), new int[] {0, 1, 2, 3});
   }
+
+  public void testExplainFailingOptionalClauses() throws Exception {
+    // minShouldMatch not satisfied, show failing SHOULDs.
+    BooleanQuery msm =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term(FIELD, "w1")), Occur.SHOULD)
+            .add(new TermQuery(new Term(FIELD, "xx")), Occur.SHOULD)
+            .add(new TermQuery(new Term(FIELD, "zz")), Occur.SHOULD)
+            .setMinimumNumberShouldMatch(2)
+            .build();
+    String msmExpl = searcher.explain(msm, 0).toString();
+    assertTrue(msmExpl.contains("no match on optional clause (field:xx)"));
+    assertTrue(msmExpl.contains("no match on optional clause (field:zz)"));
+    assertFalse(msmExpl.contains("no match on optional clause (field:w1)"));
+
+    // nothing matches in disjunction, show failing SHOULDs.
+    BooleanQuery disj =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term(FIELD, "xx")), Occur.SHOULD)
+            .add(new TermQuery(new Term(FIELD, "zz")), Occur.SHOULD)
+            .build();
+    String disjExpl = searcher.explain(disj, 0).toString();
+    assertTrue(disjExpl.contains("no match on optional clause (field:xx)"));
+    assertTrue(disjExpl.contains("no match on optional clause (field:zz)"));
+
+    // MUST clause fails, failing SHOULDs are not shown.
+    BooleanQuery mustFail =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term(FIELD, "missing")), Occur.MUST)
+            .add(new TermQuery(new Term(FIELD, "xx")), Occur.SHOULD)
+            .build();
+    assertFalse(searcher.explain(mustFail, 0).toString().contains("no match on optional clause"));
+  }
 }


### PR DESCRIPTION
The explanation now includes `no match on optional clause (…)` sub-explanations for each non-matching SHOULD clause IFF a BooleanQuery fails to match because either 1) `shouldMatchCount < minShouldMatch` or 2) `matchCount == 0`.

Previously, BooleanWeight.explain silently discarded non-matching SHOULDs. The explanation would say "Failure to match minimum number of optional clauses: X" without stating the clauses which failed to match.