### PR TITLE
Add fp16 (float16) vector encoding support - no quantization support

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -313,7 +313,7 @@ New Features
   and document length instead of corpus statistics such as document frequency. It also supports k3
   query-term frequency saturation. (Tianxiao Wei)
 
-* GITHUB#15549: Add fp16 vector encoding support. (Pulkit Gupta)
+* GITHUB#16383: Add fp16 vector encoding support. (Pulkit Gupta)
 
 Improvements
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -313,6 +313,8 @@ New Features
   and document length instead of corpus statistics such as document frequency. It also supports k3
   query-term frequency saturation. (Tianxiao Wei)
 
+* GITHUB#15549: Add fp16 vector encoding support. (Pulkit Gupta)
+
 Improvements
 ---------------------
 

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene102/Lucene102BinaryFlatVectorsScorer.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene102/Lucene102BinaryFlatVectorsScorer.java
@@ -95,6 +95,13 @@ public class Lucene102BinaryFlatVectorsScorer implements FlatVectorsScorer {
   }
 
   @Override
+  public RandomVectorScorer getRandomVectorScorer(
+      VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, short[] target)
+      throws IOException {
+    return null;
+  }
+
+  @Override
   public String toString() {
     return "Lucene102BinaryFlatVectorsScorer(nonQuantizedDelegate=" + nonQuantizedDelegate + ")";
   }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene102/Lucene102BinaryFlatVectorsScorer.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene102/Lucene102BinaryFlatVectorsScorer.java
@@ -98,7 +98,7 @@ public class Lucene102BinaryFlatVectorsScorer implements FlatVectorsScorer {
   public RandomVectorScorer getRandomVectorScorer(
       VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, short[] target)
       throws IOException {
-    return null;
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene102/Lucene102BinaryQuantizedVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene102/Lucene102BinaryQuantizedVectorsReader.java
@@ -40,6 +40,7 @@ import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.DocsWithFieldSet;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.KnnVectorValues;
@@ -212,6 +213,11 @@ public class Lucene102BinaryQuantizedVectorsReader extends FlatVectorsReader
   }
 
   @Override
+  public RandomVectorScorer getRandomVectorScorer(String field, short[] target) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void checkIntegrity(MergePolicy.OneMerge merge) throws IOException {
     rawVectorsReader.checkIntegrity(merge);
     CodecUtil.checksumEntireFile(quantizedVectorData, merge);
@@ -251,6 +257,11 @@ public class Lucene102BinaryQuantizedVectorsReader extends FlatVectorsReader
   @Override
   public ByteVectorValues getByteVectorValues(String field) throws IOException {
     return rawVectorsReader.getByteVectorValues(field);
+  }
+
+  @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsReader.java
@@ -30,6 +30,7 @@ import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.MergePolicy;
@@ -244,6 +245,11 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
   }
 
   @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     final FieldEntry fieldEntry = getFieldEntry(field);
@@ -276,6 +282,12 @@ public final class Lucene90HnswVectorsReader extends KnnVectorsReader {
 
   @Override
   public void search(String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void search(String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     throw new UnsupportedOperationException();
   }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsReader.java
@@ -32,6 +32,7 @@ import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.MergePolicy;
@@ -240,6 +241,11 @@ public final class Lucene91HnswVectorsReader extends KnnVectorsReader {
   }
 
   @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     final FieldEntry fieldEntry = getFieldEntry(field);
@@ -260,6 +266,12 @@ public final class Lucene91HnswVectorsReader extends KnnVectorsReader {
 
   @Override
   public void search(String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void search(String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     throw new UnsupportedOperationException();
   }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsReader.java
@@ -31,6 +31,7 @@ import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.MergePolicy;
@@ -237,6 +238,11 @@ public final class Lucene92HnswVectorsReader extends KnnVectorsReader {
   }
 
   @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     final FieldEntry fieldEntry = getFieldEntry(field);
@@ -257,6 +263,12 @@ public final class Lucene92HnswVectorsReader extends KnnVectorsReader {
 
   @Override
   public void search(String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void search(String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     throw new UnsupportedOperationException();
   }

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsReader.java
@@ -31,6 +31,7 @@ import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.MergePolicy;
@@ -178,6 +179,7 @@ public final class Lucene94HnswVectorsReader extends KnnVectorsReader {
         switch (info.getVectorEncoding()) {
           case BYTE -> Byte.BYTES;
           case FLOAT32 -> Float.BYTES;
+          case FLOAT16 -> Short.BYTES;
         };
     long vectorBytes = Math.multiplyExact((long) dimension, byteSize);
     long numBytes = Math.multiplyExact(vectorBytes, fieldEntry.size);
@@ -271,6 +273,11 @@ public final class Lucene94HnswVectorsReader extends KnnVectorsReader {
   }
 
   @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     final FieldEntry fieldEntry = getFieldEntry(field, VectorEncoding.FLOAT32);
@@ -306,6 +313,12 @@ public final class Lucene94HnswVectorsReader extends KnnVectorsReader {
         new OrdinalTranslatedKnnCollector(knnCollector, vectorValues::ordToDoc),
         getGraph(fieldEntry),
         vectorValues.getAcceptOrds(acceptDocs.bits()));
+  }
+
+  @Override
+  public void search(String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    throw new UnsupportedOperationException();
   }
 
   private HnswGraph getGraph(FieldEntry entry) throws IOException {

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/OffHeapFloatVectorValues.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/OffHeapFloatVectorValues.java
@@ -86,6 +86,7 @@ abstract class OffHeapFloatVectorValues extends FloatVectorValues {
         switch (fieldEntry.vectorEncoding()) {
           case BYTE -> fieldEntry.dimension();
           case FLOAT32 -> fieldEntry.dimension() * Float.BYTES;
+          case FLOAT16 -> fieldEntry.dimension() * Short.BYTES;
         };
     if (fieldEntry.docsWithFieldOffset() == -1) {
       return new DenseOffHeapVectorValues(

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsReader.java
@@ -35,6 +35,7 @@ import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.MergePolicy;
@@ -178,6 +179,7 @@ public final class Lucene95HnswVectorsReader extends KnnVectorsReader implements
         switch (info.getVectorEncoding()) {
           case BYTE -> Byte.BYTES;
           case FLOAT32 -> Float.BYTES;
+          case FLOAT16 -> Short.BYTES;
         };
     long vectorBytes = Math.multiplyExact((long) dimension, byteSize);
     long numBytes = Math.multiplyExact(vectorBytes, fieldEntry.size);
@@ -291,6 +293,11 @@ public final class Lucene95HnswVectorsReader extends KnnVectorsReader implements
   }
 
   @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     final FieldEntry fieldEntry = getFieldEntry(field, VectorEncoding.FLOAT32);
@@ -344,6 +351,12 @@ public final class Lucene95HnswVectorsReader extends KnnVectorsReader implements
         new OrdinalTranslatedKnnCollector(knnCollector, vectorValues::ordToDoc),
         getGraph(fieldEntry),
         vectorValues.getAcceptOrds(acceptDocs.bits()));
+  }
+
+  @Override
+  public void search(String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    throw new UnsupportedOperationException();
   }
 
   /** Get knn graph values; used for testing */

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsReader.java
@@ -178,8 +178,8 @@ public final class Lucene95HnswVectorsReader extends KnnVectorsReader implements
     int byteSize =
         switch (info.getVectorEncoding()) {
           case BYTE -> Byte.BYTES;
-          case FLOAT32 -> Float.BYTES;
           case FLOAT16 -> Short.BYTES;
+          case FLOAT32 -> Float.BYTES;
         };
     long vectorBytes = Math.multiplyExact((long) dimension, byteSize);
     long numBytes = Math.multiplyExact(vectorBytes, fieldEntry.size);

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
@@ -32,6 +32,7 @@ import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.MergePolicy;
@@ -228,6 +229,11 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
     return rawVectorsReader.getByteVectorValues(field);
   }
 
+  @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
   private static IndexInput openDataInput(
       SegmentReadState state,
       int versionMeta,
@@ -289,6 +295,11 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
             fieldEntry.vectorDataLength,
             quantizedVectorData);
     return vectorScorer.getRandomVectorScorer(fieldEntry.similarityFunction, vectorValues, target);
+  }
+
+  @Override
+  public RandomVectorScorer getRandomVectorScorer(String field, short[] target) throws IOException {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene102/TestLucene102BinaryQuantizedVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene102/TestLucene102BinaryQuantizedVectorsFormat.java
@@ -38,6 +38,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.KnnFloatVectorQuery;
@@ -185,6 +186,11 @@ public class TestLucene102BinaryQuantizedVectorsFormat extends BaseKnnVectorsFor
         }
       }
     }
+  }
+
+  @Override
+  protected VectorEncoding randomVectorEncoding() {
+    return random().nextBoolean() ? VectorEncoding.BYTE : VectorEncoding.FLOAT32;
   }
 
   @Override

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene102/TestLucene102HnswBinaryQuantizedVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene102/TestLucene102HnswBinaryQuantizedVectorsFormat.java
@@ -40,6 +40,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.TopDocs;
@@ -176,6 +177,11 @@ public class TestLucene102HnswBinaryQuantizedVectorsFormat extends BaseKnnVector
         }
       }
     }
+  }
+
+  @Override
+  protected VectorEncoding randomVectorEncoding() {
+    return random().nextBoolean() ? VectorEncoding.BYTE : VectorEncoding.FLOAT32;
   }
 
   @Override

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene90/Lucene90HnswVectorsWriter.java
@@ -27,6 +27,7 @@ import org.apache.lucene.codecs.BufferingKnnVectorsWriter;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.KnnVectorValues;
@@ -175,6 +176,12 @@ public final class Lucene90HnswVectorsWriter extends BufferingKnnVectorsWriter {
   @Override
   protected void writeField(FieldInfo fieldInfo, ByteVectorValues byteVectorValues, int maxDoc) {
     throw new UnsupportedOperationException("byte vectors not supported in this version");
+  }
+
+  @Override
+  protected void writeField(
+      FieldInfo fieldInfo, Float16VectorValues float16VectorValues, int maxDoc) {
+    throw new UnsupportedOperationException("float16 vectors not supported in this version");
   }
 
   /**

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene91/Lucene91HnswVectorsWriter.java
@@ -26,6 +26,7 @@ import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.DocsWithFieldSet;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.KnnVectorValues;
@@ -171,6 +172,12 @@ public final class Lucene91HnswVectorsWriter extends BufferingKnnVectorsWriter {
   @Override
   protected void writeField(FieldInfo fieldInfo, ByteVectorValues byteVectorValues, int maxDoc) {
     throw new UnsupportedOperationException("byte vectors not supported in this version");
+  }
+
+  @Override
+  protected void writeField(
+      FieldInfo fieldInfo, Float16VectorValues float16VectorValues, int maxDoc) {
+    throw new UnsupportedOperationException("float16 vectors not supported in this version");
   }
 
   /**

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene92/Lucene92HnswVectorsWriter.java
@@ -30,6 +30,7 @@ import org.apache.lucene.codecs.lucene90.IndexedDISI;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.DocsWithFieldSet;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.KnnVectorValues;
@@ -179,6 +180,12 @@ public final class Lucene92HnswVectorsWriter extends BufferingKnnVectorsWriter {
   @Override
   protected void writeField(FieldInfo fieldInfo, ByteVectorValues byteVectorValues, int maxDoc) {
     throw new UnsupportedOperationException("byte vectors not supported in this version");
+  }
+
+  @Override
+  protected void writeField(
+      FieldInfo fieldInfo, Float16VectorValues float16VectorValues, int maxDoc) {
+    throw new UnsupportedOperationException("float16 vectors not supported in this version");
   }
 
   /**

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsWriter.java
@@ -176,6 +176,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
     switch (fieldData.fieldInfo.getVectorEncoding()) {
       case BYTE -> writeByteVectors(fieldData);
       case FLOAT32 -> writeFloat32Vectors(fieldData);
+      case FLOAT16 -> throw new UnsupportedOperationException("FLOAT16 is not supported");
     }
     long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
 
@@ -241,6 +242,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
         switch (fieldData.fieldInfo.getVectorEncoding()) {
           case BYTE -> writeSortedByteVectors(fieldData, ordMap);
           case FLOAT32 -> writeSortedFloat32Vectors(fieldData, ordMap);
+          case FLOAT16 -> throw new UnsupportedOperationException("FLOAT16 is not supported");
         };
     long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
 
@@ -405,6 +407,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
                 writeVectorData(
                     tempVectorData,
                     MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState));
+            case FLOAT16 -> throw new UnsupportedOperationException("FLOAT16 is not supported");
           };
       CodecUtil.writeFooter(tempVectorData);
       IOUtils.close(tempVectorData);
@@ -461,6 +464,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
                         scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed);
                 yield hnswGraphBuilder.build(vectorValues.size());
               }
+              case FLOAT16 -> throw new UnsupportedOperationException("FLOAT16 is not supported");
             };
         writeGraph(graph);
       }
@@ -662,6 +666,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
                 return ArrayUtil.copyOfSubArray(value, 0, dim);
               }
             };
+        case FLOAT16 -> throw new UnsupportedOperationException("FLOAT16 is not supported");
       };
     }
 
@@ -683,6 +688,7 @@ public final class Lucene94HnswVectorsWriter extends KnnVectorsWriter {
                 defaultFlatVectorScorer.getRandomVectorScorerSupplier(
                     fieldInfo.getVectorSimilarityFunction(),
                     FloatVectorValues.fromFloats((List<float[]>) vectors, dim));
+            case FLOAT16 -> throw new UnsupportedOperationException("FLOAT16 is not supported");
           };
       hnswGraphBuilder =
           HnswGraphBuilder.create(scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed);

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/TestLucene94HnswVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94/TestLucene94HnswVectorsFormat.java
@@ -18,6 +18,7 @@ package org.apache.lucene.backward_codecs.lucene94;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 
 public class TestLucene94HnswVectorsFormat extends BaseKnnVectorsFormatTestCase {
@@ -42,5 +43,10 @@ public class TestLucene94HnswVectorsFormat extends BaseKnnVectorsFormatTestCase 
   @Override
   protected boolean supportsFloatVectorFallback() {
     return false;
+  }
+
+  @Override
+  protected VectorEncoding randomVectorEncoding() {
+    return random().nextBoolean() ? VectorEncoding.BYTE : VectorEncoding.FLOAT32;
   }
 }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsWriter.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene95/Lucene95HnswVectorsWriter.java
@@ -180,6 +180,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
     switch (fieldData.fieldInfo.getVectorEncoding()) {
       case BYTE -> writeByteVectors(fieldData);
       case FLOAT32 -> writeFloat32Vectors(fieldData);
+      case FLOAT16 -> throw new UnsupportedOperationException("FLOAT16 is not supported");
     }
     long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
 
@@ -246,6 +247,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
         switch (fieldData.fieldInfo.getVectorEncoding()) {
           case BYTE -> writeSortedByteVectors(fieldData, ordMap);
           case FLOAT32 -> writeSortedFloat32Vectors(fieldData, ordMap);
+          case FLOAT16 -> throw new UnsupportedOperationException("FLOAT16 is not supported");
         };
     long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
 
@@ -432,6 +434,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                 writeVectorData(
                     tempVectorData,
                     MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState));
+            case FLOAT16 -> throw new UnsupportedOperationException("FLOAT16 is not supported");
           };
       CodecUtil.writeFooter(tempVectorData);
       IOUtils.close(tempVectorData);
@@ -478,6 +481,8 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                         defaultFlatVectorScorer,
                         fieldInfo.getVectorSimilarityFunction()));
             break;
+          case FLOAT16:
+            throw new UnsupportedOperationException("FLOAT16 is not supported");
           default:
             throw new IllegalArgumentException(
                 "Unsupported vector encoding: " + fieldInfo.getVectorEncoding());
@@ -499,6 +504,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
           case FLOAT32 ->
               mergedVectorValues =
                   KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
+          case FLOAT16 -> throw new UnsupportedOperationException("FLOAT16 is not supported");
         }
         graph =
             merger.merge(
@@ -711,6 +717,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                 return ArrayUtil.copyOfSubArray(value, 0, dim);
               }
             };
+        case FLOAT16 -> throw new UnsupportedOperationException("FLOAT16 is not supported");
       };
     }
 
@@ -731,6 +738,7 @@ public final class Lucene95HnswVectorsWriter extends KnnVectorsWriter {
                 defaultFlatVectorScorer.getRandomVectorScorerSupplier(
                     fieldInfo.getVectorSimilarityFunction(),
                     FloatVectorValues.fromFloats((List<float[]>) vectors, dim));
+            case FLOAT16 -> throw new UnsupportedOperationException("FLOAT16 is not supported");
           };
       hnswGraphBuilder =
           HnswGraphBuilder.create(scorerSupplier, M, beamWidth, HnswGraphBuilder.randSeed);

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene95/TestLucene95HnswVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene95/TestLucene95HnswVectorsFormat.java
@@ -18,6 +18,7 @@ package org.apache.lucene.backward_codecs.lucene95;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 
 public class TestLucene95HnswVectorsFormat extends BaseKnnVectorsFormatTestCase {
@@ -37,6 +38,11 @@ public class TestLucene95HnswVectorsFormat extends BaseKnnVectorsFormatTestCase 
     String expectedString =
         "Lucene95RWHnswVectorsFormat(name=Lucene95RWHnswVectorsFormat, maxConn=10, beamWidth=20)";
     assertEquals(expectedString, customCodec.getKnnVectorsFormatForField("bogus_field").toString());
+  }
+
+  @Override
+  protected VectorEncoding randomVectorEncoding() {
+    return random().nextBoolean() ? VectorEncoding.BYTE : VectorEncoding.FLOAT32;
   }
 
   @Override

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene99/TestLucene99HnswQuantizedVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene99/TestLucene99HnswQuantizedVectorsFormat.java
@@ -40,6 +40,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.IndexSearcher;
@@ -373,5 +374,10 @@ public class TestLucene99HnswQuantizedVectorsFormat extends BaseKnnVectorsFormat
   @Override
   protected boolean supportsFloatVectorFallback() {
     return false;
+  }
+
+  @Override
+  protected VectorEncoding randomVectorEncoding() {
+    return random().nextBoolean() ? VectorEncoding.BYTE : VectorEncoding.FLOAT32;
   }
 }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene99/TestLucene99HnswScalarQuantizedVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene99/TestLucene99HnswScalarQuantizedVectorsFormat.java
@@ -29,6 +29,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 import org.apache.lucene.tests.util.TestUtil;
@@ -68,5 +69,10 @@ public class TestLucene99HnswScalarQuantizedVectorsFormat extends BaseKnnVectors
   @Override
   protected boolean supportsFloatVectorFallback() {
     return false;
+  }
+
+  @Override
+  protected VectorEncoding randomVectorEncoding() {
+    return random().nextBoolean() ? VectorEncoding.BYTE : VectorEncoding.FLOAT32;
   }
 }

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene99/TestLucene99ScalarQuantizedVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene99/TestLucene99ScalarQuantizedVectorsFormat.java
@@ -41,6 +41,7 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -338,5 +339,10 @@ public class TestLucene99ScalarQuantizedVectorsFormat extends BaseKnnVectorsForm
       out.writeInt(-1);
       CodecUtil.writeFooter(out);
     }
+  }
+
+  @Override
+  protected VectorEncoding randomVectorEncoding() {
+    return random().nextBoolean() ? VectorEncoding.BYTE : VectorEncoding.FLOAT32;
   }
 }

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorScorerBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorScorerBenchmark.java
@@ -221,5 +221,11 @@ public class VectorScorerBenchmark {
         VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, byte[] target) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, short[] target) {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorScorerFloat32Benchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorScorerFloat32Benchmark.java
@@ -348,5 +348,11 @@ public class VectorScorerFloat32Benchmark {
         VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, byte[] target) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, short[] target) {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/VectorUtilBenchmark.java
@@ -63,6 +63,8 @@ public class VectorUtilBenchmark {
   private byte[] dibitQuantized;
   private float[] floatsA;
   private float[] floatsB;
+  private short[] shortsA;
+  private short[] shortsB;
   private int expectedHalfByteDotProduct;
   private int expectedHalfByteSquareDistance;
 
@@ -104,9 +106,13 @@ public class VectorUtilBenchmark {
     // random float arrays for float methods
     floatsA = new float[size];
     floatsB = new float[size];
+    shortsA = new short[size];
+    shortsB = new short[size];
     for (int i = 0; i < size; ++i) {
       floatsA[i] = random.nextFloat();
+      shortsA[i] = Float.floatToFloat16(floatsA[i]);
       floatsB[i] = random.nextFloat();
+      shortsB[i] = Float.floatToFloat16(floatsB[i]);
     }
 
     // arrays for BBQ int4-bit and int4-dibit dot product benchmarks
@@ -356,6 +362,11 @@ public class VectorUtilBenchmark {
       jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
   public float floatDotProductVector() {
     return VectorUtil.dotProduct(floatsA, floatsB);
+  }
+
+  @Benchmark
+  public float fp16DotProductScalar() {
+    return VectorUtil.dotProduct(shortsA, shortsB);
   }
 
   @Benchmark

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/bitvectors/FlatBitVectorsScorer.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/bitvectors/FlatBitVectorsScorer.java
@@ -58,6 +58,13 @@ public class FlatBitVectorsScorer implements FlatVectorsScorer {
     throw new IllegalArgumentException("vectorValues must be an instance of ByteVectorValues");
   }
 
+  @Override
+  public RandomVectorScorer getRandomVectorScorer(
+      VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, short[] target)
+      throws IOException {
+    throw new IllegalArgumentException("bit vectors do not support short[] targets");
+  }
+
   static class BitRandomVectorScorer implements UpdateableRandomVectorScorer, HasKnnVectorValues {
     private final ByteVectorValues vectorValues;
     private final int bitDimensions;

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsReader.java
@@ -32,6 +32,7 @@ import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.MergePolicy;
@@ -179,6 +180,35 @@ public class SimpleTextKnnVectorsReader extends KnnVectorsReader {
   }
 
   @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    FieldInfo info = readState.fieldInfos.fieldInfo(field);
+    if (info == null) {
+      return null;
+    }
+    int dimension = info.getVectorDimension();
+    if (dimension == 0) {
+      throw new IllegalStateException(
+          "KNN vectors readers should not be called on fields that don't enable KNN vectors");
+    }
+    FieldEntry fieldEntry = fieldEntries.get(info.number);
+    if (fieldEntry == null) {
+      return null;
+    }
+    if (dimension != fieldEntry.dimension) {
+      throw new IllegalStateException(
+          "Inconsistent vector dimension for field=\""
+              + field
+              + "\"; "
+              + dimension
+              + " != "
+              + fieldEntry.dimension);
+    }
+    IndexInput bytesSlice =
+        dataIn.slice("vector-data", fieldEntry.vectorDataOffset, fieldEntry.vectorDataLength);
+    return new SimpleTextFloat16VectorValues(fieldEntry, bytesSlice);
+  }
+
+  @Override
   public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     FloatVectorValues values = getFloatVectorValues(field);
@@ -233,6 +263,36 @@ public class SimpleTextKnnVectorsReader extends KnnVectorsReader {
       }
 
       byte[] vector = values.vectorValue(ord);
+      float score = vectorSimilarity.compare(vector, target);
+      knnCollector.collect(doc, score);
+      knnCollector.incVisitedCount(1);
+    }
+  }
+
+  @Override
+  public void search(String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    Float16VectorValues values = getFloat16VectorValues(field);
+    if (target.length != values.dimension()) {
+      throw new IllegalArgumentException(
+          "vector query dimension: "
+              + target.length
+              + " differs from field dimension: "
+              + values.dimension());
+    }
+    FieldInfo info = readState.fieldInfos.fieldInfo(field);
+    VectorSimilarityFunction vectorSimilarity = info.getVectorSimilarityFunction();
+    for (int ord = 0; ord < values.size(); ord++) {
+      int doc = values.ordToDoc(ord);
+      if (acceptDocs.bits() != null && acceptDocs.bits().get(doc) == false) {
+        continue;
+      }
+
+      if (knnCollector.earlyTerminated()) {
+        break;
+      }
+
+      short[] vector = values.vectorValue(ord);
       float score = vectorSimilarity.compare(vector, target);
       knnCollector.collect(doc, score);
       knnCollector.incVisitedCount(1);
@@ -394,6 +454,103 @@ public class SimpleTextKnnVectorsReader extends KnnVectorsReader {
 
     @Override
     public SimpleTextFloatVectorValues copy() {
+      return this;
+    }
+  }
+
+  private static class SimpleTextFloat16VectorValues extends Float16VectorValues {
+
+    private final BytesRefBuilder scratch = new BytesRefBuilder();
+    private final FieldEntry entry;
+    private final IndexInput in;
+    private final short[][] values;
+
+    int curOrd;
+
+    SimpleTextFloat16VectorValues(FieldEntry entry, IndexInput in) throws IOException {
+      this.entry = entry;
+      this.in = in;
+      values = new short[entry.size()][entry.dimension];
+      curOrd = -1;
+      readAllVectors();
+    }
+
+    private SimpleTextFloat16VectorValues(SimpleTextFloat16VectorValues other) {
+      this.entry = other.entry;
+      this.in = other.in.clone();
+      this.values = other.values;
+      this.curOrd = other.curOrd;
+    }
+
+    @Override
+    public int dimension() {
+      return entry.dimension;
+    }
+
+    @Override
+    public int size() {
+      return entry.size();
+    }
+
+    @Override
+    public short[] vectorValue(int ord) {
+      return values[ord];
+    }
+
+    @Override
+    public int ordToDoc(int ord) {
+      return entry.ordToDoc[ord];
+    }
+
+    @Override
+    public DocIndexIterator iterator() {
+      return createSparseIterator();
+    }
+
+    @Override
+    public VectorScorer scorer(short[] target) {
+      if (size() == 0) {
+        return null;
+      }
+      SimpleTextFloat16VectorValues simpleTextFloat16VectorValues =
+          new SimpleTextFloat16VectorValues(this);
+      DocIndexIterator iterator = simpleTextFloat16VectorValues.iterator();
+      return new VectorScorer() {
+        @Override
+        public float score() throws IOException {
+          int ord = iterator.index();
+          return entry
+              .similarityFunction()
+              .compare(simpleTextFloat16VectorValues.vectorValue(ord), target);
+        }
+
+        @Override
+        public DocIdSetIterator iterator() {
+          return iterator;
+        }
+      };
+    }
+
+    private void readAllVectors() throws IOException {
+      for (short[] value : values) {
+        readVector(value);
+      }
+    }
+
+    private void readVector(short[] value) throws IOException {
+      SimpleTextUtil.readLine(in, scratch);
+      // skip leading "[" and strip trailing "]"
+      String s = new BytesRef(scratch.bytes(), 1, scratch.length() - 2).utf8ToString();
+      String[] shortStrings = s.split(",");
+      assert shortStrings.length == value.length
+          : " read " + s + " when expecting " + value.length + " shorts";
+      for (int i = 0; i < shortStrings.length; i++) {
+        value[i] = Short.parseShort(shortStrings[i]);
+      }
+    }
+
+    @Override
+    public SimpleTextFloat16VectorValues copy() {
       return this;
     }
   }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsReader.java
@@ -545,7 +545,7 @@ public class SimpleTextKnnVectorsReader extends KnnVectorsReader {
       assert shortStrings.length == value.length
           : " read " + s + " when expecting " + value.length + " shorts";
       for (int i = 0; i < shortStrings.length; i++) {
-        value[i] = Short.parseShort(shortStrings[i]);
+        value[i] = Short.parseShort(shortStrings[i].trim());
       }
     }
 

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextKnnVectorsWriter.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.apache.lucene.codecs.BufferingKnnVectorsWriter;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.KnnVectorValues;
@@ -87,6 +88,28 @@ public class SimpleTextKnnVectorsWriter extends BufferingKnnVectorsWriter {
   private void writeFloatVectorValue(FloatVectorValues vectors, int ord) throws IOException {
     // write vector value
     float[] value = vectors.vectorValue(ord);
+    assert value.length == vectors.dimension();
+    write(vectorData, Arrays.toString(value));
+    newline(vectorData);
+  }
+
+  @Override
+  public void writeField(FieldInfo fieldInfo, Float16VectorValues float16VectorValues, int maxDoc)
+      throws IOException {
+    long vectorDataOffset = vectorData.getFilePointer();
+    List<Integer> docIds = new ArrayList<>();
+    KnnVectorValues.DocIndexIterator iter = float16VectorValues.iterator();
+    for (int docV = iter.nextDoc(); docV != NO_MORE_DOCS; docV = iter.nextDoc()) {
+      writeFloat16VectorValue(float16VectorValues, iter.index());
+      docIds.add(docV);
+    }
+    long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
+    writeMeta(fieldInfo, vectorDataOffset, vectorDataLength, docIds);
+  }
+
+  private void writeFloat16VectorValue(Float16VectorValues vectors, int ord) throws IOException {
+    // write vector value
+    short[] value = vectors.vectorValue(ord);
     assert value.length == vectors.dimension();
     write(vectorData, Arrays.toString(value));
     newline(vectorData);

--- a/lucene/codecs/src/test/org/apache/lucene/codecs/simpletext/TestSimpleTextKnnVectorsFormat.java
+++ b/lucene/codecs/src/test/org/apache/lucene/codecs/simpletext/TestSimpleTextKnnVectorsFormat.java
@@ -28,8 +28,7 @@ public class TestSimpleTextKnnVectorsFormat extends BaseKnnVectorsFormatTestCase
 
   @Override
   protected VectorEncoding randomVectorEncoding() {
-    // TODO: Should SimpleTextKnnVectorsFormat support all encodings?
-    return VectorEncoding.FLOAT32;
+    return random().nextBoolean() ? VectorEncoding.FLOAT32 : VectorEncoding.FLOAT16;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/BufferingKnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/BufferingKnnVectorsWriter.java
@@ -68,6 +68,8 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
               }
             };
         break;
+      case FLOAT16:
+        throw new UnsupportedOperationException("FLOAT16 is not supported");
       default:
         throw new UnsupportedOperationException();
     }
@@ -106,6 +108,8 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
                   : bufferedByteVectorValues;
           writeField(fieldData.fieldInfo, byteVectorValues, maxDoc);
           break;
+        case FLOAT16:
+          throw new UnsupportedOperationException("FLOAT16 is not supported");
       }
     }
   }
@@ -208,6 +212,8 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
             MergedVectorValues.mergeByteVectorValues(fieldInfo, mergeState);
         writeField(fieldInfo, byteVectorValues, mergeState.segmentInfo.maxDoc());
         break;
+      case FLOAT16:
+        throw new UnsupportedOperationException("FLOAT16 is not supported");
     }
     return null;
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/BufferingKnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/BufferingKnnVectorsWriter.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.DocsWithFieldSet;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.Sorter;
@@ -69,7 +70,14 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
             };
         break;
       case FLOAT16:
-        throw new UnsupportedOperationException("FLOAT16 is not supported");
+        newField =
+            new FieldWriter<short[]>(fieldInfo) {
+              @Override
+              public short[] copyValue(short[] vectorValue) {
+                return ArrayUtil.copyOfSubArray(vectorValue, 0, fieldInfo.getVectorDimension());
+              }
+            };
+        break;
       default:
         throw new UnsupportedOperationException();
     }
@@ -109,7 +117,18 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
           writeField(fieldData.fieldInfo, byteVectorValues, maxDoc);
           break;
         case FLOAT16:
-          throw new UnsupportedOperationException("FLOAT16 is not supported");
+          BufferedFloat16VectorValues bufferedFloat16VectorValues =
+              new BufferedFloat16VectorValues(
+                  (List<short[]>) fieldData.vectors,
+                  fieldData.fieldInfo.getVectorDimension(),
+                  fieldData.docsWithField);
+          Float16VectorValues float16VectorValues =
+              sortMap != null
+                  ? new SortingFloat16VectorValues(
+                      bufferedFloat16VectorValues, fieldData.docsWithField, sortMap)
+                  : bufferedFloat16VectorValues;
+          writeField(fieldData.fieldInfo, float16VectorValues, maxDoc);
+          break;
       }
     }
   }
@@ -143,6 +162,46 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
 
     @Override
     public SortingFloatVectorValues copy() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DocIndexIterator iterator() {
+      return iteratorSupplier.get();
+    }
+  }
+
+  /**
+   * Sorting Float16VectorValues that iterate over documents in the order of the provided sortMap
+   */
+  private static class SortingFloat16VectorValues extends Float16VectorValues {
+    private final BufferedFloat16VectorValues delegate;
+    private final Supplier<SortingValuesIterator> iteratorSupplier;
+
+    SortingFloat16VectorValues(
+        BufferedFloat16VectorValues delegate, DocsWithFieldSet docsWithField, Sorter.DocMap sortMap)
+        throws IOException {
+      this.delegate = delegate.copy();
+      iteratorSupplier = SortingCodecReader.iteratorSupplier(delegate, sortMap);
+    }
+
+    @Override
+    public short[] vectorValue(int ord) throws IOException {
+      return delegate.vectorValue(ord);
+    }
+
+    @Override
+    public int dimension() {
+      return delegate.dimension();
+    }
+
+    @Override
+    public int size() {
+      return delegate.size();
+    }
+
+    @Override
+    public SortingFloat16VectorValues copy() {
       throw new UnsupportedOperationException();
     }
 
@@ -213,7 +272,10 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
         writeField(fieldInfo, byteVectorValues, mergeState.segmentInfo.maxDoc());
         break;
       case FLOAT16:
-        throw new UnsupportedOperationException("FLOAT16 is not supported");
+        Float16VectorValues float16VectorValues =
+            MergedVectorValues.mergeFloat16VectorValues(fieldInfo, mergeState);
+        writeField(fieldInfo, float16VectorValues, mergeState.segmentInfo.maxDoc());
+        break;
     }
     return null;
   }
