### PR TITLE
Refactor SimpleTextTermVectorsReader to reuse enums

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -160,6 +160,8 @@ Optimizations
 
 * GITHUB#15597, GITHUB#15777: Reduce memory usage of NeighborArray (Viliam Durina)
 
+* GITHUB#16351: Refactor SimpleTextTermVectorsReader to reuse enums and improve performance (Rajat Jain)
+
 Bug Fixes
 ---------------------
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsReader.java
@@ -276,18 +276,20 @@ public class SimpleTextTermVectorsReader extends TermVectorsReader {
     final boolean hasOffsets;
     final boolean hasPositions;
     final boolean hasPayloads;
+    private SimpleTVTermsEnum termsEnum;
 
     SimpleTVTerms(boolean hasOffsets, boolean hasPositions, boolean hasPayloads) {
       this.hasOffsets = hasOffsets;
       this.hasPositions = hasPositions;
       this.hasPayloads = hasPayloads;
       terms = new TreeMap<>();
+      termsEnum = new SimpleTVTermsEnum(terms);
     }
 
     @Override
     public TermsEnum iterator() throws IOException {
-      // TODO: reuse
-      return new SimpleTVTermsEnum(terms);
+      termsEnum.reset();
+      return termsEnum;
     }
 
     @Override
@@ -349,10 +351,19 @@ public class SimpleTextTermVectorsReader extends TermVectorsReader {
     SortedMap<BytesRef, SimpleTVPostings> terms;
     Iterator<Map.Entry<BytesRef, SimpleTextTermVectorsReader.SimpleTVPostings>> iterator;
     Map.Entry<BytesRef, SimpleTextTermVectorsReader.SimpleTVPostings> current;
+    private SimpleTVPostingsEnum postingsEnum;
+    private SimpleTVDocsEnum docsEnum;
 
     SimpleTVTermsEnum(SortedMap<BytesRef, SimpleTVPostings> terms) {
       this.terms = terms;
       this.iterator = terms.entrySet().iterator();
+      this.postingsEnum = new SimpleTVPostingsEnum();
+      this.docsEnum = new SimpleTVDocsEnum();
+    }
+
+    void reset() {
+      this.iterator = terms.entrySet().iterator();
+      this.current = null;
     }
 
     @Override
@@ -406,21 +417,17 @@ public class SimpleTextTermVectorsReader extends TermVectorsReader {
       if (PostingsEnum.featureRequested(flags, PostingsEnum.POSITIONS)) {
         SimpleTVPostings postings = current.getValue();
         if (postings.positions != null || postings.startOffsets != null) {
-          // TODO: reuse
-          SimpleTVPostingsEnum e = new SimpleTVPostingsEnum();
-          e.reset(
+          postingsEnum.reset(
               postings.positions, postings.startOffsets, postings.endOffsets, postings.payloads);
-          return e;
+          return postingsEnum;
         }
       }
 
-      // TODO: reuse
-      SimpleTVDocsEnum e = new SimpleTVDocsEnum();
-      e.reset(
+      docsEnum.reset(
           PostingsEnum.featureRequested(flags, PostingsEnum.FREQS) == false
               ? 1
               : current.getValue().freq);
-      return e;
+      return docsEnum;
     }
 
     @Override
@@ -487,6 +494,12 @@ public class SimpleTextTermVectorsReader extends TermVectorsReader {
       didNext = false;
     }
 
+    void reinitialize() {
+      this.doc = -1;
+      this.didNext = false;
+      this.freq = 0;
+    }
+
     @Override
     public long cost() {
       return 1;
@@ -540,6 +553,16 @@ public class SimpleTextTermVectorsReader extends TermVectorsReader {
       this.doc = -1;
       didNext = false;
       nextPos = 0;
+    }
+
+    void reinitialize() {
+      this.doc = -1;
+      this.didNext = false;
+      this.nextPos = 0;
+      this.positions = null;
+      this.startOffsets = null;
+      this.endOffsets = null;
+      this.payloads = null;
     }
 
     @Override


### PR DESCRIPTION
Refactor SimpleTextTermVectorsReader to reuse enums and improve performance

### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
