### PR TITLE
Fix FVH StringIndexOutOfBoundsException with overlapping token offsets

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -158,11 +158,6 @@ Optimizations
 
 Bug Fixes
 ---------------------
-* GITHUB#XXXXX: Fix FastVectorHighlighter StringIndexOutOfBoundsException when term offsets overlap.
-  Analyzers like CJK bigram or ik_max_word produce overlapping tokens; the highlighter now clips
-  overlapping portions instead of throwing an exception, ensuring the full matched region is
-  highlighted. (Baojun Han)
-
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
   when all values are identical. (Mike Sokolov)
 
@@ -195,6 +190,8 @@ Bug Fixes
 * GITHUB#15838: Fix luke terms export failure on Windows when field names contain characters forbidden in file name (Binlong Gao)
 
 * GITHUB#15939: Fix thread-safety issues with NFARunAutomaton. (Dimitris Rempapis)
+
+* GITHUB#16246: Fix FVH StringIndexOutOfBoundsException with overlapping token offsets. (hanbj)
 
 Changes in Runtime Behavior
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -158,6 +158,11 @@ Optimizations
 
 Bug Fixes
 ---------------------
+* GITHUB#XXXXX: Fix FastVectorHighlighter StringIndexOutOfBoundsException when term offsets overlap.
+  Analyzers like CJK bigram or ik_max_word produce overlapping tokens; the highlighter now clips
+  overlapping portions instead of throwing an exception, ensuring the full matched region is
+  highlighted. (Baojun Han)
+
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
   when all values are identical. (Mike Sokolov)
 