@@ -221,6 +283,10 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
   /** Write the provided float vector field */
   protected abstract void writeField(
       FieldInfo fieldInfo, FloatVectorValues floatVectorValues, int maxDoc) throws IOException;
+
+  /** Write the provided float16 vector field */
+  protected abstract void writeField(
+      FieldInfo fieldInfo, Float16VectorValues float16VectorValues, int maxDoc) throws IOException;
 
   /** Write the provided byte vector field */
   protected abstract void writeField(
@@ -315,6 +381,52 @@ public abstract class BufferingKnnVectorsWriter extends KnnVectorsWriter {
     @Override
     public BufferedFloatVectorValues copy() throws IOException {
       return new BufferedFloatVectorValues(vectors, dimension, docsWithField);
+    }
+  }
+
+  private static class BufferedFloat16VectorValues extends Float16VectorValues {
+    // These are always the vectors of a VectorValuesWriter, which are copied when added to it
+    final List<short[]> vectors;
+    final int dimension;
+    private final DocIdSet docsWithField;
+    private final DocIndexIterator iterator;
+
+    BufferedFloat16VectorValues(List<short[]> vectors, int dimension, DocIdSet docsWithField)
+        throws IOException {
+      this.vectors = vectors;
+      this.dimension = dimension;
+      this.docsWithField = docsWithField;
+      this.iterator = fromDISI(docsWithField.iterator());
+    }
+
+    @Override
+    public int dimension() {
+      return dimension;
+    }
+
+    @Override
+    public int size() {
+      return vectors.size();
+    }
+
+    @Override
+    public int ordToDoc(int ord) {
+      return ord;
+    }
+
+    @Override
+    public short[] vectorValue(int targetOrd) {
+      return vectors.get(targetOrd);
+    }
+
+    @Override
+    public DocIndexIterator iterator() {
+      return iterator;
+    }
+
+    @Override
+    public BufferedFloat16VectorValues copy() throws IOException {
+      return new BufferedFloat16VectorValues(vectors, dimension, docsWithField);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.SegmentReadState;
@@ -140,6 +141,11 @@ public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
             }
 
             @Override
+            public Float16VectorValues getFloat16VectorValues(String field) {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
             public void search(
                 String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) {
               throw new UnsupportedOperationException();
@@ -148,6 +154,12 @@ public abstract class KnnVectorsFormat implements NamedSPILoader.NamedSPI {
             @Override
             public void search(
                 String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void search(
+                String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) {
               throw new UnsupportedOperationException();
             }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsReader.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.search.AcceptDocs;
@@ -72,6 +73,13 @@ public abstract class KnnVectorsReader implements Closeable {
    * never {@code null}.
    */
   public abstract ByteVectorValues getByteVectorValues(String field) throws IOException;
+
+  /**
+   * Returns the {@link Float16VectorValues} for the given {@code field}. The behavior is undefined
+   * if the given field doesn't have KNN vectors enabled on its {@link FieldInfo}. The return value
+   * is never {@code null}.
+   */
+  public abstract Float16VectorValues getFloat16VectorValues(String field) throws IOException;
 
   /**
    * Return the k nearest neighbor documents as determined by comparison of their vector values for
@@ -129,6 +137,35 @@ public abstract class KnnVectorsReader implements Closeable {
    */
   public abstract void search(
       String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException;
+
+  /**
+   * Return the k nearest neighbor documents as determined by comparison of their vector values for
+   * this field, to the given vector, by the field's similarity function. The score of each document
+   * is derived from the vector similarity in a way that ensures scores are positive and that a
+   * larger score corresponds to a higher ranking.
+   *
+   * <p>The search is allowed to be approximate, meaning the results are not guaranteed to be the
+   * true k closest neighbors. For large values of k (for example when k is close to the total
+   * number of documents), the search may also retrieve fewer than k documents.
+   *
+   * <p>The returned {@link TopDocs} will contain a {@link ScoreDoc} for each nearest neighbor, in
+   * order of their similarity to the query vector (decreasing scores). The {@link TotalHits}
+   * contains the number of documents visited during the search. If the search stopped early because
+   * it hit {@code visitedLimit}, it is indicated through the relation {@code
+   * TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO}.
+   *
+   * <p>The behavior is undefined if the given field doesn't have KNN vectors enabled on its {@link
+   * FieldInfo}.
+   *
+   * @param field the vector field to search
+   * @param target the vector-valued query
+   * @param knnCollector a KnnResults collector and relevant settings for gathering vector results
+   * @param acceptDocs {@link Bits} that represents the allowed documents to match, or {@code null}
+   *     if they are all allowed to match.
+   */
+  public abstract void search(
+      String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException;
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
@@ -29,6 +29,7 @@ import org.apache.lucene.index.DocIDMerger;
 import org.apache.lucene.index.DocsWithFieldSet;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.MergeState;
@@ -92,6 +93,17 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
         KnnVectorValues.DocIndexIterator iter = mergedFloats.iterator();
         for (int doc = iter.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iter.nextDoc()) {
           floatWriter.addValue(doc, mergedFloats.vectorValue(iter.index()));
+        }
+      }
+
+      case FLOAT16 -> {
+        KnnFieldVectorsWriter<short[]> floatWriter =
+            (KnnFieldVectorsWriter<short[]>) addField(fieldInfo);
+        Float16VectorValues mergedValues =
+            MergedVectorValues.mergeFloat16VectorValues(fieldInfo, mergeState);
+        KnnVectorValues.DocIndexIterator iter = mergedValues.iterator();
+        for (int doc = iter.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iter.nextDoc()) {
+          floatWriter.addValue(doc, mergedValues.vectorValue(iter.index()));
         }
       }
     }
@@ -177,6 +189,33 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
 
     public void intoBitSet(int upTo, FixedBitSet bitSet, int offset) throws IOException {
       iterator.intoBitSet(upTo, bitSet, offset);
+    }
+
+    public int index() {
+      return iterator.index();
+    }
+  }
+
+  /**
+   * Tracks state of one sub-reader of float vectors that we are merging.
+   *
+   * @lucene.internal
+   */
+  static class Float16VectorValuesSub extends DocIDMerger.Sub {
+
+    final Float16VectorValues values;
+    final KnnVectorValues.DocIndexIterator iterator;
+
+    Float16VectorValuesSub(MergeState.DocMap docMap, Float16VectorValues values) {
+      super(docMap);
+      this.values = values;
+      this.iterator = values.iterator();
+      assert iterator.docID() == -1;
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+      return iterator.nextDoc();
     }
 
     public int index() {
@@ -273,13 +312,19 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
   public static final class MergedVectorValues {
     private MergedVectorValues() {}
 
-    private static void validateFieldEncoding(FieldInfo fieldInfo, VectorEncoding expected) {
+    private static void validateFieldEncoding(FieldInfo fieldInfo, VectorEncoding... expected) {
       assert fieldInfo != null && fieldInfo.hasVectorValues();
       VectorEncoding fieldEncoding = fieldInfo.getVectorEncoding();
-      if (fieldEncoding != expected) {
-        throw new UnsupportedOperationException(
-            "Cannot merge vectors encoded as [" + fieldEncoding + "] as " + expected);
+      for (VectorEncoding exp : expected) {
+        if (fieldEncoding == exp) {
+          return;
+        }
       }
+      throw new UnsupportedOperationException(
+          "Cannot merge vectors encoded as ["
+              + fieldEncoding
+              + "] as "
+              + Arrays.toString(expected));
     }
 
     /**
@@ -334,6 +379,21 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
               mergeState.fieldInfos,
               knnVectorsReader -> knnVectorsReader.getFloatVectorValues(fieldInfo.name),
               FloatVectorValuesSub::new),
+          mergeState);
+    }
+
+    /** Returns a merged view over all the segment's {@link FloatVectorValues}. */
+    public static Float16VectorValues mergeFloat16VectorValues(
+        FieldInfo fieldInfo, MergeState mergeState) throws IOException {
+      validateFieldEncoding(fieldInfo, VectorEncoding.FLOAT16);
+      return new MergedFloat16VectorValues(
+          mergeVectorValues(
+              mergeState.knnVectorsReaders,
+              mergeState.docMaps,
+              fieldInfo,
+              mergeState.fieldInfos,
+              knnVectorsReader -> knnVectorsReader.getFloat16VectorValues(fieldInfo.name),
+              Float16VectorValuesSub::new),
           mergeState);
     }
 
@@ -452,6 +512,104 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
 
       @Override
       public FloatVectorValues copy() {
+        throw new UnsupportedOperationException();
+      }
+    }
+
+    static class MergedFloat16VectorValues extends Float16VectorValues {
+      private final List<Float16VectorValuesSub> subs;
+      private final DocIDMerger<Float16VectorValuesSub> docIdMerger;
+      private final int size;
+      private int docId = -1;
+      private int lastOrd = -1;
+      Float16VectorValuesSub current;
+
+      MergedFloat16VectorValues(List<Float16VectorValuesSub> subs, MergeState mergeState)
+          throws IOException {
+        this.subs = subs;
+        docIdMerger = DocIDMerger.of(subs, mergeState.needsIndexSort);
+        int totalSize = 0;
+        for (Float16VectorValuesSub sub : subs) {
+          totalSize += sub.values.size();
+        }
+        size = totalSize;
+      }
+
+      @Override
+      public DocIndexIterator iterator() {
+        return new DocIndexIterator() {
+          private int index = -1;
+
+          @Override
+          public int docID() {
+            return docId;
+          }
+
+          @Override
+          public int index() {
+            return index;
+          }
+
+          @Override
+          public int nextDoc() throws IOException {
+            current = docIdMerger.next();
+            if (current == null) {
+              docId = NO_MORE_DOCS;
+              index = NO_MORE_DOCS;
+            } else {
+              docId = current.mappedDocID;
+              ++lastOrd;
+              ++index;
+            }
+            return docId;
+          }
+
+          @Override
+          public int advance(int target) throws IOException {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public long cost() {
+            return size;
+          }
+        };
+      }
+
+      @Override
+      public short[] vectorValue(int ord) throws IOException {
+        if (ord != lastOrd) {
+          throw new IllegalStateException(
+              "only supports forward iteration with a single iterator: ord="
+                  + ord
+                  + ", lastOrd="
+                  + lastOrd);
+        }
+        return current.values.vectorValue(current.index());
+      }
+
+      @Override
+      public int size() {
+        return size;
+      }
+
+      @Override
+      public int dimension() {
+        return subs.get(0).values.dimension();
+      }
+
+      @Override
+      public int ordToDoc(int ord) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public VectorScorer scorer(short[] target) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Float16VectorValues copy() {
         throw new UnsupportedOperationException();
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsWriter.java
@@ -197,7 +197,7 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
   }
 
   /**
-   * Tracks state of one sub-reader of float vectors that we are merging.
+   * Tracks state of one sub-reader of float16 vectors that we are merging.
    *
    * @lucene.internal
    */
@@ -312,19 +312,13 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
   public static final class MergedVectorValues {
     private MergedVectorValues() {}
 
-    private static void validateFieldEncoding(FieldInfo fieldInfo, VectorEncoding... expected) {
+    private static void validateFieldEncoding(FieldInfo fieldInfo, VectorEncoding expected) {
       assert fieldInfo != null && fieldInfo.hasVectorValues();
       VectorEncoding fieldEncoding = fieldInfo.getVectorEncoding();
-      for (VectorEncoding exp : expected) {
-        if (fieldEncoding == exp) {
-          return;
-        }
+      if (fieldEncoding != expected) {
+        throw new UnsupportedOperationException(
+            "Cannot merge vectors encoded as [" + fieldEncoding + "] as " + expected);
       }
-      throw new UnsupportedOperationException(
-          "Cannot merge vectors encoded as ["
-              + fieldEncoding
-              + "] as "
-              + Arrays.toString(expected));
     }
 
     /**
@@ -382,7 +376,7 @@ public abstract class KnnVectorsWriter implements Accountable, Closeable {
           mergeState);
     }
 
-    /** Returns a merged view over all the segment's {@link FloatVectorValues}. */
+    /** Returns a merged view over all the segment's {@link Float16VectorValues}. */
     public static Float16VectorValues mergeFloat16VectorValues(
         FieldInfo fieldInfo, MergeState mergeState) throws IOException {
       validateFieldEncoding(fieldInfo, VectorEncoding.FLOAT16);

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/DefaultFlatVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/DefaultFlatVectorScorer.java
@@ -19,6 +19,7 @@ package org.apache.lucene.codecs.hnsw;
 
 import java.io.IOException;
 import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
@@ -42,6 +43,9 @@ public class DefaultFlatVectorScorer implements FlatVectorsScorer {
     switch (vectorValues.getEncoding()) {
       case FLOAT32 -> {
         return new FloatScoringSupplier((FloatVectorValues) vectorValues, similarityFunction);
+      }
+      case FLOAT16 -> {
+        return new Float16ScoringSupplier((Float16VectorValues) vectorValues, similarityFunction);
       }
       case BYTE -> {
         return new ByteScoringSupplier((ByteVectorValues) vectorValues, similarityFunction);
@@ -80,6 +84,21 @@ public class DefaultFlatVectorScorer implements FlatVectorsScorer {
               + vectorValues.dimension());
     }
     return new ByteVectorScorer((ByteVectorValues) vectorValues, target, similarityFunction);
+  }
+
+  @Override
+  public RandomVectorScorer getRandomVectorScorer(
+      VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, short[] target)
+      throws IOException {
+    assert vectorValues instanceof Float16VectorValues;
+    if (target.length != vectorValues.dimension()) {
+      throw new IllegalArgumentException(
+          "vector query dimension: "
+              + target.length
+              + " differs from field dimension: "
+              + vectorValues.dimension());
+    }
+    return new Float16VectorScorer((Float16VectorValues) vectorValues, target, similarityFunction);
   }
 
   @Override
@@ -168,6 +187,46 @@ public class DefaultFlatVectorScorer implements FlatVectorsScorer {
     }
   }
 
+  private static final class Float16ScoringSupplier implements RandomVectorScorerSupplier {
+    private final Float16VectorValues vectors;
+    private final Float16VectorValues targetVectors;
+    private final VectorSimilarityFunction similarityFunction;
+
+    private Float16ScoringSupplier(
+        Float16VectorValues vectors, VectorSimilarityFunction similarityFunction)
+        throws IOException {
+      this.vectors = vectors;
+      targetVectors = vectors.copy();
+      this.similarityFunction = similarityFunction;
+    }
+
+    @Override
+    public UpdateableRandomVectorScorer scorer() throws IOException {
+      short[] vector = new short[vectors.dimension()];
+      return new UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer(vectors) {
+        @Override
+        public float score(int node) throws IOException {
+          return similarityFunction.compare(vector, targetVectors.vectorValue(node));
+        }
+
+        @Override
+        public void setScoringOrdinal(int node) throws IOException {
+          System.arraycopy(targetVectors.vectorValue(node), 0, vector, 0, vector.length);
+        }
+      };
+    }
+
+    @Override
+    public RandomVectorScorerSupplier copy() throws IOException {
+      return new Float16ScoringSupplier(vectors, similarityFunction);
+    }
+
+    @Override
+    public String toString() {
+      return "Float16ScoringSupplier(similarityFunction=" + similarityFunction + ")";
+    }
+  }
+
   /** A {@link RandomVectorScorer} for float vectors. */
   private static class FloatVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
     private final FloatVectorValues values;
@@ -176,6 +235,25 @@ public class DefaultFlatVectorScorer implements FlatVectorsScorer {
 
     public FloatVectorScorer(
         FloatVectorValues values, float[] query, VectorSimilarityFunction similarityFunction) {
+      super(values);
+      this.values = values;
+      this.query = query;
+      this.similarityFunction = similarityFunction;
+    }
+
+    @Override
+    public float score(int node) throws IOException {
+      return similarityFunction.compare(query, values.vectorValue(node));
+    }
+  }
+
+  private static class Float16VectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
+    private final Float16VectorValues values;
+    private final short[] query;
+    private final VectorSimilarityFunction similarityFunction;
+
+    public Float16VectorScorer(
+        Float16VectorValues values, short[] query, VectorSimilarityFunction similarityFunction) {
       super(values);
       this.values = values;
       this.query = query;

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatFieldVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatFieldVectorsWriter.java
@@ -53,9 +53,9 @@ public abstract class FlatFieldVectorsWriter<T> extends KnnFieldVectorsWriter<T>
   @SuppressWarnings("unchecked")
   public KnnVectorValues asKnnVectorValues(VectorEncoding encoding, int dim) throws IOException {
     return switch (encoding) {
-      case FLOAT32 -> FloatVectorValues.fromFloats((List<float[]>) getVectors(), dim);
-      case FLOAT16 -> Float16VectorValues.fromFloats16((List<short[]>) getVectors(), dim);
       case BYTE -> ByteVectorValues.fromBytes((List<byte[]>) getVectors(), dim);
+      case FLOAT16 -> Float16VectorValues.fromFloats16((List<short[]>) getVectors(), dim);
+      case FLOAT32 -> FloatVectorValues.fromFloats((List<float[]>) getVectors(), dim);
     };
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatFieldVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatFieldVectorsWriter.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.lucene.codecs.KnnFieldVectorsWriter;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.DocsWithFieldSet;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorEncoding;
@@ -53,6 +54,7 @@ public abstract class FlatFieldVectorsWriter<T> extends KnnFieldVectorsWriter<T>
   public KnnVectorValues asKnnVectorValues(VectorEncoding encoding, int dim) throws IOException {
     return switch (encoding) {
       case FLOAT32 -> FloatVectorValues.fromFloats((List<float[]>) getVectors(), dim);
+      case FLOAT16 -> Float16VectorValues.fromFloats16((List<short[]>) getVectors(), dim);
       case BYTE -> ByteVectorValues.fromBytes((List<byte[]>) getVectors(), dim);
     };
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsReader.java
@@ -59,6 +59,12 @@ public abstract class FlatVectorsReader extends KnnVectorsReader implements Acco
     // don't scan stored field data. If we didn't index it, produce no search results
   }
 
+  @Override
+  public void search(String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    // don't scan stored field data. If we didn't index it, produce no search results
+  }
+
   /**
    * Returns a {@link RandomVectorScorer} for the given field and target vector.
    *
@@ -79,6 +85,17 @@ public abstract class FlatVectorsReader extends KnnVectorsReader implements Acco
    * @throws IOException if an I/O error occurs when reading from the index.
    */
   public abstract RandomVectorScorer getRandomVectorScorer(String field, byte[] target)
+      throws IOException;
+
+  /**
+   * Returns a {@link RandomVectorScorer} for the given field and target vector.
+   *
+   * @param field the field to search
+   * @param target the target vector
+   * @return a {@link RandomVectorScorer} for the given field and target vector.
+   * @throws IOException if an I/O error occurs when reading from the index.
+   */
+  public abstract RandomVectorScorer getRandomVectorScorer(String field, short[] target)
       throws IOException;
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/FlatVectorsScorer.java
@@ -68,6 +68,10 @@ public interface FlatVectorsScorer {
       VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, byte[] target)
       throws IOException;
 
+  RandomVectorScorer getRandomVectorScorer(
+      VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, short[] target)
+      throws IOException;
+
   static void checkDimensions(int queryLen, int fieldLen) {
     if (queryLen != fieldLen) {
       throw new IllegalArgumentException(

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/PrefetchableFlatVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/PrefetchableFlatVectorScorer.java
@@ -78,6 +78,15 @@ public class PrefetchableFlatVectorScorer implements FlatVectorsScorer {
   }
 
   @Override
+  public RandomVectorScorer getRandomVectorScorer(
+      VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, short[] target)
+      throws IOException {
+    return new PrefetchableRandomVectorScorer(
+        (RandomVectorScorer.AbstractRandomVectorScorer)
+            flatVectorsScorer.getRandomVectorScorer(similarityFunction, vectorValues, target));
+  }
+
+  @Override
   public String toString() {
     return "PrefetchableFlatVectorScorer()";
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/hnsw/ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/hnsw/ScalarQuantizedVectorScorer.java
@@ -109,6 +109,13 @@ public class ScalarQuantizedVectorScorer implements FlatVectorsScorer {
   }
 
   @Override
+  public RandomVectorScorer getRandomVectorScorer(
+      VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, short[] target)
+      throws IOException {
+    return nonQuantizedDelegate.getRandomVectorScorer(similarityFunction, vectorValues, target);
+  }
+
+  @Override
   public String toString() {
     return "ScalarQuantizedVectorScorer(" + "nonQuantizedDelegate=" + nonQuantizedDelegate + ')';
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorScorer.java
@@ -107,6 +107,13 @@ public class Lucene104ScalarQuantizedVectorScorer implements FlatVectorsScorer {
     return nonQuantizedDelegate.getRandomVectorScorer(similarityFunction, vectorValues, target);
   }
 
+  @Override
+  public RandomVectorScorer getRandomVectorScorer(
+      VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, short[] target)
+      throws IOException {
+    return nonQuantizedDelegate.getRandomVectorScorer(similarityFunction, vectorValues, target);
+  }
+
   public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
       VectorSimilarityFunction similarityFunction,
       QuantizedByteVectorValues scoringVectors,

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsReader.java
@@ -37,6 +37,7 @@ import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.DocsWithFieldSet;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.KnnVectorValues;
@@ -222,6 +223,11 @@ public class Lucene104ScalarQuantizedVectorsReader extends FlatVectorsReader
   }
 
   @Override
+  public RandomVectorScorer getRandomVectorScorer(String field, short[] target) throws IOException {
+    return rawVectorsReader.getRandomVectorScorer(field, target);
+  }
+
+  @Override
   public void checkIntegrity(MergePolicy.OneMerge merge) throws IOException {
     rawVectorsReader.checkIntegrity(merge);
     CodecUtil.checksumEntireFile(quantizedVectorData, merge);
@@ -282,6 +288,11 @@ public class Lucene104ScalarQuantizedVectorsReader extends FlatVectorsReader
   }
 
   @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    return rawVectorsReader.getFloat16VectorValues(field);
+  }
+
+  @Override
   public void search(String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     rawVectorsReader.search(field, target, knnCollector, acceptDocs);
@@ -329,6 +340,12 @@ public class Lucene104ScalarQuantizedVectorsReader extends FlatVectorsReader
   }
 
   @Override
+  public void search(String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    rawVectorsReader.search(field, target, knnCollector, acceptDocs);
+  }
+
+  @Override
   public void close() throws IOException {
     IOUtils.close(quantizedVectorData, rawVectorsReader);
   }
@@ -349,7 +366,10 @@ public class Lucene104ScalarQuantizedVectorsReader extends FlatVectorsReader
     var raw = rawVectorsReader.getOffHeapByteSize(fieldInfo);
     var fieldEntry = fields.get(fieldInfo.name);
     if (fieldEntry == null) {
-      assert fieldInfo.getVectorEncoding() == VectorEncoding.BYTE;
+      // Only FLOAT32 fields are scalar-quantized by this format; BYTE and FLOAT16 fields are
+      // stored raw by the delegate and therefore have no quantized field entry here.
+      assert fieldInfo.getVectorEncoding() == VectorEncoding.BYTE
+          || fieldInfo.getVectorEncoding() == VectorEncoding.FLOAT16;
       return raw;
     }
     var quant = Map.of(VECTOR_DATA_EXTENSION, fieldEntry.vectorDataLength());

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloat16VectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloat16VectorValues.java
@@ -1,0 +1,334 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.codecs.lucene95;
+
+import java.io.IOException;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.lucene90.IndexedDISI;
+import org.apache.lucene.index.Float16VectorValues;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.VectorScorer;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+
+/** Read the vector values from the index input. This supports both iterated and random access. */
+public abstract class OffHeapFloat16VectorValues extends Float16VectorValues
+    implements HasIndexSlice {
+
+  protected final int dimension;
+  protected final int size;
+  protected final IndexInput slice;
+  protected final int byteSize;
+  protected int lastOrd = -1;
+  protected final short[] value;
+  protected final VectorSimilarityFunction similarityFunction;
+  protected final FlatVectorsScorer flatVectorsScorer;
+
+  OffHeapFloat16VectorValues(
+      int dimension,
+      int size,
+      IndexInput slice,
+      int byteSize,
+      FlatVectorsScorer flatVectorsScorer,
+      VectorSimilarityFunction similarityFunction) {
+    this.dimension = dimension;
+    this.size = size;
+    this.slice = slice;
+    this.byteSize = byteSize;
+    this.similarityFunction = similarityFunction;
+    this.flatVectorsScorer = flatVectorsScorer;
+    value = new short[dimension];
+  }
+
+  @Override
+  public int dimension() {
+    return dimension;
+  }
+
+  @Override
+  public int size() {
+    return size;
+  }
+
+  @Override
+  public IndexInput getSlice() {
+    return slice;
+  }
+
+  @Override
+  public short[] vectorValue(int targetOrd) throws IOException {
+    if (lastOrd == targetOrd) {
+      return value;
+    }
+    slice.seek((long) targetOrd * byteSize);
+    slice.readShorts(value, 0, dimension);
+    lastOrd = targetOrd;
+    return value;
+  }
+
+  @Override
+  public VectorEncoding getEncoding() {
+    return VectorEncoding.FLOAT16;
+  }
+
+  public static OffHeapFloat16VectorValues load(
+      VectorSimilarityFunction vectorSimilarityFunction,
+      FlatVectorsScorer flatVectorsScorer,
+      OrdToDocDISIReaderConfiguration configuration,
+      VectorEncoding vectorEncoding,
+      int dimension,
+      long vectorDataOffset,
+      long vectorDataLength,
+      IndexInput vectorData)
+      throws IOException {
+    if (configuration.docsWithFieldOffset == -2 || vectorEncoding != VectorEncoding.FLOAT16) {
+      return new EmptyOffHeapVectorValues(dimension, flatVectorsScorer, vectorSimilarityFunction);
+    }
+    IndexInput bytesSlice = vectorData.slice("vector-data", vectorDataOffset, vectorDataLength);
+    int byteSize = dimension * Short.BYTES;
+
+    if (configuration.docsWithFieldOffset == -1) {
+      return new DenseOffHeapVectorValues(
+          dimension,
+          configuration.size,
+          bytesSlice,
+          byteSize,
+          flatVectorsScorer,
+          vectorSimilarityFunction);
+    } else {
+      return new SparseOffHeapVectorValues(
+          configuration,
+          vectorData,
+          bytesSlice,
+          dimension,
+          byteSize,
+          flatVectorsScorer,
+          vectorSimilarityFunction);
+    }
+  }
+
+  /**
+   * Dense vector values that are stored off-heap. This is the most common case when every doc has a
+   * vector.
+   */
+  public static class DenseOffHeapVectorValues extends OffHeapFloat16VectorValues {
+
+    public DenseOffHeapVectorValues(
+        int dimension,
+        int size,
+        IndexInput slice,
+        int byteSize,
+        FlatVectorsScorer flatVectorsScorer,
+        VectorSimilarityFunction similarityFunction) {
+      super(dimension, size, slice, byteSize, flatVectorsScorer, similarityFunction);
+    }
+
+    @Override
+    public DenseOffHeapVectorValues copy() throws IOException {
+      return new DenseOffHeapVectorValues(
+          dimension, size, slice.clone(), byteSize, flatVectorsScorer, similarityFunction);
+    }
+
+    @Override
+    public int ordToDoc(int ord) {
+      return ord;
+    }
+
+    @Override
+    public Bits getAcceptOrds(Bits acceptDocs) {
+      return acceptDocs;
+    }
+
+    @Override
+    public DocIndexIterator iterator() {
+      return createDenseIterator();
+    }
+
+    @Override
+    public VectorScorer scorer(short[] query) throws IOException {
+      DenseOffHeapVectorValues copy = copy();
+      DocIndexIterator iterator = copy.iterator();
+      RandomVectorScorer randomVectorScorer =
+          flatVectorsScorer.getRandomVectorScorer(similarityFunction, copy, query);
+      return new VectorScorer() {
+        @Override
+        public float score() throws IOException {
+          return randomVectorScorer.score(iterator.docID());
+        }
+
+        @Override
+        public DocIdSetIterator iterator() {
+          return iterator;
+        }
+
+        @Override
+        public VectorScorer.Bulk bulk(DocIdSetIterator matchingDocs) {
+          return Bulk.fromRandomScorerDense(randomVectorScorer, iterator, matchingDocs);
+        }
+      };
+    }
+  }
+
+  private static class SparseOffHeapVectorValues extends OffHeapFloat16VectorValues {
+    private final DirectMonotonicReader ordToDoc;
+    private final IndexedDISI disi;
+    // dataIn was used to init a new IndexedDIS for #randomAccess()
+    private final IndexInput dataIn;
+    private final OrdToDocDISIReaderConfiguration configuration;
+
+    public SparseOffHeapVectorValues(
+        OrdToDocDISIReaderConfiguration configuration,
+        IndexInput dataIn,
+        IndexInput slice,
+        int dimension,
+        int byteSize,
+        FlatVectorsScorer flatVectorsScorer,
+        VectorSimilarityFunction similarityFunction)
+        throws IOException {
+
+      super(dimension, configuration.size, slice, byteSize, flatVectorsScorer, similarityFunction);
+      this.configuration = configuration;
+      final RandomAccessInput addressesData =
+          dataIn.randomAccessSlice(configuration.addressesOffset, configuration.addressesLength);
+      this.dataIn = dataIn;
+      this.ordToDoc = DirectMonotonicReader.getInstance(configuration.meta, addressesData);
+      this.disi =
+          new IndexedDISI(
+              dataIn,
+              configuration.docsWithFieldOffset,
+              configuration.docsWithFieldLength,
+              configuration.jumpTableEntryCount,
+              configuration.denseRankPower,
+              configuration.size);
+    }
+
+    @Override
+    public SparseOffHeapVectorValues copy() throws IOException {
+      return new SparseOffHeapVectorValues(
+          configuration,
+          dataIn,
+          slice.clone(),
+          dimension,
+          byteSize,
+          flatVectorsScorer,
+          similarityFunction);
+    }
+
+    @Override
+    public int ordToDoc(int ord) {
+      return (int) ordToDoc.get(ord);
+    }
+
+    @Override
+    public Bits getAcceptOrds(Bits acceptDocs) {
+      if (acceptDocs == null) {
+        return null;
+      }
+      return new Bits() {
+        @Override
+        public boolean get(int index) {
+          return acceptDocs.get(ordToDoc(index));
+        }
+
+        @Override
+        public int length() {
+          return size;
+        }
+      };
+    }
+
+    @Override
+    public DocIndexIterator iterator() {
+      return IndexedDISI.asDocIndexIterator(disi);
+    }
+
+    @Override
+    public VectorScorer scorer(short[] query) throws IOException {
+      SparseOffHeapVectorValues copy = copy();
+      DocIndexIterator iterator = copy.iterator();
+      RandomVectorScorer randomVectorScorer =
+          flatVectorsScorer.getRandomVectorScorer(similarityFunction, copy, query);
+      return new VectorScorer() {
+        @Override
+        public float score() throws IOException {
+          return randomVectorScorer.score(iterator.index());
+        }
+
+        @Override
+        public DocIdSetIterator iterator() {
+          return iterator;
+        }
+
+        @Override
+        public VectorScorer.Bulk bulk(DocIdSetIterator matchingDocs) {
+          return Bulk.fromRandomScorerSparse(randomVectorScorer, iterator, matchingDocs);
+        }
+      };
+    }
+  }
+
+  private static class EmptyOffHeapVectorValues extends OffHeapFloat16VectorValues {
+
+    public EmptyOffHeapVectorValues(
+        int dimension,
+        FlatVectorsScorer flatVectorsScorer,
+        VectorSimilarityFunction similarityFunction) {
+      super(dimension, 0, null, 0, flatVectorsScorer, similarityFunction);
+    }
+
+    @Override
+    public int dimension() {
+      return super.dimension();
+    }
+
+    @Override
+    public int size() {
+      return 0;
+    }
+
+    @Override
+    public EmptyOffHeapVectorValues copy() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public short[] vectorValue(int targetOrd) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DocIndexIterator iterator() {
+      return createDenseIterator();
+    }
+
+    @Override
+    public Bits getAcceptOrds(Bits acceptDocs) {
+      return null;
+    }
+
+    @Override
+    public VectorScorer scorer(short[] query) {
+      return null;
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloat16VectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene95/OffHeapFloat16VectorValues.java
@@ -127,10 +127,7 @@ public abstract class OffHeapFloat16VectorValues extends Float16VectorValues
     }
   }
 
-  /**
-   * Dense vector values that are stored off-heap. This is the most common case when every doc has a
-   * vector.
-   */
+  /** Dense vector values that are stored off-heap. This is the case when every doc has a vector. */
   public static class DenseOffHeapVectorValues extends OffHeapFloat16VectorValues {
 
     public DenseOffHeapVectorValues(
@@ -192,7 +189,7 @@ public abstract class OffHeapFloat16VectorValues extends Float16VectorValues
   private static class SparseOffHeapVectorValues extends OffHeapFloat16VectorValues {
     private final DirectMonotonicReader ordToDoc;
     private final IndexedDISI disi;
-    // dataIn was used to init a new IndexedDIS for #randomAccess()
+    // dataIn was used to init a new IndexedDISI for #randomAccess()
     private final IndexInput dataIn;
     private final OrdToDocDISIReaderConfiguration configuration;
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
@@ -372,8 +372,8 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
       int byteSize =
           switch (info.getVectorEncoding()) {
             case BYTE -> Byte.BYTES;
-            case FLOAT32 -> Float.BYTES;
             case FLOAT16 -> Short.BYTES;
+            case FLOAT32 -> Float.BYTES;
           };
       long vectorBytes = Math.multiplyExact((long) infoVectorDimension, byteSize);
       long numBytes = Math.multiplyExact(vectorBytes, size);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsReader.java
@@ -28,12 +28,14 @@ import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.codecs.lucene95.OffHeapByteVectorValues;
+import org.apache.lucene.codecs.lucene95.OffHeapFloat16VectorValues;
 import org.apache.lucene.codecs.lucene95.OffHeapFloatVectorValues;
 import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.MergePolicy;
@@ -254,6 +256,20 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
   }
 
   @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    final FieldEntry fieldEntry = getFieldEntry(field, VectorEncoding.FLOAT16);
+    return OffHeapFloat16VectorValues.load(
+        fieldEntry.similarityFunction,
+        vectorScorer,
+        fieldEntry.ordToDoc,
+        fieldEntry.vectorEncoding,
+        fieldEntry.dimension,
+        fieldEntry.vectorDataOffset,
+        fieldEntry.vectorDataLength,
+        vectorData);
+  }
+
+  @Override
   public FlatVectorsScorer getFlatVectorScorer(String field) throws IOException {
     return vectorScorer;
   }
@@ -281,6 +297,24 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
     return vectorScorer.getRandomVectorScorer(
         fieldEntry.similarityFunction,
         OffHeapByteVectorValues.load(
+            fieldEntry.similarityFunction,
+            vectorScorer,
+            fieldEntry.ordToDoc,
+            fieldEntry.vectorEncoding,
+            fieldEntry.dimension,
+            fieldEntry.vectorDataOffset,
+            fieldEntry.vectorDataLength,
+            vectorData),
+        target);
+  }
+
+  @Override
+  public RandomVectorScorer getRandomVectorScorer(String field, short[] target) throws IOException {
+
+    final FieldEntry fieldEntry = getFieldEntry(field, VectorEncoding.FLOAT16);
+    return vectorScorer.getRandomVectorScorer(
+        fieldEntry.similarityFunction,
+        OffHeapFloat16VectorValues.load(
             fieldEntry.similarityFunction,
             vectorScorer,
             fieldEntry.ordToDoc,
@@ -339,6 +373,7 @@ public final class Lucene99FlatVectorsReader extends FlatVectorsReader {
           switch (info.getVectorEncoding()) {
             case BYTE -> Byte.BYTES;
             case FLOAT32 -> Float.BYTES;
+            case FLOAT16 -> Short.BYTES;
           };
       long vectorBytes = Math.multiplyExact((long) infoVectorDimension, byteSize);
       long numBytes = Math.multiplyExact(vectorBytes, size);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsWriter.java
@@ -34,6 +34,7 @@ import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.DocsWithFieldSet;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.KnnVectorValues;
@@ -182,6 +183,7 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
         switch (encoding) {
           case BYTE -> Float.BYTES;
           case FLOAT32 -> 64; // optimal alignment for Arm Neoverse machines.
+          case FLOAT16 -> Float.BYTES;
         });
   }
 
@@ -193,6 +195,7 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
     switch (encoding) {
       case BYTE -> writeByteVectors(fieldWriter);
       case FLOAT32 -> writeFloat32Vectors(fieldWriter, fieldInfo);
+      case FLOAT16 -> writeFloat16Vectors(fieldWriter, fieldInfo);
     }
     long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
 
@@ -207,6 +210,17 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
             .order(ByteOrder.LITTLE_ENDIAN);
     for (Object v : fieldWriter.getVectors()) {
       buffer.asFloatBuffer().put((float[]) v);
+      vectorData.writeBytes(buffer.array(), buffer.array().length);
+    }
+  }
+
+  private void writeFloat16Vectors(FlatFieldVectorsWriter<?> fieldWriter, FieldInfo fieldInfo)
+      throws IOException {
+    final ByteBuffer buffer =
+        ByteBuffer.allocate(fieldInfo.getVectorDimension() * Short.BYTES)
+            .order(ByteOrder.LITTLE_ENDIAN);
+    for (Object v : fieldWriter.getVectors()) {
+      buffer.asShortBuffer().put((short[]) v);
       vectorData.writeBytes(buffer.array(), buffer.array().length);
     }
   }
@@ -233,6 +247,7 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
     switch (encoding) {
       case BYTE -> writeSortedByteVectors(fieldWriter, ordMap);
       case FLOAT32 -> writeSortedFloat32Vectors(fieldWriter, fieldInfo, ordMap);
+      case FLOAT16 -> writeSortedFloat16Vectors(fieldWriter, fieldInfo, ordMap);
     }
     long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
 
@@ -247,6 +262,18 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
     for (int ordinal : ordMap) {
       float[] vector = (float[]) fieldWriter.getVectors().get(ordinal);
       buffer.asFloatBuffer().put(vector);
+      vectorData.writeBytes(buffer.array(), buffer.array().length);
+    }
+  }
+
+  private void writeSortedFloat16Vectors(
+      FlatFieldVectorsWriter<?> fieldWriter, FieldInfo fieldInfo, int[] ordMap) throws IOException {
+    final ByteBuffer buffer =
+        ByteBuffer.allocate(fieldInfo.getVectorDimension() * Short.BYTES)
+            .order(ByteOrder.LITTLE_ENDIAN);
+    for (int ordinal : ordMap) {
+      short[] vector = (short[]) fieldWriter.getVectors().get(ordinal);
+      buffer.asShortBuffer().put(vector);
       vectorData.writeBytes(buffer.array(), buffer.array().length);
     }
   }
@@ -277,6 +304,11 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
               writeVectorData(
                   vectorData,
                   KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(
+                      fieldInfo, mergeState));
+          case FLOAT16 ->
+              writeFloat16VectorData(
+                  vectorData,
+                  KnnVectorsWriter.MergedVectorValues.mergeFloat16VectorValues(
                       fieldInfo, mergeState));
         };
     long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
@@ -347,6 +379,26 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
     return docsWithField;
   }
 
+  /**
+   * Writes the vector values to the output and returns a set of documents that contains vectors.
+   */
+  private static DocsWithFieldSet writeFloat16VectorData(
+      IndexOutput output, Float16VectorValues float16VectorValues) throws IOException {
+    DocsWithFieldSet docsWithField = new DocsWithFieldSet();
+    ByteBuffer buffer =
+        ByteBuffer.allocate(float16VectorValues.dimension() * VectorEncoding.FLOAT16.byteSize)
+            .order(ByteOrder.LITTLE_ENDIAN);
+    KnnVectorValues.DocIndexIterator iter = float16VectorValues.iterator();
+    for (int docV = iter.nextDoc(); docV != NO_MORE_DOCS; docV = iter.nextDoc()) {
+      // write vector
+      short[] value = float16VectorValues.vectorValue(iter.index());
+      buffer.asShortBuffer().put(value);
+      output.writeBytes(buffer.array(), buffer.limit());
+      docsWithField.add(docV);
+    }
+    return docsWithField;
+  }
+
   @Override
   public void close() throws IOException {
     IOUtils.close(meta, vectorData);
@@ -382,6 +434,13 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
             new DefaultFieldWriter<float[]>(fieldInfo) {
               @Override
               public float[] copyValue(float[] value) {
+                return ArrayUtil.copyOfSubArray(value, 0, dim);
+              }
+            };
+        case FLOAT16 ->
+            new DefaultFieldWriter<short[]>(fieldInfo) {
+              @Override
+              public short[] copyValue(short[] value) {
                 return ArrayUtil.copyOfSubArray(value, 0, dim);
               }
             };

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99FlatVectorsWriter.java
@@ -23,6 +23,7 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.ShortBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.lucene.codecs.CodecUtil;
@@ -182,8 +183,8 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
     return output.alignFilePointer(
         switch (encoding) {
           case BYTE -> Float.BYTES;
-          case FLOAT32 -> 64; // optimal alignment for Arm Neoverse machines.
           case FLOAT16 -> Float.BYTES;
+          case FLOAT32 -> 64; // optimal alignment for Arm Neoverse machines.
         });
   }
 
@@ -194,8 +195,8 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
     long vectorDataOffset = alignOutput(vectorData, encoding);
     switch (encoding) {
       case BYTE -> writeByteVectors(fieldWriter);
-      case FLOAT32 -> writeFloat32Vectors(fieldWriter, fieldInfo);
       case FLOAT16 -> writeFloat16Vectors(fieldWriter, fieldInfo);
+      case FLOAT32 -> writeFloat32Vectors(fieldWriter, fieldInfo);
     }
     long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
 
@@ -219,8 +220,10 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
     final ByteBuffer buffer =
         ByteBuffer.allocate(fieldInfo.getVectorDimension() * Short.BYTES)
             .order(ByteOrder.LITTLE_ENDIAN);
+    final ShortBuffer shortBuffer = buffer.asShortBuffer();
     for (Object v : fieldWriter.getVectors()) {
-      buffer.asShortBuffer().put((short[]) v);
+      shortBuffer.rewind();
+      shortBuffer.put((short[]) v);
       vectorData.writeBytes(buffer.array(), buffer.array().length);
     }
   }
@@ -246,8 +249,8 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
     long vectorDataOffset = alignOutput(vectorData, encoding);
     switch (encoding) {
       case BYTE -> writeSortedByteVectors(fieldWriter, ordMap);
-      case FLOAT32 -> writeSortedFloat32Vectors(fieldWriter, fieldInfo, ordMap);
       case FLOAT16 -> writeSortedFloat16Vectors(fieldWriter, fieldInfo, ordMap);
+      case FLOAT32 -> writeSortedFloat32Vectors(fieldWriter, fieldInfo, ordMap);
     }
     long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
 
@@ -271,9 +274,11 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
     final ByteBuffer buffer =
         ByteBuffer.allocate(fieldInfo.getVectorDimension() * Short.BYTES)
             .order(ByteOrder.LITTLE_ENDIAN);
+    final ShortBuffer shortBuffer = buffer.asShortBuffer();
     for (int ordinal : ordMap) {
       short[] vector = (short[]) fieldWriter.getVectors().get(ordinal);
-      buffer.asShortBuffer().put(vector);
+      shortBuffer.rewind();
+      shortBuffer.put(vector);
       vectorData.writeBytes(buffer.array(), buffer.array().length);
     }
   }
@@ -300,15 +305,15 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
               writeByteVectorData(
                   vectorData,
                   KnnVectorsWriter.MergedVectorValues.mergeByteVectorValues(fieldInfo, mergeState));
-          case FLOAT32 ->
-              writeVectorData(
-                  vectorData,
-                  KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(
-                      fieldInfo, mergeState));
           case FLOAT16 ->
               writeFloat16VectorData(
                   vectorData,
                   KnnVectorsWriter.MergedVectorValues.mergeFloat16VectorValues(
+                      fieldInfo, mergeState));
+          case FLOAT32 ->
+              writeVectorData(
+                  vectorData,
+                  KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(
                       fieldInfo, mergeState));
         };
     long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
@@ -388,11 +393,13 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
     ByteBuffer buffer =
         ByteBuffer.allocate(float16VectorValues.dimension() * VectorEncoding.FLOAT16.byteSize)
             .order(ByteOrder.LITTLE_ENDIAN);
+    ShortBuffer shortBuffer = buffer.asShortBuffer();
     KnnVectorValues.DocIndexIterator iter = float16VectorValues.iterator();
     for (int docV = iter.nextDoc(); docV != NO_MORE_DOCS; docV = iter.nextDoc()) {
       // write vector
       short[] value = float16VectorValues.vectorValue(iter.index());
-      buffer.asShortBuffer().put(value);
+      shortBuffer.rewind();
+      shortBuffer.put(value);
       output.writeBytes(buffer.array(), buffer.limit());
       docsWithField.add(docV);
     }
@@ -430,17 +437,17 @@ public final class Lucene99FlatVectorsWriter extends FlatVectorsWriter {
                 return ArrayUtil.copyOfSubArray(value, 0, dim);
               }
             };
-        case FLOAT32 ->
-            new DefaultFieldWriter<float[]>(fieldInfo) {
-              @Override
-              public float[] copyValue(float[] value) {
-                return ArrayUtil.copyOfSubArray(value, 0, dim);
-              }
-            };
         case FLOAT16 ->
             new DefaultFieldWriter<short[]>(fieldInfo) {
               @Override
               public short[] copyValue(short[] value) {
+                return ArrayUtil.copyOfSubArray(value, 0, dim);
+              }
+            };
+        case FLOAT32 ->
+            new DefaultFieldWriter<float[]>(fieldInfo) {
+              @Override
+              public float[] copyValue(float[] value) {
                 return ArrayUtil.copyOfSubArray(value, 0, dim);
               }
             };

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
@@ -32,6 +32,7 @@ import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.MergePolicy;
@@ -278,6 +279,11 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
     return flatVectorsReader.getByteVectorValues(field);
   }
 
+  @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    return flatVectorsReader.getFloat16VectorValues(field);
+  }
+
   private FieldEntry getFieldEntryOrThrow(String field) {
     final FieldInfo info = fieldInfos.fieldInfo(field);
     final FieldEntry entry;
@@ -316,6 +322,17 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
   public void search(String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     final FieldEntry fieldEntry = getFieldEntry(field, VectorEncoding.BYTE);
+    search(
+        fieldEntry,
+        knnCollector,
+        acceptDocs,
+        () -> flatVectorsReader.getRandomVectorScorer(field, target));
+  }
+
+  @Override
+  public void search(String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    final FieldEntry fieldEntry = getFieldEntry(field, VectorEncoding.FLOAT16);
     search(
         fieldEntry,
         knnCollector,

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
@@ -425,8 +425,8 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
       KnnVectorValues vectorValues =
           switch (fieldInfo.getVectorEncoding()) {
             case BYTE -> flatVectorsReader.getByteVectorValues(fieldInfo.name);
-            case FLOAT32 -> flatVectorsReader.getFloatVectorValues(fieldInfo.name);
             case FLOAT16 -> flatVectorsReader.getFloat16VectorValues(fieldInfo.name);
+            case FLOAT32 -> flatVectorsReader.getFloatVectorValues(fieldInfo.name);
           };
       int totalVectorCount = vectorValues == null ? 0 : vectorValues.size();
       if (totalVectorCount > 0 && shouldCreateGraph(tinySegmentsThreshold, totalVectorCount)) {
@@ -706,19 +706,19 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
                 beamWidth,
                 infoStream,
                 tinySegmentsThreshold);
-        case FLOAT32 ->
+        case FLOAT16 ->
             new FieldWriter<>(
                 scorer,
-                (FlatFieldVectorsWriter<float[]>) flatFieldVectorsWriter,
+                (FlatFieldVectorsWriter<short[]>) flatFieldVectorsWriter,
                 fieldInfo,
                 M,
                 beamWidth,
                 infoStream,
                 tinySegmentsThreshold);
-        case FLOAT16 ->
+        case FLOAT32 ->
             new FieldWriter<>(
                 scorer,
-                (FlatFieldVectorsWriter<short[]>) flatFieldVectorsWriter,
+                (FlatFieldVectorsWriter<float[]>) flatFieldVectorsWriter,
                 fieldInfo,
                 M,
                 beamWidth,

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
@@ -426,6 +426,7 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
           switch (fieldInfo.getVectorEncoding()) {
             case BYTE -> flatVectorsReader.getByteVectorValues(fieldInfo.name);
             case FLOAT32 -> flatVectorsReader.getFloatVectorValues(fieldInfo.name);
+            case FLOAT16 -> flatVectorsReader.getFloat16VectorValues(fieldInfo.name);
           };
       int totalVectorCount = vectorValues == null ? 0 : vectorValues.size();
       if (totalVectorCount > 0 && shouldCreateGraph(tinySegmentsThreshold, totalVectorCount)) {
@@ -709,6 +710,15 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
             new FieldWriter<>(
                 scorer,
                 (FlatFieldVectorsWriter<float[]>) flatFieldVectorsWriter,
+                fieldInfo,
+                M,
+                beamWidth,
+                infoStream,
+                tinySegmentsThreshold);
+        case FLOAT16 ->
+            new FieldWriter<>(
+                scorer,
+                (FlatFieldVectorsWriter<short[]>) flatFieldVectorsWriter,
                 fieldInfo,
                 M,
                 beamWidth,

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99ScalarQuantizedVectorScorer.java
@@ -86,6 +86,14 @@ public class Lucene99ScalarQuantizedVectorScorer implements FlatVectorsScorer {
   }
 
   @Override
+  public RandomVectorScorer getRandomVectorScorer(
+      VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, short[] target)
+      throws IOException {
+    // It is possible to get to this branch during initial indexing and flush
+    return nonQuantizedDelegate.getRandomVectorScorer(similarityFunction, vectorValues, target);
+  }
+
+  @Override
   public String toString() {
     return "ScalarQuantizedVectorScorer(" + "nonQuantizedDelegate=" + nonQuantizedDelegate + ')';
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldKnnVectorsFormat.java
@@ -32,6 +32,7 @@ import org.apache.lucene.codecs.hnsw.HnswGraphProvider;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.MergeState;
@@ -295,6 +296,16 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
     }
 
     @Override
+    public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+      final FieldInfo info = fieldInfos.fieldInfo(field);
+      final KnnVectorsReader reader;
+      if (info == null || (reader = fields.get(info.number)) == null) {
+        return null;
+      }
+      return reader.getFloat16VectorValues(field);
+    }
+
+    @Override
     public void search(
         String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
         throws IOException {
@@ -309,6 +320,18 @@ public abstract class PerFieldKnnVectorsFormat extends KnnVectorsFormat {
     @Override
     public void search(
         String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+        throws IOException {
+      final FieldInfo info = fieldInfos.fieldInfo(field);
+      final KnnVectorsReader reader;
+      if (info == null || (reader = fields.get(info.number)) == null) {
+        return;
+      }
+      reader.search(field, target, knnCollector, acceptDocs);
+    }
+
+    @Override
+    public void search(
+        String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
         throws IOException {
       final FieldInfo info = fieldInfos.fieldInfo(field);
       final KnnVectorsReader reader;

--- a/lucene/core/src/java/org/apache/lucene/document/KnnFloat16VectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnFloat16VectorField.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.document;
+
+import java.util.Objects;
+import org.apache.lucene.index.Float16VectorValues;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.KnnFloat16VectorQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.VectorUtil;
+
+/**
+ * A field that contains a single float16 numeric vector (or none) for each document. Vectors are
+ * dense - that is, every dimension of a vector contains an explicit value, stored packed into an
+ * array (of type short[]) whose length is the vector dimension. Values can be retrieved using
+ * {@link Float16VectorValues}, which is a forward-only docID-based iterator and also offers
+ * random-access by dense ordinal (not docId). {@link VectorSimilarityFunction} may be used to
+ * compare vectors at query time (for example as part of result ranking). A {@link
+ * KnnFloat16VectorField} may be associated with a search similarity function defining the metric
+ * used for nearest-neighbor search among vectors of that field.
+ *
+ * @lucene.experimental
+ */
+public class KnnFloat16VectorField extends Field {
+
+  private static FieldType createType(short[] v, VectorSimilarityFunction similarityFunction) {
+    if (v == null) {
+      throw new IllegalArgumentException("vector value must not be null");
+    }
+    int dimension = v.length;
+    if (dimension == 0) {
+      throw new IllegalArgumentException("cannot index an empty vector");
+    }
+    if (similarityFunction == null) {
+      throw new IllegalArgumentException("similarity function must not be null");
+    }
+    FieldType type = new FieldType();
+    type.setVectorAttributes(dimension, VectorEncoding.FLOAT16, similarityFunction);
+    type.freeze();
+    return type;
+  }
+
+  /**
+   * A convenience method for creating a vector field type.
+   *
+   * @param dimension dimension of vectors
+   * @param similarityFunction a function defining vector proximity.
+   * @throws IllegalArgumentException if any parameter is null, or has dimension &gt; 1024.
+   */
+  public static FieldType createFieldType(
+      int dimension, VectorSimilarityFunction similarityFunction) {
+    FieldType type = new FieldType();
+    type.setVectorAttributes(dimension, VectorEncoding.FLOAT16, similarityFunction);
+    type.freeze();
+    return type;
+  }
+
+  /**
+   * Create a new vector query for the provided field targeting the float vector
+   *
+   * @param field The field to query
+   * @param queryVector The float vector target
+   * @param k The number of nearest neighbors to gather
+   * @return A new vector query
+   */
+  public static Query newVectorQuery(String field, short[] queryVector, int k) {
+    return new KnnFloat16VectorQuery(field, queryVector, k);
+  }
+
+  /**
+   * Creates a numeric vector field. Fields are single-valued: each document has either one value or
+   * no value. Vectors of a single field share the same dimension and similarity function. Note that
+   * some vector similarities (like {@link VectorSimilarityFunction#DOT_PRODUCT}) require values to
+   * be unit-length, which can be enforced using {@link VectorUtil#l2normalize(float[])}.
+   *
+   * @param name field name
+   * @param vector value
+   * @param similarityFunction a function defining vector proximity.
+   * @throws IllegalArgumentException if any parameter is null, or the vector is empty or has
+   *     dimension &gt; 1024.
+   */
+  public KnnFloat16VectorField(
+      String name, short[] vector, VectorSimilarityFunction similarityFunction) {
+    super(name, createType(vector, similarityFunction));
+    fieldsData = vector; // null check done above
+  }
+
+  /**
+   * Creates a new KnnFloatVectorField with the specified name, vector, similarity function, and
+   * encoding.
+   *
+   * @param name the field name
+   * @param vector the float vector value
+   * @param similarityFunction the similarity function to use for vector comparisons
+   * @param vectorEncoding the encoding format for the vector
+   */
+  public KnnFloat16VectorField(
+      String name,
+      short[] vector,
+      VectorSimilarityFunction similarityFunction,
+      VectorEncoding vectorEncoding) {
+    super(name, createType(vector, similarityFunction));
+    fieldsData = vector; // null check done above
+  }
+
+  /**
+   * Creates a numeric vector field with the default EUCLIDEAN_HNSW (L2) similarity. Fields are
+   * single-valued: each document has either one value or no value. Vectors of a single field share
+   * the same dimension and similarity function.
+   *
+   * @param name field name
+   * @param vector value
+   * @throws IllegalArgumentException if any parameter is null, or the vector is empty or has
+   *     dimension &gt; 1024.
+   */
+  public KnnFloat16VectorField(String name, short[] vector) {
+    this(name, vector, VectorSimilarityFunction.EUCLIDEAN);
+  }
+
+  /**
+   * Creates a numeric vector field. Fields are single-valued: each document has either one value or
+   * no value. Vectors of a single field share the same dimension and similarity function.
+   *
+   * @param name field name
+   * @param vector value
+   * @param fieldType field type
+   * @throws IllegalArgumentException if any parameter is null, or the vector is empty or has
+   *     dimension &gt; 1024.
+   */
+  public KnnFloat16VectorField(String name, short[] vector, FieldType fieldType) {
+    super(name, fieldType);
+    if (fieldType.vectorEncoding() != VectorEncoding.FLOAT16) {
+      throw new IllegalArgumentException(
+          "Attempt to create a vector for field "
+              + name
+              + " using float[] but the field encoding is "
+              + fieldType.vectorEncoding());
+    }
+    Objects.requireNonNull(vector, "vector value must not be null");
+    if (vector.length != fieldType.vectorDimension()) {
+      throw new IllegalArgumentException(
+          "The number of vector dimensions does not match the field type");
+    }
+    fieldsData = vector;
+  }
+
+  /** Return the vector value of this field */
+  public short[] vectorValue() {
+    return (short[]) fieldsData;
+  }
+
+  /**
+   * Set the vector value of this field
+   *
+   * @param value the value to set; must not be null, and length must match the field type
+   */
+  public void setVectorValue(short[] value) {
+    if (value == null) {
+      throw new IllegalArgumentException("value must not be null");
+    }
+    if (value.length != type.vectorDimension()) {
+      throw new IllegalArgumentException(
+          "value length " + value.length + " must match field dimension " + type.vectorDimension());
+    }
+    fieldsData = value;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/document/KnnFloat16VectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/KnnFloat16VectorField.java
@@ -17,12 +17,9 @@
 
 package org.apache.lucene.document;
 
-import java.util.Objects;
 import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
-import org.apache.lucene.search.KnnFloat16VectorQuery;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.util.VectorUtil;
 
 /**
@@ -32,8 +29,8 @@ import org.apache.lucene.util.VectorUtil;
  * {@link Float16VectorValues}, which is a forward-only docID-based iterator and also offers
  * random-access by dense ordinal (not docId). {@link VectorSimilarityFunction} may be used to
  * compare vectors at query time (for example as part of result ranking). A {@link
- * KnnFloat16VectorField} may be associated with a search similarity function defining the metric
- * used for nearest-neighbor search among vectors of that field.
+ * KnnFloat16VectorField} is associated with a search similarity function defining the metric used
+ * for nearest-neighbor search among vectors of that field.
  *
  * @lucene.experimental
  */
@@ -57,107 +54,18 @@ public class KnnFloat16VectorField extends Field {
   }
 
   /**
-   * A convenience method for creating a vector field type.
-   *
-   * @param dimension dimension of vectors
-   * @param similarityFunction a function defining vector proximity.
-   * @throws IllegalArgumentException if any parameter is null, or has dimension &gt; 1024.
-   */
-  public static FieldType createFieldType(
-      int dimension, VectorSimilarityFunction similarityFunction) {
-    FieldType type = new FieldType();
-    type.setVectorAttributes(dimension, VectorEncoding.FLOAT16, similarityFunction);
-    type.freeze();
-    return type;
-  }
-
-  /**
-   * Create a new vector query for the provided field targeting the float vector
-   *
-   * @param field The field to query
-   * @param queryVector The float vector target
-   * @param k The number of nearest neighbors to gather
-   * @return A new vector query
-   */
-  public static Query newVectorQuery(String field, short[] queryVector, int k) {
-    return new KnnFloat16VectorQuery(field, queryVector, k);
-  }
-
-  /**
-   * Creates a numeric vector field. Fields are single-valued: each document has either one value or
-   * no value. Vectors of a single field share the same dimension and similarity function. Note that
-   * some vector similarities (like {@link VectorSimilarityFunction#DOT_PRODUCT}) require values to
-   * be unit-length, which can be enforced using {@link VectorUtil#l2normalize(float[])}.
-   *
-   * @param name field name
-   * @param vector value
-   * @param similarityFunction a function defining vector proximity.
-   * @throws IllegalArgumentException if any parameter is null, or the vector is empty or has
-   *     dimension &gt; 1024.
-   */
-  public KnnFloat16VectorField(
-      String name, short[] vector, VectorSimilarityFunction similarityFunction) {
-    super(name, createType(vector, similarityFunction));
-    fieldsData = vector; // null check done above
-  }
-
-  /**
-   * Creates a new KnnFloatVectorField with the specified name, vector, similarity function, and
-   * encoding.
-   *
-   * @param name the field name
-   * @param vector the float vector value
-   * @param similarityFunction the similarity function to use for vector comparisons
-   * @param vectorEncoding the encoding format for the vector
-   */
-  public KnnFloat16VectorField(
-      String name,
-      short[] vector,
-      VectorSimilarityFunction similarityFunction,
-      VectorEncoding vectorEncoding) {
-    super(name, createType(vector, similarityFunction));
-    fieldsData = vector; // null check done above
-  }
-
-  /**
-   * Creates a numeric vector field with the default EUCLIDEAN_HNSW (L2) similarity. Fields are
-   * single-valued: each document has either one value or no value. Vectors of a single field share
-   * the same dimension and similarity function.
-   *
-   * @param name field name
-   * @param vector value
-   * @throws IllegalArgumentException if any parameter is null, or the vector is empty or has
-   *     dimension &gt; 1024.
-   */
-  public KnnFloat16VectorField(String name, short[] vector) {
-    this(name, vector, VectorSimilarityFunction.EUCLIDEAN);
-  }
-
-  /**
    * Creates a numeric vector field. Fields are single-valued: each document has either one value or
    * no value. Vectors of a single field share the same dimension and similarity function.
    *
    * @param name field name
    * @param vector value
-   * @param fieldType field type
-   * @throws IllegalArgumentException if any parameter is null, or the vector is empty or has
-   *     dimension &gt; 1024.
+   * @param similarityFunction a function defining vector proximity.
+   * @throws IllegalArgumentException if any parameter is null, or the vector is empty
    */
-  public KnnFloat16VectorField(String name, short[] vector, FieldType fieldType) {
-    super(name, fieldType);
-    if (fieldType.vectorEncoding() != VectorEncoding.FLOAT16) {
-      throw new IllegalArgumentException(
-          "Attempt to create a vector for field "
-              + name
-              + " using float[] but the field encoding is "
-              + fieldType.vectorEncoding());
-    }
-    Objects.requireNonNull(vector, "vector value must not be null");
-    if (vector.length != fieldType.vectorDimension()) {
-      throw new IllegalArgumentException(
-          "The number of vector dimensions does not match the field type");
-    }
-    fieldsData = vector;
+  public KnnFloat16VectorField(
+      String name, short[] vector, VectorSimilarityFunction similarityFunction) {
+    super(name, createType(vector, similarityFunction));
+    fieldsData = VectorUtil.checkFiniteFloat16(vector); // null check done above
   }
 
   /** Return the vector value of this field */
@@ -178,6 +86,6 @@ public class KnnFloat16VectorField extends Field {
       throw new IllegalArgumentException(
           "value length " + value.length + " must match field dimension " + type.vectorDimension());
     }
-    fieldsData = value;
+    fieldsData = VectorUtil.checkFiniteFloat16(value);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -2857,16 +2857,16 @@ public final class CheckIndex implements Closeable {
                     status,
                     reader);
                 break;
-              case FLOAT32:
-                checkFloatVectorValues(
-                    Objects.requireNonNull(reader.getFloatVectorValues(fieldInfo.name)),
+              case FLOAT16:
+                checkFloat16VectorValues(
+                    Objects.requireNonNull(reader.getFloat16VectorValues(fieldInfo.name)),
                     fieldInfo,
                     status,
                     reader);
                 break;
-              case FLOAT16:
-                checkFloat16VectorValues(
-                    Objects.requireNonNull(reader.getFloat16VectorValues(fieldInfo.name)),
+              case FLOAT32:
+                checkFloatVectorValues(
+                    Objects.requireNonNull(reader.getFloatVectorValues(fieldInfo.name)),
                     fieldInfo,
                     status,
                     reader);

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -2864,6 +2864,13 @@ public final class CheckIndex implements Closeable {
                     status,
                     reader);
                 break;
+              case FLOAT16:
+                checkFloat16VectorValues(
+                    Objects.requireNonNull(reader.getFloat16VectorValues(fieldInfo.name)),
+                    fieldInfo,
+                    status,
+                    reader);
+                break;
               default:
                 throw new CheckIndexException(
                     "Field \""
@@ -3086,6 +3093,58 @@ public final class CheckIndex implements Closeable {
 
   private static void checkFloatVectorValues(
       FloatVectorValues values,
+      FieldInfo fieldInfo,
+      CheckIndex.Status.VectorValuesStatus status,
+      CodecReader codecReader)
+      throws IOException {
+    int count = 0;
+    int everyNdoc = Math.max(values.size() / 64, 1);
+    while (count < values.size()) {
+      // search the first maxNumSearches vectors to exercise the graph
+      if (values.ordToDoc(count) % everyNdoc == 0) {
+        KnnCollector collector = new TopKnnCollector(10, Integer.MAX_VALUE);
+        if (vectorsReaderSupportsSearch(codecReader, fieldInfo.name)) {
+          codecReader
+              .getVectorReader()
+              .search(
+                  fieldInfo.name,
+                  values.vectorValue(count),
+                  collector,
+                  AcceptDocs.fromLiveDocs(null, codecReader.maxDoc()));
+          TopDocs docs = collector.topDocs();
+          if (docs.scoreDocs.length == 0) {
+            throw new CheckIndexException(
+                "Field \"" + fieldInfo.name + "\" failed to search k nearest neighbors");
+          }
+        }
+      }
+      int valueLength = values.vectorValue(count).length;
+      if (valueLength != fieldInfo.getVectorDimension()) {
+        throw new CheckIndexException(
+            "Field \""
+                + fieldInfo.name
+                + "\" has a value whose dimension="
+                + valueLength
+                + " not matching the field's dimension="
+                + fieldInfo.getVectorDimension());
+      }
+      ++count;
+    }
+    if (count != values.size()) {
+      throw new CheckIndexException(
+          "Field \""
+              + fieldInfo.name
+              + "\" has size="
+              + values.size()
+              + " but when iterated, returns "
+              + count
+              + " docs with values");
+    }
+    status.totalVectorValues += count;
+  }
+
+  private static void checkFloat16VectorValues(
+      Float16VectorValues values,
       FieldInfo fieldInfo,
       CheckIndex.Status.VectorValuesStatus status,
       CodecReader codecReader)

--- a/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
@@ -259,6 +259,20 @@ public abstract class CodecReader extends LeafReader {
   }
 
   @Override
+  public final Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    ensureOpen();
+    FieldInfo fi = getFieldInfos().fieldInfo(field);
+    if (fi == null
+        || fi.getVectorDimension() == 0
+        || fi.getVectorEncoding() != VectorEncoding.FLOAT16) {
+      // Field does not exist or does not index vectors
+      return null;
+    }
+
+    return getVectorReader().getFloat16VectorValues(field);
+  }
+
+  @Override
   public final void searchNearestVectors(
       String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
@@ -266,7 +280,22 @@ public abstract class CodecReader extends LeafReader {
     FieldInfo fi = getFieldInfos().fieldInfo(field);
     if (fi == null
         || fi.getVectorDimension() == 0
-        || fi.getVectorEncoding() != VectorEncoding.FLOAT32) {
+        || (fi.getVectorEncoding() != VectorEncoding.FLOAT32)) {
+      // Field does not exist or does not index vectors
+      return;
+    }
+    getVectorReader().search(field, target, knnCollector, acceptDocs);
+  }
+
+  @Override
+  public final void searchNearestVectors(
+      String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    ensureOpen();
+    FieldInfo fi = getFieldInfos().fieldInfo(field);
+    if (fi == null
+        || fi.getVectorDimension() == 0
+        || fi.getVectorEncoding() != VectorEncoding.FLOAT16) {
       // Field does not exist or does not index vectors
       return;
     }

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesLeafReader.java
@@ -59,6 +59,11 @@ abstract class DocValuesLeafReader extends LeafReader {
   }
 
   @Override
+  public final Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void searchNearestVectors(
       String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
@@ -68,6 +73,13 @@ abstract class DocValuesLeafReader extends LeafReader {
   @Override
   public void searchNearestVectors(
       String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void searchNearestVectors(
+      String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     throw new UnsupportedOperationException();
   }

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -339,6 +339,15 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     }
 
     @Override
+    public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+      final Float16VectorValues vectorValues = in.getFloat16VectorValues(field);
+      if (vectorValues == null) {
+        return null;
+      }
+      return new ExitableFloat16VectorValues(vectorValues);
+    }
+
+    @Override
     public ByteVectorValues getByteVectorValues(String field) throws IOException {
       final ByteVectorValues vectorValues = in.getByteVectorValues(field);
       if (vectorValues == null) {
@@ -430,6 +439,14 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
 
     @Override
     public void searchNearestVectors(
+        String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+        throws IOException {
+      AcceptDocs timeoutCheckingAcceptDocs = new ExitableAcceptDocs(acceptDocs);
+      in.searchNearestVectors(field, target, knnCollector, timeoutCheckingAcceptDocs);
+    }
+
+    @Override
+    public void searchNearestVectors(
         String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
         throws IOException {
       AcceptDocs timeoutCheckingAcceptDocs = new ExitableAcceptDocs(acceptDocs);
@@ -507,6 +524,49 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
 
       @Override
       public FloatVectorValues copy() {
+        throw new UnsupportedOperationException();
+      }
+    }
+
+    private class ExitableFloat16VectorValues extends Float16VectorValues {
+      private final Float16VectorValues vectorValues;
+
+      public ExitableFloat16VectorValues(Float16VectorValues vectorValues) {
+        this.vectorValues = vectorValues;
+      }
+
+      @Override
+      public int dimension() {
+        return vectorValues.dimension();
+      }
+
+      @Override
+      public short[] vectorValue(int ord) throws IOException {
+        return vectorValues.vectorValue(ord);
+      }
+
+      @Override
+      public int ordToDoc(int ord) {
+        return vectorValues.ordToDoc(ord);
+      }
+
+      @Override
+      public int size() {
+        return vectorValues.size();
+      }
+
+      @Override
+      public DocIndexIterator iterator() {
+        return createExitableIterator(vectorValues.iterator(), queryTimeout);
+      }
+
+      @Override
+      public VectorScorer scorer(short[] target) throws IOException {
+        return vectorValues.scorer(target);
+      }
+
+      @Override
+      public Float16VectorValues copy() {
         throw new UnsupportedOperationException();
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
@@ -359,6 +359,11 @@ public abstract class FilterLeafReader extends LeafReader {
   }
 
   @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    return in.getFloat16VectorValues(field);
+  }
+
+  @Override
   public ByteVectorValues getByteVectorValues(String field) throws IOException {
     return in.getByteVectorValues(field);
   }
@@ -366,6 +371,13 @@ public abstract class FilterLeafReader extends LeafReader {
   @Override
   public void searchNearestVectors(
       String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    in.searchNearestVectors(field, target, knnCollector, acceptDocs);
+  }
+
+  @Override
+  public void searchNearestVectors(
+      String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     in.searchNearestVectors(field, target, knnCollector, acceptDocs);
   }

--- a/lucene/core/src/java/org/apache/lucene/index/Float16VectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Float16VectorValues.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.index;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.lucene.document.KnnFloat16VectorField;
+import org.apache.lucene.search.VectorScorer;
+
+/**
+ * This class provides access to per-document float16 vector values indexed as {@link
+ * KnnFloat16VectorField}.
+ *
+ * @lucene.experimental
+ */
+public abstract class Float16VectorValues extends KnnVectorValues {
+
+  /** Sole constructor */
+  protected Float16VectorValues() {}
+
+  /**
+   * Return the vector value for the given vector ordinal which must be in [0, size() - 1],
+   * otherwise IndexOutOfBoundsException is thrown. The returned array may be shared across calls.
+   *
+   * @return the vector value
+   */
+  public abstract short[] vectorValue(int ord) throws IOException;
+
+  @Override
+  public abstract Float16VectorValues copy() throws IOException;
+
+  /**
+   * Checks the Vector Encoding of a field
+   *
+   * @throws IllegalStateException if {@code field} has vectors, but using a different encoding
+   * @lucene.internal
+   * @lucene.experimental
+   */
+  public static void checkField(LeafReader in, String field) {
+    FieldInfo fi = in.getFieldInfos().fieldInfo(field);
+    if (fi != null && fi.hasVectorValues() && fi.getVectorEncoding() != VectorEncoding.FLOAT16) {
+      throw new IllegalStateException(
+          "Unexpected vector encoding ("
+              + fi.getVectorEncoding()
+              + ") for field "
+              + field
+              + "(expected="
+              + VectorEncoding.FLOAT16
+              + ")");
+    }
+  }
+
+  /**
+   * Return a {@link VectorScorer} for the given query vector and the current {@link
+   * Float16VectorValues}. When the underlying format quantizes the vectors, this will return a
+   * {@link VectorScorer} that scores against the quantized vectors.
+   *
+   * @param target the query vector
+   * @return a {@link VectorScorer} instance or null
+   */
+  public VectorScorer scorer(short[] target) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Rescore using the given query vector and the current {@link Float16VectorValues}. This is
+   * unique from scorer() in that it is explicitly for rescoring an existing set of hits and thus
+   * will often utilize the highest fidelity scoring algorithm available. This is useful when the
+   * initial search used a quantized index or an approximate search algorithm, and now we want to
+   * rescore the hits using the full fidelity vectors. The default implementation is to call {@link
+   * #scorer(short[])} assuming that the scorer is already the highest fidelity implementation
+   * available.
+   *
+   * @param target the query vector
+   * @return a {@link VectorScorer} instance or null
+   * @throws IOException if an I/O error occurs
+   */
+  public VectorScorer rescorer(short[] target) throws IOException {
+    return scorer(target);
+  }
+
+  @Override
+  public VectorEncoding getEncoding() {
+    return VectorEncoding.FLOAT16;
+  }
+
+  /**
+   * Creates a {@link Float16VectorValues} from a list of float arrays.
+   *
+   * @param vectors the list of float arrays
+   * @param dim the dimension of the vectors
+   * @return a {@link Float16VectorValues} instance
+   */
+  public static Float16VectorValues fromFloats16(List<short[]> vectors, int dim) {
+    return new Float16VectorValues() {
+      @Override
+      public int size() {
+        return vectors.size();
+      }
+
+      @Override
+      public int dimension() {
+        return dim;
+      }
+
+      @Override
+      public short[] vectorValue(int targetOrd) {
+        return vectors.get(targetOrd);
+      }
+
+      @Override
+      public Float16VectorValues copy() {
+        return this;
+      }
+
+      @Override
+      public DocIndexIterator iterator() {
+        return createDenseIterator();
+      }
+    };
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/index/Float16VectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Float16VectorValues.java
@@ -99,9 +99,9 @@ public abstract class Float16VectorValues extends KnnVectorValues {
   }
 
   /**
-   * Creates a {@link Float16VectorValues} from a list of float arrays.
+   * Creates a {@link Float16VectorValues} from a list of float16 vectors.
    *
-   * @param vectors the list of float arrays
+   * @param vectors the list of float16 vectors, each stored as a {@code short[]}
    * @param dim the dimension of the vectors
    * @return a {@link Float16VectorValues} instance
    */

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -1259,19 +1259,6 @@ final class IndexingChain implements Accountable {
     int consumed = 0;
     int batchDocID;
     switch (encoding) {
-      case FLOAT32 -> {
-        KnnFieldVectorsWriter<float[]> writer =
-            (KnnFieldVectorsWriter<float[]>) pf.knnFieldVectorsWriter;
-        while ((batchDocID = cursor.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
-          ColumnValidation.checkDocID(column, batchDocID, numDocs);
-          ColumnValidation.checkVectorDocIDStrictlyIncreasing(column, batchDocID, prevBatchDocID);
-          float[] vec = (float[]) cursor.value();
-          ColumnValidation.checkVectorDimension(column, vec.length, dimension, batchDocID);
-          writer.addValue(baseDocID + batchDocID, vec);
-          prevBatchDocID = batchDocID;
-          consumed++;
-        }
-      }
       case BYTE -> {
         KnnFieldVectorsWriter<byte[]> writer =
             (KnnFieldVectorsWriter<byte[]>) pf.knnFieldVectorsWriter;
@@ -1292,6 +1279,19 @@ final class IndexingChain implements Accountable {
           ColumnValidation.checkDocID(column, batchDocID, numDocs);
           ColumnValidation.checkVectorDocIDStrictlyIncreasing(column, batchDocID, prevBatchDocID);
           short[] vec = (short[]) cursor.value();
+          ColumnValidation.checkVectorDimension(column, vec.length, dimension, batchDocID);
+          writer.addValue(baseDocID + batchDocID, vec);
+          prevBatchDocID = batchDocID;
+          consumed++;
+        }
+      }
+      case FLOAT32 -> {
+        KnnFieldVectorsWriter<float[]> writer =
+            (KnnFieldVectorsWriter<float[]>) pf.knnFieldVectorsWriter;
+        while ((batchDocID = cursor.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+          ColumnValidation.checkDocID(column, batchDocID, numDocs);
+          ColumnValidation.checkVectorDocIDStrictlyIncreasing(column, batchDocID, prevBatchDocID);
+          float[] vec = (float[]) cursor.value();
           ColumnValidation.checkVectorDimension(column, vec.length, dimension, batchDocID);
           writer.addValue(baseDocID + batchDocID, vec);
           prevBatchDocID = batchDocID;
@@ -1704,12 +1704,12 @@ final class IndexingChain implements Accountable {
       case BYTE ->
           ((KnnFieldVectorsWriter<byte[]>) pf.knnFieldVectorsWriter)
               .addValue(docID, ((KnnByteVectorField) field).vectorValue());
-      case FLOAT32 ->
-          ((KnnFieldVectorsWriter<float[]>) pf.knnFieldVectorsWriter)
-              .addValue(docID, ((KnnFloatVectorField) field).vectorValue());
       case FLOAT16 ->
           ((KnnFieldVectorsWriter<short[]>) pf.knnFieldVectorsWriter)
               .addValue(docID, ((KnnFloat16VectorField) field).vectorValue());
+      case FLOAT32 ->
+          ((KnnFieldVectorsWriter<float[]>) pf.knnFieldVectorsWriter)
+              .addValue(docID, ((KnnFloatVectorField) field).vectorValue());
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -40,6 +40,7 @@ import org.apache.lucene.codecs.PointsFormat;
 import org.apache.lucene.codecs.PointsWriter;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.document.KnnFloat16VectorField;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StoredValue;
@@ -1284,6 +1285,19 @@ final class IndexingChain implements Accountable {
           consumed++;
         }
       }
+      case FLOAT16 -> {
+        KnnFieldVectorsWriter<short[]> writer =
+            (KnnFieldVectorsWriter<short[]>) pf.knnFieldVectorsWriter;
+        while ((batchDocID = cursor.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+          ColumnValidation.checkDocID(column, batchDocID, numDocs);
+          ColumnValidation.checkVectorDocIDStrictlyIncreasing(column, batchDocID, prevBatchDocID);
+          short[] vec = (short[]) cursor.value();
+          ColumnValidation.checkVectorDimension(column, vec.length, dimension, batchDocID);
+          writer.addValue(baseDocID + batchDocID, vec);
+          prevBatchDocID = batchDocID;
+          consumed++;
+        }
+      }
     }
     if (column.density() == Column.Density.DENSE) {
       ColumnValidation.checkDenseCount(column, consumed, numDocs);
@@ -1693,6 +1707,9 @@ final class IndexingChain implements Accountable {
       case FLOAT32 ->
           ((KnnFieldVectorsWriter<float[]>) pf.knnFieldVectorsWriter)
               .addValue(docID, ((KnnFloatVectorField) field).vectorValue());
+      case FLOAT16 ->
+          ((KnnFieldVectorsWriter<short[]>) pf.knnFieldVectorsWriter)
+              .addValue(docID, ((KnnFloat16VectorField) field).vectorValue());
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -220,6 +220,14 @@ public abstract non-sealed class LeafReader extends IndexReader {
   public abstract FloatVectorValues getFloatVectorValues(String field) throws IOException;
 
   /**
+   * Returns {@link Float16VectorValues} for this field, or null if no {@link Float16VectorValues}
+   * were indexed. The returned instance should only be used by a single thread.
+   *
+   * @lucene.experimental
+   */
+  public abstract Float16VectorValues getFloat16VectorValues(String field) throws IOException;
+
+  /**
    * Returns {@link ByteVectorValues} for this field, or null if no {@link ByteVectorValues} were
    * indexed. The returned instance should only be used by a single thread.
    *
@@ -325,6 +333,50 @@ public abstract non-sealed class LeafReader extends IndexReader {
    * true k closest neighbors. For large values of k (for example when k is close to the total
    * number of documents), the search may also retrieve fewer than k documents.
    *
+   * <p>The returned {@link TopDocs} will contain a {@link ScoreDoc} for each nearest neighbor,
+   * sorted in order of their similarity to the query vector (decreasing scores). The {@link
+   * TotalHits} contains the number of documents visited during the search. If the search stopped
+   * early because it hit {@code visitedLimit}, it is indicated through the relation {@code
+   * TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO}.
+   *
+   * @param field the vector field to search
+   * @param target the short vector-valued query
+   * @param k the number of docs to return
+   * @param acceptDocs {@link AcceptDocs} that represents the allowed documents to match
+   * @param visitedLimit the maximum number of nodes that the search is allowed to visit
+   * @return the k nearest neighbor documents, along with their (searchStrategy-specific) scores.
+   * @lucene.experimental
+   */
+  public final TopDocs searchNearestVectors(
+      String field, short[] target, int k, AcceptDocs acceptDocs, int visitedLimit)
+      throws IOException {
+    FieldInfo fi = getFieldInfos().fieldInfo(field);
+    if (fi == null || fi.getVectorDimension() == 0) {
+      return TopDocsCollector.EMPTY_TOPDOCS;
+    }
+    Float16VectorValues vectorValues = getFloat16VectorValues(fi.name);
+    if (vectorValues == null) {
+      return TopDocsCollector.EMPTY_TOPDOCS;
+    }
+    k = Math.min(k, vectorValues.size());
+    if (k == 0) {
+      return TopDocsCollector.EMPTY_TOPDOCS;
+    }
+    KnnCollector collector = new TopKnnCollector(k, visitedLimit);
+    searchNearestVectors(field, target, collector, acceptDocs);
+    return collector.topDocs();
+  }
+
+  /**
+   * Return the k nearest neighbor documents as determined by comparison of their vector values for
+   * this field, to the given vector, by the field's similarity function. The score of each document
+   * is derived from the vector similarity in a way that ensures scores are positive and that a
+   * larger score corresponds to a higher ranking.
+   *
+   * <p>The search is allowed to be approximate, meaning the results are not guaranteed to be the
+   * true k closest neighbors. For large values of k (for example when k is close to the total
+   * number of documents), the search may also retrieve fewer than k documents.
+   *
    * <p>The returned {@link TopDocs} will contain a {@link ScoreDoc} for each nearest neighbor, in
    * order of their similarity to the query vector (decreasing scores). The {@link TotalHits}
    * contains the number of documents visited during the search. If the search stopped early because
@@ -342,6 +394,35 @@ public abstract non-sealed class LeafReader extends IndexReader {
    */
   public abstract void searchNearestVectors(
       String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException;
+
+  /**
+   * Return the k nearest neighbor documents as determined by comparison of their vector values for
+   * this field, to the given vector, by the field's similarity function. The score of each document
+   * is derived from the vector similarity in a way that ensures scores are positive and that a
+   * larger score corresponds to a higher ranking.
+   *
+   * <p>The search is allowed to be approximate, meaning the results are not guaranteed to be the
+   * true k closest neighbors. For large values of k (for example when k is close to the total
+   * number of documents), the search may also retrieve fewer than k documents.
+   *
+   * <p>The returned {@link TopDocs} will contain a {@link ScoreDoc} for each nearest neighbor, in
+   * order of their similarity to the query vector (decreasing scores). The {@link TotalHits}
+   * contains the number of documents visited during the search. If the search stopped early because
+   * it hit {@code visitedLimit}, it is indicated through the relation {@code
+   * TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO}.
+   *
+   * <p>The behavior is undefined if the given field doesn't have KNN vectors enabled on its {@link
+   * FieldInfo}. The return value is never {@code null}.
+   *
+   * @param field the vector field to search
+   * @param target the short vector-valued query
+   * @param knnCollector collector with settings for gathering the vector results.
+   * @param acceptDocs {@link AcceptDocs} that represents the allowed documents to match
+   * @lucene.experimental
+   */
+  public abstract void searchNearestVectors(
+      String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException;
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -340,7 +340,7 @@ public abstract non-sealed class LeafReader extends IndexReader {
    * TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO}.
    *
    * @param field the vector field to search
-   * @param target the short vector-valued query
+   * @param target the fp16 vector-valued query
    * @param k the number of docs to return
    * @param acceptDocs {@link AcceptDocs} that represents the allowed documents to match
    * @param visitedLimit the maximum number of nodes that the search is allowed to visit
@@ -416,7 +416,7 @@ public abstract non-sealed class LeafReader extends IndexReader {
    * FieldInfo}. The return value is never {@code null}.
    *
    * @param field the vector field to search
-   * @param target the short vector-valued query
+   * @param target the fp16 vector-valued query
    * @param knnCollector collector with settings for gathering the vector results.
    * @param acceptDocs {@link AcceptDocs} that represents the allowed documents to match
    * @lucene.experimental

--- a/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
@@ -457,6 +457,12 @@ public class ParallelLeafReader extends LeafReader {
   }
 
   @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    LeafReader reader = fieldToReader.get(field);
+    return reader == null ? null : reader.getFloat16VectorValues(field);
+  }
+
+  @Override
   public ByteVectorValues getByteVectorValues(String fieldName) throws IOException {
     ensureOpen();
     LeafReader reader = fieldToReader.get(fieldName);
@@ -471,6 +477,17 @@ public class ParallelLeafReader extends LeafReader {
     LeafReader reader = fieldToReader.get(fieldName);
     if (reader != null) {
       reader.searchNearestVectors(fieldName, target, knnCollector, acceptDocs);
+    }
+  }
+
+  @Override
+  public void searchNearestVectors(
+      String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    ensureOpen();
+    LeafReader reader = fieldToReader.get(field);
+    if (reader != null) {
+      reader.searchNearestVectors(field, target, knnCollector, acceptDocs);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
@@ -175,6 +175,11 @@ public final class SlowCodecReaderWrapper {
       }
 
       @Override
+      public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+        return reader.getFloat16VectorValues(field);
+      }
+
+      @Override
       public void search(
           String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
           throws IOException {
@@ -184,6 +189,13 @@ public final class SlowCodecReaderWrapper {
       @Override
       public void search(
           String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+          throws IOException {
+        reader.searchNearestVectors(field, target, knnCollector, acceptDocs);
+      }
+
+      @Override
+      public void search(
+          String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
           throws IOException {
         reader.searchNearestVectors(field, target, knnCollector, acceptDocs);
       }

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCompositeCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCompositeCodecReaderWrapper.java
@@ -941,6 +941,86 @@ final class SlowCompositeCodecReaderWrapper extends CodecReader {
       return new MergedByteVectorValues(dimension, size, subs);
     }
 
+    @Override
+    public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+      List<DocValuesSub<Float16VectorValues>> subs = new ArrayList<>();
+      int i = 0;
+      int dimension = -1;
+      int size = 0;
+      for (CodecReader reader : codecReaders) {
+        Float16VectorValues values = reader.getFloat16VectorValues(field);
+        subs.add(new DocValuesSub<>(values, docStarts[i], size));
+        if (values != null) {
+          if (dimension == -1) {
+            dimension = values.dimension();
+          }
+          size += values.size();
+        }
+        i++;
+      }
+      return new MergedFloat16VectorValues(dimension, size, subs);
+    }
+
+    class MergedFloat16VectorValues extends Float16VectorValues {
+      final int dimension;
+      final int size;
+      final List<DocValuesSub<Float16VectorValues>> subs;
+      final MergedDocIterator<Float16VectorValues> iter;
+      final int[] starts;
+      int lastSubIndex;
+
+      MergedFloat16VectorValues(
+          int dimension, int size, List<DocValuesSub<Float16VectorValues>> subs) {
+        this.dimension = dimension;
+        this.size = size;
+        this.subs = subs;
+        iter = new MergedDocIterator<>(subs);
+        // [0, start(1), ..., size] - we want the extra element
+        // to avoid checking for out-of-array bounds
+        starts = new int[subs.size() + 1];
+        for (int i = 0; i < subs.size(); i++) {
+          starts[i] = subs.get(i).ordStart;
+        }
+        starts[starts.length - 1] = size;
+      }
+
+      @Override
+      public MergedDocIterator<Float16VectorValues> iterator() {
+        return iter;
+      }
+
+      @Override
+      public int dimension() {
+        return dimension;
+      }
+
+      @Override
+      public int size() {
+        return size;
+      }
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public Float16VectorValues copy() throws IOException {
+        List<DocValuesSub<Float16VectorValues>> subsCopy = new ArrayList<>();
+        for (DocValuesSub<Float16VectorValues> sub : subs) {
+          subsCopy.add(sub.copy());
+        }
+        return new MergedFloat16VectorValues(dimension, size, subsCopy);
+      }
+
+      @Override
+      public short[] vectorValue(int ord) throws IOException {
+        assert ord >= 0 && ord < size;
+        // We need to implement fully random-access API here in order to support callers like
+        // SortingCodecReader that rely on it.
+        lastSubIndex = findSub(ord, lastSubIndex, starts);
+        DocValuesSub<Float16VectorValues> sub = subs.get(lastSubIndex);
+        assert sub.sub != null;
+        return (sub.sub).vectorValue(ord - sub.ordStart);
+      }
+    }
+
     class MergedByteVectorValues extends ByteVectorValues {
       final int dimension;
       final int size;
@@ -1036,6 +1116,13 @@ final class SlowCompositeCodecReaderWrapper extends CodecReader {
     @Override
     public void search(
         String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+        throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void search(
+        String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
         throws IOException {
       throw new UnsupportedOperationException();
     }

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -383,6 +383,43 @@ public final class SortingCodecReader extends FilterCodecReader {
     }
   }
 
+  private static class SortingFloat16VectorValues extends Float16VectorValues {
+    final Float16VectorValues delegate;
+    final SortingIteratorSupplier iteratorSupplier;
+
+    SortingFloat16VectorValues(Float16VectorValues delegate, Sorter.DocMap sortMap)
+        throws IOException {
+      this.delegate = delegate;
+      // SortingValuesIterator consumes the iterator and records the docs and ord mapping
+      iteratorSupplier = iteratorSupplier(delegate, sortMap);
+    }
+
+    @Override
+    public short[] vectorValue(int ord) throws IOException {
+      return delegate.vectorValue(ord);
+    }
+
+    @Override
+    public DocIndexIterator iterator() {
+      return iteratorSupplier.get();
+    }
+
+    @Override
+    public int dimension() {
+      return delegate.dimension();
+    }
+
+    @Override
+    public int size() {
+      return iteratorSupplier.size();
+    }
+
+    @Override
+    public Float16VectorValues copy() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
   /**
    * Return a sorted view of <code>reader</code> according to the order defined by <code>sort</code>
    * . If the reader is already sorted, this method might return the reader as-is.
@@ -582,6 +619,11 @@ public final class SortingCodecReader extends FilterCodecReader {
       }
 
       @Override
+      public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+        return new SortingFloat16VectorValues(delegate.getFloat16VectorValues(field), docMap);
+      }
+
+      @Override
       public void search(
           String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) {
         throw new UnsupportedOperationException();
@@ -590,6 +632,13 @@ public final class SortingCodecReader extends FilterCodecReader {
       @Override
       public void search(
           String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void search(
+          String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+          throws IOException {
         throw new UnsupportedOperationException();
       }
 

--- a/lucene/core/src/java/org/apache/lucene/index/VectorEncoding.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorEncoding.java
@@ -29,7 +29,10 @@ public enum VectorEncoding {
   BYTE(1),
 
   /** Encodes vector using 32 bits of precision per sample in IEEE floating point format. */
-  FLOAT32(4);
+  FLOAT32(4),
+
+  /** Encodes vector using 16 bits of precision per sample in IEEE floating point format. */
+  FLOAT16(2);
 
   /**
    * The number of bytes required to encode a scalar in this format. A vector will nominally require
@@ -39,5 +42,10 @@ public enum VectorEncoding {
 
   VectorEncoding(int byteSize) {
     this.byteSize = byteSize;
+  }
+
+  /** Returns true if this is a floating-point encoding ({@link #FLOAT32} or {@link #FLOAT16}). */
+  public boolean isFloatingPoint() {
+    return this == FLOAT32 || this == FLOAT16;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/VectorEncoding.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorEncoding.java
@@ -31,7 +31,10 @@ public enum VectorEncoding {
   /** Encodes vector using 32 bits of precision per sample in IEEE floating point format. */
   FLOAT32(4),
 
-  /** Encodes vector using 16 bits of precision per sample in IEEE floating point format. */
+  /**
+   * Encodes vector using 16 bits of precision per sample in IEEE half-precision floating-point
+   * format.
+   */
   FLOAT16(2);
 
   /**
@@ -42,10 +45,5 @@ public enum VectorEncoding {
 
   VectorEncoding(int byteSize) {
     this.byteSize = byteSize;
-  }
-
-  /** Returns true if this is a floating-point encoding ({@link #FLOAT32} or {@link #FLOAT16}). */
-  public boolean isFloatingPoint() {
-    return this == FLOAT32 || this == FLOAT16;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java
@@ -42,6 +42,11 @@ public enum VectorSimilarityFunction {
     public float compare(byte[] v1, byte[] v2) {
       return 1 / (1f + squareDistance(v1, v2));
     }
+
+    @Override
+    public float compare(short[] v1, short[] v2) {
+      return normalizeDistanceToUnitInterval(squareDistance(v1, v2));
+    }
   },
 
   /**
@@ -61,6 +66,11 @@ public enum VectorSimilarityFunction {
     public float compare(byte[] v1, byte[] v2) {
       return dotProductScore(v1, v2);
     }
+
+    @Override
+    public float compare(short[] v1, short[] v2) {
+      return normalizeToUnitInterval(dotProduct(v1, v2));
+    }
   },
 
   /**
@@ -79,6 +89,11 @@ public enum VectorSimilarityFunction {
     public float compare(byte[] v1, byte[] v2) {
       return (1 + cosine(v1, v2)) / 2;
     }
+
+    @Override
+    public float compare(short[] v1, short[] v2) {
+      return normalizeToUnitInterval(cosine(v1, v2));
+    }
   },
 
   /**
@@ -94,6 +109,11 @@ public enum VectorSimilarityFunction {
 
     @Override
     public float compare(byte[] v1, byte[] v2) {
+      return scaleMaxInnerProductScore(dotProduct(v1, v2));
+    }
+
+    @Override
+    public float compare(short[] v1, short[] v2) {
       return scaleMaxInnerProductScore(dotProduct(v1, v2));
     }
   };
@@ -118,4 +138,14 @@ public enum VectorSimilarityFunction {
    * @return the value of the similarity function applied to the two vectors
    */
   public abstract float compare(byte[] v1, byte[] v2);
+
+  /**
+   * Calculates a similarity score between the two vectors with a specified function. Higher
+   * similarity scores correspond to closer vectors. Each short represents a vector dimension.
+   *
+   * @param v1 a vector
+   * @param v2 another vector, of the same dimension
+   * @return the value of the similarity function applied to the two vectors
+   */
+  public abstract float compare(short[] v1, short[] v2);
 }

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
@@ -65,6 +65,17 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public float dotProduct(short[] a, short[] b) {
+    assert a.length == b.length : "Vector lengths must match";
+
+    float sum = 0f;
+    for (int i = 0; i < a.length; i++) {
+      sum = Float.float16ToFloat(a[i]) * Float.float16ToFloat(b[i]) + sum;
+    }
+    return sum;
+  }
+
+  @Override
   public float cosine(float[] a, float[] b) {
     float sum = 0.0f;
     float norm1 = 0.0f;
@@ -106,6 +117,22 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public float cosine(short[] a, short[] b) {
+    float sum = 0.0f;
+    float norm1 = 0.0f;
+    float norm2 = 0.0f;
+
+    for (int i = 0; i < a.length; i++) {
+      float f1 = Float.float16ToFloat(a[i]);
+      float f2 = Float.float16ToFloat(b[i]);
+      sum = fma(f1, f2, sum);
+      norm1 = fma(f1, f1, norm1);
+      norm2 = fma(f2, f2, norm2);
+    }
+    return (float) (sum / Math.sqrt((double) norm1 * (double) norm2));
+  }
+
+  @Override
   public float squareDistance(float[] a, float[] b) {
     float res = 0;
     int i = 0;
@@ -141,6 +168,16 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
     for (; i < a.length; i++) {
       float diff = a[i] - b[i];
       res = fma(diff, diff, res);
+    }
+    return res;
+  }
+
+  @Override
+  public float squareDistance(short[] a, short[] b) {
+    float res = 0f; // Accumulate in float32 for precision
+    for (int i = 0; i < a.length; i++) {
+      float diff = Float.float16ToFloat(a[i]) - Float.float16ToFloat(b[i]);
+      res += diff * diff;
     }
     return res;
   }

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
@@ -27,11 +27,22 @@ public interface VectorUtilSupport {
   /** Calculates the dot product of the given float arrays. */
   float dotProduct(float[] a, float[] b);
 
+  /**
+   * Calculates the dot product of the given short arrays used when we are using float16 vectors.
+   */
+  float dotProduct(short[] a, short[] b);
+
   /** Returns the cosine similarity between the two vectors. */
   float cosine(float[] v1, float[] v2);
 
+  /** Returns the cosine similarity between the two vectors. */
+  float cosine(short[] v1, short[] v2);
+
   /** Returns the sum of squared differences of the two vectors. */
   float squareDistance(float[] a, float[] b);
+
+  /** Returns the sum of squared differences of the two vectors. */
+  float squareDistance(short[] a, short[] b);
 
   /** Returns the dot product computed over signed bytes. */
   int dotProduct(byte[] a, byte[] b);

--- a/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
@@ -26,6 +26,7 @@ import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
@@ -181,6 +182,7 @@ public class FieldExistsQuery extends Query {
           iterator =
               switch (fieldInfo.getVectorEncoding()) {
                 case FLOAT32 -> context.reader().getFloatVectorValues(field).iterator();
+                case FLOAT16 -> context.reader().getFloat16VectorValues(field).iterator();
                 case BYTE -> context.reader().getByteVectorValues(field).iterator();
               };
         } else if (fieldInfo.getDocValuesType()
@@ -298,6 +300,11 @@ public class FieldExistsQuery extends Query {
         FloatVectorValues floatVectorValues = reader.getFloatVectorValues(field);
         assert floatVectorValues != null : "unexpected null float vector values";
         yield floatVectorValues.size();
+      }
+      case FLOAT16 -> {
+        Float16VectorValues float16VectorValues = reader.getFloat16VectorValues(field);
+        assert float16VectorValues != null : "unexpected null float vector values";
+        yield float16VectorValues.size();
       }
       case BYTE -> {
         ByteVectorValues byteVectorValues = reader.getByteVectorValues(field);

--- a/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldExistsQuery.java
@@ -181,9 +181,9 @@ public class FieldExistsQuery extends Query {
         } else if (fieldInfo.getVectorDimension() != 0) { // the field indexes vectors
           iterator =
               switch (fieldInfo.getVectorEncoding()) {
-                case FLOAT32 -> context.reader().getFloatVectorValues(field).iterator();
-                case FLOAT16 -> context.reader().getFloat16VectorValues(field).iterator();
                 case BYTE -> context.reader().getByteVectorValues(field).iterator();
+                case FLOAT16 -> context.reader().getFloat16VectorValues(field).iterator();
+                case FLOAT32 -> context.reader().getFloatVectorValues(field).iterator();
               };
         } else if (fieldInfo.getDocValuesType()
             != DocValuesType.NONE) { // the field indexes doc values
@@ -296,20 +296,20 @@ public class FieldExistsQuery extends Query {
   private int getVectorValuesSize(FieldInfo fi, LeafReader reader) throws IOException {
     assert fi.name.equals(field);
     return switch (fi.getVectorEncoding()) {
-      case FLOAT32 -> {
-        FloatVectorValues floatVectorValues = reader.getFloatVectorValues(field);
-        assert floatVectorValues != null : "unexpected null float vector values";
-        yield floatVectorValues.size();
+      case BYTE -> {
+        ByteVectorValues byteVectorValues = reader.getByteVectorValues(field);
+        assert byteVectorValues != null : "unexpected null byte vector values";
+        yield byteVectorValues.size();
       }
       case FLOAT16 -> {
         Float16VectorValues float16VectorValues = reader.getFloat16VectorValues(field);
         assert float16VectorValues != null : "unexpected null float vector values";
         yield float16VectorValues.size();
       }
-      case BYTE -> {
-        ByteVectorValues byteVectorValues = reader.getByteVectorValues(field);
-        assert byteVectorValues != null : "unexpected null byte vector values";
-        yield byteVectorValues.size();
+      case FLOAT32 -> {
+        FloatVectorValues floatVectorValues = reader.getFloatVectorValues(field);
+        assert floatVectorValues != null : "unexpected null float vector values";
+        yield floatVectorValues.size();
       }
     };
   }

--- a/lucene/core/src/java/org/apache/lucene/search/KnnFloat16VectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnFloat16VectorQuery.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import static org.apache.lucene.search.knn.KnnSearchStrategy.Hnsw.DEFAULT;
+
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.document.KnnFloat16VectorField;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Float16VectorValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.knn.KnnCollectorManager;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
+import org.apache.lucene.util.ArrayUtil;
+
+/**
+ * Uses {@link KnnVectorsReader#search(String, short[], KnnCollector, AcceptDocs)} to perform
+ * nearest neighbour search.
+ *
+ * <p>This query also allows for performing a kNN search subject to a filter. In this case, it first
+ * executes the filter for each leaf, then chooses a strategy dynamically:
+ *
+ * <ul>
+ *   <li>If the filter cost is less than k, just execute an exact search
+ *   <li>Otherwise run a kNN search subject to the filter
+ *   <li>If the kNN search visits too many vectors without completing, stop and run an exact search
+ * </ul>
+ */
+public class KnnFloat16VectorQuery extends AbstractKnnVectorQuery {
+
+  private static final TopDocs NO_RESULTS = TopDocsCollector.EMPTY_TOPDOCS;
+
+  protected final short[] target;
+
+  /**
+   * Find the <code>k</code> nearest documents to the target vector according to the vectors in the
+   * given field. <code>target</code> vector.
+   *
+   * @param field a field that has been indexed as a {@link KnnFloat16VectorField}.
+   * @param target the target of the search
+   * @param k the number of documents to find
+   * @throws IllegalArgumentException if <code>k</code> is less than 1
+   */
+  public KnnFloat16VectorQuery(String field, short[] target, int k) {
+    this(field, target, k, null);
+  }
+
+  /**
+   * Find the <code>k</code> nearest documents to the target vector according to the vectors in the
+   * given field. <code>target</code> vector.
+   *
+   * @param field a field that has been indexed as a {@link KnnFloat16VectorField}.
+   * @param target the target of the search
+   * @param k the number of documents to find
+   * @param filter a filter applied before the vector search
+   * @throws IllegalArgumentException if <code>k</code> is less than 1
+   */
+  public KnnFloat16VectorQuery(String field, short[] target, int k, Query filter) {
+    this(field, target, k, filter, DEFAULT);
+  }
+
+  /**
+   * Find the <code>k</code> nearest documents to the target vector according to the vectors in the
+   * given field. <code>target</code> vector.
+   *
+   * @param field a field that has been indexed as a {@link KnnFloat16VectorField}.
+   * @param target the target of the search
+   * @param k the number of documents to find
+   * @param filter a filter applied before the vector search
+   * @param searchStrategy the search strategy to use. If null, the default strategy will be used.
+   *     The underlying format may not support all strategies and is free to ignore the requested
+   *     strategy.
+   * @lucene.experimental
+   */
+  public KnnFloat16VectorQuery(
+      String field, short[] target, int k, Query filter, KnnSearchStrategy searchStrategy) {
+    super(field, k, filter, searchStrategy);
+    this.target = target;
+  }
+
+  @Override
+  protected TopDocs approximateSearch(
+      LeafReaderContext context,
+      AcceptDocs acceptDocs,
+      int visitedLimit,
+      KnnCollectorManager knnCollectorManager)
+      throws IOException {
+    KnnCollector knnCollector =
+        knnCollectorManager.newCollector(visitedLimit, searchStrategy, context);
+    LeafReader reader = context.reader();
+    Float16VectorValues float16VectorValues = reader.getFloat16VectorValues(field);
+    if (float16VectorValues == null) {
+      Float16VectorValues.checkField(reader, field);
+      return NO_RESULTS;
+    }
+    if (Math.min(knnCollector.k(), float16VectorValues.size()) == 0) {
+      return NO_RESULTS;
+    }
+    reader.searchNearestVectors(field, target, knnCollector, acceptDocs);
+    TopDocs results = knnCollector.topDocs();
+    return results != null ? results : NO_RESULTS;
+  }
+
+  @Override
+  VectorScorer createVectorScorer(LeafReaderContext context, FieldInfo fi) throws IOException {
+    LeafReader reader = context.reader();
+    Float16VectorValues vectorValues = reader.getFloat16VectorValues(field);
+    if (vectorValues == null) {
+      Float16VectorValues.checkField(reader, field);
+      return null;
+    }
+    return vectorValues.scorer(target);
+  }
+
+  @Override
+  public String toString(String field) {
+    StringBuilder buffer = new StringBuilder();
+    buffer.append(getClass().getSimpleName() + ":");
+    buffer.append(this.field + "[" + target[0] + ",...]");
+    buffer.append("[" + k + "]");
+    if (this.filter != null) {
+      buffer.append("[" + this.filter + "]");
+    }
+    return buffer.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (super.equals(o) == false) return false;
+    KnnFloat16VectorQuery that = (KnnFloat16VectorQuery) o;
+    return Arrays.equals(target, that.target);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + Arrays.hashCode(target);
+    return result;
+  }
+
+  /**
+   * @return the target query vector of the search. Each vector element is a short (float16).
+   */
+  public short[] getTargetCopy() {
+    return ArrayUtil.copyArray(target);
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/KnnFloat16VectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnFloat16VectorQuery.java
@@ -20,6 +20,7 @@ import static org.apache.lucene.search.knn.KnnSearchStrategy.Hnsw.DEFAULT;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.document.KnnFloat16VectorField;
 import org.apache.lucene.index.FieldInfo;
@@ -29,6 +30,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.knn.KnnCollectorManager;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.VectorUtil;
 
 /**
  * Uses {@link KnnVectorsReader#search(String, short[], KnnCollector, AcceptDocs)} to perform
@@ -92,7 +94,7 @@ public class KnnFloat16VectorQuery extends AbstractKnnVectorQuery {
   public KnnFloat16VectorQuery(
       String field, short[] target, int k, Query filter, KnnSearchStrategy searchStrategy) {
     super(field, k, filter, searchStrategy);
-    this.target = target;
+    this.target = VectorUtil.checkFiniteFloat16(Objects.requireNonNull(target, "target"));
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/store/DataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/DataInput.java
@@ -80,6 +80,20 @@ public abstract class DataInput implements Cloneable {
   }
 
   /**
+   * Reads a specified number of shorts into an array at the specified offset.
+   *
+   * @param values the array to read shorts into
+   * @param offset the offset in the array to start storing shorts
+   * @param len the number of shorts to read
+   */
+  public void readShorts(short[] values, int offset, int len) throws IOException {
+    Objects.checkFromIndexSize(offset, len, values.length);
+    for (int i = 0; i < len; i++) {
+      values[offset + i] = readShort();
+    }
+  }
+
+  /**
    * Reads four bytes and returns an int (LE byte order).
    *
    * @see DataOutput#writeInt(int)

--- a/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MemorySegmentIndexInput.java
@@ -265,6 +265,18 @@ abstract class MemorySegmentIndexInput extends IndexInput implements MemorySegme
   }
 
   @Override
+  public void readShorts(short[] dst, int offset, int length) throws IOException {
+    try {
+      MemorySegment.copy(curSegment, LAYOUT_LE_SHORT, curPosition, dst, offset, length);
+      curPosition += Short.BYTES * (long) length;
+    } catch (IndexOutOfBoundsException _) {
+      super.readShorts(dst, offset, length);
+    } catch (NullPointerException | IllegalStateException e) {
+      throw alreadyClosed(e);
+    }
+  }
+
+  @Override
   public final int readInt() throws IOException {
     try {
       final int v = curSegment.get(LAYOUT_LE_INT, curPosition);

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -479,6 +479,27 @@ public final class VectorUtil {
     return v;
   }
 
+  /**
+   * Checks if a float16 vector, encoded as {@code short[]}, only has finite components. A float16
+   * value is non-finite (i.e. an infinity or NaN) when all five exponent bits are set, which is
+   * detected by {@code (v[i] & 0x7C00) == 0x7C00}. This bitmask check is used instead of {@code
+   * Float.isFinite(Float.float16ToFloat(v[i]))} because it avoids a per-element half-to-single
+   * precision conversion and is measurably faster.
+   *
+   * @param v shorts containing a float16 vector
+   * @return the vector for call-chaining
+   * @throws IllegalArgumentException if any component of the vector is not finite
+   */
+  public static short[] checkFiniteFloat16(short[] v) {
+    for (int i = 0; i < v.length; i++) {
+      if ((v[i] & 0x7C00) == 0x7C00) {
+        throw new IllegalArgumentException(
+            "non-finite float16 value at vector[" + i + "]=" + Float.float16ToFloat(v[i]));
+      }
+    }
+    return v;
+  }
+
   /** Returns true if all dimensions of provided vector are zero, false otherwise. */
   public static boolean isZeroVector(float[] v) {
     for (float value : v) {

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -76,6 +76,22 @@ public final class VectorUtil {
     return r;
   }
 
+  public static float dotProduct(short[] a, short[] b) {
+    if (a.length != b.length) {
+      throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);
+    }
+    float result = IMPL.dotProduct(a, b);
+    assert Float.isFinite(result)
+        : "not finite: "
+            + result
+            + " from <"
+            + java.util.Arrays.toString(a)
+            + ","
+            + java.util.Arrays.toString(b)
+            + ">";
+    return result;
+  }
+
   /**
    * Returns the cosine similarity between the two vectors.
    *
@@ -98,6 +114,14 @@ public final class VectorUtil {
     return IMPL.cosine(a, b);
   }
 
+  /** Returns the cosine similarity between the two vectors. */
+  public static float cosine(short[] a, short[] b) {
+    if (a.length != b.length) {
+      throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);
+    }
+    return IMPL.cosine(a, b);
+  }
+
   /**
    * Returns the sum of squared differences of the two vectors.
    *
@@ -110,6 +134,20 @@ public final class VectorUtil {
     float r = IMPL.squareDistance(a, b);
     assert Float.isFinite(r);
     return r;
+  }
+
+  /**
+   * Returns the sum of squared differences of the two vectors.
+   *
+   * @throws IllegalArgumentException if the vectors' dimensions differ.
+   */
+  public static float squareDistance(short[] a, short[] b) {
+    if (a.length != b.length) {
+      throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);
+    }
+    float result = IMPL.squareDistance(a, b);
+    assert Float.isFinite(result);
+    return result;
   }
 
   /** Returns the sum of squared differences of the two vectors. */

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswMerger.java
@@ -109,6 +109,8 @@ public class ConcurrentHnswMerger extends IncrementalHnswGraphMerger {
       case BYTE -> initializerIterator = initReader.getByteVectorValues(fieldInfo.name).iterator();
       case FLOAT32 ->
           initializerIterator = initReader.getFloatVectorValues(fieldInfo.name).iterator();
+      case FLOAT16 ->
+          initializerIterator = initReader.getFloat16VectorValues(fieldInfo.name).iterator();
     }
 
     IntIntHashMap newIdToOldOrdinal = new IntIntHashMap(initGraphSize);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswMerger.java
@@ -107,10 +107,10 @@ public class ConcurrentHnswMerger extends IncrementalHnswGraphMerger {
 
     switch (fieldInfo.getVectorEncoding()) {
       case BYTE -> initializerIterator = initReader.getByteVectorValues(fieldInfo.name).iterator();
-      case FLOAT32 ->
-          initializerIterator = initReader.getFloatVectorValues(fieldInfo.name).iterator();
       case FLOAT16 ->
           initializerIterator = initReader.getFloat16VectorValues(fieldInfo.name).iterator();
+      case FLOAT32 ->
+          initializerIterator = initReader.getFloatVectorValues(fieldInfo.name).iterator();
     }
 
     IntIntHashMap newIdToOldOrdinal = new IntIntHashMap(initGraphSize);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/IncrementalHnswGraphMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/IncrementalHnswGraphMerger.java
@@ -97,6 +97,7 @@ public class IncrementalHnswGraphMerger implements HnswGraphMerger {
         switch (fieldInfo.getVectorEncoding()) {
           case BYTE -> reader.getByteVectorValues(fieldInfo.name);
           case FLOAT32 -> reader.getFloatVectorValues(fieldInfo.name);
+          case FLOAT16 -> reader.getFloat16VectorValues(fieldInfo.name);
         };
 
     int candidateVectorCount = countLiveVectors(liveDocs, knnVectorValues);
@@ -174,6 +175,9 @@ public class IncrementalHnswGraphMerger implements HnswGraphMerger {
         case FLOAT32 ->
             vectorsIter =
                 graphReaders.get(i).reader.getFloatVectorValues(fieldInfo.name).iterator();
+        case FLOAT16 ->
+            vectorsIter =
+                graphReaders.get(i).reader.getFloat16VectorValues(fieldInfo.name).iterator();
       }
       newDocIdToOldOrdinals[i] = new IntIntHashMap(graphReaders.get(i).graphSize);
       MergeState.DocMap docMap = graphReaders.get(i).initDocMap();

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/IncrementalHnswGraphMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/IncrementalHnswGraphMerger.java
@@ -96,8 +96,8 @@ public class IncrementalHnswGraphMerger implements HnswGraphMerger {
     KnnVectorValues knnVectorValues =
         switch (fieldInfo.getVectorEncoding()) {
           case BYTE -> reader.getByteVectorValues(fieldInfo.name);
-          case FLOAT32 -> reader.getFloatVectorValues(fieldInfo.name);
           case FLOAT16 -> reader.getFloat16VectorValues(fieldInfo.name);
+          case FLOAT32 -> reader.getFloatVectorValues(fieldInfo.name);
         };
 
     int candidateVectorCount = countLiveVectors(liveDocs, knnVectorValues);
@@ -172,12 +172,12 @@ public class IncrementalHnswGraphMerger implements HnswGraphMerger {
       switch (fieldInfo.getVectorEncoding()) {
         case BYTE ->
             vectorsIter = graphReaders.get(i).reader.getByteVectorValues(fieldInfo.name).iterator();
-        case FLOAT32 ->
-            vectorsIter =
-                graphReaders.get(i).reader.getFloatVectorValues(fieldInfo.name).iterator();
         case FLOAT16 ->
             vectorsIter =
                 graphReaders.get(i).reader.getFloat16VectorValues(fieldInfo.name).iterator();
+        case FLOAT32 ->
+            vectorsIter =
+                graphReaders.get(i).reader.getFloatVectorValues(fieldInfo.name).iterator();
       }
       newDocIdToOldOrdinals[i] = new IntIntHashMap(graphReaders.get(i).graphSize);
       MergeState.DocMap docMap = graphReaders.get(i).initDocMap();

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/BaseQuantizedByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/BaseQuantizedByteVectorValues.java
@@ -40,16 +40,6 @@ public abstract class BaseQuantizedByteVectorValues extends ByteVectorValues
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Return a {@link VectorScorer} for the given fp16 query vector.
-   *
-   * @param query the query vector
-   * @return a {@link VectorScorer} instance or null
-   */
-  public VectorScorer scorer(short[] query) throws IOException {
-    throw new UnsupportedOperationException();
-  }
-
   @Override
   public IndexInput getSlice() {
     return null;

--- a/lucene/core/src/java/org/apache/lucene/util/quantization/BaseQuantizedByteVectorValues.java
+++ b/lucene/core/src/java/org/apache/lucene/util/quantization/BaseQuantizedByteVectorValues.java
@@ -40,6 +40,16 @@ public abstract class BaseQuantizedByteVectorValues extends ByteVectorValues
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Return a {@link VectorScorer} for the given fp16 query vector.
+   *
+   * @param query the query vector
+   * @return a {@link VectorScorer} instance or null
+   */
+  public VectorScorer scorer(short[] query) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
   @Override
   public IndexInput getSlice() {
     return null;

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFlatVectorsScorer.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFlatVectorsScorer.java
@@ -45,6 +45,7 @@ public class Lucene99MemorySegmentFlatVectorsScorer implements FlatVectorsScorer
     return switch (vectorValues.getEncoding()) {
       case FLOAT32 -> getFloatScoringSupplier((FloatVectorValues) vectorValues, similarityType);
       case BYTE -> getByteScorerSupplier((ByteVectorValues) vectorValues, similarityType);
+      case FLOAT16 -> delegate.getRandomVectorScorerSupplier(similarityType, vectorValues);
     };
   }
 
@@ -95,6 +96,13 @@ public class Lucene99MemorySegmentFlatVectorsScorer implements FlatVectorsScorer
         return scorer.get();
       }
     }
+    return delegate.getRandomVectorScorer(similarityType, vectorValues, target);
+  }
+
+  @Override
+  public RandomVectorScorer getRandomVectorScorer(
+      VectorSimilarityFunction similarityType, KnnVectorValues vectorValues, short[] target)
+      throws IOException {
     return delegate.getRandomVectorScorer(similarityType, vectorValues, target);
   }
 

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFlatVectorsScorer.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentFlatVectorsScorer.java
@@ -43,9 +43,9 @@ public class Lucene99MemorySegmentFlatVectorsScorer implements FlatVectorsScorer
   public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
       VectorSimilarityFunction similarityType, KnnVectorValues vectorValues) throws IOException {
     return switch (vectorValues.getEncoding()) {
-      case FLOAT32 -> getFloatScoringSupplier((FloatVectorValues) vectorValues, similarityType);
       case BYTE -> getByteScorerSupplier((ByteVectorValues) vectorValues, similarityType);
       case FLOAT16 -> delegate.getRandomVectorScorerSupplier(similarityType, vectorValues);
+      case FLOAT32 -> getFloatScoringSupplier((FloatVectorValues) vectorValues, similarityType);
     };
   }
 

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentScalarQuantizedVectorScorer.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/Lucene99MemorySegmentScalarQuantizedVectorScorer.java
@@ -80,6 +80,13 @@ class Lucene99MemorySegmentScalarQuantizedVectorScorer implements FlatVectorsSco
   }
 
   @Override
+  public RandomVectorScorer getRandomVectorScorer(
+      VectorSimilarityFunction similarityFunction, KnnVectorValues vectorValues, short[] target)
+      throws IOException {
+    return DELEGATE.getRandomVectorScorer(similarityFunction, vectorValues, target);
+  }
+
+  @Override
   public String toString() {
     return "Lucene99MemorySegmentScalarQuantizedVectorScorer()";
   }

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/NativeVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/NativeVectorUtilSupport.java
@@ -581,6 +581,21 @@ final class NativeVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public float dotProduct(short[] a, short[] b) {
+    return delegateVectorUtilSupport.dotProduct(a, b);
+  }
+
+  @Override
+  public float cosine(short[] v1, short[] v2) {
+    return delegateVectorUtilSupport.cosine(v1, v2);
+  }
+
+  @Override
+  public float squareDistance(short[] a, short[] b) {
+    return delegateVectorUtilSupport.squareDistance(a, b);
+  }
+
+  @Override
   public void expand8(int[] arr) {
     invokeOrDelegate(
         expand8$MH,

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -56,6 +56,9 @@ import org.apache.lucene.util.SuppressForbidden;
  */
 final class PanamaVectorUtilSupport implements VectorUtilSupport {
 
+  // Delegate for float16 (short[]) operations until JDK 27 provides Float16Vector support
+  private static final DefaultVectorUtilSupport FLOAT16_DELEGATE = new DefaultVectorUtilSupport();
+
   // preferred vector sizes, which can be altered for testing
   private static final VectorSpecies<Float> FLOAT_SPECIES;
   private static final VectorSpecies<Double> DOUBLE_SPECIES =
@@ -298,6 +301,23 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     FloatVector res1 = acc1.add(acc2);
     FloatVector res2 = acc3.add(acc4);
     return res1.add(res2).reduceLanes(ADD);
+  }
+
+  // float16 (short[]) operations delegate to scalar implementation until JDK 27
+
+  @Override
+  public float dotProduct(short[] a, short[] b) {
+    return FLOAT16_DELEGATE.dotProduct(a, b);
+  }
+
+  @Override
+  public float cosine(short[] a, short[] b) {
+    return FLOAT16_DELEGATE.cosine(a, b);
+  }
+
+  @Override
+  public float squareDistance(short[] a, short[] b) {
+    return FLOAT16_DELEGATE.squareDistance(a, b);
   }
 
   // Binary functions, these all follow a general pattern like this:

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestKnnVectorsFormatCustomWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestKnnVectorsFormatCustomWriter.java
@@ -130,6 +130,7 @@ public class TestKnnVectorsFormatCustomWriter extends BaseKnnVectorsFormatTestCa
       return switch (fi.getVectorEncoding()) {
         case FLOAT32 -> new FloatPaged(fi);
         case BYTE -> new BytePaged(fi);
+        case FLOAT16 -> new Float16Paged(fi);
       };
     }
 
@@ -259,6 +260,27 @@ public class TestKnnVectorsFormatCustomWriter extends BaseKnnVectorsFormatTestCa
       byte[] deserialize(ByteBuffer buf) {
         byte[] out = new byte[dim];
         buf.get(out);
+        return out;
+      }
+    }
+
+    private static final class Float16Paged extends PagedFieldVectorsWriter<short[]> {
+      private final int dim;
+
+      Float16Paged(FieldInfo fi) {
+        super(fi, fi.getVectorDimension() * Short.BYTES);
+        this.dim = fi.getVectorDimension();
+      }
+
+      @Override
+      void serialize(ByteBuffer buf, short[] vector) {
+        buf.asShortBuffer().put(vector);
+      }
+
+      @Override
+      short[] deserialize(ByteBuffer buf) {
+        short[] out = new short[dim];
+        buf.asShortBuffer().get(out);
         return out;
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestKnnVectorsFormatCustomWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene99/TestKnnVectorsFormatCustomWriter.java
@@ -128,9 +128,9 @@ public class TestKnnVectorsFormatCustomWriter extends BaseKnnVectorsFormatTestCa
 
     static PagedFieldVectorsWriter<?> create(FieldInfo fi) {
       return switch (fi.getVectorEncoding()) {
-        case FLOAT32 -> new FloatPaged(fi);
         case BYTE -> new BytePaged(fi);
         case FLOAT16 -> new Float16Paged(fi);
+        case FLOAT32 -> new FloatPaged(fi);
       };
     }
 

--- a/lucene/core/src/test/org/apache/lucene/document/TestField.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestField.java
@@ -32,6 +32,7 @@ import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnFloat16VectorQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
@@ -808,6 +809,54 @@ public class TestField extends LuceneTestCase {
             IllegalArgumentException.class,
             () -> nanField.setVectorValue(new float[] {1, 2, Float.NaN, 4, 5}));
     assertTrue(nanError.getMessage().contains("non-finite"));
+  }
+
+  public void testKnnFloat16FieldNonFinite() {
+    short one = Float.floatToFloat16(1f);
+    short two = Float.floatToFloat16(2f);
+    short[] finite = {one, two, Float.floatToFloat16(3f)};
+
+    // constructor rejects a non-finite (+Infinity) component
+    IllegalArgumentException ctorError =
+        expectThrows(
+            IllegalArgumentException.class,
+            () ->
+                new KnnFloat16VectorField(
+                    "knnF16",
+                    new short[] {one, (short) 0x7C00, two}, // 0x7C00 = +Infinity
+                    VectorSimilarityFunction.EUCLIDEAN));
+    assertTrue(ctorError.getMessage(), ctorError.getMessage().contains("non-finite"));
+
+    // constructing with a finite vector succeeds
+    KnnFloat16VectorField field =
+        new KnnFloat16VectorField("knnF16", finite, VectorSimilarityFunction.EUCLIDEAN);
+
+    // setVectorValue rejects NaN (0x7E00)
+    IllegalArgumentException nanError =
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> field.setVectorValue(new short[] {one, (short) 0x7E00, two}));
+    assertTrue(nanError.getMessage(), nanError.getMessage().contains("non-finite"));
+
+    // setVectorValue with a finite vector succeeds
+    field.setVectorValue(new short[] {two, one, Float.floatToFloat16(4f)});
+  }
+
+  public void testKnnFloat16QueryNonFinite() {
+    short one = Float.floatToFloat16(1f);
+
+    // null target
+    expectThrows(NullPointerException.class, () -> new KnnFloat16VectorQuery("f", null, 1));
+
+    // -Infinity (0xFC00) target
+    IllegalArgumentException infError =
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new KnnFloat16VectorQuery("f", new short[] {one, (short) 0xFC00}, 1));
+    assertTrue(infError.getMessage(), infError.getMessage().contains("non-finite"));
+
+    // finite target constructs fine
+    new KnnFloat16VectorQuery("f", new short[] {one, Float.floatToFloat16(2f)}, 1);
   }
 
   private void trySetByteValue(Field f) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
@@ -113,6 +113,11 @@ public class TestSegmentToThreadMapping extends LuceneTestCase {
       }
 
       @Override
+      public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+        return null;
+      }
+
+      @Override
       public ByteVectorValues getByteVectorValues(String field) {
         return null;
       }
@@ -120,6 +125,11 @@ public class TestSegmentToThreadMapping extends LuceneTestCase {
       @Override
       public void searchNearestVectors(
           String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) {}
+
+      @Override
+      public void searchNearestVectors(
+          String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+          throws IOException {}
 
       @Override
       public void searchNearestVectors(

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -912,6 +912,9 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
           case FLOAT32:
             vectorValues = leafReader.getFloatVectorValues("field");
             break;
+          case FLOAT16:
+            vectorValues = leafReader.getFloat16VectorValues("field");
+            break;
           default:
             throw new AssertionError();
         }

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -909,11 +909,11 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
           case BYTE:
             vectorValues = leafReader.getByteVectorValues("field");
             break;
-          case FLOAT32:
-            vectorValues = leafReader.getFloatVectorValues("field");
-            break;
           case FLOAT16:
             vectorValues = leafReader.getFloat16VectorValues("field");
+            break;
+          case FLOAT32:
+            vectorValues = leafReader.getFloatVectorValues("field");
             break;
           default:
             throw new AssertionError();

--- a/lucene/core/src/test/org/apache/lucene/search/TestVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestVectorScorer.java
@@ -23,9 +23,11 @@ import java.io.IOException;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.document.KnnFloat16VectorField;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.VectorEncoding;
@@ -50,6 +52,10 @@ public class TestVectorScorer extends LuceneTestCase {
           break;
         case FLOAT32:
           vectorScorer = context.reader().getFloatVectorValues("field").scorer(new float[] {1, 2});
+          break;
+        case FLOAT16:
+          Float16VectorValues val = context.reader().getFloat16VectorValues("field");
+          vectorScorer = val.scorer(new short[] {1, 2});
           break;
         default:
           throw new IllegalArgumentException("unexpected vector encoding: " + encoding);
@@ -77,6 +83,12 @@ public class TestVectorScorer extends LuceneTestCase {
           v[j] = (byte) contents[i][j];
         }
         doc.add(new KnnByteVectorField(field, v, EUCLIDEAN));
+      } else if (encoding == VectorEncoding.FLOAT16) {
+        short[] v = new short[contents[i].length];
+        for (int j = 0; j < v.length; j++) {
+          v[j] = Float.floatToFloat16(contents[i][j]);
+        }
+        doc.add(new KnnFloat16VectorField(field, v, EUCLIDEAN));
       } else {
         doc.add(new KnnFloatVectorField(field, contents[i]));
       }

--- a/lucene/core/src/test/org/apache/lucene/search/TestVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestVectorScorer.java
@@ -50,12 +50,12 @@ public class TestVectorScorer extends LuceneTestCase {
         case BYTE:
           vectorScorer = context.reader().getByteVectorValues("field").scorer(new byte[] {1, 2});
           break;
-        case FLOAT32:
-          vectorScorer = context.reader().getFloatVectorValues("field").scorer(new float[] {1, 2});
-          break;
         case FLOAT16:
           Float16VectorValues val = context.reader().getFloat16VectorValues("field");
           vectorScorer = val.scorer(new short[] {1, 2});
+          break;
+        case FLOAT32:
+          vectorScorer = context.reader().getFloatVectorValues("field").scorer(new float[] {1, 2});
           break;
         default:
           throw new IllegalArgumentException("unexpected vector encoding: " + encoding);
@@ -90,7 +90,7 @@ public class TestVectorScorer extends LuceneTestCase {
         }
         doc.add(new KnnFloat16VectorField(field, v, EUCLIDEAN));
       } else {
-        doc.add(new KnnFloatVectorField(field, contents[i]));
+        doc.add(new KnnFloatVectorField(field, contents[i], EUCLIDEAN));
       }
       doc.add(new StringField("id", "id" + i, Field.Store.YES));
       writer.addDocument(doc);

--- a/lucene/core/src/test/org/apache/lucene/search/TestVectorScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestVectorScorer.java
@@ -52,7 +52,8 @@ public class TestVectorScorer extends LuceneTestCase {
           break;
         case FLOAT16:
           Float16VectorValues val = context.reader().getFloat16VectorValues("field");
-          vectorScorer = val.scorer(new short[] {1, 2});
+          vectorScorer =
+              val.scorer(new short[] {Float.floatToFloat16(1f), Float.floatToFloat16(2f)});
           break;
         case FLOAT32:
           vectorScorer = context.reader().getFloatVectorValues("field").scorer(new float[] {1, 2});

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -122,6 +122,37 @@ public class TestVectorUtil extends LuceneTestCase {
     expectThrows(IllegalArgumentException.class, () -> VectorUtil.l2normalize(v));
   }
 
+  public void testCheckFiniteFloat16() {
+    // finite vector passes and returns the same array
+    short[] finite = {
+      Float.floatToFloat16(-1.5f),
+      Float.floatToFloat16(0f),
+      Float.floatToFloat16(3.25f),
+      (short) 0x7BFF, // largest finite float16 (65504)
+      (short) 0xFBFF // most negative finite float16 (-65504)
+    };
+    assertSame(finite, VectorUtil.checkFiniteFloat16(finite));
+
+    // +Infinity
+    IllegalArgumentException e =
+        expectThrows(
+            IllegalArgumentException.class,
+            () ->
+                VectorUtil.checkFiniteFloat16(
+                    new short[] {Float.floatToFloat16(1f), (short) 0x7C00}));
+    assertTrue(e.getMessage(), e.getMessage().contains("non-finite float16 value at vector[1]"));
+
+    // -Infinity
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> VectorUtil.checkFiniteFloat16(new short[] {(short) 0xFC00}));
+
+    // NaN (any non-zero mantissa with all exponent bits set)
+    expectThrows(
+        IllegalArgumentException.class,
+        () -> VectorUtil.checkFiniteFloat16(new short[] {(short) 0x7E00}));
+  }
+
   public void testNormalizeToUnitInterval() {
     for (int i = 0; i < 100; i++) {
       // Generates a float in the range [-1.0, 1.0)

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -49,6 +49,7 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
@@ -125,6 +126,8 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
           flatVectorScorer.getRandomVectorScorer(similarityFunction, vectorsCopy, (byte[]) query);
       case FLOAT32 ->
           flatVectorScorer.getRandomVectorScorer(similarityFunction, vectorsCopy, (float[]) query);
+      case FLOAT16 ->
+          flatVectorScorer.getRandomVectorScorer(similarityFunction, vectorsCopy, (short[]) query);
     };
   }
 
@@ -180,6 +183,13 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
                     knnVectorField(
                         "field",
                         (T) ((FloatVectorValues) vectors).vectorValue(ord),
+                        similarityFunction));
+              }
+              case FLOAT16 -> {
+                doc.add(
+                    knnVectorField(
+                        "field",
+                        (T) ((Float16VectorValues) vectors).vectorValue(ord),
                         similarityFunction));
               }
             }
@@ -247,6 +257,13 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
                       (T) ((FloatVectorValues) vectors).vectorValue(i),
                       similarityFunction));
             }
+            case FLOAT16 -> {
+              doc.add(
+                  knnVectorField(
+                      vectorFieldName,
+                      (T) ((Float16VectorValues) vectors).vectorValue(i),
+                      similarityFunction));
+            }
           }
           doc.add(new StringField("id", Integer.toString(i), Field.Store.NO));
           w.addDocument(doc);
@@ -285,6 +302,9 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
       }
       case FLOAT32 -> {
         return (T) ((FloatVectorValues) vectors).vectorValue(ord);
+      }
+      case FLOAT16 -> {
+        return (T) ((Float16VectorValues) vectors).vectorValue(ord);
       }
     }
     throw new AssertionError("unknown encoding " + vectors.getEncoding());
@@ -812,6 +832,9 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
             case FLOAT32 ->
                 similarityFunction.compare(
                     ((FloatVectorValues) vectorValues).vectorValue(i), (float[]) target);
+            case FLOAT16 ->
+                similarityFunction.compare(
+                    ((Float16VectorValues) vectorValues).vectorValue(i), (short[]) target);
           };
       minScore = Math.min(minScore, score);
     }
@@ -1034,6 +1057,9 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
           if (getVectorEncoding() == VectorEncoding.BYTE) {
             expected.add(
                 j, similarityFunction.compare((byte[]) query, (byte[]) vectorValue(vectors, j)));
+          } else if (getVectorEncoding() == VectorEncoding.FLOAT16) {
+            expected.add(
+                j, similarityFunction.compare((short[]) query, (short[]) vectorValue(vectors, j)));
           } else {
             expected.add(
                 j, similarityFunction.compare((float[]) query, (float[]) vectorValue(vectors, j)));
@@ -1255,6 +1281,71 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
   }
 
   /** Returns vectors evenly distributed around the upper unit semicircle. */
+  static class CircularFloat16VectorValues extends Float16VectorValues {
+    private final int size;
+    private final short[] value;
+
+    int doc = -1;
+
+    CircularFloat16VectorValues(int size) {
+      this.size = size;
+      value = new short[2];
+    }
+
+    @Override
+    public CircularFloat16VectorValues copy() {
+      return new CircularFloat16VectorValues(size);
+    }
+
+    @Override
+    public int dimension() {
+      return 2;
+    }
+
+    @Override
+    public int size() {
+      return size;
+    }
+
+    public short[] vectorValue() {
+      return vectorValue(doc);
+    }
+
+    public int docID() {
+      return doc;
+    }
+
+    public int nextDoc() {
+      return advance(doc + 1);
+    }
+
+    public int advance(int target) {
+      if (target >= 0 && target < size) {
+        doc = target;
+      } else {
+        doc = NO_MORE_DOCS;
+      }
+      return doc;
+    }
+
+    @Override
+    public short[] vectorValue(int ord) {
+      return unitVector2d(ord / (double) size, value);
+    }
+
+    private static short[] unitVector2d(double piRadians, short[] value) {
+      value[0] = Float.floatToFloat16((float) Math.cos(Math.PI * piRadians));
+      value[1] = Float.floatToFloat16((float) Math.sin(Math.PI * piRadians));
+      return value;
+    }
+
+    @Override
+    public VectorScorer scorer(short[] target) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  /** Returns vectors evenly distributed around the upper unit semicircle. */
   static class CircularByteVectorValues extends ByteVectorValues {
     private final int size;
     private final float[] value;
@@ -1357,6 +1448,11 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
                 (float[]) vectorValue(u, ord),
                 (float[]) vectorValue(v, ord),
                 1e-4f);
+        case FLOAT16 ->
+            assertArrayEquals(
+                "vectors do not match for doc=" + uDoc,
+                (short[]) vectorValue(u, ord),
+                (short[]) vectorValue(v, ord));
         default ->
             throw new IllegalArgumentException("unknown vector encoding: " + getVectorEncoding());
       }
@@ -1367,6 +1463,14 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     float[][] vectors = new float[size][];
     for (int offset = 0; offset < size; offset++) {
       vectors[offset] = randomVector(random, dimension);
+    }
+    return vectors;
+  }
+
+  static short[][] createRandomFloat16Vectors(int size, int dimension, Random random) {
+    short[][] vectors = new short[size][];
+    for (int offset = 0; offset < size; offset++) {
+      vectors[offset] = randomFloat16Vector(random, dimension);
     }
     return vectors;
   }
@@ -1408,6 +1512,15 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     }
     VectorUtil.l2normalize(vec);
     return vec;
+  }
+
+  static short[] randomFloat16Vector(Random random, int dim) {
+    float[] vec = randomVector(random, dim);
+    short[] v = new short[vec.length];
+    for (int i = 0; i < dim; i++) {
+      v[i] = Float.floatToFloat16(vec[i]);
+    }
+    return v;
   }
 
   static byte[] randomVector8(Random random, int dim) {

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/HnswGraphTestCase.java
@@ -124,10 +124,10 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
     return switch (getVectorEncoding()) {
       case BYTE ->
           flatVectorScorer.getRandomVectorScorer(similarityFunction, vectorsCopy, (byte[]) query);
-      case FLOAT32 ->
-          flatVectorScorer.getRandomVectorScorer(similarityFunction, vectorsCopy, (float[]) query);
       case FLOAT16 ->
           flatVectorScorer.getRandomVectorScorer(similarityFunction, vectorsCopy, (short[]) query);
+      case FLOAT32 ->
+          flatVectorScorer.getRandomVectorScorer(similarityFunction, vectorsCopy, (float[]) query);
     };
   }
 
@@ -178,18 +178,18 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
                         (T) ((ByteVectorValues) vectors).vectorValue(ord),
                         similarityFunction));
               }
-              case FLOAT32 -> {
-                doc.add(
-                    knnVectorField(
-                        "field",
-                        (T) ((FloatVectorValues) vectors).vectorValue(ord),
-                        similarityFunction));
-              }
               case FLOAT16 -> {
                 doc.add(
                     knnVectorField(
                         "field",
                         (T) ((Float16VectorValues) vectors).vectorValue(ord),
+                        similarityFunction));
+              }
+              case FLOAT32 -> {
+                doc.add(
+                    knnVectorField(
+                        "field",
+                        (T) ((FloatVectorValues) vectors).vectorValue(ord),
                         similarityFunction));
               }
             }
@@ -250,18 +250,18 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
                       (T) ((ByteVectorValues) vectors).vectorValue(i),
                       similarityFunction));
             }
-            case FLOAT32 -> {
-              doc.add(
-                  knnVectorField(
-                      vectorFieldName,
-                      (T) ((FloatVectorValues) vectors).vectorValue(i),
-                      similarityFunction));
-            }
             case FLOAT16 -> {
               doc.add(
                   knnVectorField(
                       vectorFieldName,
                       (T) ((Float16VectorValues) vectors).vectorValue(i),
+                      similarityFunction));
+            }
+            case FLOAT32 -> {
+              doc.add(
+                  knnVectorField(
+                      vectorFieldName,
+                      (T) ((FloatVectorValues) vectors).vectorValue(i),
                       similarityFunction));
             }
           }
@@ -300,11 +300,11 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
       case BYTE -> {
         return (T) ((ByteVectorValues) vectors).vectorValue(ord);
       }
-      case FLOAT32 -> {
-        return (T) ((FloatVectorValues) vectors).vectorValue(ord);
-      }
       case FLOAT16 -> {
         return (T) ((Float16VectorValues) vectors).vectorValue(ord);
+      }
+      case FLOAT32 -> {
+        return (T) ((FloatVectorValues) vectors).vectorValue(ord);
       }
     }
     throw new AssertionError("unknown encoding " + vectors.getEncoding());
@@ -829,12 +829,12 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
             case BYTE ->
                 similarityFunction.compare(
                     ((ByteVectorValues) vectorValues).vectorValue(i), (byte[]) target);
-            case FLOAT32 ->
-                similarityFunction.compare(
-                    ((FloatVectorValues) vectorValues).vectorValue(i), (float[]) target);
             case FLOAT16 ->
                 similarityFunction.compare(
                     ((Float16VectorValues) vectorValues).vectorValue(i), (short[]) target);
+            case FLOAT32 ->
+                similarityFunction.compare(
+                    ((FloatVectorValues) vectorValues).vectorValue(i), (float[]) target);
           };
       minScore = Math.min(minScore, score);
     }
@@ -1442,17 +1442,17 @@ abstract class HnswGraphTestCase<T> extends LuceneTestCase {
                 "vectors do not match for doc=" + uDoc,
                 (byte[]) vectorValue(u, ord),
                 (byte[]) vectorValue(v, ord));
+        case FLOAT16 ->
+            assertArrayEquals(
+                "vectors do not match for doc=" + uDoc,
+                (short[]) vectorValue(u, ord),
+                (short[]) vectorValue(v, ord));
         case FLOAT32 ->
             assertArrayEquals(
                 "vectors do not match for doc=" + uDoc,
                 (float[]) vectorValue(u, ord),
                 (float[]) vectorValue(v, ord),
                 1e-4f);
-        case FLOAT16 ->
-            assertArrayEquals(
-                "vectors do not match for doc=" + uDoc,
-                (short[]) vectorValue(u, ord),
-                (short[]) vectorValue(v, ord));
         default ->
             throw new IllegalArgumentException("unknown vector encoding: " + getVectorEncoding());
       }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/MockFloat16VectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/MockFloat16VectorValues.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+import org.apache.lucene.index.Float16VectorValues;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.ArrayUtil;
+
+class MockFloat16VectorValues extends Float16VectorValues {
+  private final int dimension;
+  private final short[][] denseValues;
+  protected final short[][] values;
+  private final int numVectors;
+  private final short[] scratch;
+
+  static MockFloat16VectorValues fromValues(short[][] values) {
+    short[] firstNonNull = null;
+    int j = 0;
+    while (firstNonNull == null && j < values.length) {
+      firstNonNull = values[j++];
+    }
+    int dimension = firstNonNull.length;
+    int maxDoc = values.length;
+    short[][] denseValues = new short[maxDoc][];
+    int count = 0;
+    for (int i = 0; i < maxDoc; i++) {
+      if (values[i] != null) {
+        denseValues[count++] = values[i];
+      }
+    }
+    return new MockFloat16VectorValues(values, dimension, denseValues, count);
+  }
+
+  MockFloat16VectorValues(short[][] values, int dimension, short[][] denseValues, int numVectors) {
+    this.dimension = dimension;
+    this.values = values;
+    this.denseValues = denseValues;
+    this.numVectors = numVectors;
+    this.scratch = new short[dimension];
+  }
+
+  @Override
+  public int size() {
+    return values.length;
+  }
+
+  @Override
+  public int dimension() {
+    return dimension;
+  }
+
+  @Override
+  public MockFloat16VectorValues copy() {
+    return new MockFloat16VectorValues(
+        ArrayUtil.copyArray(values), dimension, ArrayUtil.copyArray(denseValues), numVectors);
+  }
+
+  @Override
+  public short[] vectorValue(int ord) {
+    if (LuceneTestCase.random().nextBoolean()) {
+      return values[ord];
+    } else {
+      // Sometimes use the same scratch array repeatedly, mimicing what the codec will do.
+      // This should help us catch cases of aliasing where the same vector values source is used
+      // twice in a single computation.
+      System.arraycopy(values[ord], 0, scratch, 0, dimension);
+      return scratch;
+    }
+  }
+
+  @Override
+  public DocIndexIterator iterator() {
+    return createDenseIterator();
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/MockFloat16VectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/MockFloat16VectorValues.java
@@ -75,7 +75,7 @@ class MockFloat16VectorValues extends Float16VectorValues {
     if (LuceneTestCase.random().nextBoolean()) {
       return values[ord];
     } else {
-      // Sometimes use the same scratch array repeatedly, mimicing what the codec will do.
+      // Sometimes use the same scratch array repeatedly, mimicking what the codec will do.
       // This should help us catch cases of aliasing where the same vector values source is used
       // twice in a single computation.
       System.arraycopy(values[ord], 0, scratch, 0, dimension);

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloat16VectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloat16VectorGraph.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import java.io.IOException;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KnnFloat16VectorField;
+import org.apache.lucene.index.Float16VectorValues;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.KnnFloat16VectorQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.FixedBitSet;
+import org.junit.Before;
+
+/** Tests HNSW KNN graphs */
+public class TestHnswFloat16VectorGraph extends HnswGraphTestCase<short[]> {
+
+  @Before
+  public void setup() {
+    similarityFunction = RandomizedTest.randomFrom(VectorSimilarityFunction.values());
+  }
+
+  @Override
+  VectorEncoding getVectorEncoding() {
+    return VectorEncoding.FLOAT16;
+  }
+
+  @Override
+  Query knnQuery(String field, short[] vector, int k) {
+    return new KnnFloat16VectorQuery(field, vector, k);
+  }
+
+  @Override
+  short[] randomVector(int dim) {
+    return randomFloat16Vector(random(), dim);
+  }
+
+  @Override
+  MockFloat16VectorValues vectorValues(int size, int dimension) {
+    return MockFloat16VectorValues.fromValues(
+        createRandomFloat16Vectors(size, dimension, random()));
+  }
+
+  @Override
+  MockFloat16VectorValues vectorValues(float[][] values) {
+    short[][] float16Values = new short[values.length][];
+    for (int i = 0; i < values.length; i++) {
+
+      float16Values[i] = new short[values[i].length];
+      for (int j = 0; j < values[i].length; j++) {
+        float16Values[i][j] = Float.floatToFloat16(values[i][j]);
+      }
+    }
+    return MockFloat16VectorValues.fromValues(float16Values);
+  }
+
+  @Override
+  MockFloat16VectorValues vectorValues(LeafReader reader, String fieldName) throws IOException {
+    Float16VectorValues vectorValues = reader.getFloat16VectorValues(fieldName);
+    short[][] vectors = new short[reader.maxDoc()][];
+    for (int i = 0; i < vectorValues.size(); i++) {
+      vectors[vectorValues.ordToDoc(i)] =
+          ArrayUtil.copyOfSubArray(vectorValues.vectorValue(i), 0, vectorValues.dimension());
+    }
+    return MockFloat16VectorValues.fromValues(vectors);
+  }
+
+  @Override
+  MockFloat16VectorValues vectorValues(
+      int size, int dimension, KnnVectorValues pregeneratedVectorValues, int pregeneratedOffset) {
+    MockFloat16VectorValues pvv = (MockFloat16VectorValues) pregeneratedVectorValues;
+    short[][] vectors = new short[size][];
+    short[][] randomVectors =
+        createRandomFloat16Vectors(size - pvv.values.length, dimension, random());
+
+    for (int i = 0; i < pregeneratedOffset; i++) {
+      vectors[i] = randomVectors[i];
+    }
+
+    for (int currentOrd = 0; currentOrd < pvv.size(); currentOrd++) {
+      vectors[pregeneratedOffset + currentOrd] = pvv.values[currentOrd];
+    }
+
+    for (int i = pregeneratedOffset + pvv.values.length; i < vectors.length; i++) {
+      vectors[i] = randomVectors[i - pvv.values.length];
+    }
+
+    return MockFloat16VectorValues.fromValues(vectors);
+  }
+
+  @Override
+  Field knnVectorField(String name, short[] vector, VectorSimilarityFunction similarityFunction) {
+    return new KnnFloat16VectorField(name, vector, similarityFunction);
+  }
+
+  @Override
+  CircularFloat16VectorValues circularVectorValues(int nDoc) {
+    return new CircularFloat16VectorValues(nDoc);
+  }
+
+  @Override
+  short[] getTargetVector() {
+    return new short[] {Float.floatToFloat16(1f), Float.floatToFloat16(0f)};
+  }
+
+  public void testSearchWithSkewedAcceptOrds() throws IOException {
+    int nDoc = 1000;
+    similarityFunction = VectorSimilarityFunction.EUCLIDEAN;
+    Float16VectorValues vectors = circularVectorValues(nDoc);
+    RandomVectorScorerSupplier scorerSupplier = buildScorerSupplier(vectors);
+    HnswGraphBuilder builder = HnswGraphBuilder.create(scorerSupplier, 16, 100, random().nextInt());
+    OnHeapHnswGraph hnsw = builder.build(vectors.size());
+
+    // Skip over half of the documents that are closest to the query vector
+    FixedBitSet acceptOrds = new FixedBitSet(nDoc);
+    for (int i = 500; i < nDoc; i++) {
+      acceptOrds.set(i);
+    }
+    KnnCollector nn =
+        HnswGraphSearcher.search(
+            buildScorer(vectors, getTargetVector()), 10, hnsw, acceptOrds, Integer.MAX_VALUE);
+
+    TopDocs nodes = nn.topDocs();
+    assertEquals("Number of found results is not equal to [10].", 10, nodes.scoreDocs.length);
+    int sum = 0;
+    for (ScoreDoc node : nodes.scoreDocs) {
+      assertTrue("the results include a deleted document: " + node, acceptOrds.get(node.doc));
+      sum += node.doc;
+    }
+    // We still expect to get reasonable recall. The lowest non-skipped docIds
+    // are closest to the query vector: sum(500,509) = 5045
+    assertTrue("sum(result docs)=" + sum, sum < 5100);
+  }
+}

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
@@ -27,6 +27,7 @@ import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.LeafMetaData;
@@ -176,6 +177,11 @@ public class TermVectorLeafReader extends LeafReader {
   }
 
   @Override
+  public Float16VectorValues getFloat16VectorValues(String field) {
+    return null;
+  }
+
+  @Override
   public ByteVectorValues getByteVectorValues(String fieldName) {
     return null;
   }
@@ -183,6 +189,11 @@ public class TermVectorLeafReader extends LeafReader {
   @Override
   public void searchNearestVectors(
       String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) {}
+
+  @Override
+  public void searchNearestVectors(
+      String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {}
 
   @Override
   public void searchNearestVectors(

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -37,6 +37,7 @@ import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.document.KnnFloat16VectorField;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.BaseTermsEnum;
 import org.apache.lucene.index.BinaryDocValues;
@@ -48,6 +49,7 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.FieldInvertState;
 import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.ImpactsEnum;
 import org.apache.lucene.index.IndexOptions;
@@ -835,6 +837,29 @@ public class MemoryIndex {
                 + vectorField.name()
                 + "] is not a float vector field, but the field info is configured for float vectors");
       }
+
+      case FLOAT16 -> {
+        if (vectorField instanceof KnnFloat16VectorField float16VectorField) {
+          if (info.float16VectorCount == 1) {
+            throw new IllegalArgumentException(
+                "Only one value per field allowed for float16 vector field ["
+                    + vectorField.name()
+                    + "]");
+          }
+          info.float16VectorCount++;
+          if (info.float16VectorValues == null) {
+            info.float16VectorValues = new short[1][];
+          }
+          info.float16VectorValues[0] =
+              ArrayUtil.copyOfSubArray(
+                  float16VectorField.vectorValue(), 0, info.fieldInfo.getVectorDimension());
+          return;
+        }
+        throw new IllegalArgumentException(
+            "Field ["
+                + vectorField.name()
+                + "] is not a float16 vector field, but the field info is configured for float16 vectors");
+      }
     }
   }
 
@@ -1243,8 +1268,12 @@ public class MemoryIndex {
     /** the float vectors added for this field */
     private float[][] floatVectorValues;
 
+    private short[][] float16VectorValues;
+
     /** Number of byte vectors added for this field */
     private int byteVectorCount;
+
+    private int float16VectorCount;
 
     /** the byte vectors added for this field */
     private byte[][] byteVectorValues;
@@ -1748,6 +1777,15 @@ public class MemoryIndex {
     }
 
     @Override
+    public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+      Info info = fields.get(field);
+      if (info == null || info.float16VectorValues == null) {
+        return null;
+      }
+      return new MemoryFloat16VectorValues(info);
+    }
+
+    @Override
     public ByteVectorValues getByteVectorValues(String fieldName) {
       Info info = fields.get(fieldName);
       if (info == null || info.byteVectorValues == null) {
@@ -1759,6 +1797,11 @@ public class MemoryIndex {
     @Override
     public void searchNearestVectors(
         String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) {}
+
+    @Override
+    public void searchNearestVectors(
+        String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+        throws IOException {}
 
     @Override
     public void searchNearestVectors(
@@ -2372,6 +2415,70 @@ public class MemoryIndex {
 
     @Override
     public MemoryFloatVectorValues copy() {
+      return this;
+    }
+  }
+
+  private static final class MemoryFloat16VectorValues extends Float16VectorValues {
+    private final Info info;
+
+    MemoryFloat16VectorValues(Info info) {
+      this.info = info;
+    }
+
+    @Override
+    public int dimension() {
+      return info.fieldInfo.getVectorDimension();
+    }
+
+    @Override
+    public int size() {
+      return info.float16VectorCount;
+    }
+
+    @Override
+    public short[] vectorValue(int ord) {
+      if (ord == 0) {
+        return info.float16VectorValues[0];
+      } else {
+        return null;
+      }
+    }
+
+    @Override
+    public DocIndexIterator iterator() {
+      return createDenseIterator();
+    }
+
+    @Override
+    public VectorScorer scorer(short[] query) {
+      if (query.length != info.fieldInfo.getVectorDimension()) {
+        throw new IllegalArgumentException(
+            "query vector dimension "
+                + query.length
+                + " does not match field dimension "
+                + info.fieldInfo.getVectorDimension());
+      }
+      MemoryFloat16VectorValues vectorValues = new MemoryFloat16VectorValues(info);
+      DocIndexIterator iterator = vectorValues.iterator();
+      return new VectorScorer() {
+        @Override
+        public float score() throws IOException {
+          assert iterator.docID() == 0;
+          return info.fieldInfo
+              .getVectorSimilarityFunction()
+              .compare(vectorValues.vectorValue(0), query);
+        }
+
+        @Override
+        public DocIdSetIterator iterator() {
+          return iterator;
+        }
+      };
+    }
+
+    @Override
+    public MemoryFloat16VectorValues copy() {
       return this;
     }
   }

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -815,28 +815,6 @@ public class MemoryIndex {
                 + vectorField.name()
                 + "] is not a byte vector field, but the field info is configured for byte vectors");
       }
-      case FLOAT32 -> {
-        if (vectorField instanceof KnnFloatVectorField floatVectorField) {
-          if (info.floatVectorCount == 1) {
-            throw new IllegalArgumentException(
-                "Only one value per field allowed for float vector field ["
-                    + vectorField.name()
-                    + "]");
-          }
-          info.floatVectorCount++;
-          if (info.floatVectorValues == null) {
-            info.floatVectorValues = new float[1][];
-          }
-          info.floatVectorValues[0] =
-              ArrayUtil.copyOfSubArray(
-                  floatVectorField.vectorValue(), 0, info.fieldInfo.getVectorDimension());
-          return;
-        }
-        throw new IllegalArgumentException(
-            "Field ["
-                + vectorField.name()
-                + "] is not a float vector field, but the field info is configured for float vectors");
-      }
 
       case FLOAT16 -> {
         if (vectorField instanceof KnnFloat16VectorField float16VectorField) {
@@ -859,6 +837,29 @@ public class MemoryIndex {
             "Field ["
                 + vectorField.name()
                 + "] is not a float16 vector field, but the field info is configured for float16 vectors");
+      }
+
+      case FLOAT32 -> {
+        if (vectorField instanceof KnnFloatVectorField floatVectorField) {
+          if (info.floatVectorCount == 1) {
+            throw new IllegalArgumentException(
+                "Only one value per field allowed for float vector field ["
+                    + vectorField.name()
+                    + "]");
+          }
+          info.floatVectorCount++;
+          if (info.floatVectorValues == null) {
+            info.floatVectorValues = new float[1][];
+          }
+          info.floatVectorValues[0] =
+              ArrayUtil.copyOfSubArray(
+                  floatVectorField.vectorValue(), 0, info.fieldInfo.getVectorDimension());
+          return;
+        }
+        throw new IllegalArgumentException(
+            "Field ["
+                + vectorField.name()
+                + "] is not a float vector field, but the field info is configured for float vectors");
       }
     }
   }
@@ -1268,11 +1269,13 @@ public class MemoryIndex {
     /** the float vectors added for this field */
     private float[][] floatVectorValues;
 
+    /** the float16 vectors added for this field */
     private short[][] float16VectorValues;
 
     /** Number of byte vectors added for this field */
     private int byteVectorCount;
 
+    /** Number of float16 vectors added for this field */
     private int float16VectorCount;
 
     /** the byte vectors added for this field */

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionValues.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionValues.java
@@ -74,6 +74,10 @@ public abstract class FunctionValues {
     throw new UnsupportedOperationException();
   }
 
+  public short[] float16VectorVal(int doc) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
   public byte[] byteVectorVal(int doc) throws IOException {
     throw new UnsupportedOperationException();
   }

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/ConstKnnFloat16ValueSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/ConstKnnFloat16ValueSource.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.queries.function.valuesource;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.queries.function.FunctionValues;
+import org.apache.lucene.queries.function.ValueSource;
+
+/** Function that returns a constant float16 vector value for every document. */
+public class ConstKnnFloat16ValueSource extends ValueSource {
+  private final short[] vector;
+
+  public ConstKnnFloat16ValueSource(short[] constVector) {
+    this.vector = Objects.requireNonNull(constVector, "constVector");
+  }
+
+  @Override
+  public FunctionValues getValues(Map<Object, Object> context, LeafReaderContext readerContext)
+      throws IOException {
+    return new FunctionValues() {
+      @Override
+      public short[] float16VectorVal(int doc) {
+        return vector;
+      }
+
+      @Override
+      public String strVal(int doc) {
+        return Arrays.toString(vector);
+      }
+
+      @Override
+      public String toString(int doc) throws IOException {
+        return description() + '=' + strVal(doc);
+      }
+    };
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ConstKnnFloat16ValueSource other = (ConstKnnFloat16ValueSource) o;
+    return Arrays.equals(vector, other.vector);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass().hashCode(), Arrays.hashCode(vector));
+  }
+
+  @Override
+  public String description() {
+    return "ConstKnnFloat16ValueSource(" + Arrays.toString(vector) + ')';
+  }
+}

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/Float16KnnVectorFieldSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/Float16KnnVectorFieldSource.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.queries.function.valuesource;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.lucene.index.Float16VectorValues;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.queries.function.FunctionValues;
+import org.apache.lucene.queries.function.ValueSource;
+import org.apache.lucene.search.DocIdSetIterator;
+
+/**
+ * An implementation for retrieving {@link FunctionValues} instances for float16 knn vectors fields.
+ */
+public class Float16KnnVectorFieldSource extends ValueSource {
+  private final String fieldName;
+
+  public Float16KnnVectorFieldSource(String fieldName) {
+    this.fieldName = fieldName;
+  }
+
+  @Override
+  public FunctionValues getValues(Map<Object, Object> context, LeafReaderContext readerContext)
+      throws IOException {
+
+    final LeafReader reader = readerContext.reader();
+    final Float16VectorValues vectorValues = reader.getFloat16VectorValues(fieldName);
+
+    if (vectorValues == null) {
+      VectorFieldFunction.checkField(reader, fieldName, VectorEncoding.FLOAT16);
+      return new VectorFieldFunction(this) {
+        private final DocIdSetIterator empty = DocIdSetIterator.empty();
+
+        @Override
+        public short[] float16VectorVal(int doc) throws IOException {
+          return null;
+        }
+
+        @Override
+        protected DocIdSetIterator getVectorIterator() {
+          return empty;
+        }
+      };
+    }
+
+    return new VectorFieldFunction(this) {
+      KnnVectorValues.DocIndexIterator iterator = vectorValues.iterator();
+
+      @Override
+      public short[] float16VectorVal(int doc) throws IOException {
+        if (exists(doc)) {
+          return vectorValues.vectorValue(iterator.index());
+        } else {
+          return null;
+        }
+      }
+
+      @Override
+      protected DocIdSetIterator getVectorIterator() {
+        return iterator;
+      }
+    };
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Float16KnnVectorFieldSource other = (Float16KnnVectorFieldSource) o;
+    return Objects.equals(fieldName, other.fieldName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass().hashCode(), fieldName);
+  }
+
+  @Override
+  public String description() {
+    return "Float16KnnVectorFieldSource(" + fieldName + ")";
+  }
+}

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/Float16VectorSimilarityFunction.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/Float16VectorSimilarityFunction.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.queries.function.valuesource;
+
+import java.io.IOException;
+import org.apache.lucene.queries.function.FunctionValues;
+import org.apache.lucene.queries.function.ValueSource;
+
+/**
+ * <code>Float16VectorSimilarityFunction</code> returns a similarity function between two knn
+ * vectors with float16 elements.
+ */
+public class Float16VectorSimilarityFunction extends VectorSimilarityFunction {
+  public Float16VectorSimilarityFunction(
+      org.apache.lucene.index.VectorSimilarityFunction similarityFunction,
+      ValueSource vector1,
+      ValueSource vector2) {
+    super(similarityFunction, vector1, vector2);
+  }
+
+  @Override
+  protected float func(int doc, FunctionValues f1, FunctionValues f2) throws IOException {
+
+    var v1 = f1.float16VectorVal(doc);
+    var v2 = f2.float16VectorVal(doc);
+
+    if (v1 == null || v2 == null) {
+      return 0.f;
+    }
+
+    assert v1.length == v2.length : "Vectors must have the same length";
+    return similarityFunction.compare(v1, v2);
+  }
+}

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/faiss/FaissKnnVectorsReader.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/faiss/FaissKnnVectorsReader.java
@@ -35,6 +35,7 @@ import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.MergePolicy;
@@ -169,6 +170,11 @@ final class FaissKnnVectorsReader extends KnnVectorsReader {
   }
 
   @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    throw new UnsupportedOperationException("Float16 vectors not supported");
+  }
+
+  @Override
   public void search(
       String field, float[] vector, KnnCollector knnCollector, AcceptDocs acceptDocs) {
     FaissLibrary.Index index = indexMap.get(field);
@@ -183,6 +189,12 @@ final class FaissKnnVectorsReader extends KnnVectorsReader {
     // TODO: Support using SQ8 quantization, see:
     //  - https://github.com/opensearch-project/k-NN/pull/2425
     throw new UnsupportedOperationException("Byte vectors not supported");
+  }
+
+  @Override
+  public void search(String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    throw new UnsupportedOperationException("Float16 vectors not supported");
   }
 
   @Override

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/faiss/FaissKnnVectorsWriter.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/codecs/faiss/FaissKnnVectorsWriter.java
@@ -104,6 +104,7 @@ final class FaissKnnVectorsWriter extends KnnVectorsWriter {
           // TODO: Support using SQ8 quantization, see:
           //  - https://github.com/opensearch-project/k-NN/pull/2425
           throw new UnsupportedOperationException("Byte vectors not supported");
+      case FLOAT16 -> throw new UnsupportedOperationException("Float16 vectors not supported");
       case FLOAT32 -> {
         FloatVectorValues merged =
             KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
@@ -130,6 +131,8 @@ final class FaissKnnVectorsWriter extends KnnVectorsWriter {
             // TODO: Support using SQ8 quantization, see:
             //  - https://github.com/opensearch-project/k-NN/pull/2425
             throw new UnsupportedOperationException("Byte vectors not supported");
+
+        case FLOAT16 -> throw new UnsupportedOperationException("Float16 vectors not supported");
 
         case FLOAT32 -> {
           @SuppressWarnings("unchecked")

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingKnnVectorsFormat.java
@@ -28,6 +28,7 @@ import org.apache.lucene.codecs.hnsw.HnswGraphProvider;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.MergeState;
@@ -160,6 +161,20 @@ public class AssertingKnnVectorsFormat extends KnnVectorsFormat {
     }
 
     @Override
+    public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+      FieldInfo fi = fis.fieldInfo(field);
+      assert fi != null
+          && fi.getVectorDimension() > 0
+          && fi.getVectorEncoding() == VectorEncoding.FLOAT16;
+      Float16VectorValues values = delegate.getFloat16VectorValues(field);
+      assert values != null;
+      assert values.iterator().docID() == -1;
+      assert values.size() >= 0;
+      assert values.dimension() > 0;
+      return values;
+    }
+
+    @Override
     public void search(
         String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
         throws IOException {
@@ -179,6 +194,18 @@ public class AssertingKnnVectorsFormat extends KnnVectorsFormat {
       assert fi != null
           && fi.getVectorDimension() > 0
           && fi.getVectorEncoding() == VectorEncoding.BYTE;
+      acceptDocs = AssertingAcceptDocs.wrap(acceptDocs);
+      delegate.search(field, target, knnCollector, acceptDocs);
+    }
+
+    @Override
+    public void search(
+        String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+        throws IOException {
+      FieldInfo fi = fis.fieldInfo(field);
+      assert fi != null
+          && fi.getVectorDimension() > 0
+          && fi.getVectorEncoding() == VectorEncoding.FLOAT16;
       acceptDocs = AssertingAcceptDocs.wrap(acceptDocs);
       delegate.search(field, target, knnCollector, acceptDocs);
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -1914,6 +1914,14 @@ public class AssertingLeafReader extends FilterLeafReader {
     super.searchNearestVectors(field, target, knnCollector, acceptDocs);
   }
 
+  @Override
+  public void searchNearestVectors(
+      String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    acceptDocs = AssertingAcceptDocs.wrap(acceptDocs);
+    super.searchNearestVectors(field, target, knnCollector, acceptDocs);
+  }
+
   // we don't change behavior of the reader: just validate the API.
 
   @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -145,12 +145,12 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
   protected void addRandomFields(Document doc) {
     switch (vectorEncoding) {
       case BYTE -> doc.add(new KnnByteVectorField("v2", randomVector8(30), similarityFunction));
-      case FLOAT32 ->
-          doc.add(new KnnFloatVectorField("v2", randomNormalizedVector(30), similarityFunction));
       case FLOAT16 ->
           doc.add(
               new KnnFloat16VectorField(
                   "v2", randomNormalizedFloat16Vector(30), similarityFunction));
+      case FLOAT32 ->
+          doc.add(new KnnFloatVectorField("v2", randomNormalizedVector(30), similarityFunction));
     }
   }
 
@@ -975,14 +975,14 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
                 doc.add(new KnnByteVectorField(fieldName, b, fieldSimilarityFunctions[field]));
                 fieldTotals[field] += b[0];
               }
-              case FLOAT32 -> {
-                float[] v = randomNormalizedVector(fieldDims[field]);
-                doc.add(new KnnFloatVectorField(fieldName, v, fieldSimilarityFunctions[field]));
-                fieldTotals[field] += v[0];
-              }
               case FLOAT16 -> {
                 short[] v = randomNormalizedFloat16Vector(fieldDims[field]);
                 doc.add(new KnnFloat16VectorField(fieldName, v, fieldSimilarityFunctions[field]));
+                fieldTotals[field] += v[0];
+              }
+              case FLOAT32 -> {
+                float[] v = randomNormalizedVector(fieldDims[field]);
+                doc.add(new KnnFloatVectorField(fieldName, v, fieldSimilarityFunctions[field]));
                 fieldTotals[field] += v[0];
               }
             }
@@ -1010,9 +1010,9 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
                 }
               }
             }
-            case FLOAT32 -> {
+            case FLOAT16 -> {
               for (LeafReaderContext ctx : r.leaves()) {
-                FloatVectorValues vectorValues = ctx.reader().getFloatVectorValues(fieldName);
+                Float16VectorValues vectorValues = ctx.reader().getFloat16VectorValues(fieldName);
                 if (vectorValues != null) {
                   docCount += vectorValues.size();
                   KnnVectorValues.DocIndexIterator iterator = vectorValues.iterator();
@@ -1023,9 +1023,9 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
                 }
               }
             }
-            case FLOAT16 -> {
+            case FLOAT32 -> {
               for (LeafReaderContext ctx : r.leaves()) {
-                Float16VectorValues vectorValues = ctx.reader().getFloat16VectorValues(fieldName);
+                FloatVectorValues vectorValues = ctx.reader().getFloatVectorValues(fieldName);
                 if (vectorValues != null) {
                   docCount += vectorValues.size();
                   KnnVectorValues.DocIndexIterator iterator = vectorValues.iterator();
@@ -1950,15 +1950,15 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
               fieldValuesCheckSum += b[0];
               doc.add(new KnnByteVectorField("knn_vector", b, similarityFunction));
             }
-            case FLOAT32 -> {
-              float[] v = randomNormalizedVector(dim);
-              fieldValuesCheckSum += v[0];
-              doc.add(new KnnFloatVectorField("knn_vector", v, similarityFunction));
-            }
             case FLOAT16 -> {
               short[] v = randomNormalizedFloat16Vector(dim);
               fieldValuesCheckSum += v[0];
               doc.add(new KnnFloat16VectorField("knn_vector", v, similarityFunction));
+            }
+            case FLOAT32 -> {
+              float[] v = randomNormalizedVector(dim);
+              fieldValuesCheckSum += v[0];
+              doc.add(new KnnFloatVectorField("knn_vector", v, similarityFunction));
             }
           }
           fieldDocCount++;
@@ -1999,9 +1999,9 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
               }
             }
           }
-          case FLOAT32 -> {
+          case FLOAT16 -> {
             for (LeafReaderContext ctx : r.leaves()) {
-              FloatVectorValues vectorValues = ctx.reader().getFloatVectorValues("knn_vector");
+              Float16VectorValues vectorValues = ctx.reader().getFloat16VectorValues("knn_vector");
               if (vectorValues != null) {
                 docCount += vectorValues.size();
                 StoredFields storedFields = ctx.reader().storedFields();
@@ -2020,9 +2020,9 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
               }
             }
           }
-          case FLOAT16 -> {
+          case FLOAT32 -> {
             for (LeafReaderContext ctx : r.leaves()) {
-              Float16VectorValues vectorValues = ctx.reader().getFloat16VectorValues("knn_vector");
+              FloatVectorValues vectorValues = ctx.reader().getFloatVectorValues("knn_vector");
               if (vectorValues != null) {
                 docCount += vectorValues.size();
                 StoredFields storedFields = ctx.reader().storedFields();

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BaseKnnVectorsFormatTestCase.java
@@ -49,6 +49,7 @@ import org.apache.lucene.codecs.simpletext.SimpleTextKnnVectorsReader;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.document.KnnFloat16VectorField;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StoredField;
@@ -61,6 +62,7 @@ import org.apache.lucene.index.DocValuesSkipIndexType;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
@@ -145,6 +147,10 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
       case BYTE -> doc.add(new KnnByteVectorField("v2", randomVector8(30), similarityFunction));
       case FLOAT32 ->
           doc.add(new KnnFloatVectorField("v2", randomNormalizedVector(30), similarityFunction));
+      case FLOAT16 ->
+          doc.add(
+              new KnnFloat16VectorField(
+                  "v2", randomNormalizedFloat16Vector(30), similarityFunction));
     }
   }
 
@@ -974,6 +980,11 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
                 doc.add(new KnnFloatVectorField(fieldName, v, fieldSimilarityFunctions[field]));
                 fieldTotals[field] += v[0];
               }
+              case FLOAT16 -> {
+                short[] v = randomNormalizedFloat16Vector(fieldDims[field]);
+                doc.add(new KnnFloat16VectorField(fieldName, v, fieldSimilarityFunctions[field]));
+                fieldTotals[field] += v[0];
+              }
             }
             fieldDocCounts[field]++;
           }
@@ -1002,6 +1013,19 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
             case FLOAT32 -> {
               for (LeafReaderContext ctx : r.leaves()) {
                 FloatVectorValues vectorValues = ctx.reader().getFloatVectorValues(fieldName);
+                if (vectorValues != null) {
+                  docCount += vectorValues.size();
+                  KnnVectorValues.DocIndexIterator iterator = vectorValues.iterator();
+                  while (true) {
+                    if (!(iterator.nextDoc() != NO_MORE_DOCS)) break;
+                    checksum += vectorValues.vectorValue(iterator.index())[0];
+                  }
+                }
+              }
+            }
+            case FLOAT16 -> {
+              for (LeafReaderContext ctx : r.leaves()) {
+                Float16VectorValues vectorValues = ctx.reader().getFloat16VectorValues(fieldName);
                 if (vectorValues != null) {
                   docCount += vectorValues.size();
                   KnnVectorValues.DocIndexIterator iterator = vectorValues.iterator();
@@ -1774,6 +1798,19 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     return v;
   }
 
+  public static short[] randomNormalizedFloat16Vector(int dim) {
+    float[] v = randomVector(dim);
+    VectorUtil.l2normalize(v);
+    for (int i = 0; i < v.length; i++) {
+      v[i] = Float.float16ToFloat(Float.floatToFloat16(v[i]));
+    }
+    short[] s = new short[v.length];
+    for (int i = 0; i < v.length; i++) {
+      s[i] = Float.floatToFloat16(v[i]);
+    }
+    return s;
+  }
+
   public static float[] randomNormalizedVector(int dim) {
     float[] v = randomVector(dim);
     VectorUtil.l2normalize(v);
@@ -1836,7 +1873,8 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     // enumerators
     assertEquals(0, VectorEncoding.BYTE.ordinal());
     assertEquals(1, VectorEncoding.FLOAT32.ordinal());
-    assertEquals(2, VectorEncoding.values().length);
+    assertEquals(2, VectorEncoding.FLOAT16.ordinal());
+    assertEquals(3, VectorEncoding.values().length);
   }
 
   public void testAdvance() throws Exception {
@@ -1917,6 +1955,11 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
               fieldValuesCheckSum += v[0];
               doc.add(new KnnFloatVectorField("knn_vector", v, similarityFunction));
             }
+            case FLOAT16 -> {
+              short[] v = randomNormalizedFloat16Vector(dim);
+              fieldValuesCheckSum += v[0];
+              doc.add(new KnnFloat16VectorField("knn_vector", v, similarityFunction));
+            }
           }
           fieldDocCount++;
           fieldSumDocIDs += docID;
@@ -1959,6 +2002,27 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
           case FLOAT32 -> {
             for (LeafReaderContext ctx : r.leaves()) {
               FloatVectorValues vectorValues = ctx.reader().getFloatVectorValues("knn_vector");
+              if (vectorValues != null) {
+                docCount += vectorValues.size();
+                StoredFields storedFields = ctx.reader().storedFields();
+                KnnVectorValues.DocIndexIterator iter = vectorValues.iterator();
+                for (iter.nextDoc(); iter.docID() != NO_MORE_DOCS; iter.nextDoc()) {
+                  int ord = iter.index();
+                  checksum += vectorValues.vectorValue(ord)[0];
+                  Document doc = storedFields.document(iter.docID(), Set.of("id"));
+                  sumDocIds += Integer.parseInt(doc.get("id"));
+                }
+                for (int ord = 0; ord < vectorValues.size(); ord++) {
+                  Document doc = storedFields.document(vectorValues.ordToDoc(ord), Set.of("id"));
+                  sumOrdToDocIds += Integer.parseInt(doc.get("id"));
+                }
+                assertOffHeapByteSize(ctx.reader(), "knn_vector");
+              }
+            }
+          }
+          case FLOAT16 -> {
+            for (LeafReaderContext ctx : r.leaves()) {
+              Float16VectorValues vectorValues = ctx.reader().getFloat16VectorValues("knn_vector");
               if (vectorValues != null) {
                 docCount += vectorValues.size();
                 StoredFields storedFields = ctx.reader().storedFields();
@@ -2350,6 +2414,7 @@ public abstract class BaseKnnVectorsFormatTestCase extends BaseIndexFileFormatTe
     return switch (fieldInfo.getVectorEncoding()) {
       case BYTE -> reader.getByteVectorValues(fieldInfo.getName()).size();
       case FLOAT32 -> reader.getFloatVectorValues(fieldInfo.getName()).size();
+      case FLOAT16 -> reader.getFloat16VectorValues(fieldInfo.getName()).size();
     };
   }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/MergeReaderWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/MergeReaderWrapper.java
@@ -30,6 +30,7 @@ import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.LeafMetaData;
 import org.apache.lucene.index.LeafReader;
@@ -236,6 +237,11 @@ class MergeReaderWrapper extends LeafReader {
   }
 
   @Override
+  public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+    return in.getFloat16VectorValues(field);
+  }
+
+  @Override
   public ByteVectorValues getByteVectorValues(String fieldName) throws IOException {
     return in.getByteVectorValues(fieldName);
   }
@@ -243,6 +249,13 @@ class MergeReaderWrapper extends LeafReader {
   @Override
   public void searchNearestVectors(
       String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+      throws IOException {
+    in.searchNearestVectors(field, target, knnCollector, acceptDocs);
+  }
+
+  @Override
+  public void searchNearestVectors(
+      String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     in.searchNearestVectors(field, target, knnCollector, acceptDocs);
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
@@ -27,6 +27,7 @@ import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.Float16VectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafMetaData;
@@ -238,6 +239,11 @@ public class QueryUtils {
       }
 
       @Override
+      public Float16VectorValues getFloat16VectorValues(String field) throws IOException {
+        return null;
+      }
+
+      @Override
       public ByteVectorValues getByteVectorValues(String field) throws IOException {
         return null;
       }
@@ -245,6 +251,11 @@ public class QueryUtils {
       @Override
       public void searchNearestVectors(
           String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) {}
+
+      @Override
+      public void searchNearestVectors(
+          String field, short[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
+          throws IOException {}
 
       @Override
       public void searchNearestVectors(


### PR DESCRIPTION
### Description

Introduce a new FLOAT16 VectorEncoding that stores vectors at half precision (16 bits per dimension, represented as short[]).  This introduces the raw fp16 encoding only; scalar quantization of fp16 vectors is intentionally excluded for simplifying the PR and reviewing process. Will raise another PR with quantization support. 

Initital full PR with both new encoding and quantization support: #15549 