### PR TITLE
Fix NPE in RoaringDocIdSet.Iterator#intoBitSet

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -158,9 +158,6 @@ Optimizations
 
 Bug Fixes
 ---------------------
-* GITHUB#16250: Fix NullPointerException in RoaringDocIdSet#intoBitSet when the iterator is already
-  exhausted. (Venkateshwaran Shanmugham)
-
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
   when all values are identical. (Mike Sokolov)
 
@@ -584,6 +581,9 @@ Bug Fixes
   count instead of the full ordinal array, matching OffHeapByteVectorValues. (Vignesh)
 
 * GITHUB#16179: Fix minor lock/unlock acquisition order in DocumentsWriterDeleteQueue (Chris Hegarty)
+
+* GITHUB#16250: Fix NullPointerException in RoaringDocIdSet#intoBitSet when the iterator is already
+  exhausted. (Venkateshwaran Shanmugham)
 
 Other
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -158,6 +158,9 @@ Optimizations
 
 Bug Fixes
 ---------------------
+* GITHUB#16250: Fix NullPointerException in RoaringDocIdSet#intoBitSet when the iterator is already
+  exhausted. (Venkateshwaran Shanmugham)
+
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
   when all values are identical. (Mike Sokolov)
 

--- a/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
@@ -454,6 +454,9 @@ public class RoaringDocIdSet extends DocIdSet {
     @Override
     public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
       for (; ; ) {
+        if (sub == null) {
+          break;
+        }
         int subUpto = upTo - (block << 16);
         if (subUpto < 0) {
           break;

--- a/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
@@ -454,7 +454,7 @@ public class RoaringDocIdSet extends DocIdSet {
     @Override
     public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
       for (; ; ) {
-        if (sub == null) {
+        if (doc == NO_MORE_DOCS) {
           break;
         }
         int subUpto = upTo - (block << 16);

--- a/lucene/core/src/test/org/apache/lucene/util/TestRoaringDocIdSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestRoaringDocIdSet.java
@@ -238,4 +238,23 @@ public class TestRoaringDocIdSet extends BaseDocIdSetTestCase<RoaringDocIdSet> {
     RoaringDocIdSet.Builder b = new RoaringDocIdSet.Builder(100);
     expectThrows(IllegalArgumentException.class, () -> b.add(10, 5));
   }
+
+  public void testIntoBitSetWhenExhausted() throws IOException {
+    int maxDoc = 3 << 16; // 3 blocks; docs only in block 0
+    RoaringDocIdSet set = new RoaringDocIdSet.Builder(maxDoc).add(5).add(10).add(20).build();
+
+    DocIdSetIterator it = set.iterator();
+    while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {}
+    FixedBitSet bitSet = new FixedBitSet(maxDoc);
+    it.intoBitSet(maxDoc, bitSet, 0);
+    assertEquals(DocIdSetIterator.NO_MORE_DOCS, it.docID());
+    assertTrue(bitSet.scanIsEmpty());
+
+    it = set.iterator();
+    assertEquals(DocIdSetIterator.NO_MORE_DOCS, it.advance(maxDoc));
+    bitSet = new FixedBitSet(maxDoc);
+    it.intoBitSet(maxDoc, bitSet, 0);
+    assertEquals(DocIdSetIterator.NO_MORE_DOCS, it.docID());
+    assertTrue(bitSet.scanIsEmpty());
+  }
 }


### PR DESCRIPTION
### Description

RoaringDocIdSet.Iterator#intoBitSet can throw a NullPointerException when called after the iterator has been exhausted.

Once iteration reaches NO_MORE_DOCS, the underlying sub iterator is cleared. intoBitSet() does not currently handle that state and can still attempt to dereference the sub iterator.

Add a null check before accessing the sub iterator and treat exhausted iterators as a no-op.

Add a regression test that exhausts the iterator using both nextDoc() and advance() before calling intoBitSet().

The LRUQueryCache path reported in GITHUB#16250 has since been reworked on main, but the iterator bug itself is still present and the new test fails without this fix.

Fixes #16250

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