--- a/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/BaseFragmentsBuilder.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/vectorhighlight/BaseFragmentsBuilder.java
@@ -214,18 +214,30 @@ public abstract class BaseFragmentsBuilder implements FragmentsBuilder {
     int srcIndex = 0;
     for (SubInfo subInfo : fragInfo.getSubInfos()) {
       for (Toffs to : subInfo.termsOffsets()) {
+        int toffsStart = to.getStartOffset() - modifiedStartOffset[0];
+        int toffsEnd = to.getEndOffset() - modifiedStartOffset[0];
+        // Skip tokens with truly invalid offsets that cannot be salvaged.
+        if (toffsEnd < toffsStart || toffsEnd > src.length() || toffsEnd <= 0) {
+          continue;
+        }
+        if (toffsStart < 0) {
+          toffsStart = 0;
+        }
+        // Handle overlapping tokens: analyzers (e.g. CJK bigram, ik_max_word) commonly
+        // produce tokens whose offsets overlap. Rather than skipping, highlight the
+        // non-overlapping tail so the full matched region is covered.
+        if (toffsStart < srcIndex) {
+          if (toffsEnd <= srcIndex) {
+            continue;
+          }
+          toffsStart = srcIndex;
+        }
         fragment
-            .append(
-                encoder.encodeText(
-                    src.substring(srcIndex, to.getStartOffset() - modifiedStartOffset[0])))
+            .append(encoder.encodeText(src.substring(srcIndex, toffsStart)))
             .append(getPreTag(preTags, subInfo.seqnum()))
-            .append(
-                encoder.encodeText(
-                    src.substring(
-                        to.getStartOffset() - modifiedStartOffset[0],
-                        to.getEndOffset() - modifiedStartOffset[0])))
+            .append(encoder.encodeText(src.substring(toffsStart, toffsEnd)))
             .append(getPostTag(postTags, subInfo.seqnum()));
-        srcIndex = to.getEndOffset() - modifiedStartOffset[0];
+        srcIndex = toffsEnd;
       }
     }
     fragment.append(encoder.encodeText(src.substring(srcIndex)));

--- a/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestBaseFragmentsBuilderOverlappingOffsets.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestBaseFragmentsBuilderOverlappingOffsets.java
@@ -76,7 +76,8 @@ public class TestBaseFragmentsBuilderOverlappingOffsets extends LuceneTestCase {
   }
 
   /**
-   * Token entirely contained within a previously highlighted region should be skipped without error.
+   * Token entirely contained within a previously highlighted region should be skipped without
+   * error.
    */
   public void testFullyContainedTokenIsSkipped() {
     String src = "abcdefghij";
@@ -95,8 +96,8 @@ public class TestBaseFragmentsBuilderOverlappingOffsets extends LuceneTestCase {
   }
 
   /**
-   * CJK max-word segmentation: "中华人民共和国" produces 7 overlapping tokens that collectively
-   * cover [0,7). All characters must be highlighted.
+   * CJK max-word segmentation: "中华人民共和国" produces 7 overlapping tokens that collectively cover
+   * [0,7). All characters must be highlighted.
    */
   public void testCjkMaxWordOverlappingTokens() {
     String src = "中华人民共和国";
@@ -183,7 +184,7 @@ public class TestBaseFragmentsBuilderOverlappingOffsets extends LuceneTestCase {
     assertEquals("the <b>quick</b><b> brow</b>n fox", result);
   }
 
-  /** Inverted offset (endOffset < startOffset) should be skipped without error. */
+  /** Inverted offset (endOffset &lt; startOffset) should be skipped without error. */
   public void testInvertedOffsetsSkipped() {
     String src = "hello world";
 

--- a/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestBaseFragmentsBuilderOverlappingOffsets.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/vectorhighlight/TestBaseFragmentsBuilderOverlappingOffsets.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search.vectorhighlight;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.search.highlight.DefaultEncoder;
+import org.apache.lucene.search.highlight.Encoder;
+import org.apache.lucene.search.vectorhighlight.FieldFragList.WeightedFragInfo;
+import org.apache.lucene.search.vectorhighlight.FieldFragList.WeightedFragInfo.SubInfo;
+import org.apache.lucene.search.vectorhighlight.FieldPhraseList.WeightedPhraseInfo.Toffs;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+/**
+ * Tests that BaseFragmentsBuilder handles overlapping token offsets correctly.
+ *
+ * <p>Analyzers like CJK bigram, ik_max_word, and other multi-granularity tokenizers produce tokens
+ * with overlapping offsets. For example, "中华人民共和国" may produce tokens at [0,2), [0,4), [1,3),
+ * [2,4), [2,7), [4,6), [4,7). The highlighter must handle these without throwing
+ * StringIndexOutOfBoundsException and should highlight the full matched region.
+ *
+ * @see <a href="https://github.com/elastic/elasticsearch/issues/73072">Elasticsearch #73072</a>
+ */
+public class TestBaseFragmentsBuilderOverlappingOffsets extends LuceneTestCase {
+
+  private static final Encoder ENCODER = new DefaultEncoder();
+  private static final String[] PRE_TAGS = {"<b>"};
+  private static final String[] POST_TAGS = {"</b>"};
+
+  private String makeFragment(String sourceText, WeightedFragInfo fragInfo) {
+    SimpleFragmentsBuilder sfb = new SimpleFragmentsBuilder();
+    FieldType ft = new FieldType(TextField.TYPE_STORED);
+    ft.setStoreTermVectors(true);
+    Field[] values = new Field[] {new Field("f", sourceText, ft)};
+    StringBuilder buffer = new StringBuilder();
+    int[] index = {0};
+    return sfb.makeFragment(buffer, index, values, fragInfo, PRE_TAGS, POST_TAGS, ENCODER);
+  }
+
+  /**
+   * Overlapping tokens [0,10) and [8,14): the second token starts before the first one ends. Before
+   * the fix this throws StringIndexOutOfBoundsException: Range [10, 8) out of bounds.
+   */
+  public void testOverlappingTokensHighlightExtendedRegion() {
+    String src = "hello world test data";
+
+    List<Toffs> toffsList = new ArrayList<>();
+    toffsList.add(new Toffs(0, 10));
+    toffsList.add(new Toffs(8, 14));
+
+    List<SubInfo> subInfos = new ArrayList<>();
+    subInfos.add(new SubInfo("term", toffsList, 0, 1.0f));
+
+    WeightedFragInfo fragInfo = new WeightedFragInfo(0, 21, subInfos, 1.0f);
+    String result = makeFragment(src, fragInfo);
+
+    // [0,10) highlighted, then [8,14) clipped to [10,14)
+    assertEquals("<b>hello worl</b><b>d te</b>st data", result);
+  }
+
+  /**
+   * Token entirely contained within a previously highlighted region should be skipped without error.
+   */
+  public void testFullyContainedTokenIsSkipped() {
+    String src = "abcdefghij";
+
+    List<Toffs> toffsList = new ArrayList<>();
+    toffsList.add(new Toffs(0, 8)); // covers [0,8)
+    toffsList.add(new Toffs(2, 5)); // entirely within [0,8)
+
+    List<SubInfo> subInfos = new ArrayList<>();
+    subInfos.add(new SubInfo("term", toffsList, 0, 1.0f));
+
+    WeightedFragInfo fragInfo = new WeightedFragInfo(0, 10, subInfos, 1.0f);
+    String result = makeFragment(src, fragInfo);
+
+    assertEquals("<b>abcdefgh</b>ij", result);
+  }
+
+  /**
+   * CJK max-word segmentation: "中华人民共和国" produces 7 overlapping tokens that collectively
+   * cover [0,7). All characters must be highlighted.
+   */
+  public void testCjkMaxWordOverlappingTokens() {
+    String src = "中华人民共和国";
+
+    List<Toffs> toffsList = new ArrayList<>();
+    toffsList.add(new Toffs(0, 2)); // 中华
+    toffsList.add(new Toffs(0, 4)); // 中华人民
+    toffsList.add(new Toffs(1, 3)); // 华人
+    toffsList.add(new Toffs(2, 4)); // 人民
+    toffsList.add(new Toffs(2, 7)); // 人民共和国
+    toffsList.add(new Toffs(4, 6)); // 共和
+    toffsList.add(new Toffs(4, 7)); // 共和国
+
+    List<SubInfo> subInfos = new ArrayList<>();
+    subInfos.add(new SubInfo("term", toffsList, 0, 7.0f));
+
+    WeightedFragInfo fragInfo = new WeightedFragInfo(0, 7, subInfos, 7.0f);
+    String result = makeFragment(src, fragInfo);
+
+    // Tokens: [0,2) -> "中华", [0,4) clipped to [2,4) -> "人民",
+    // [2,7) clipped to [4,7) -> "共和国". Rest fully contained, skipped.
+    assertEquals("<b>中华</b><b>人民</b><b>共和国</b>", result);
+  }
+
+  /** CJK overlapping tokens with surrounding non-highlighted context. */
+  public void testCjkMaxWordWithContext() {
+    String src = "我爱中华人民共和国万岁";
+
+    List<Toffs> toffsList = new ArrayList<>();
+    toffsList.add(new Toffs(2, 4)); // 中华
+    toffsList.add(new Toffs(2, 6)); // 中华人民
+    toffsList.add(new Toffs(3, 5)); // 华人
+    toffsList.add(new Toffs(4, 6)); // 人民
+    toffsList.add(new Toffs(4, 9)); // 人民共和国
+    toffsList.add(new Toffs(6, 8)); // 共和
+    toffsList.add(new Toffs(6, 9)); // 共和国
+
+    List<SubInfo> subInfos = new ArrayList<>();
+    subInfos.add(new SubInfo("term", toffsList, 0, 7.0f));
+
+    WeightedFragInfo fragInfo = new WeightedFragInfo(0, 11, subInfos, 7.0f);
+    String result = makeFragment(src, fragInfo);
+
+    assertEquals("我爱<b>中华</b><b>人民</b><b>共和国</b>万岁", result);
+  }
+
+  /** Token whose endOffset exceeds source length should be skipped. */
+  public void testTokenExceedingSourceLength() {
+    String src = "short";
+
+    List<Toffs> toffsList = new ArrayList<>();
+    toffsList.add(new Toffs(0, 3)); // valid
+    toffsList.add(new Toffs(3, 99)); // endOffset > src.length()
+
+    List<SubInfo> subInfos = new ArrayList<>();
+    subInfos.add(new SubInfo("term", toffsList, 0, 1.0f));
+
+    WeightedFragInfo fragInfo = new WeightedFragInfo(0, 5, subInfos, 1.0f);
+    String result = makeFragment(src, fragInfo);
+
+    assertEquals("<b>sho</b>rt", result);
+  }
+
+  /** Multiple SubInfos with overlapping offsets across different query terms. */
+  public void testOverlappingAcrossSubInfos() {
+    String src = "the quick brown fox";
+
+    List<Toffs> toffs1 = new ArrayList<>();
+    toffs1.add(new Toffs(4, 9)); // "quick"
+    SubInfo sub1 = new SubInfo("quick", toffs1, 0, 1.0f);
+
+    List<Toffs> toffs2 = new ArrayList<>();
+    toffs2.add(new Toffs(7, 14)); // "ck brow" - overlaps with "quick"
+    SubInfo sub2 = new SubInfo("overlap", toffs2, 1, 1.0f);
+
+    List<SubInfo> subInfos = new ArrayList<>();
+    subInfos.add(sub1);
+    subInfos.add(sub2);
+
+    WeightedFragInfo fragInfo = new WeightedFragInfo(0, 19, subInfos, 2.0f);
+    String result = makeFragment(src, fragInfo);
+
+    // "quick" [4,9) highlighted, then [7,14) clipped to [9,14) = " brow"
+    assertEquals("the <b>quick</b><b> brow</b>n fox", result);
+  }
+
+  /** Inverted offset (endOffset < startOffset) should be skipped without error. */
+  public void testInvertedOffsetsSkipped() {
+    String src = "hello world";
+
+    List<Toffs> toffsList = new ArrayList<>();
+    toffsList.add(new Toffs(5, 3)); // inverted: end < start
+    toffsList.add(new Toffs(0, 5)); // valid
+
+    List<SubInfo> subInfos = new ArrayList<>();
+    subInfos.add(new SubInfo("term", toffsList, 0, 1.0f));
+
+    WeightedFragInfo fragInfo = new WeightedFragInfo(0, 11, subInfos, 1.0f);
+    String result = makeFragment(src, fragInfo);
+
+    // Inverted offset skipped, valid token highlighted
+    assertEquals("<b>hello</b> world", result);
+  }
+}


### PR DESCRIPTION
## Description
  `Caused by: java.lang.StringIndexOutOfBoundsException: Range [592, 588) out of bounds for length 671
	at jdk.internal.util.Preconditions$1.apply(Preconditions.java:55) ~[?:?]
	at jdk.internal.util.Preconditions$1.apply(Preconditions.java:52) ~[?:?]
	at jdk.internal.util.Preconditions$4.apply(Preconditions.java:213) ~[?:?]
	at jdk.internal.util.Preconditions$4.apply(Preconditions.java:210) ~[?:?]
	at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:98) ~[?:?]
	at jdk.internal.util.Preconditions.outOfBoundsCheckFromToIndex(Preconditions.java:112) ~[?:?]
	at jdk.internal.util.Preconditions.checkFromToIndex(Preconditions.java:349) ~[?:?]
	at java.lang.String.checkBoundsBeginEnd(String.java:4861) ~[?:?]
	at java.lang.String.substring(String.java:2830) ~[?:?]
	at org.apache.lucene.search.vectorhighlight.BaseFragmentsBuilder.makeFragment(BaseFragmentsBuilder.java:220) ~[lucene-highlighter-10.2.2.jar:?]
	at org.elasticsearch.search.fetch.subphase.highlight.SourceScoreOrderFragmentsBuilder.makeFragment(SourceScoreOrderFragmentsBuilder.java:68) ~[elasticsearch-9.1.3.jar:?]
	at org.apache.lucene.search.vectorhighlight.BaseFragmentsBuilder.createFragments(BaseFragmentsBuilder.java:169) ~[lucene-highlighter-10.2.2.jar:?]
	at org.apache.lucene.search.vectorhighlight.FastVectorHighlighter.getBestFragments(FastVectorHighlighter.java:216) ~[lucene-highlighter-10.2.2.jar:?]
	at org.elasticsearch.search.fetch.subphase.highlight.FastVectorHighlighter.highlight(FastVectorHighlighter.java:175) ~[elasticsearch-9.1.3.jar:?]
	at org.elasticsearch.search.fetch.subphase.highlight.HighlightPhase$1.process(HighlightPhase.java:70) ~[elasticsearch-9.1.3.jar:?]
	at org.elasticsearch.search.fetch.FetchPhase$1.nextDoc(FetchPhase.java:209) ~[elasticsearch-9.1.3.jar:?]
	at org.elasticsearch.search.fetch.FetchPhaseDocsIterator.iterate(FetchPhaseDocsIterator.java:90) ~[elasticsearch-9.1.3.jar:?]
	at org.elasticsearch.search.fetch.FetchPhase.buildSearchHits(FetchPhase.java:226) ~[elasticsearch-9.1.3.jar:?]
	at org.elasticsearch.search.fetch.FetchPhase.execute(FetchPhase.java:91) ~[elasticsearch-9.1.3.jar:?]
	at org.elasticsearch.search.SearchService.lambda$executeFetchPhase$30(SearchService.java:1493) ~[elasticsearch-9.1.3.jar:?]
	... 1 more`

  `BaseFragmentsBuilder.makeFragment()` throws `StringIndexOutOfBoundsException`
  when token offsets overlap. This is common with CJK analyzers (e.g. CJK bigram,
  ik_max_word) that produce multiple granularity tokens for the same text span.

  For example, "中华人民共和国" produces tokens: [0,2), [0,4), [1,3), [2,4), [2,7), [4,6), [4,7).

  The root cause is the sequential `srcIndex` cursor assumes tokens are non-overlapping.
  When the previous token's endOffset > next token's startOffset,
  `substring(srcIndex, toffsStart)` is called with begin > end.

  ## Fix

  Rather than skipping overlapping tokens entirely, clip them to their
  non-overlapping tail so the full matched region is highlighted:
  - Fully contained tokens → skip
  - Partially overlapping tokens → clip startOffset to srcIndex
  - Invalid offsets (inverted, out-of-bounds) → skip

  ## Test plan

  - [x] Added `TestBaseFragmentsBuilderOverlappingOffsets` with 7 test cases
  - [x] Verified the test reproduces the crash without the fix
  - [x] Verified all tests pass with the fix