### PR TITLE
Fix backward advanceExact in DocValuesRangeIterator#intoBitSet MAYBE …

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -509,7 +509,7 @@ Optimizations
 * GITHUB#16172: Bulk-evaluate skip-indexed sorted and sorted-set doc-values range queries via a block-aware
   DocValuesRangeIterator#intoBitSet. (Costin Leau)
 
-* GITHUB#16166: Add bulk range evaluation for multi-valued sorted numeric doc values. (Costin Leau)
+* GITHUB#16166, GITHUB#16253: Add bulk range evaluation for multi-valued sorted numeric doc values. (Costin Leau, Zhang Chao)
 
 Bug Fixes
 ---------------------
@@ -579,8 +579,6 @@ Bug Fixes
   count instead of the full ordinal array, matching OffHeapByteVectorValues. (Vignesh)
 
 * GITHUB#16179: Fix minor lock/unlock acquisition order in DocumentsWriterDeleteQueue (Chris Hegarty)
-
-* GITHUB#16253: Fix backward advanceExact in DocValuesRangeIterator#intoBitSet (Zhang Chao)
 
 Other
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -580,6 +580,8 @@ Bug Fixes
 
 * GITHUB#16179: Fix minor lock/unlock acquisition order in DocumentsWriterDeleteQueue (Chris Hegarty)
 
+* GITHUB#16253: Fix backward advanceExact in DocValuesRangeIterator#intoBitSet (Zhang Chao)
+
 Other
 ---------------------
 * GITHUB#15586: Document that scoring and ranking may change across major Lucene versions, and that applications requiring stable ranking should explicitly configure Similarity. (Parveen Saini)

--- a/lucene/core/src/java/org/apache/lucene/search/DocValuesRangeIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocValuesRangeIterator.java
@@ -389,7 +389,11 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
     @Override
     void intoMaybeBlock(int blockStart, int blockEnd, FixedBitSet bitSet, int offset)
         throws IOException {
-      numericValues.rangeIntoBitSet(blockStart, blockEnd, minValue, maxValue, bitSet, offset);
+      // numericValues is the same instance as disi, so a preceding matches() call may have
+      // moved it beyond blockStart. Adjust the starting point to keep rangeIntoBitSet's
+      // advanceExact calls forward-only.
+      int from = Math.max(blockStart, numericValues.docID());
+      numericValues.rangeIntoBitSet(from, blockEnd, minValue, maxValue, bitSet, offset);
     }
   }
 
