### PR TITLE
Improve sorting logic in NeighborArray and add test for stable order

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -141,6 +141,8 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#16320: Improve sorting logic in NeighborArray and add test for stable order with equal scores (Rajat Jain)
+
 * GITHUB#16254: Enable the vectorized findNextGEQ path on aarch64, where it was disabled on cores
   with fewer than 8 int lanes (Graviton2 and Graviton4). The vector compare beats the scalar
   fallback by +75% on Graviton4 and +35% on Graviton2 (AdvanceBenchmark). (Shitij Bhargava)

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -307,32 +307,6 @@ public class NeighborArray {
     return "NeighborArray[" + size + "]";
   }
 
-  private int ascSortFindRightMostInsertionPoint(float newScore, int bound) {
-    int insertionPoint = Arrays.binarySearch(scores, 0, bound, newScore);
-    if (insertionPoint >= 0) {
-      // find the right most position with the same score
-      while ((insertionPoint < bound - 1)
-          && (scores[insertionPoint + 1] == scores[insertionPoint])) {
-        insertionPoint++;
-      }
-      insertionPoint++;
-    } else {
-      insertionPoint = -insertionPoint - 1;
-    }
-    return insertionPoint;
-  }
-
-  private int descSortFindRightMostInsertionPoint(float newScore, int bound) {
-    int start = 0;
-    int end = bound - 1;
-    while (start <= end) {
-      int mid = (start + end) / 2;
-      if (scores[mid] < newScore) end = mid - 1;
-      else start = mid + 1;
-    }
-    return start;
-  }
-
   /**
    * Find first non-diverse neighbour among the list of neighbors starting from the most distant
    * neighbours

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -158,7 +158,7 @@ public class NeighborArray {
 
     int count = size - sortedNodeSize;
     int[] uncheckedIndexes = new int[count];
-    int[] unsortedIndexes = new int[count];
+    Integer[] unsortedIndexes = new Integer[count];
     int[] newNodes = new int[size];
     float[] newScores = new float[size];
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -155,47 +155,93 @@ public class NeighborArray {
       return null;
     }
     assert sortedNodeSize < size;
-    int[] uncheckedIndexes = new int[size - sortedNodeSize];
-    int count = 0;
-    while (sortedNodeSize != size) {
-      // TODO: Instead of doing an array copy on every insertion, I think we can do better here:
-      //       Remember the insertion point of each unsorted node and insert them altogether
-      //       We can save several array copy by doing that
-      uncheckedIndexes[count] = insertSortedInternal(scorer); // sortedNodeSize is increased inside
-      for (int i = 0; i < count; i++) {
-        if (uncheckedIndexes[i] >= uncheckedIndexes[count]) {
-          // the previous inserted nodes has been shifted
-          uncheckedIndexes[i]++;
-        }
+
+    int count = size - sortedNodeSize;
+    int[] uncheckedIndexes = new int[count];
+    int[] unsortedIndexes = new int[count];
+    int[] newNodes = new int[size];
+    float[] newScores = new float[size];
+
+    for (int i = 0; i < count; i++) {
+      int index = sortedNodeSize + i;
+      unsortedIndexes[i] = index;
+      float score = scores[index];
+      if (Float.isNaN(score)) {
+        score = scorer.score(nodes[index]);
       }
-      count++;
+      scores[index] = score;
     }
+
+    Arrays.sort(
+        unsortedIndexes,
+        (left, right) -> {
+          float leftScore = scores[left];
+          float rightScore = scores[right];
+          if (scoresDescOrder) {
+            if (leftScore > rightScore) {
+              return -1;
+            } else if (leftScore < rightScore) {
+              return 1;
+            }
+          } else {
+            if (leftScore < rightScore) {
+              return -1;
+            } else if (leftScore > rightScore) {
+              return 1;
+            }
+          }
+          return 0;
+        });
+
+    int prefixCursor = 0;
+    int unsortedCursor = 0;
+    int outCursor = 0;
+    while (prefixCursor < sortedNodeSize && unsortedCursor < count) {
+      int prefixIndex = prefixCursor;
+      int unsortedIndex = unsortedIndexes[unsortedCursor];
+      if (shouldTakePrefix(prefixIndex, unsortedIndex)) {
+        newNodes[outCursor] = nodes[prefixIndex];
+        newScores[outCursor] = scores[prefixIndex];
+        prefixCursor++;
+      } else {
+        newNodes[outCursor] = nodes[unsortedIndex];
+        newScores[outCursor] = scores[unsortedIndex];
+        uncheckedIndexes[unsortedCursor] = outCursor;
+        unsortedCursor++;
+      }
+      outCursor++;
+    }
+
+    while (prefixCursor < sortedNodeSize) {
+      newNodes[outCursor] = nodes[prefixCursor];
+      newScores[outCursor] = scores[prefixCursor];
+      prefixCursor++;
+      outCursor++;
+    }
+
+    while (unsortedCursor < count) {
+      int unsortedIndex = unsortedIndexes[unsortedCursor];
+      newNodes[outCursor] = nodes[unsortedIndex];
+      newScores[outCursor] = scores[unsortedIndex];
+      uncheckedIndexes[unsortedCursor] = outCursor;
+      unsortedCursor++;
+      outCursor++;
+    }
+
+    nodes = newNodes;
+    scores = newScores;
+    sortedNodeSize = size;
     Arrays.sort(uncheckedIndexes);
     return uncheckedIndexes;
   }
 
-  /** insert the first unsorted node into its sorted position */
-  private int insertSortedInternal(RandomVectorScorer scorer) throws IOException {
-    assert sortedNodeSize < size : "Call this method only when there's unsorted node";
-    int tmpNode = nodes[sortedNodeSize];
-    float tmpScore = scores[sortedNodeSize];
-
-    if (Float.isNaN(tmpScore)) {
-      tmpScore = scorer.score(tmpNode);
+  private boolean shouldTakePrefix(int prefixIndex, int unsortedIndex) {
+    float prefixScore = scores[prefixIndex];
+    float unsortedScore = scores[unsortedIndex];
+    if (scoresDescOrder) {
+      return prefixScore >= unsortedScore;
     }
-
-    int insertionPoint =
-        scoresDescOrder
-            ? descSortFindRightMostInsertionPoint(tmpScore, sortedNodeSize)
-            : ascSortFindRightMostInsertionPoint(tmpScore, sortedNodeSize);
-    System.arraycopy(
-        nodes, insertionPoint, nodes, insertionPoint + 1, sortedNodeSize - insertionPoint);
-    System.arraycopy(
-        scores, insertionPoint, scores, insertionPoint + 1, sortedNodeSize - insertionPoint);
-    nodes[insertionPoint] = tmpNode;
-    scores[insertionPoint] = tmpScore;
-    ++sortedNodeSize;
-    return insertionPoint;
+    return prefixScore <= unsortedScore;
   }
 
   /** This method is for test only. */

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/NeighborArray.java
@@ -247,7 +247,10 @@ public class NeighborArray {
   /** This method is for test only. */
   void insertSorted(int newNode, float newScore) throws IOException {
     addOutOfOrder(newNode, newScore);
-    insertSortedInternal(null);
+    if (size == sortedNodeSize) {
+      return;
+    }
+    sort(null);
   }
 
   public int size() {

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestNeighborArray.java
@@ -189,6 +189,20 @@ public class TestNeighborArray extends LuceneTestCase {
     assertScoresEqual(new float[] {7, 6, 5, 4, 3, 2, 1}, neighbors2);
   }
 
+  public void testSortDescStableOrderForEqualScores() throws IOException {
+    NeighborArray neighbors = new NeighborArray(5, true);
+    neighbors.addInOrder(0, 1.0f);
+    neighbors.addInOrder(1, 0.8f);
+    neighbors.addOutOfOrder(2, 0.8f);
+    neighbors.addOutOfOrder(3, 0.9f);
+
+    int[] unchecked = neighbors.sort(null);
+
+    assertArrayEquals(new int[] {1, 3}, unchecked);
+    assertNodesEqual(new int[] {0, 3, 1, 2}, neighbors);
+    assertScoresEqual(new float[] {1.0f, 0.9f, 0.8f, 0.8f}, neighbors);
+  }
+
   public void testAddWithScoringFunction() throws IOException {
     NeighborArray neighbors = new NeighborArray(10, true);
     neighbors.addOutOfOrder(1, Float.NaN);


### PR DESCRIPTION
Fixes https://github.com/apache/lucene/issues/16321
### Description
The legacy sorting logic in NeighborArray below takes `O(N^2)` in worst case, as it is a form of insertion sort and pushes/copies the rest of the array towards the end for each uncheckedIndex.

The solution I'm proposing takes `O(N)` time complexity and `O(N)` space complexity.
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
