### PR TITLE
perf(util): add `FixedBitSet.copyOf()` fast paths for `SparseLiveDocs` and `DenseLiveDocs`

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -291,7 +291,7 @@ Improvements
 
 Optimizations
 ---------------------
-* GITHUB#16XXX: Add fast paths to FixedBitSet.copyOf() for SparseLiveDocs and DenseLiveDocs,
+* GITHUB#16282: Add fast paths to FixedBitSet.copyOf() for SparseLiveDocs and DenseLiveDocs,
   avoiding the O(maxDoc) generic fallback. SparseLiveDocs now copies in O(deletedDocs) by
   iterating only deleted doc IDs; DenseLiveDocs copies in O(maxDoc/64) by cloning the backing
   FixedBitSet directly. (salvatorecampagna)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -291,7 +291,10 @@ Improvements
 
 Optimizations
 ---------------------
-(No changes)
+* GITHUB#16XXX: Add fast paths to FixedBitSet.copyOf() for SparseLiveDocs and DenseLiveDocs,
+  avoiding the O(maxDoc) generic fallback. SparseLiveDocs now copies in O(deletedDocs) by
+  iterating only deleted doc IDs; DenseLiveDocs copies in O(maxDoc/64) by cloning the backing
+  FixedBitSet directly. (salvatorecampagna)
 
 Bug Fixes
 ---------------------

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/LiveDocsCopyOfBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/LiveDocsCopyOfBenchmark.java
@@ -36,8 +36,8 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
 /**
- * Benchmarks {@link FixedBitSet#copyOf(org.apache.lucene.util.Bits)} for {@link SparseLiveDocs}
- * and {@link DenseLiveDocs} inputs.
+ * Benchmarks {@link FixedBitSet#copyOf(org.apache.lucene.util.Bits)} for {@link SparseLiveDocs} and
+ * {@link DenseLiveDocs} inputs.
  *
  * <p>This benchmark measures the speedup from the fast paths added to {@code copyOf()} for the
  * {@link SparseLiveDocs} and {@link DenseLiveDocs} types introduced by GITHUB#15413. Without these

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/LiveDocsCopyOfBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/LiveDocsCopyOfBenchmark.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.lucene.util.DenseLiveDocs;
+import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.SparseFixedBitSet;
+import org.apache.lucene.util.SparseLiveDocs;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmarks {@link FixedBitSet#copyOf(org.apache.lucene.util.Bits)} for {@link SparseLiveDocs}
+ * and {@link DenseLiveDocs} inputs.
+ *
+ * <p>This benchmark measures the speedup from the fast paths added to {@code copyOf()} for the
+ * {@link SparseLiveDocs} and {@link DenseLiveDocs} types introduced by GITHUB#15413. Without these
+ * fast paths, both types fall through to the generic O(maxDoc) loop. With them:
+ *
+ * <ul>
+ *   <li>{@link SparseLiveDocs}: O(deletedDocs) by iterating only the set bits of the deleted-docs
+ *       bitset, then clearing those positions in the result
+ *   <li>{@link DenseLiveDocs}: O(maxDoc/64) by cloning the backing {@link FixedBitSet} directly
+ * </ul>
+ *
+ * <h2>Usage</h2>
+ *
+ * <p>Run all benchmarks:
+ *
+ * <pre>
+ * java -jar lucene-benchmark-jmh.jar "LiveDocsCopyOfBenchmark"
+ * </pre>
+ *
+ * @see SparseLiveDocs
+ * @see DenseLiveDocs
+ * @see LiveDocsBenchmark
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 3)
+@Fork(
+    value = 1,
+    jvmArgsAppend = {"-Xmx2g", "-Xms2g"})
+public class LiveDocsCopyOfBenchmark {
+
+  /** Number of documents in the segment. */
+  @Param({"1000000", "10000000", "100000000"})
+  int maxDoc;
+
+  /**
+   * Percentage of documents to delete.
+   *
+   * <p>Kept low to stay in the SparseLiveDocs regime ({@literal <=}1%). At these rates the
+   * O(deletedDocs) vs O(maxDoc) difference is most pronounced.
+   */
+  @Param({"0.001", "0.01"})
+  double deletionRate;
+
+  private SparseLiveDocs sparseLiveDocs;
+  private DenseLiveDocs denseLiveDocs;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    Random random = new Random(42);
+    int numDeleted = Math.max(1, (int) (maxDoc * deletionRate));
+
+    SparseFixedBitSet sparseSet = new SparseFixedBitSet(maxDoc);
+    FixedBitSet fixedSet = new FixedBitSet(maxDoc);
+    fixedSet.set(0, maxDoc);
+
+    for (int i = 0; i < numDeleted; i++) {
+      int doc = random.nextInt(maxDoc);
+      sparseSet.set(doc);
+      fixedSet.clear(doc);
+    }
+
+    sparseLiveDocs = SparseLiveDocs.builder(sparseSet, maxDoc).build();
+    denseLiveDocs = DenseLiveDocs.builder(fixedSet, maxDoc).build();
+  }
+
+  @Benchmark
+  public FixedBitSet copyOfSparseLiveDocs() {
+    return FixedBitSet.copyOf(sparseLiveDocs);
+  }
+
+  @Benchmark
+  public FixedBitSet copyOfDenseLiveDocs() {
+    return FixedBitSet.copyOf(denseLiveDocs);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/DenseLiveDocs.java
+++ b/lucene/core/src/java/org/apache/lucene/util/DenseLiveDocs.java
@@ -144,6 +144,10 @@ public final class DenseLiveDocs implements LiveDocs {
     return deletedCount;
   }
 
+  FixedBitSet toFixedBitSet() {
+    return liveDocs.clone();
+  }
+
   /**
    * Returns the memory usage in bytes.
    *

--- a/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/FixedBitSet.java
@@ -867,6 +867,10 @@ public final class FixedBitSet extends BitSet {
 
     if (bits instanceof FixedBitSet fbs) {
       return fbs.clone();
+    } else if (bits instanceof DenseLiveDocs denseLiveDocs) {
+      return denseLiveDocs.toFixedBitSet();
+    } else if (bits instanceof SparseLiveDocs sparseLiveDocs) {
+      return sparseLiveDocs.toFixedBitSet();
     } else {
       int length = bits.length();
       FixedBitSet bitSet = new FixedBitSet(length);

--- a/lucene/core/src/java/org/apache/lucene/util/SparseLiveDocs.java
+++ b/lucene/core/src/java/org/apache/lucene/util/SparseLiveDocs.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.util;
 
-import java.util.Arrays;
 import java.util.Locale;
 import org.apache.lucene.search.DocIdSetIterator;
 
@@ -146,19 +145,14 @@ public final class SparseLiveDocs implements LiveDocs {
   }
 
   FixedBitSet toFixedBitSet() {
-    int numWords = FixedBitSet.bits2words(maxDoc);
-    long[] rawBits = new long[numWords];
-    Arrays.fill(rawBits, -1L);
-    int ghostBits = maxDoc & 63;
-    if (ghostBits != 0) {
-      rawBits[numWords - 1] = (1L << ghostBits) - 1;
-    }
+    FixedBitSet result = new FixedBitSet(maxDoc);
+    result.set(0, maxDoc);
     for (int doc = deletedDocs.nextSetBit(0);
         doc != DocIdSetIterator.NO_MORE_DOCS;
         doc = deletedDocs.nextSetBit(doc + 1)) {
-      rawBits[doc >> 6] &= ~(1L << doc);
+      result.clear(doc);
     }
-    return new FixedBitSet(rawBits, maxDoc);
+    return result;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/SparseLiveDocs.java
+++ b/lucene/core/src/java/org/apache/lucene/util/SparseLiveDocs.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.util;
 
+import java.util.Arrays;
 import java.util.Locale;
 import org.apache.lucene.search.DocIdSetIterator;
 
@@ -142,6 +143,22 @@ public final class SparseLiveDocs implements LiveDocs {
   @Override
   public int deletedCount() {
     return deletedCount;
+  }
+
+  FixedBitSet toFixedBitSet() {
+    int numWords = FixedBitSet.bits2words(maxDoc);
+    long[] rawBits = new long[numWords];
+    Arrays.fill(rawBits, -1L);
+    int ghostBits = maxDoc & 63;
+    if (ghostBits != 0) {
+      rawBits[numWords - 1] = (1L << ghostBits) - 1;
+    }
+    for (int doc = deletedDocs.nextSetBit(0);
+        doc != DocIdSetIterator.NO_MORE_DOCS;
+        doc = deletedDocs.nextSetBit(doc + 1)) {
+      rawBits[doc >> 6] &= ~(1L << doc);
+    }
+    return new FixedBitSet(rawBits, maxDoc);
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/util/TestFixedBitSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestFixedBitSet.java
@@ -905,4 +905,41 @@ public class TestFixedBitSet extends BaseBitSetTestCase<FixedBitSet> {
       }
     }
   }
+
+  public void testCopyOfDenseLiveDocs() {
+    final int maxDoc = atLeast(1000);
+    final int numDeleted = random().nextInt(maxDoc / 2) + 1;
+
+    FixedBitSet liveDocsBitSet = new FixedBitSet(maxDoc);
+    liveDocsBitSet.set(0, maxDoc);
+    for (int i = 0; i < numDeleted; i++) {
+      liveDocsBitSet.clear(random().nextInt(maxDoc));
+    }
+    DenseLiveDocs dense = DenseLiveDocs.builder(liveDocsBitSet, maxDoc).build();
+
+    FixedBitSet result = FixedBitSet.copyOf(dense);
+
+    assertEquals(maxDoc, result.length());
+    for (int doc = 0; doc < maxDoc; doc++) {
+      assertEquals("mismatch at doc " + doc, dense.get(doc), result.get(doc));
+    }
+  }
+
+  public void testCopyOfSparseLiveDocs() {
+    final int maxDoc = atLeast(1000);
+    final int numDeleted = random().nextInt(Math.max(1, maxDoc / 100)) + 1;
+
+    SparseFixedBitSet deletedDocsBitSet = new SparseFixedBitSet(maxDoc);
+    for (int i = 0; i < numDeleted; i++) {
+      deletedDocsBitSet.set(random().nextInt(maxDoc));
+    }
+    SparseLiveDocs sparse = SparseLiveDocs.builder(deletedDocsBitSet, maxDoc).build();
+
+    FixedBitSet result = FixedBitSet.copyOf(sparse);
+
+    assertEquals(maxDoc, result.length());
+    for (int doc = 0; doc < maxDoc; doc++) {
+      assertEquals("mismatch at doc " + doc, sparse.get(doc), result.get(doc));
+    }
+  }
 }


### PR DESCRIPTION
## TL;DR

Make `FixedBitSet.copyOf()` 135x to 193x faster for `DenseLiveDocs` and 11x to 48x faster for `SparseLiveDocs`.

## Summary

`FixedBitSet.copyOf(Bits)` has fast paths for `FixedBitSet` and `FixedBits` but not for `SparseLiveDocs` and `DenseLiveDocs`, the two `LiveDocs` types introduced in #15413. Both fall through to the generic O(maxDoc) per-bit loop. The hot caller is `PendingDeletes.getMutableBits()`, which invokes `FixedBitSet.copyOf(liveDocs)` on the first delete after a reader snapshot. Under write-heavy workloads this cost accumulates across open reader generations.

Each type now exposes a package-private `toFixedBitSet()` method that `FixedBitSet.copyOf()` delegates to, keeping the copy logic next to the data it knows about. `DenseLiveDocs` stores live docs in a `FixedBitSet` with identical semantics, so `toFixedBitSet()` clones it at O(maxDoc/64). `SparseLiveDocs` stores deleted positions in a `SparseFixedBitSet`, so `toFixedBitSet()` allocates a `FixedBitSet`, calls `set(0, maxDoc)` to mark all docs live in O(maxDoc/64), then iterates only the deleted positions via `nextSetBit` clearing each one, for a total of O(maxDoc/64 + deletedDocs).

## Benchmarks

`LiveDocsCopyOfBenchmark`, `FixedBitSet.copyOf()` average time (us/op), `-wi 5 -i 7 -f 3`. Baseline = `main` HEAD; contender = this PR.

### DenseLiveDocs

| maxDoc | del rate | baseline (us) | err% | contender (us) | err% | speedup |
|-------:|:--------:|--------------:|-----:|---------------:|-----:|--------:|
| 1M | 0.1% | 317.838 +/- 5.686 | 1.8% | 2.362 +/- 0.039 | 1.7% | **135x** |
| 10M | 0.1% | 3166.801 +/- 91.964 | 2.9% | 20.797 +/- 1.160 | 5.6% | **152x** |
| 100M | 0.1% | 31434.474 +/- 234.936 | 0.7% | 198.186 +/- 11.443 | 5.8% | **159x** |
| 1M | 1% | 371.669 +/- 6.345 | 1.7% | 2.302 +/- 0.054 | 2.3% | **162x** |
| 10M | 1% | 3766.590 +/- 35.200 | 0.9% | 19.476 +/- 0.684 | 3.5% | **193x** |
| 100M | 1% | 37788.094 +/- 191.936 | 0.5% | 203.131 +/- 10.855 | 5.3% | **186x** |

### SparseLiveDocs

| maxDoc | del rate | baseline (us) | err% | contender (us) | err% | speedup |
|-------:|:--------:|--------------:|-----:|---------------:|-----:|--------:|
| 1M | 0.1% | 518.084 +/- 6.739 | 1.3% | 10.900 +/- 0.096 | 0.9% | **48x** |
| 10M | 0.1% | 4976.429 +/- 55.761 | 1.1% | 111.454 +/- 1.495 | 1.3% | **45x** |
| 100M | 0.1% | 49412.733 +/- 424.527 | 0.9% | 1152.935 +/- 12.952 | 1.1% | **43x** |
| 1M | 1% | 1201.822 +/- 43.661 | 3.6% | 97.187 +/- 1.349 | 1.4% | **12x** |
| 10M | 1% | 12062.162 +/- 146.840 | 1.2% | 986.402 +/- 14.975 | 1.5% | **12x** |
| 100M | 1% | 119511.553 +/- 688.099 | 0.6% | 10884.173 +/- 159.084 | 1.5% | **11x** |

The `SparseLiveDocs` speedup shrinks as the deletion rate grows: the contender always pays O(maxDoc/64) to fill the backing array via `set(0, maxDoc)`, and on top of that clears one position per deleted document. At low deletion rates the fill dominates and the gap with the O(maxDoc) baseline is large; at higher rates the clearing loop contributes more and the advantage narrows.