### PR TITLE
Fix seed-dependent failure in TestForceNoBulkScoringQuery

### DIFF
--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestForceNoBulkScoringQuery.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestForceNoBulkScoringQuery.java
@@ -94,7 +94,10 @@ public class TestForceNoBulkScoringQuery extends LuceneTestCase {
       iw.commit();
 
       try (IndexReader reader = DirectoryReader.open(dir)) {
-        IndexSearcher searcher = newSearcher(reader);
+        // use a plain searcher: newSearcher may wrap with AssertingIndexSearcher, whose
+        // ScorerSupplier sometimes builds the bulk scorer from scorer() instead of delegating to
+        // bulkScorer(), which breaks the sanity check below for some seeds
+        IndexSearcher searcher = new IndexSearcher(reader);
         // disable query caching, so that we exercise the search path directly rather than
         // any bulk-scoring optimizations the cache may apply internally
         searcher.setQueryCache(null);


### PR DESCRIPTION
`TestForceNoBulkScoringQuery#testBulkScoringIsDisabled` fails deterministically with some seeds since #16350, e.g. on current `main`:

```
gradlew -p lucene/monitor test --tests TestForceNoBulkScoringQuery.testBulkScoringIsDisabled -Dtests.seed=BDD18A3ADD885193 -Dtests.locale=ii-CN -Dtests.timezone=Etc/Zulu
```

```
junit.framework.AssertionFailedError: Expected exception AssertionError but no exception was thrown
    at org.apache.lucene.monitor.TestForceNoBulkScoringQuery.testBulkScoringIsDisabled(TestForceNoBulkScoringQuery.java:105)
```

The sanity check added in #16350 assumes that searching the un-wrapped `ThrowsOnBulkScoreQuery` always reaches its `ScorerSupplier#bulkScorer()`. But `newSearcher(reader)` may wrap the searcher with `AssertingIndexSearcher`, whose scorer supplier deliberately builds the bulk scorer from `scorer()` instead of delegating (the `usually(random)` branch in `AssertingWeight` — ~1% of seeds in normal runs, more under nightly). In that case the expected `AssertionError` is never thrown and the sanity check fails before the actual `ForceNoBulkScoringQuery` behavior is exercised.

Since the scorer/bulkScorer dispatch is exactly what this test asserts on, use a plain `IndexSearcher` so the dispatch is deterministic. The failing seed above passes with this change (and the sanity check still fires, i.e. the plain searcher does reach `bulkScorer()`).

First hit on an unrelated PR's CI (#16368). Happy to restructure — e.g. keep the randomized searcher for the wrapped-query assertion only — if you'd prefer.