### PR TITLE
Optimize reuse of SimpleTVPostingsEnum and SimpleTVDocsEnum in Simple…

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -139,6 +139,9 @@ Improvements
 
 * GITHUB#15558: Refactor QueryCache for performance. (Sagar Upadhyaya)
 
+* GITHUB#16311: Improved simple text term vectors postings reuse by allowing reused postings enums to be
+  reinitialized in place when available, reducing unnecessary object creation. (Rajat Jain)
+
 Optimizations
 ---------------------
 * GITHUB#16254: Enable the vectorized findNextGEQ path on aarch64, where it was disabled on cores

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
@@ -406,16 +406,24 @@ public class SimpleTextTermVectorsReader extends TermVectorsReader {
       if (PostingsEnum.featureRequested(flags, PostingsEnum.POSITIONS)) {
         SimpleTVPostings postings = current.getValue();
         if (postings.positions != null || postings.startOffsets != null) {
-          // TODO: reuse
-          SimpleTVPostingsEnum e = new SimpleTVPostingsEnum();
+          SimpleTVPostingsEnum e;
+          if (reuse instanceof SimpleTVPostingsEnum reuseEnum) {
+            e = reuseEnum;
+          } else {
+            e = new SimpleTVPostingsEnum();
+          }
           e.reset(
               postings.positions, postings.startOffsets, postings.endOffsets, postings.payloads);
           return e;
         }
       }
 
-      // TODO: reuse
-      SimpleTVDocsEnum e = new SimpleTVDocsEnum();
+      SimpleTVDocsEnum e;
+      if (reuse instanceof SimpleTVDocsEnum reuseEnum) {
+        e = reuseEnum;
+      } else {
+        e = new SimpleTVDocsEnum();
+      }
       e.reset(
           PostingsEnum.featureRequested(flags, PostingsEnum.FREQS) == false
               ? 1


### PR DESCRIPTION
Fixes https://github.com/apache/lucene/issues/16310.
### Description

We are re-using the `SimpleTVPostingsEnum` instance variable `reuse` instead of creating a new one.

It would be wonderful if someone can guide me through specific benchmarks I can run to prove the memory optimization I acheived.
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
