### PR TITLE
Avoid redundant work in AbstractKnnVectorQuery.rewrite's optimistic path

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -168,6 +168,8 @@ Optimizations
 
 * GITHUB#15597, GITHUB#15777: Reduce memory usage of NeighborArray (Viliam Durina)
 
+* GITHUB#12324: ELiminate redundant work in AbstractKnnVectorQuery.rewrite (Mike Sokolov)
+
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -146,7 +146,9 @@ abstract class AbstractKnnVectorQuery extends Query {
       }
       assert leafReaderContexts.size() == tasks.size();
       assert perLeafResults.size() == reader.leaves().size();
-      topK = runSearchTasks(tasks, taskExecutor, perLeafResults, leafReaderContexts);
+      if (tasks.size() > 0) {
+        topK = runSearchTasks(tasks, taskExecutor, perLeafResults, leafReaderContexts);
+      }
     }
     if (topK.scoreDocs.length == 0) {
       return MatchNoDocsQuery.INSTANCE;


### PR DESCRIPTION
Found this dumb optimization opportunity while debugging something else. In the normal case, our optimism is borne out and we don't need to revisit any segments for additional HNSW explorations. But we go ahead and run the empty list of tasks anyway. That would be dumb but relatively harmless, but then we also re-merge all the segment results into a global TopK (`mergeLeafResults` gets called twice) -- which we have already had to do in order to determine the min competitive score.