@@ -416,7 +420,11 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
     @Override
     void intoMaybeBlock(int blockStart, int blockEnd, FixedBitSet bitSet, int offset)
         throws IOException {
-      sortedNumericValues.rangeIntoBitSet(blockStart, blockEnd, minValue, maxValue, bitSet, offset);
+      // sortedNumericValues is the same instance as disi, so a preceding matches() call may have
+      // moved it beyond blockStart. Adjust the starting point to keep rangeIntoBitSet's
+      // advanceExact calls forward-only.
+      int from = Math.max(blockStart, sortedNumericValues.docID());
+      sortedNumericValues.rangeIntoBitSet(from, blockEnd, minValue, maxValue, bitSet, offset);
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/BaseDocValuesSkipperTests.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseDocValuesSkipperTests.java
@@ -19,7 +19,7 @@ package org.apache.lucene.search;
 import java.io.IOException;
 import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.NumericDocValues;
-import org.apache.lucene.tests.index.AssertingLeafReader;
+import org.apache.lucene.tests.index.AssertingLeafReader.AssertingNumericDocValues;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
 public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
@@ -55,7 +55,7 @@ public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
    * {@link #DENSE_END}-1 are dense (all have values); docs from {@link #DENSE_END} onward are
    * sparse (only even docs have a value).
    *
-   * <p>The returned instance is wrapped in {@link AssertingLeafReader.AssertingNumericDocValues},
+   * <p>The returned instance is wrapped in {@link AssertingNumericDocValues},
    * which enforces the forward-only iteration contracts like real sparse implementations rely on.
    */
   protected static NumericDocValues docValues(long queryMin, long queryMax) {
@@ -111,7 +111,7 @@ public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
             return 42;
           }
         };
-    return new AssertingLeafReader.AssertingNumericDocValues(values, MAX_DOC);
+    return new AssertingNumericDocValues(values, MAX_DOC);
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/search/BaseDocValuesSkipperTests.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseDocValuesSkipperTests.java
@@ -55,8 +55,8 @@ public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
    * {@link #DENSE_END}-1 are dense (all have values); docs from {@link #DENSE_END} onward are
    * sparse (only even docs have a value).
    *
-   * <p>The returned instance is wrapped in {@link AssertingNumericDocValues},
-   * which enforces the forward-only iteration contracts like real sparse implementations rely on.
+   * <p>The returned instance is wrapped in {@link AssertingNumericDocValues}, which enforces the
+   * forward-only iteration contracts like real sparse implementations rely on.
    */
   protected static NumericDocValues docValues(long queryMin, long queryMax) {
     NumericDocValues values =

--- a/lucene/core/src/test/org/apache/lucene/search/BaseDocValuesSkipperTests.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseDocValuesSkipperTests.java
@@ -33,9 +33,9 @@ public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
   static final int MAX_DOC = 2048;
 
   /**
-   * Single definition of the fake field's data shape: the first doc that has a value and is
-   * greater than or equal to {@code target}, or {@link DocIdSetIterator#NO_MORE_DOCS}. Pure
-   * function, does not touch iteration state.
+   * Single definition of the fake field's data shape: the first doc that has a value and is greater
+   * than or equal to {@code target}, or {@link DocIdSetIterator#NO_MORE_DOCS}. Pure function, does
+   * not touch iteration state.
    */
   private static int firstDocWithValueOnOrAfter(int target) {
     if (target >= MAX_DOC) {

--- a/lucene/core/src/test/org/apache/lucene/search/BaseDocValuesSkipperTests.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseDocValuesSkipperTests.java
@@ -19,6 +19,7 @@ package org.apache.lucene.search;
 import java.io.IOException;
 import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.tests.index.AssertingLeafReader;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
 public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
@@ -28,70 +29,89 @@ public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
   // both in the same level-1 block [1024,1151] — exercising the docIDRunEnd density check.
   static final int DENSE_END = 1088;
 
+  /** Number of docs in the fake segment; docs at or beyond this bound do not exist. */
+  static final int MAX_DOC = 2048;
+
+  /**
+   * Single definition of the fake field's data shape: the first doc that has a value and is
+   * greater than or equal to {@code target}, or {@link DocIdSetIterator#NO_MORE_DOCS}. Pure
+   * function, does not touch iteration state.
+   */
+  private static int firstDocWithValueOnOrAfter(int target) {
+    if (target >= MAX_DOC) {
+      return DocIdSetIterator.NO_MORE_DOCS;
+    } else if (target < DENSE_END) {
+      return target;
+    } else {
+      // sparse: round up to even
+      int d = target + (target & 1);
+      return d >= MAX_DOC ? DocIdSetIterator.NO_MORE_DOCS : d;
+    }
+  }
+
   /**
    * Fake numeric doc values: value pattern repeats every 1024 docs (d%1024 in [0,128) matches,
    * [128,256) is above queryMax, [256,512) is below queryMin, [512,1024) is a mix). Docs 0 through
    * {@link #DENSE_END}-1 are dense (all have values); docs from {@link #DENSE_END} onward are
    * sparse (only even docs have a value).
+   *
+   * <p>The returned instance is wrapped in {@link AssertingLeafReader.AssertingNumericDocValues},
+   * which enforces the forward-only iteration contracts like real sparse implementations rely on.
    */
   protected static NumericDocValues docValues(long queryMin, long queryMax) {
-    return new NumericDocValues() {
+    NumericDocValues values =
+        new NumericDocValues() {
 
-      int doc = -1;
+          int doc = -1;
 
-      @Override
-      public boolean advanceExact(int target) throws IOException {
-        int advanced = advance(target);
-        return advanced == target;
-      }
+          @Override
+          public boolean advanceExact(int target) throws IOException {
+            // Per the advanceExact contract, position on target whether or not it has a value
+            // (the asserting wrapper checks this).
+            doc = target;
+            return firstDocWithValueOnOrAfter(target) == target;
+          }
 
-      @Override
-      public int docID() {
-        return doc;
-      }
+          @Override
+          public int docID() {
+            return doc;
+          }
 
-      @Override
-      public int nextDoc() throws IOException {
-        return advance(doc + 1);
-      }
+          @Override
+          public int nextDoc() throws IOException {
+            return advance(doc + 1);
+          }
 
-      @Override
-      public int advance(int target) throws IOException {
-        if (target >= 2048) {
-          return doc = DocIdSetIterator.NO_MORE_DOCS;
-        } else if (target < DENSE_END) {
-          return doc = target;
-        } else {
-          // sparse: round up to even
-          int d = target + (target & 1);
-          return doc = (d >= 2048) ? DocIdSetIterator.NO_MORE_DOCS : d;
-        }
-      }
+          @Override
+          public int advance(int target) throws IOException {
+            return doc = firstDocWithValueOnOrAfter(target);
+          }
 
-      @Override
-      public long longValue() throws IOException {
-        int d = doc % 1024;
-        if (d < 128) {
-          return (queryMin + queryMax) >> 1;
-        } else if (d < 256) {
-          return queryMax + 1;
-        } else if (d < 512) {
-          return queryMin - 1;
-        } else {
-          return switch ((d / 2) % 3) {
-            case 0 -> queryMin - 1;
-            case 1 -> queryMax + 1;
-            case 2 -> (queryMin + queryMax) >> 1;
-            default -> throw new AssertionError();
-          };
-        }
-      }
+          @Override
+          public long longValue() throws IOException {
+            int d = doc % 1024;
+            if (d < 128) {
+              return (queryMin + queryMax) >> 1;
+            } else if (d < 256) {
+              return queryMax + 1;
+            } else if (d < 512) {
+              return queryMin - 1;
+            } else {
+              return switch ((d / 2) % 3) {
+                case 0 -> queryMin - 1;
+                case 1 -> queryMax + 1;
+                case 2 -> (queryMin + queryMax) >> 1;
+                default -> throw new AssertionError();
+              };
+            }
+          }
 
-      @Override
-      public long cost() {
-        return 42;
-      }
-    };
+          @Override
+          public long cost() {
+            return 42;
+          }
+        };
+    return new AssertingLeafReader.AssertingNumericDocValues(values, MAX_DOC);
   }
 
   /**
@@ -123,7 +143,7 @@ public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
         // the level is the log2 of the interval
         if (doc < 0) {
           return -1;
-        } else if (doc >= 2048) {
+        } else if (doc >= MAX_DOC) {
           return DocIdSetIterator.NO_MORE_DOCS;
         } else {
           int mask = (1 << rangeLog) - 1;
@@ -173,7 +193,7 @@ public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
         int rangeLog = 9 - numLevels() + level;
         int blockSize = 1 << rangeLog;
         int minDoc = minDocID(level);
-        if (minDoc < 0 || minDoc >= 2048) {
+        if (minDoc < 0 || minDoc >= MAX_DOC) {
           return 0;
         }
         if (minDoc >= DENSE_END) {
@@ -197,7 +217,7 @@ public abstract class BaseDocValuesSkipperTests extends LuceneTestCase {
 
       @Override
       public int docCount() {
-        return DENSE_END + (2048 - DENSE_END) / 2; // 1088 + 480 = 1568
+        return DENSE_END + (MAX_DOC - DENSE_END) / 2; // 1088 + 480 = 1568
       }
 
       @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRangeIterator.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.util.FixedBitSet;
 
 public class TestDocValuesRangeIterator extends BaseDocValuesSkipperTests {
 
@@ -289,5 +290,23 @@ public class TestDocValuesRangeIterator extends BaseDocValuesSkipperTests {
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertEquals(1089, iter.docIDRunEnd());
+  }
+
+  public void testIntoBitSetAfterMatchesOnSparseRegion() throws IOException {
+    DocValuesRangeIterator iter = createIterator(true);
+    SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
+    // Doc 1537 is in the sparse region, in a block with mixed values -> MAYBE
+    approx.advance(1537);
+    assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
+    assertFalse(iter.matches());
+    FixedBitSet bitSet = new FixedBitSet(2048);
+    iter.intoBitSet(2048, bitSet, 0);
+    FixedBitSet expected = new FixedBitSet(2048);
+    for (int doc = 1537; doc < 2048; doc++) {
+      if (docHasValue(doc) && valueInRange(doc)) {
+        expected.set(doc);
+      }
+    }
+    assertEquals(expected, bitSet);
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortedNumericDocValuesRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortedNumericDocValuesRangeIterator.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.tests.index.AssertingLeafReader;
 import org.apache.lucene.util.FixedBitSet;
 
 /**
@@ -90,6 +91,12 @@ public class TestSortedNumericDocValuesRangeIterator extends BaseDocValuesSkippe
   }
 
   private static SortedNumericDocValues sortedNumericDocValues(long queryMin, long queryMax) {
+    SortedNumericDocValues values = newSortedNumericDocValues(queryMin, queryMax);
+    // Enforce the forward-only iteration contracts like real sparse implementations rely on.
+    return AssertingLeafReader.AssertingSortedNumericDocValues.create(values, MAX_DOC);
+  }
+
+  private static SortedNumericDocValues newSortedNumericDocValues(long queryMin, long queryMax) {
     return new SortedNumericDocValues() {
       int doc = -1;
       int valueIdx = 0;
@@ -397,5 +404,23 @@ public class TestSortedNumericDocValuesRangeIterator extends BaseDocValuesSkippe
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertEquals(1089, iter.docIDRunEnd());
+  }
+
+  public void testIntoBitSetAfterMatchesOnSparseRegion() throws IOException {
+    DocValuesRangeIterator iter = createIterator(true);
+    SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
+    // Doc 1537 is in the sparse region, in a block with mixed values -> MAYBE
+    approx.advance(1537);
+    assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
+    assertFalse(iter.matches());
+    FixedBitSet bitSet = new FixedBitSet(MAX_DOC);
+    iter.intoBitSet(MAX_DOC, bitSet, 0);
+    FixedBitSet expected = new FixedBitSet(MAX_DOC);
+    for (int doc = 1537; doc < MAX_DOC; doc++) {
+      if (docHasValue(doc) && valueInRange(doc)) {
+        expected.set(doc);
+      }
+    }
+    assertEquals(expected, bitSet);
   }
 }


### PR DESCRIPTION
1. **The fix**. `numericValues` / `sortedNumericValues` is the same instance as disi, so a preceding `matches()` call may have moved it beyond blockStart. Adjust the starting point to keep `rangeIntoBitSet`'s `advanceExact` calls forward-only.

2. **Testing**. This bug went uncaught because the mock `NumericDocValues` / `SortedNumericDocValues` did not enforce the forward-only iteration contract, so we wrap them in `AssertingLeafReader.AssertingNumericDocValues` / `AssertingSortedNumericDocValues`