### PR TITLE
Remove IOException from LeafReader.getDocValuesSkipper()

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -98,6 +98,11 @@ API Changes
 * GITHUB#16052: Remove IOException from LeafReader#getPointValues, LeafReader#terms,
   LeafReader#getDocCount signatures. (Ignacio Vera)
 
+* GITHUB#16388: Remove IOException from LeafReader#getDocValuesSkipper signature.
+  (Alan Woodward)
+
+* GITHUB#16387: Don't throw IOException from PointValues metadata methods. (Alan Woodward)
+
 * GITHUB#16281: The checkIntegrity() method of codec Producer APIs gains a OneMerge parameter,
   which is used to check for aborted merges during checksum validation. (Tanguy Leroux)
 
@@ -312,8 +317,6 @@ API Changes
   retrieval of many binary doc values at once. (Costin Leau)
 
 * GITHUB#16363: Add API to use a custom `DictionarySuggester` instead of hardcoded `GeneratingSuggester`
-
-* GITHUB#16387: Don't throw IOException from PointValues metadata methods. (Alan Woodward)
 
 New Features
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/codecs/DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/DocValuesProducer.java
@@ -81,7 +81,7 @@ public abstract class DocValuesProducer implements Closeable {
    * thread-safe: it will only be used by a single thread. The return value is undefined if {@link
    * FieldInfo#docValuesSkipIndexType()} returns {@link DocValuesSkipIndexType#NONE}.
    */
-  public abstract DocValuesSkipper getSkipper(FieldInfo field) throws IOException;
+  public abstract DocValuesSkipper getSkipper(FieldInfo field);
 
   /**
    * Checks consistency of this producer

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -2516,13 +2516,16 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
   }
 
   @Override
-  public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
+  public DocValuesSkipper getSkipper(FieldInfo field) {
     final DocValuesSkipperEntry entry = skippers.get(field.number);
 
     final IndexInput skipperSource = skipIndexData != null ? skipIndexData : data;
-    final IndexInput input = skipperSource.slice("doc value skipper", entry.offset, entry.length);
+
     // TODO: should we write to disk the actual max level for this segment?
     return new DocValuesSkipper() {
+
+      IndexInput input;
+
       final int[] minDocID = new int[SKIP_INDEX_MAX_LEVEL];
       final int[] maxDocID = new int[SKIP_INDEX_MAX_LEVEL];
 
@@ -2539,6 +2542,9 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
 
       @Override
       public void advance(int target) throws IOException {
+        if (input == null) {
+          input = skipperSource.slice("doc value skipper", entry.offset, entry.length);
+        }
         if (target > entry.maxDocId) {
           // skipper is exhausted
           for (int i = 0; i < SKIP_INDEX_MAX_LEVEL; i++) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
@@ -343,7 +343,7 @@ public abstract class PerFieldDocValuesFormat extends DocValuesFormat {
     }
 
     @Override
-    public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
+    public DocValuesSkipper getSkipper(FieldInfo field) {
       DocValuesProducer producer = fields.get(field.number);
       return producer == null ? null : producer.getSkipper(field);
     }

--- a/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
@@ -197,7 +197,7 @@ public abstract class CodecReader extends LeafReader {
   }
 
   @Override
-  public final DocValuesSkipper getDocValuesSkipper(String field) throws IOException {
+  public final DocValuesSkipper getDocValuesSkipper(String field) {
     ensureOpen();
     FieldInfo fi = getFieldInfos().fieldInfo(field);
     if (fi == null || fi.docValuesSkipIndexType() == DocValuesSkipIndexType.NONE) {

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesLeafReader.java
@@ -113,7 +113,7 @@ abstract class DocValuesLeafReader extends LeafReader {
   }
 
   @Override
-  public DocValuesSkipper getDocValuesSkipper(String field) throws IOException {
+  public DocValuesSkipper getDocValuesSkipper(String field) {
     throw new UnsupportedOperationException();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesSkipper.java
@@ -142,7 +142,7 @@ public abstract class DocValuesSkipper {
    * @param reader the index reader to be queried
    * @param field the field to retrieve values for
    */
-  public static long globalMinValue(IndexReader reader, String field) throws IOException {
+  public static long globalMinValue(IndexReader reader, String field) {
     long minValue = Long.MAX_VALUE;
     for (LeafReaderContext ctx : reader.leaves()) {
       if (ctx.reader().getFieldInfos().fieldInfo(field) == null) {
@@ -166,7 +166,7 @@ public abstract class DocValuesSkipper {
    * @param reader the index reader to be queried
    * @param field the field to retrieve values for
    */
-  public static long globalMaxValue(IndexReader reader, String field) throws IOException {
+  public static long globalMaxValue(IndexReader reader, String field) {
     long maxValue = Long.MIN_VALUE;
     for (LeafReaderContext ctx : reader.leaves()) {
       if (ctx.reader().getFieldInfos().fieldInfo(field) == null) {
@@ -189,7 +189,7 @@ public abstract class DocValuesSkipper {
    * @param reader the index reader to be queried
    * @param field the field to retrieve values for
    */
-  public static int globalDocCount(IndexReader reader, String field) throws IOException {
+  public static int globalDocCount(IndexReader reader, String field) {
     int docCount = 0;
     for (LeafReaderContext ctx : reader.leaves()) {
       DocValuesSkipper skipper = ctx.reader().getDocValuesSkipper(field);

--- a/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
@@ -451,7 +451,7 @@ public abstract class FilterLeafReader extends LeafReader {
   }
 
   @Override
-  public DocValuesSkipper getDocValuesSkipper(String field) throws IOException {
+  public DocValuesSkipper getDocValuesSkipper(String field) {
     ensureOpen();
     return in.getDocValuesSkipper(field);
   }

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -209,7 +209,7 @@ public abstract non-sealed class LeafReader extends IndexReader {
    * interest, or {@code null} if a skip index was not indexed. The returned instance should be
    * confined to the thread that created it.
    */
-  public abstract DocValuesSkipper getDocValuesSkipper(String field) throws IOException;
+  public abstract DocValuesSkipper getDocValuesSkipper(String field);
 
   /**
    * Returns {@link FloatVectorValues} for this field, or null if no {@link FloatVectorValues} were

--- a/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
@@ -428,7 +428,7 @@ public class ParallelLeafReader extends LeafReader {
   }
 
   @Override
-  public DocValuesSkipper getDocValuesSkipper(String field) throws IOException {
+  public DocValuesSkipper getDocValuesSkipper(String field) {
     ensureOpen();
     LeafReader reader = fieldToReader.get(field);
     return reader == null ? null : reader.getDocValuesSkipper(field);

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentDocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentDocValuesProducer.java
@@ -124,7 +124,7 @@ class SegmentDocValuesProducer extends DocValuesProducer {
   }
 
   @Override
-  public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
+  public DocValuesSkipper getSkipper(FieldInfo field) {
     DocValuesProducer dvProducer = dvProducersByField.get(field.number);
     assert dvProducer != null;
     return dvProducer.getSkipper(field);

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCodecReaderWrapper.java
@@ -264,7 +264,7 @@ public final class SlowCodecReaderWrapper {
       }
 
       @Override
-      public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
+      public DocValuesSkipper getSkipper(FieldInfo field) {
         return reader.getDocValuesSkipper(field.name);
       }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SlowCompositeCodecReaderWrapper.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SlowCompositeCodecReaderWrapper.java
@@ -488,7 +488,7 @@ final class SlowCompositeCodecReaderWrapper extends CodecReader {
     }
 
     @Override
-    public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
+    public DocValuesSkipper getSkipper(FieldInfo field) {
       throw new UnsupportedOperationException("This method is for searching not for merging");
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -711,7 +711,7 @@ public final class SortingCodecReader extends FilterCodecReader {
       }
 
       @Override
-      public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
+      public DocValuesSkipper getSkipper(FieldInfo field) {
         // We can hardly return information about min/max values if doc IDs have been reordered.
         return null;
       }

--- a/lucene/core/src/java/org/apache/lucene/search/NumericFieldStats.java
+++ b/lucene/core/src/java/org/apache/lucene/search/NumericFieldStats.java
@@ -74,7 +74,7 @@ public final class NumericFieldStats {
     return new Stats(decodeLong(minPacked), decodeLong(maxPacked), docCount);
   }
 
-  private static Stats getStatsFromSkipper(IndexReader reader, String field) throws IOException {
+  private static Stats getStatsFromSkipper(IndexReader reader, String field) {
     Long min = null;
     Long max = null;
     int docCount = 0;

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
@@ -146,7 +146,7 @@ public class TermVectorLeafReader extends LeafReader {
   }
 
   @Override
-  public DocValuesSkipper getDocValuesSkipper(String field) throws IOException {
+  public DocValuesSkipper getDocValuesSkipper(String field) {
     return null;
   }
 

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -1724,7 +1724,7 @@ public class MemoryIndex {
     }
 
     @Override
-    public DocValuesSkipper getDocValuesSkipper(String field) throws IOException {
+    public DocValuesSkipper getDocValuesSkipper(String field) {
       // Skipping isn't needed on a 1-doc index.
       return null;
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingDocValuesFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingDocValuesFormat.java
@@ -294,7 +294,7 @@ public class AssertingDocValuesFormat extends DocValuesFormat {
     }
 
     @Override
-    public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
+    public DocValuesSkipper getSkipper(FieldInfo field) {
       assert fieldInfos.fieldInfo(field.name).number == field.number;
       assert field.docValuesSkipIndexType() != DocValuesSkipIndexType.NONE;
       DocValuesSkipper skipper = in.getSkipper(field);

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -1823,7 +1823,7 @@ public class AssertingLeafReader extends FilterLeafReader {
   }
 
   @Override
-  public DocValuesSkipper getDocValuesSkipper(String field) throws IOException {
+  public DocValuesSkipper getDocValuesSkipper(String field) {
     DocValuesSkipper skipper = super.getDocValuesSkipper(field);
     FieldInfo fi = getFieldInfos().fieldInfo(field);
     if (skipper != null) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/MergeReaderWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/MergeReaderWrapper.java
@@ -190,7 +190,7 @@ class MergeReaderWrapper extends LeafReader {
   }
 
   @Override
-  public DocValuesSkipper getDocValuesSkipper(String field) throws IOException {
+  public DocValuesSkipper getDocValuesSkipper(String field) {
     ensureOpen();
     FieldInfo fi = getFieldInfos().fieldInfo(field);
     if (fi == null) {

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/MismatchedCodecReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/MismatchedCodecReader.java
@@ -162,7 +162,7 @@ public class MismatchedCodecReader extends FilterCodecReader {
     }
 
     @Override
-    public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
+    public DocValuesSkipper getSkipper(FieldInfo field) {
       return in.getSkipper(remapFieldInfo(field));
     }
 

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/search/QueryUtils.java
@@ -228,7 +228,7 @@ public class QueryUtils {
       }
 
       @Override
-      public DocValuesSkipper getDocValuesSkipper(String field) throws IOException {
+      public DocValuesSkipper getDocValuesSkipper(String field) {
         return null;
       }
 


### PR DESCRIPTION
All of the global metadata available without calling advance() on a skipper is loaded at Skipper creation time and can therefore be returned without doing any IO. The only reason we need to do IO to create a Skipper is slicing an IndexInput, and that can be done lazily in advance() as skippers are designed to only be consumed in a single thread.  This removes the throws declaration from LeafReader.getDocValuesSkipper(), which in combination with a similar change on PointValues will make numeric field metadata available without IO.