### PR TITLE
Fix integer underflow in assertion in SparseFixedBitSet

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/SparseFixedBitSet.java
+++ b/lucene/core/src/java/org/apache/lucene/util/SparseFixedBitSet.java
@@ -41,12 +41,12 @@ public class SparseFixedBitSet extends BitSet {
   private static final long SINGLE_ELEMENT_ARRAY_BYTES_USED = RamUsageEstimator.sizeOf(new long[1]);
   private static final int MASK_4096 = (1 << 12) - 1;
 
-  private static int blockCount(int length) {
+  static int blockCount(int length) {
     int blockCount = length >>> 12;
     if ((blockCount << 12) < length) {
       ++blockCount;
     }
-    assert (blockCount << 12) >= length;
+    assert ((long) blockCount << 12) >= length;
     return blockCount;
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestSparseFixedBitSet.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestSparseFixedBitSet.java
@@ -155,4 +155,8 @@ public class TestSparseFixedBitSet extends BaseBitSetTestCase<SparseFixedBitSet>
       }
     }
   }
+
+  public void testLargeValuesDoNotOverflow() {
+    assertEquals(524288, SparseFixedBitSet.blockCount(2147479553));
+  }
 }


### PR DESCRIPTION
For values close to Integer.MAX_VALUE, the blockCount calculation in SparseFixedBitSet can result in an assertion tripping.  The method checks that the calculated block count will cover the full length of the bitset; if the block count covers the whole integer range, the check will underflow to a negative value, which compares as smaller than the passed-in length.  This is fixed by a simple cast to long.

Note that the error is only in the assertion; the actual calculated block count is correct and there is no production bug.