### PR TITLE
Fix CharArraySet equals/hashCode contract

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -649,6 +649,8 @@ Other
 
 * GITHUB#16215: Extract segment-boundary check into helper in QueryUtils (Luca Cavanna)
 
+* GITHUB#16261: Fix CharArraySet equals/hashCode to be content-based and incorporate ignoreCase. (Mayya Sharipova)
+
 ======================= Lucene 10.4.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/analysis/CharArrayMap.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/CharArrayMap.java
@@ -61,6 +61,11 @@ public class CharArrayMap<V> extends AbstractMap<Object, V> {
     values = (V[]) new Object[size];
   }
 
+  /** Returns {@code true} if this map matches keys case-insensitively. */
+  public boolean isIgnoreCase() {
+    return ignoreCase;
+  }
+
   /**
    * Creates a map from the mappings in another map.
    *

--- a/lucene/core/src/java/org/apache/lucene/analysis/CharArraySet.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/CharArraySet.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.analysis;
 
 import java.util.AbstractSet;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
@@ -166,6 +167,31 @@ public class CharArraySet extends AbstractSet<Object> {
     return map.originalKeySet().iterator();
   }
 
+  /** Returns {@code true} if this set matches entries case-insensitively. */
+  public boolean isIgnoreCase() {
+    return map.isIgnoreCase();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) return true;
+    if (!(o instanceof CharArraySet other)) return false;
+    if (isIgnoreCase() != other.isIgnoreCase()) return false;
+    if (size() != other.size()) return false;
+    return containsAll(other);
+  }
+
+  @Override
+  public int hashCode() {
+    int h = Boolean.hashCode(isIgnoreCase());
+    for (Object o : this) {
+      if (o instanceof char[] chars) {
+        h += Arrays.hashCode(chars);
+      }
+    }
+    return h;
+  }
+
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder("[");
@@ -177,6 +203,7 @@ public class CharArraySet extends AbstractSet<Object> {
         sb.append(item);
       }
     }
-    return sb.append(']').toString();
+    sb.append("](ignoreCase=").append(isIgnoreCase()).append(')');
+    return sb.toString();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/analysis/CharArraySet.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/CharArraySet.java
@@ -184,9 +184,9 @@ public class CharArraySet extends AbstractSet<Object> {
   @Override
   public int hashCode() {
     int h = Boolean.hashCode(isIgnoreCase());
-    for (Object o : this) {
-      if (o instanceof char[] chars) {
-        h += Arrays.hashCode(chars);
+    for (char[] key : map.keys) {
+      if (key != null) {
+        h += Arrays.hashCode(key);
       }
     }
     return h;

--- a/lucene/core/src/test/org/apache/lucene/analysis/TestCharArrayMap.java
+++ b/lucene/core/src/test/org/apache/lucene/analysis/TestCharArrayMap.java
@@ -206,7 +206,7 @@ public class TestCharArrayMap extends LuceneTestCase {
 
   public void testToString() {
     CharArrayMap<Integer> cm = new CharArrayMap<>(Collections.singletonMap("test", 1), false);
-    assertEquals("[test]", cm.keySet().toString());
+    assertEquals("[test](ignoreCase=false)", cm.keySet().toString());
     assertEquals("[1]", cm.values().toString());
     assertEquals("[test=1]", cm.entrySet().toString());
     assertEquals("{test=1}", cm.toString());

--- a/lucene/core/src/test/org/apache/lucene/analysis/TestCharArraySet.java
+++ b/lucene/core/src/test/org/apache/lucene/analysis/TestCharArraySet.java
@@ -373,8 +373,34 @@ public class TestCharArraySet extends LuceneTestCase {
 
   public void testToString() {
     CharArraySet set = CharArraySet.copy(Collections.singleton("test"));
-    assertEquals("[test]", set.toString());
+    assertEquals("[test](ignoreCase=false)", set.toString());
     set.add("test2");
     assertTrue(set.toString().contains(", "));
+
+    CharArraySet ignoreCase = new CharArraySet(Collections.singleton("test"), true);
+    assertEquals("[test](ignoreCase=true)", ignoreCase.toString());
+  }
+
+  public void testEqualsAndHashCode_sameContentSameIgnoreCase() {
+    for (boolean ignoreCase : new boolean[] {false, true}) {
+      CharArraySet a = new CharArraySet(Arrays.asList(TEST_STOP_WORDS), ignoreCase);
+      CharArraySet b = new CharArraySet(Arrays.asList(TEST_STOP_WORDS), ignoreCase);
+      assertNotSame(a, b);
+      assertEquals(a, b);
+      assertEquals(a.hashCode(), b.hashCode());
+    }
+  }
+
+  public void testEqualsAndHashCode_sameContentDifferentIgnoreCase() {
+    CharArraySet sensitive = new CharArraySet(Arrays.asList("hund", "katze"), false);
+    CharArraySet insensitive = new CharArraySet(Arrays.asList("hund", "katze"), true);
+    assertNotEquals(sensitive, insensitive);
+    assertNotEquals(sensitive.hashCode(), insensitive.hashCode());
+  }
+
+  public void testEqualsAndHashCode_differentContent() {
+    CharArraySet a = new CharArraySet(Arrays.asList("hund"), false);
+    CharArraySet b = new CharArraySet(Arrays.asList("katze"), false);
+    assertNotEquals(a, b);
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/analysis/TestCharArraySet.java
+++ b/lucene/core/src/test/org/apache/lucene/analysis/TestCharArraySet.java
@@ -403,4 +403,11 @@ public class TestCharArraySet extends LuceneTestCase {
     CharArraySet b = new CharArraySet(Arrays.asList("katze"), false);
     assertNotEquals(a, b);
   }
+
+  public void testEqualsAndHashCode_ignoreCaseMixedCasing() {
+    CharArraySet upper = new CharArraySet(Arrays.asList("Hund", "Katze"), true);
+    CharArraySet lower = new CharArraySet(Arrays.asList("hund", "katze"), true);
+    assertEquals(upper, lower);
+    assertEquals(upper.hashCode(), lower.hashCode());
+  }
 }


### PR DESCRIPTION
- Fix violation: inherited hashCode was identity-based (char[].hashCode()), breaking equals/hashCode contract
- Override hashCode() with content-stable implementation using Arrays.hashCode() per element
- Incorporate ignoreCase into both equals() and hashCode() so sets differing only in case mode are treated as unequal
- Expose ignoreCase via isIgnoreCase() on CharArrayMap and CharArraySet

Potential breakage: code comparing two CharArraySet instances with same words but different ignoreCase will now see them as unequal; code using CharArraySet as a map key will observe different bucketing.

