### PR TITLE
Skip runs of excluded docs in ReqExclBulkScorer for two-phase clauses

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -141,6 +141,10 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#16307: ReqExclBulkScorer now skips runs of excluded docs via
+  TwoPhaseIterator#docIDRunEnd for two-phase excluded clauses (e.g. a doc-values
+  not-equals filter), instead of advancing one doc at a time. (Jim Ferenczi)
+
 * GITHUB#16254: Enable the vectorized findNextGEQ path on aarch64, where it was disabled on cores
   with fewer than 8 int lanes (Graviton2 and Graviton4). The vector compare beats the scalar
   fallback by +75% on Graviton4 and +35% on Graviton2 (AdvanceBenchmark). (Shitij Bhargava)

--- a/lucene/core/src/java/org/apache/lucene/search/ReqExclBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ReqExclBulkScorer.java
@@ -62,9 +62,8 @@ final class ReqExclBulkScorer extends BulkScorer {
           upTo = Math.min(exclApproximation.docIDRunEnd(), max);
         } else if (exclTwoPhase.matches()) {
           // upTo is excluded; skip the whole run of consecutive excluded docs at once, like the
-          // non-two-phase branch above. Note that TwoPhaseIterator#docIDRunEnd defaults to the
-          // current doc (unlike DocIdSetIterator#docIDRunEnd, which returns docID()+1), so clamp to
-          // at least upTo+1 to guarantee progress when the run end is not overridden.
+          // non-two-phase branch above. Clamp to at least upTo+1 to guarantee progress in case a
+          // TwoPhaseIterator returns a run end that does not move past the current doc.
           upTo = Math.max(upTo + 1, Math.min(exclTwoPhase.docIDRunEnd(), max));
         }
         exclDoc = exclApproximation.nextDoc();

--- a/lucene/core/src/java/org/apache/lucene/search/ReqExclBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ReqExclBulkScorer.java
@@ -61,8 +61,11 @@ final class ReqExclBulkScorer extends BulkScorer {
           // from upTo to docIdRunEnd() are excluded, so we scored up to docIdRunEnd()
           upTo = Math.min(exclApproximation.docIDRunEnd(), max);
         } else if (exclTwoPhase.matches()) {
-          // upTo is excluded so we can consider that we scored up to upTo+1
-          upTo += 1;
+          // upTo is excluded; skip the whole run of consecutive excluded docs at once, like the
+          // non-two-phase branch above. Note that TwoPhaseIterator#docIDRunEnd defaults to the
+          // current doc (unlike DocIdSetIterator#docIDRunEnd, which returns docID()+1), so clamp to
+          // at least upTo+1 to guarantee progress when the run end is not overridden.
+          upTo = Math.max(upTo + 1, Math.min(exclTwoPhase.docIDRunEnd(), max));
         }
         exclDoc = exclApproximation.nextDoc();
       } else {

--- a/lucene/core/src/java/org/apache/lucene/search/TwoPhaseIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TwoPhaseIterator.java
@@ -117,10 +117,11 @@ public abstract class TwoPhaseIterator {
    * <p><b>Note</b>: It is illegal to call this method when the approximation is exhausted or not
    * positioned.
    *
-   * <p>The default implementation returns the current doc ID of the approximation.
+   * <p>The default implementation assumes runs of a single doc ID and returns the current doc ID of
+   * the approximation plus one, mirroring {@link DocIdSetIterator#docIDRunEnd()}.
    */
   public int docIDRunEnd() throws IOException {
-    return approximation().docID();
+    return approximation().docID() + 1;
   }
 
   /**


### PR DESCRIPTION
`ReqExclBulkScorer` skips runs of excluded docs via `docIDRunEnd()` only for a plain `DocIdSetIterator` excluded clause; a two-phase clause advances one doc at a time. This uses `TwoPhaseIterator#docIDRunEnd()` in the two-phase branch too — as `DenseConjunctionBulkScorer` already does — clamped to at least `upTo + 1` since its default returns the current doc.

Speeds up filters with a two-phase excluded clause that matches most docs, e.g. a doc-values `!= v` query. Covered by the existing randomized `TestReqExclBulkScorer#testRandomTwoPhase` (its `RandomTwoPhaseView` overrides `docIDRunEnd()`).
