### PR TITLE
SkipBlockRangeIterator should report docCount as its cost

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -323,6 +323,8 @@ Optimizations
 * GITHUB#16283: Use Panama Vector API to SIMD-evaluate fixed-cardinality sorted numeric range queries in
   rangeIntoBitSet. (Costin Leau)
 
+* GITHUB#16352: Better cost() estimation for SkipBlockRangeIterator. (Alan Woodward)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/SkipBlockRangeIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SkipBlockRangeIterator.java
@@ -108,7 +108,7 @@ public class SkipBlockRangeIterator extends AbstractDocIdSetIterator {
 
   @Override
   public long cost() {
-    return DocIdSetIterator.NO_MORE_DOCS;
+    return skipper.docCount();
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/search/TestSkipBlockRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSkipBlockRangeIterator.java
@@ -54,4 +54,10 @@ public class TestSkipBlockRangeIterator extends BaseDocValuesSkipperTests {
 
     assertEquals(expected, bitSet);
   }
+
+  public void testCost() {
+    DocValuesSkipper skipper = docValuesSkipper(1, 30, random().nextBoolean());
+    SkipBlockRangeIterator it = new SkipBlockRangeIterator(skipper, 1, 30);
+    assertEquals(DENSE_END + (MAX_DOC - DENSE_END) / 2, it.cost());
+  }
 }


### PR DESCRIPTION
Currently it returns DocIdSetIterator.NO_MORE_DOCS, meaning that it will compare as more costly to almost any other iterator and never be used to drive iteration in conjunctions, even against expensive two-phase queries that report max_doc as their cost.
