### PR TITLE
Optimize SimpleTextBKDWriter.rotateToTree tree-layout computation to O(1) per node

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -154,6 +154,8 @@ Optimizations
 
 * GITHUB#14874: Improve off-heap KNN byte vector query performance in cases where indexing and search are performed by the same process. (Kaival Parikh)
 
+* GITHUB#16354: Optimize layout computation in SimpleTextBKDWriter.rotateToTree to O(1) per node (Rajat Jain)
+
 * GITHUB#15043: Vectorize L2 normalize function. (Ramakrishna Chilaka)
 
 * GITHUB#15085, GITHUB#15092: Hunspell suggestions: Ensure candidate roots are not worse before updating. (Ilia Permiashkin)

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextBKDWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextBKDWriter.java
@@ -583,7 +583,8 @@ final class SimpleTextBKDWriter implements Closeable {
       rotateToTree(2 * nodeID, offset, leftHalf, index, leafBlockStartValues);
 
       // Recurse right
-      rotateToTree(2 * nodeID + 1, rootOffset + 1, count - leftHalf - 1, index, leafBlockStartValues);
+      rotateToTree(
+          2 * nodeID + 1, rootOffset + 1, count - leftHalf - 1, index, leafBlockStartValues);
     }
   }
 

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextBKDWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextBKDWriter.java
@@ -549,65 +549,41 @@ final class SimpleTextBKDWriter implements Closeable {
     }
   }
 
-  // TODO: there must be a simpler way?
   private void rotateToTree(
       int nodeID, int offset, int count, byte[] index, List<byte[]> leafBlockStartValues) {
-    // System.out.println("ROTATE: nodeID=" + nodeID + " offset=" + offset + " count=" + count + "
-    // bpd=" + config.bytesPerDim() + " index.length=" + index.length);
+
+    if (count == 0) {
+      return;
+    }
+
+    int leftHalf;
     if (count == 1) {
-      // Leaf index node
-      // System.out.println("  leaf index node");
-      // System.out.println("  index[" + nodeID + "] = blockStartValues[" + offset + "]");
-      System.arraycopy(
-          leafBlockStartValues.get(offset),
-          0,
-          index,
-          nodeID * (1 + config.bytesPerDim()) + 1,
-          config.bytesPerDim());
-    } else if (count > 1) {
-      // Internal index node: binary partition of count
-      int countAtLevel = 1;
-      int totalCount = 0;
-      while (true) {
-        int countLeft = count - totalCount;
-        // System.out.println("    cycle countLeft=" + countLeft + " coutAtLevel=" + countAtLevel);
-        if (countLeft <= countAtLevel) {
-          // This is the last level, possibly partially filled:
-          int lastLeftCount = Math.min(countAtLevel / 2, countLeft);
-          assert lastLeftCount >= 0;
-          int leftHalf = (totalCount - 1) / 2 + lastLeftCount;
-
-          int rootOffset = offset + leftHalf;
-          /*
-          System.out.println("  last left count " + lastLeftCount);
-          System.out.println("  leftHalf " + leftHalf + " rightHalf=" + (count-leftHalf-1));
-          System.out.println("  rootOffset=" + rootOffset);
-          */
-
-          System.arraycopy(
-              leafBlockStartValues.get(rootOffset),
-              0,
-              index,
-              nodeID * (1 + config.bytesPerDim()) + 1,
-              config.bytesPerDim());
-          // System.out.println("  index[" + nodeID + "] = blockStartValues[" + rootOffset + "]");
-
-          // TODO: we could optimize/specialize, when we know it's simply fully balanced binary tree
-          // under here, to save this while loop on each recursion
-
-          // Recurse left
-          rotateToTree(2 * nodeID, offset, leftHalf, index, leafBlockStartValues);
-
-          // Recurse right
-          rotateToTree(
-              2 * nodeID + 1, rootOffset + 1, count - leftHalf - 1, index, leafBlockStartValues);
-          return;
-        }
-        totalCount += countAtLevel;
-        countAtLevel *= 2;
-      }
+      leftHalf = 0;
     } else {
-      assert count == 0;
+      // O(1) calculation for the number of nodes in the left subtree
+      // of a complete binary tree.
+      int h = Integer.highestOneBit(count);
+      int halfH = h >>> 1; // Same as h / 2
+      leftHalf = halfH - 1 + Math.min(count - h + 1, halfH);
+    }
+
+    int rootOffset = offset + leftHalf;
+    int bytesPerDim = config.bytesPerDim();
+
+    // Unify the arraycopy for both leaf and internal nodes
+    System.arraycopy(
+        leafBlockStartValues.get(rootOffset),
+        0,
+        index,
+        nodeID * (1 + bytesPerDim) + 1,
+        bytesPerDim);
+
+    if (count > 1) {
+      // Recurse left
+      rotateToTree(2 * nodeID, offset, leftHalf, index, leafBlockStartValues);
+
+      // Recurse right
+      rotateToTree(2 * nodeID + 1, rootOffset + 1, count - leftHalf - 1, index, leafBlockStartValues);
     }
   }
 


### PR DESCRIPTION
Fixes: #16353 

### Description
This PR optimizes the `rotateToTree` method in `SimpleTextBKDWriter` to avoid iterative loop overhead when calculating binary tree partitions.

`rotateToTree` converts a sorted, flat list of leaf block split/start values into a flat array structure representing a balanced complete binary search tree.

#### The Problem / Bottleneck
To partition nodes for the left subtree (`leftHalf`) at each level of recursion, the method previously used an iterative `while(true)` loop to calculate the level-by-level boundaries. This loop ran in O(log(count)) time at each step of the recursion. Since recursion occurs for every node in the tree, the overall mathematical partition computation overhead was O(N log N) for N inner nodes.

#### The Optimization
1. **O(1) Left Subtree Count:** We replaced the iterative `while(true)` loop with a bitwise constant-time O(1) calculation to determine the exact number of nodes in the left subtree of a complete binary tree:
   ```java
   int h = Integer.highestOneBit(count);
   int halfH = h >>> 1;
   int leftHalf = halfH - 1 + Math.min(count - h + 1, halfH);
This leverages the fact that complete binary trees have a mathematically rigid structure that can be derived in constant time using bit-shifts.

3. Unified Array Copying: We consolidated the System.arraycopy code to handle both leaf and internal nodes under a single, unified execution path, reducing code duplication and branch prediction overhead.

4. Dead Code Cleanup: Removed legacy debug output and outdated comments.