### PR TITLE
Fix RoaringDocIdSet#add(min, max) corruption at exactly 4096 block cardinality

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -476,7 +476,7 @@ Optimizations
 
 * GITHUB#16080: Add a BulkScrer implementation spcialized for filters that match dense ranges. (Ignacio Vera)
 
-* GITHUB#16081: Implement LeafCollector#collectRange in the collectors used in LRUCache. (Ignacio Vera)
+* GITHUB#16081, GITHUB#16256: Implement LeafCollector#collectRange in the collectors used in LRUCache. (Ignacio Vera, Zhang Chao)
 
 * GITHUB#16084: Added range encoding to  RoaringDocIdSet. (Ignacio Vera)
 

--- a/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/RoaringDocIdSet.java
@@ -199,7 +199,7 @@ public class RoaringDocIdSet extends DocIdSet {
       assert (toDocExclusive >>> 16) == block || toDocExclusive == (block + 1) << 16;
       assert fromDoc < toDocExclusive;
       final int span = toDocExclusive - fromDoc;
-      if (currentBlockCardinality + span < MAX_ARRAY_LENGTH) {
+      if (currentBlockCardinality + span <= MAX_ARRAY_LENGTH) {
         for (int d = fromDoc; d < toDocExclusive; d++) {
           buffer[currentBlockCardinality++] = (short) d;
         }

--- a/lucene/core/src/test/org/apache/lucene/util/TestRoaringDocIdSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestRoaringDocIdSet.java
@@ -198,6 +198,23 @@ public class TestRoaringDocIdSet extends BaseDocIdSetTestCase<RoaringDocIdSet> {
     assertEquals(maxDoc, expected, b.build());
   }
 
+  public void testAddRangeBlockCardinalityAtSparseBufferCapacity() throws IOException {
+    int maxDoc = 5_000;
+    // Cover the boundary at the sparse buffer capacity
+    for (int blockCardinality : new int[] {4095, 4096, 4097}) {
+      BitSet expected = new BitSet(maxDoc);
+      expected.set(0);
+
+      int docsInRange = blockCardinality - 1; // contiguous-range after the singleton at doc 0
+      int rangeEnd = 2 + docsInRange; // added via the contiguous-range add(min, max)
+      expected.set(2, rangeEnd);
+      RoaringDocIdSet.Builder b = new RoaringDocIdSet.Builder(maxDoc);
+      b.add(0);
+      b.add(2, rangeEnd);
+      assertEquals(maxDoc, expected, b.build());
+    }
+  }
+
   public void testAddRangeEmptyNoOp() throws IOException {
     int maxDoc = 100;
     RoaringDocIdSet.Builder b = new RoaringDocIdSet.Builder(maxDoc);


### PR DESCRIPTION
At exactly 4096, `appendRangeInCurrentBlock` writes to the dense buffer while `flush()` still reads from the sparse buffer, which can cause an AssertionError or wrong results.