### PR TITLE
Don't throw IOException from PointValues metadata methods

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -310,6 +310,8 @@ API Changes
 
 * GITHUB#16363: Add API to use a custom `DictionarySuggester` instead of hardcoded `GeneratingSuggester`
 
+* GITHUB#16387: Don't throw IOException from PointValues metadata methods. (Alan Woodward)
+
 New Features
 ---------------------
 

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextBKDReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextBKDReader.java
@@ -444,17 +444,17 @@ final class SimpleTextBKDReader extends PointValues {
   }
 
   @Override
-  public int getNumDimensions() throws IOException {
+  public int getNumDimensions() {
     return config.numDims();
   }
 
   @Override
-  public int getNumIndexDimensions() throws IOException {
+  public int getNumIndexDimensions() {
     return config.numIndexDims();
   }
 
   @Override
-  public int getBytesPerDimension() throws IOException {
+  public int getBytesPerDimension() {
     return config.bytesPerDim();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -646,31 +646,31 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     }
 
     @Override
-    public byte[] getMinPackedValue() throws IOException {
+    public byte[] getMinPackedValue() {
       checkAndThrow();
       return in.getMinPackedValue();
     }
 
     @Override
-    public byte[] getMaxPackedValue() throws IOException {
+    public byte[] getMaxPackedValue() {
       checkAndThrow();
       return in.getMaxPackedValue();
     }
 
     @Override
-    public int getNumDimensions() throws IOException {
+    public int getNumDimensions() {
       checkAndThrow();
       return in.getNumDimensions();
     }
 
     @Override
-    public int getNumIndexDimensions() throws IOException {
+    public int getNumIndexDimensions() {
       checkAndThrow();
       return in.getNumIndexDimensions();
     }
 
     @Override
-    public int getBytesPerDimension() throws IOException {
+    public int getBytesPerDimension() {
       checkAndThrow();
       return in.getBytesPerDimension();
     }

--- a/lucene/core/src/java/org/apache/lucene/index/PointValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PointValues.java
@@ -118,7 +118,7 @@ public abstract class PointValues {
    *
    * @see PointValues#size()
    */
-  public static long size(IndexReader reader, String field) throws IOException {
+  public static long size(IndexReader reader, String field) {
     long size = 0;
     for (LeafReaderContext ctx : reader.leaves()) {
       PointValues values = ctx.reader().getPointValues(field);
@@ -135,7 +135,7 @@ public abstract class PointValues {
    *
    * @see PointValues#getDocCount()
    */
-  public static int getDocCount(IndexReader reader, String field) throws IOException {
+  public static int getDocCount(IndexReader reader, String field) {
     int count = 0;
     for (LeafReaderContext ctx : reader.leaves()) {
       PointValues values = ctx.reader().getPointValues(field);
@@ -152,7 +152,7 @@ public abstract class PointValues {
    *
    * @see PointValues#getMinPackedValue()
    */
-  public static byte[] getMinPackedValue(IndexReader reader, String field) throws IOException {
+  public static byte[] getMinPackedValue(IndexReader reader, String field) {
     byte[] minValue = null;
     for (LeafReaderContext ctx : reader.leaves()) {
       PointValues values = ctx.reader().getPointValues(field);
@@ -187,7 +187,7 @@ public abstract class PointValues {
    *
    * @see PointValues#getMaxPackedValue()
    */
-  public static byte[] getMaxPackedValue(IndexReader reader, String field) throws IOException {
+  public static byte[] getMaxPackedValue(IndexReader reader, String field) {
     byte[] maxValue = null;
     for (LeafReaderContext ctx : reader.leaves()) {
       PointValues values = ctx.reader().getPointValues(field);
@@ -473,21 +473,21 @@ public abstract class PointValues {
   /**
    * Returns minimum value for each dimension, packed, or null if {@link #size} is <code>0</code>
    */
-  public abstract byte[] getMinPackedValue() throws IOException;
+  public abstract byte[] getMinPackedValue();
 
   /**
    * Returns maximum value for each dimension, packed, or null if {@link #size} is <code>0</code>
    */
-  public abstract byte[] getMaxPackedValue() throws IOException;
+  public abstract byte[] getMaxPackedValue();
 
   /** Returns how many dimensions are represented in the values */
-  public abstract int getNumDimensions() throws IOException;
+  public abstract int getNumDimensions();
 
   /** Returns how many dimensions are used for the index */
-  public abstract int getNumIndexDimensions() throws IOException;
+  public abstract int getNumIndexDimensions();
 
   /** Returns the number of bytes per dimension */
-  public abstract int getBytesPerDimension() throws IOException;
+  public abstract int getBytesPerDimension();
 
   /** Returns the total number of indexed points across all documents. */
   public abstract long size();

--- a/lucene/core/src/java/org/apache/lucene/index/PointValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PointValuesWriter.java
@@ -286,32 +286,32 @@ class PointValuesWriter {
             }
             return new PointValues() {
               @Override
-              public PointTree getPointTree() throws IOException {
+              public PointTree getPointTree() {
                 return values;
               }
 
               @Override
-              public byte[] getMinPackedValue() throws IOException {
+              public byte[] getMinPackedValue() {
                 throw new UnsupportedOperationException();
               }
 
               @Override
-              public byte[] getMaxPackedValue() throws IOException {
+              public byte[] getMaxPackedValue() {
                 throw new UnsupportedOperationException();
               }
 
               @Override
-              public int getNumDimensions() throws IOException {
+              public int getNumDimensions() {
                 throw new UnsupportedOperationException();
               }
 
               @Override
-              public int getNumIndexDimensions() throws IOException {
+              public int getNumIndexDimensions() {
                 throw new UnsupportedOperationException();
               }
 
               @Override
-              public int getBytesPerDimension() throws IOException {
+              public int getBytesPerDimension() {
                 throw new UnsupportedOperationException();
               }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCompositeCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCompositeCodecReaderWrapper.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -613,7 +612,7 @@ final class SlowCompositeCodecReaderWrapper extends CodecReader {
       return new PointValues() {
 
         @Override
-        public PointTree getPointTree() throws IOException {
+        public PointTree getPointTree() {
           return new PointTree() {
 
             @Override
@@ -681,110 +680,98 @@ final class SlowCompositeCodecReaderWrapper extends CodecReader {
 
             @Override
             public byte[] getMinPackedValue() {
-              try {
-                byte[] minPackedValue = null;
-                for (PointValuesSub sub : values) {
-                  if (minPackedValue == null) {
-                    minPackedValue = sub.sub.getMinPackedValue().clone();
-                  } else {
-                    byte[] leafMinPackedValue = sub.sub.getMinPackedValue();
-                    int numIndexDimensions = sub.sub.getNumIndexDimensions();
-                    int numBytesPerDimension = sub.sub.getBytesPerDimension();
-                    ArrayUtil.ByteArrayComparator comparator =
-                        ArrayUtil.getUnsignedComparator(numBytesPerDimension);
-                    for (int i = 0; i < numIndexDimensions; ++i) {
-                      if (comparator.compare(
-                              leafMinPackedValue,
-                              i * numBytesPerDimension,
-                              minPackedValue,
-                              i * numBytesPerDimension)
-                          < 0) {
-                        System.arraycopy(
+              byte[] minPackedValue = null;
+              for (PointValuesSub sub : values) {
+                if (minPackedValue == null) {
+                  minPackedValue = sub.sub.getMinPackedValue().clone();
+                } else {
+                  byte[] leafMinPackedValue = sub.sub.getMinPackedValue();
+                  int numIndexDimensions = sub.sub.getNumIndexDimensions();
+                  int numBytesPerDimension = sub.sub.getBytesPerDimension();
+                  ArrayUtil.ByteArrayComparator comparator =
+                      ArrayUtil.getUnsignedComparator(numBytesPerDimension);
+                  for (int i = 0; i < numIndexDimensions; ++i) {
+                    if (comparator.compare(
                             leafMinPackedValue,
                             i * numBytesPerDimension,
                             minPackedValue,
-                            i * numBytesPerDimension,
-                            numBytesPerDimension);
-                      }
+                            i * numBytesPerDimension)
+                        < 0) {
+                      System.arraycopy(
+                          leafMinPackedValue,
+                          i * numBytesPerDimension,
+                          minPackedValue,
+                          i * numBytesPerDimension,
+                          numBytesPerDimension);
                     }
                   }
                 }
-                return minPackedValue;
-              } catch (IOException e) {
-                throw new UncheckedIOException(e);
               }
+              return minPackedValue;
             }
 
             @Override
             public byte[] getMaxPackedValue() {
-              try {
-                byte[] maxPackedValue = null;
-                for (PointValuesSub sub : values) {
-                  if (maxPackedValue == null) {
-                    maxPackedValue = sub.sub.getMaxPackedValue().clone();
-                  } else {
-                    byte[] leafMinPackedValue = sub.sub.getMaxPackedValue();
-                    int numIndexDimensions = sub.sub.getNumIndexDimensions();
-                    int numBytesPerDimension = sub.sub.getBytesPerDimension();
-                    ArrayUtil.ByteArrayComparator comparator =
-                        ArrayUtil.getUnsignedComparator(numBytesPerDimension);
-                    for (int i = 0; i < numIndexDimensions; ++i) {
-                      if (comparator.compare(
-                              leafMinPackedValue,
-                              i * numBytesPerDimension,
-                              maxPackedValue,
-                              i * numBytesPerDimension)
-                          > 0) {
-                        System.arraycopy(
+              byte[] maxPackedValue = null;
+              for (PointValuesSub sub : values) {
+                if (maxPackedValue == null) {
+                  maxPackedValue = sub.sub.getMaxPackedValue().clone();
+                } else {
+                  byte[] leafMinPackedValue = sub.sub.getMaxPackedValue();
+                  int numIndexDimensions = sub.sub.getNumIndexDimensions();
+                  int numBytesPerDimension = sub.sub.getBytesPerDimension();
+                  ArrayUtil.ByteArrayComparator comparator =
+                      ArrayUtil.getUnsignedComparator(numBytesPerDimension);
+                  for (int i = 0; i < numIndexDimensions; ++i) {
+                    if (comparator.compare(
                             leafMinPackedValue,
                             i * numBytesPerDimension,
                             maxPackedValue,
-                            i * numBytesPerDimension,
-                            numBytesPerDimension);
-                      }
+                            i * numBytesPerDimension)
+                        > 0) {
+                      System.arraycopy(
+                          leafMinPackedValue,
+                          i * numBytesPerDimension,
+                          maxPackedValue,
+                          i * numBytesPerDimension,
+                          numBytesPerDimension);
                     }
                   }
                 }
-                return maxPackedValue;
-              } catch (IOException e) {
-                throw new UncheckedIOException(e);
               }
+              return maxPackedValue;
             }
           };
         }
 
         @Override
-        public byte[] getMinPackedValue() throws IOException {
+        public byte[] getMinPackedValue() {
           return getPointTree().getMinPackedValue();
         }
 
         @Override
-        public byte[] getMaxPackedValue() throws IOException {
+        public byte[] getMaxPackedValue() {
           return getPointTree().getMaxPackedValue();
         }
 
         @Override
-        public int getNumDimensions() throws IOException {
+        public int getNumDimensions() {
           return values.get(0).sub.getNumDimensions();
         }
 
         @Override
-        public int getNumIndexDimensions() throws IOException {
+        public int getNumIndexDimensions() {
           return values.get(0).sub.getNumIndexDimensions();
         }
 
         @Override
-        public int getBytesPerDimension() throws IOException {
+        public int getBytesPerDimension() {
           return values.get(0).sub.getBytesPerDimension();
         }
 
         @Override
         public long size() {
-          try {
-            return getPointTree().size();
-          } catch (IOException e) {
-            throw new UncheckedIOException(e);
-          }
+          return getPointTree().size();
         }
 
         @Override

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -84,27 +84,27 @@ public final class SortingCodecReader extends FilterCodecReader {
     }
 
     @Override
-    public byte[] getMinPackedValue() throws IOException {
+    public byte[] getMinPackedValue() {
       return in.getMinPackedValue();
     }
 
     @Override
-    public byte[] getMaxPackedValue() throws IOException {
+    public byte[] getMaxPackedValue() {
       return in.getMaxPackedValue();
     }
 
     @Override
-    public int getNumDimensions() throws IOException {
+    public int getNumDimensions() {
       return in.getNumDimensions();
     }
 
     @Override
-    public int getNumIndexDimensions() throws IOException {
+    public int getNumIndexDimensions() {
       return in.getNumIndexDimensions();
     }
 
     @Override
-    public int getBytesPerDimension() throws IOException {
+    public int getBytesPerDimension() {
       return in.getBytesPerDimension();
     }
 

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -1009,17 +1009,17 @@ public class BKDReader extends PointValues {
   }
 
   @Override
-  public int getNumDimensions() throws IOException {
+  public int getNumDimensions() {
     return config.numDims();
   }
 
   @Override
-  public int getNumIndexDimensions() throws IOException {
+  public int getNumIndexDimensions() {
     return config.numIndexDims();
   }
 
   @Override
-  public int getBytesPerDimension() throws IOException {
+  public int getBytesPerDimension() {
     return config.bytesPerDim();
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
@@ -1212,14 +1212,11 @@ public class TestIndexWriterReader extends LuceneTestCase {
     Comparator<LeafReader> leafSorter =
         Comparator.comparingLong(
             r -> {
-              try {
-                PointValues points = r.getPointValues(FIELD_NAME);
-                if (points != null) {
-                  byte[] sortValue =
-                      ASC_SORT ? points.getMinPackedValue() : points.getMaxPackedValue();
-                  return LongPoint.decodeDimension(sortValue, 0);
-                }
-              } catch (IOException _) {
+              PointValues points = r.getPointValues(FIELD_NAME);
+              if (points != null) {
+                byte[] sortValue =
+                    ASC_SORT ? points.getMinPackedValue() : points.getMaxPackedValue();
+                return LongPoint.decodeDimension(sortValue, 0);
               }
               return MISSING_VALUE;
             });

--- a/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestDocIdSetBuilder.java
@@ -334,27 +334,27 @@ public class TestDocIdSetBuilder extends LuceneTestCase {
     }
 
     @Override
-    public byte[] getMinPackedValue() throws IOException {
+    public byte[] getMinPackedValue() {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public byte[] getMaxPackedValue() throws IOException {
+    public byte[] getMaxPackedValue() {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public int getNumDimensions() throws IOException {
+    public int getNumDimensions() {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public int getNumIndexDimensions() throws IOException {
+    public int getNumIndexDimensions() {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public int getBytesPerDimension() throws IOException {
+    public int getBytesPerDimension() {
       throw new UnsupportedOperationException();
     }
 

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -2131,27 +2131,27 @@ public class MemoryIndex {
       }
 
       @Override
-      public byte[] getMinPackedValue() throws IOException {
+      public byte[] getMinPackedValue() {
         return info.minPackedValue;
       }
 
       @Override
-      public byte[] getMaxPackedValue() throws IOException {
+      public byte[] getMaxPackedValue() {
         return info.maxPackedValue;
       }
 
       @Override
-      public int getNumDimensions() throws IOException {
+      public int getNumDimensions() {
         return info.fieldInfo.getPointDimensionCount();
       }
 
       @Override
-      public int getNumIndexDimensions() throws IOException {
+      public int getNumIndexDimensions() {
         return info.fieldInfo.getPointDimensionCount();
       }
 
       @Override
-      public int getBytesPerDimension() throws IOException {
+      public int getBytesPerDimension() {
         return info.fieldInfo.getPointNumBytes();
       }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/cranky/CrankyPointsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/cranky/CrankyPointsFormat.java
@@ -187,42 +187,27 @@ class CrankyPointsFormat extends PointsFormat {
         }
 
         @Override
-        public byte[] getMinPackedValue() throws IOException {
-          if (random.nextInt(100) == 0) {
-            throw new IOException("Fake IOException");
-          }
+        public byte[] getMinPackedValue() {
           return delegate.getMinPackedValue();
         }
 
         @Override
-        public byte[] getMaxPackedValue() throws IOException {
-          if (random.nextInt(100) == 0) {
-            throw new IOException("Fake IOException");
-          }
+        public byte[] getMaxPackedValue() {
           return delegate.getMaxPackedValue();
         }
 
         @Override
-        public int getNumDimensions() throws IOException {
-          if (random.nextInt(100) == 0) {
-            throw new IOException("Fake IOException");
-          }
+        public int getNumDimensions() {
           return delegate.getNumDimensions();
         }
 
         @Override
-        public int getNumIndexDimensions() throws IOException {
-          if (random.nextInt(100) == 0) {
-            throw new IOException("Fake IOException");
-          }
+        public int getNumIndexDimensions() {
           return delegate.getNumIndexDimensions();
         }
 
         @Override
-        public int getBytesPerDimension() throws IOException {
-          if (random.nextInt(100) == 0) {
-            throw new IOException("Fake IOException");
-          }
+        public int getBytesPerDimension() {
           return delegate.getBytesPerDimension();
         }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -1523,31 +1523,31 @@ public class AssertingLeafReader extends FilterLeafReader {
     }
 
     @Override
-    public byte[] getMinPackedValue() throws IOException {
+    public byte[] getMinPackedValue() {
       assertThread("Points", creationThread);
       return Objects.requireNonNull(in.getMinPackedValue());
     }
 
     @Override
-    public byte[] getMaxPackedValue() throws IOException {
+    public byte[] getMaxPackedValue() {
       assertThread("Points", creationThread);
       return Objects.requireNonNull(in.getMaxPackedValue());
     }
 
     @Override
-    public int getNumDimensions() throws IOException {
+    public int getNumDimensions() {
       assertThread("Points", creationThread);
       return in.getNumDimensions();
     }
 
     @Override
-    public int getNumIndexDimensions() throws IOException {
+    public int getNumIndexDimensions() {
       assertThread("Points", creationThread);
       return in.getNumIndexDimensions();
     }
 
     @Override
-    public int getBytesPerDimension() throws IOException {
+    public int getBytesPerDimension() {
       assertThread("Points", creationThread);
       return in.getBytesPerDimension();
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/BasePointsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/BasePointsFormatTestCase.java
@@ -1375,27 +1375,27 @@ public abstract class BasePointsFormatTestCase extends BaseIndexFileFormatTestCa
       }
 
       @Override
-      public byte[] getMinPackedValue() throws IOException {
+      public byte[] getMinPackedValue() {
         throw new UnsupportedOperationException();
       }
 
       @Override
-      public byte[] getMaxPackedValue() throws IOException {
+      public byte[] getMaxPackedValue() {
         throw new UnsupportedOperationException();
       }
 
       @Override
-      public int getNumDimensions() throws IOException {
+      public int getNumDimensions() {
         throw new UnsupportedOperationException();
       }
 
       @Override
-      public int getNumIndexDimensions() throws IOException {
+      public int getNumIndexDimensions() {
         throw new UnsupportedOperationException();
       }
 
       @Override
-      public int getBytesPerDimension() throws IOException {
+      public int getBytesPerDimension() {
         throw new UnsupportedOperationException();
       }
 


### PR DESCRIPTION
Metadata is loaded at segment open time and doesn't require any IO to load once the IndexReader is available.  Stop throwing IOException from these methods.