### PR TITLE
Collapse repeated wildcard asterisks

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -151,6 +151,10 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#16382: WildcardQuery.toAutomaton now collapses consecutive unescaped '*'
+  wildcards into a single any-string automaton, avoiding a quadratic blow-up in
+  automaton size for patterns with many repeated asterisks. (Vismay Tiwari)
+
 * GITHUB#16307: ReqExclBulkScorer now skips runs of excluded docs via
   TwoPhaseIterator#docIDRunEnd for two-phase excluded clauses (e.g. a doc-values
   not-equals filter), instead of advancing one doc at a time. (Jim Ferenczi)

--- a/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
@@ -70,15 +70,20 @@ public class WildcardQuery extends AutomatonQuery {
 
     String wildcardText = wildcardquery.text();
 
+    boolean lastWasWildcardString = false;
     for (int i = 0; i < wildcardText.length(); ) {
       final int c = wildcardText.codePointAt(i);
       int length = Character.charCount(c);
       switch (c) {
         case WILDCARD_STRING:
-          automata.add(Automata.makeAnyString());
+          if (!lastWasWildcardString) {
+            automata.add(Automata.makeAnyString());
+            lastWasWildcardString = true;
+          }
           break;
         case WILDCARD_CHAR:
           automata.add(Automata.makeAnyChar());
+          lastWasWildcardString = false;
           break;
         case WILDCARD_ESCAPE:
           // add the next codepoint instead, if it exists
@@ -86,10 +91,12 @@ public class WildcardQuery extends AutomatonQuery {
             final int nextChar = wildcardText.codePointAt(i + length);
             length += Character.charCount(nextChar);
             automata.add(Automata.makeChar(nextChar));
+            lastWasWildcardString = false;
             break;
           } // else fallthru, lenient parsing with a trailing \
         default:
           automata.add(Automata.makeChar(c));
+          lastWasWildcardString = false;
       }
       i += length;
     }

--- a/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
@@ -69,22 +69,19 @@ public class WildcardQuery extends AutomatonQuery {
 
     String wildcardText = wildcardquery.text();
 
-    boolean lastWasWildcardString = false;
     for (int i = 0; i < wildcardText.length(); ) {
       final int c = wildcardText.codePointAt(i);
       int length = Character.charCount(c);
       switch (c) {
         case WILDCARD_STRING -> {
-          // collapse consecutive '*' into a single any-string automaton
-          if (!lastWasWildcardString) {
+          // Collapse consecutive '*' ("**" is equivalent to "*"): only append an
+          // any-string automaton when the previous segment isn't already one.
+          if (automata.isEmpty()
+              || Operations.isTotal(automata.get(automata.size() - 1)) == false) {
             automata.add(Automata.makeAnyString());
-            lastWasWildcardString = true;
           }
         }
-        case WILDCARD_CHAR -> {
-          automata.add(Automata.makeAnyChar());
-          lastWasWildcardString = false;
-        }
+        case WILDCARD_CHAR -> automata.add(Automata.makeAnyChar());
         case WILDCARD_ESCAPE -> {
           // add the escaped codepoint as a literal if it exists; a trailing
           // '\' is parsed leniently as a literal '\'
@@ -95,12 +92,8 @@ public class WildcardQuery extends AutomatonQuery {
           } else {
             automata.add(Automata.makeChar(c));
           }
-          lastWasWildcardString = false;
         }
-        default -> {
-          automata.add(Automata.makeChar(c));
-          lastWasWildcardString = false;
-        }
+        default -> automata.add(Automata.makeChar(c));
       }
       i += length;
     }

--- a/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
@@ -76,8 +76,7 @@ public class WildcardQuery extends AutomatonQuery {
         case WILDCARD_STRING -> {
           // Collapse consecutive '*' ("**" is equivalent to "*"): only append an
           // any-string automaton when the previous segment isn't already one.
-          if (automata.isEmpty()
-              || Operations.isTotal(automata.get(automata.size() - 1)) == false) {
+          if (automata.isEmpty() || Operations.isTotal(automata.getLast()) == false) {
             automata.add(Automata.makeAnyString());
           }
         }

--- a/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WildcardQuery.java
@@ -64,7 +64,6 @@ public class WildcardQuery extends AutomatonQuery {
    *
    * @lucene.internal
    */
-  @SuppressWarnings("fallthrough")
   public static Automaton toAutomaton(Term wildcardquery) {
     List<Automaton> automata = new ArrayList<>();
 
@@ -75,28 +74,33 @@ public class WildcardQuery extends AutomatonQuery {
       final int c = wildcardText.codePointAt(i);
       int length = Character.charCount(c);
       switch (c) {
-        case WILDCARD_STRING:
+        case WILDCARD_STRING -> {
+          // collapse consecutive '*' into a single any-string automaton
           if (!lastWasWildcardString) {
             automata.add(Automata.makeAnyString());
             lastWasWildcardString = true;
           }
-          break;
-        case WILDCARD_CHAR:
+        }
+        case WILDCARD_CHAR -> {
           automata.add(Automata.makeAnyChar());
           lastWasWildcardString = false;
-          break;
-        case WILDCARD_ESCAPE:
-          // add the next codepoint instead, if it exists
+        }
+        case WILDCARD_ESCAPE -> {
+          // add the escaped codepoint as a literal if it exists; a trailing
+          // '\' is parsed leniently as a literal '\'
           if (i + length < wildcardText.length()) {
             final int nextChar = wildcardText.codePointAt(i + length);
             length += Character.charCount(nextChar);
             automata.add(Automata.makeChar(nextChar));
-            lastWasWildcardString = false;
-            break;
-          } // else fallthru, lenient parsing with a trailing \
-        default:
+          } else {
+            automata.add(Automata.makeChar(c));
+          }
+          lastWasWildcardString = false;
+        }
+        default -> {
           automata.add(Automata.makeChar(c));
           lastWasWildcardString = false;
+        }
       }
       i += length;
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestWildcardQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestWildcardQuery.java
@@ -39,6 +39,7 @@ import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 
 /** TestWildcardQuery tests the '*' and '?' wildcard characters. */
@@ -233,6 +234,14 @@ public class TestWildcardQuery extends LuceneTestCase {
 
     reader.close();
     indexStore.close();
+  }
+
+  public void testRepeatedAsterisksCollapse() {
+    Automaton single = WildcardQuery.toAutomaton(new Term("field", "*"));
+    Automaton repeated = WildcardQuery.toAutomaton(new Term("field", "*".repeat(1000)));
+
+    assertEquals(single.getNumStates(), repeated.getNumStates());
+    assertEquals(single.getNumTransitions(), repeated.getNumTransitions());
   }
 
   private Directory getIndexStore(String field, String[] contents) throws IOException {

--- a/lucene/core/src/test/org/apache/lucene/search/TestWildcardQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestWildcardQuery.java
@@ -274,7 +274,7 @@ public class TestWildcardQuery extends LuceneTestCase {
   public void testInterleavedStarQuestionDoesNotBlowUp() {
     // '*?' repeated does not collapse (the '*' are not consecutive), but it
     // must still build a linearly-sized automaton rather than exploding the way
-    // repeated '*' used to before this fix (gh-16134).
+    // repeated '*' used to before this fix (GITHUB#16134).
     int n = 5000;
     Automaton a = WildcardQuery.toAutomaton(new Term("field", "*?".repeat(n)));
     assertTrue(

--- a/lucene/core/src/test/org/apache/lucene/search/TestWildcardQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestWildcardQuery.java
@@ -38,9 +38,11 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.automaton.AutomatonTestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
+import org.apache.lucene.util.automaton.Operations;
 
 /** TestWildcardQuery tests the '*' and '?' wildcard characters. */
 public class TestWildcardQuery extends LuceneTestCase {
@@ -236,12 +238,48 @@ public class TestWildcardQuery extends LuceneTestCase {
     indexStore.close();
   }
 
-  public void testRepeatedAsterisksCollapse() {
-    Automaton single = WildcardQuery.toAutomaton(new Term("field", "*"));
-    Automaton repeated = WildcardQuery.toAutomaton(new Term("field", "*".repeat(1000)));
+  private static Automaton det(Automaton a) {
+    return Operations.determinize(a, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+  }
 
+  public void testRepeatedAsterisksCollapse() {
+    // Consecutive '*' must collapse to a single any-string automaton: same
+    // language as a single '*', and the same (tiny) shape, not a huge one.
+    Automaton single = det(WildcardQuery.toAutomaton(new Term("field", "*")));
+    Automaton repeated = det(WildcardQuery.toAutomaton(new Term("field", "*".repeat(1000))));
+
+    assertTrue(AutomatonTestUtil.sameLanguage(single, repeated));
     assertEquals(single.getNumStates(), repeated.getNumStates());
     assertEquals(single.getNumTransitions(), repeated.getNumTransitions());
+  }
+
+  public void testRepeatedAsterisksCollapseWithEscapesAndLiterals() {
+    // Collapsing applies only to unescaped, consecutive '*'. An escaped '\*'
+    // stays a literal and the surrounding literals / '?' are untouched, so
+    // "a\*b***c?" matches the same language as its single-'*' form "a\*b*c?".
+    Automaton collapsed = det(WildcardQuery.toAutomaton(new Term("field", "a\\*b***c?")));
+    Automaton reference = det(WildcardQuery.toAutomaton(new Term("field", "a\\*b*c?")));
+
+    assertTrue(AutomatonTestUtil.sameLanguage(reference, collapsed));
+    assertEquals(reference.getNumStates(), collapsed.getNumStates());
+    assertEquals(reference.getNumTransitions(), collapsed.getNumTransitions());
+
+    // Escaped '\*' is a literal, so "\*\*\*" matches the string "***", not the
+    // any-string '*' — it must NOT be collapsed.
+    Automaton single = det(WildcardQuery.toAutomaton(new Term("field", "*")));
+    Automaton literalStars = det(WildcardQuery.toAutomaton(new Term("field", "\\*\\*\\*")));
+    assertFalse(AutomatonTestUtil.sameLanguage(single, literalStars));
+  }
+
+  public void testInterleavedStarQuestionDoesNotBlowUp() {
+    // '*?' repeated does not collapse (the '*' are not consecutive), but it
+    // must still build a linearly-sized automaton rather than exploding the way
+    // repeated '*' used to before this fix (gh-16134).
+    int n = 5000;
+    Automaton a = WildcardQuery.toAutomaton(new Term("field", "*?".repeat(n)));
+    assertTrue(
+        "expected roughly linear size, got " + a.getNumTransitions() + " transitions for " + n,
+        a.getNumTransitions() < 100L * n);
   }
 
   private Directory getIndexStore(String field, String[] contents) throws IOException {


### PR DESCRIPTION
### Description

Fixes #16134.

`WildcardQuery.toAutomaton` created a separate `Automata.makeAnyString()` automaton for every unescaped `*`. Consecutive `*` wildcards match the same language as a single `*`, but the repeated form made `Operations.concatenate` build a much larger automaton.

This collapses consecutive unescaped `*` tokens while preserving escaped `\*` as a literal. It also adds a regression test that checks repeated asterisks produce the same automaton shape as a single asterisk.

Before the change, `WildcardQuery.toAutomaton(new Term("field", "*".repeat(10000)))` built `50,005,000` transitions locally. After the change, the same input builds `1` transition.

Validation:

- `./gradlew tidy`
- `./gradlew :lucene:core:test --tests TestWildcardQuery -Dtests.seed=5EEC297244EB01E6 -Dtests.asserts=true -Dtests.file.encoding=UTF-8`
- `./gradlew :lucene:core:check -Dtests.seed=5EEC297244EB01E6 -Dtests.asserts=true -Dtests.file.encoding=UTF-8`
