### PR TITLE
Lazily allocate DocAndScoreAccBuffer in MaxScoreBulkScorer

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -308,6 +308,9 @@ Optimizations
 * GITHUB#16146: Speed up no-score filtered-optional Boolean queries by routing dense conjunctions with cached FixedBitSet filters
   through ConstantScoreBulkScorer, which batches matches in bulk via DocIdStream. (Costin Leau)
 
+* GITHUB#16316: Lazily allocate buffers in MaxScoreBulkScorer.  These are now only allocated when going
+  via code paths that actually use them. (Alan Woodward)
+
 Bug Fixes
 ---------------------
 (No changes)

--- a/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java
@@ -52,7 +52,7 @@ final class MaxScoreBulkScorer extends BulkScorer {
   private FixedBitSet filterMatches = null;
 
   private final DocAndFloatFeatureBuffer docAndScoreBuffer = new DocAndFloatFeatureBuffer();
-  private final DocAndScoreAccBuffer docAndScoreAccBuffer;
+  private final DocAndScoreAccBuffer docAndScoreAccBuffer = new DocAndScoreAccBuffer();
 
   MaxScoreBulkScorer(int maxDoc, List<Scorer> scorers, Scorer filter) throws IOException {
     this.maxDoc = maxDoc;
@@ -69,8 +69,6 @@ final class MaxScoreBulkScorer extends BulkScorer {
     this.cost = cost;
     essentialQueue = DisiPriorityQueue.ofMaxSize(allScorers.length);
     maxScoreSums = new double[allScorers.length];
-    docAndScoreAccBuffer = new DocAndScoreAccBuffer();
-    docAndScoreAccBuffer.growNoCopy(INNER_WINDOW_SIZE);
 
     if (this.filter != null && this.filter.twoPhaseView == null && maxDoc >= INNER_WINDOW_SIZE) {
       long minScorerCost = allScorers[0].cost;
@@ -309,6 +307,7 @@ final class MaxScoreBulkScorer extends BulkScorer {
   /** Flush {@link #windowMatches} and {@link #windowScores} into {@link #docAndScoreAccBuffer}. */
   private void flushWindowToDocAndScoreAccBuffer(int innerWindowMin, int innerWindowSize)
       throws IOException {
+    docAndScoreAccBuffer.growNoCopy(innerWindowSize);
     docAndScoreAccBuffer.size = 0;
     windowMatches.forEach(
         0,


### PR DESCRIPTION
This buffer is only used in certain code paths, so allocation in the constructor adds unnecessary costs.
