### PR TITLE
Fix occasional ConcurrentModificationException in TestInfoStream

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestInfoStream.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestInfoStream.java
@@ -129,26 +129,28 @@ public class TestInfoStream extends LuceneTestCase {
     boolean foundInit = false;
     int flushedCount = 0;
     int mergedCount = 0;
-    for (String message : infoStream) {
-      // we don't want to be printing full diagnostics every time a segment is mentioned in the log,
-      // only when it is first flushed
-      if (message.contains("diagnostics")) {
-        if (message.startsWith("[IW] publishFlushedSegment")) {
-          flushedCount++;
-        } else if (message.startsWith("[IW] merged new segment")) {
-          mergedCount++;
-        } else {
-          fail("message contains diagnostics: " + message);
+    synchronized (infoStream) {
+      for (String message : infoStream) {
+        // we don't want to be printing full diagnostics every time a segment is mentioned in the log,
+        // only when it is first flushed
+        if (message.contains("diagnostics")) {
+          if (message.startsWith("[IW] publishFlushedSegment")) {
+            flushedCount++;
+          } else if (message.startsWith("[IW] merged new segment")) {
+            mergedCount++;
+          } else {
+            fail("message contains diagnostics: " + message);
+          }
         }
+        if (message.contains("init segments")) {
+          assertEquals("[IW] init segments: \n", message);
+          foundInit = true;
+        }
+        // System.out.print(message);
       }
-      if (message.contains("init segments")) {
-        assertEquals("[IW] init segments: \n", message);
-        foundInit = true;
-      }
-      // System.out.print(message);
+      assertTrue("init message not found", foundInit);
+      assertEquals(2, flushedCount);
+      assertEquals(1, mergedCount);
     }
-    assertTrue("init message not found", foundInit);
-    assertEquals(2, flushedCount);
-    assertEquals(1, mergedCount);
-  }
+  }g
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestInfoStream.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestInfoStream.java
@@ -131,8 +131,8 @@ public class TestInfoStream extends LuceneTestCase {
     int mergedCount = 0;
     synchronized (infoStream) {
       for (String message : infoStream) {
-        // we don't want to be printing full diagnostics every time a segment is mentioned in the log,
-        // only when it is first flushed
+        // we don't want to be printing full diagnostics every time a segment is mentioned in the
+        // log, only when it is first flushed
         if (message.contains("diagnostics")) {
           if (message.startsWith("[IW] publishFlushedSegment")) {
             flushedCount++;
@@ -152,5 +152,5 @@ public class TestInfoStream extends LuceneTestCase {
       assertEquals(2, flushedCount);
       assertEquals(1, mergedCount);
     }
-  }g
+  }
 }


### PR DESCRIPTION
IndexWriter merge threads might still be writing to the InfoStream after the writer is closed.  Synchronize on the infostream List so that we don't get CMEs when iterating over it to check messages.