### PR TITLE
Handle inconsistent schema on flush with index sorts (#15125)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -87,6 +87,8 @@ Bug Fixes
   been aborted, so IndexWriter#rollback and abortMerges no longer block until the entire graph is
   built. (Jeho Jeong)
 
+* GITHUB#15125: Handle inconsistent schema on flush with index sorts (Nhat Nguyen)
+
 Other
 ---------------------
 * GITHUB#16266: Remove deprecated search(Query, Collector) calls in QueryUtils by replacing

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -181,7 +181,7 @@ final class IndexingChain implements Accountable {
       @Override
       public NumericDocValues getNumericDocValues(String field) {
         PerField pf = getPerField(field);
-        if (pf == null) {
+        if (pf == null || pf.fieldInfo == null) {
           return null;
         }
         if (pf.fieldInfo.getDocValuesType() == DocValuesType.NUMERIC) {
@@ -193,7 +193,7 @@ final class IndexingChain implements Accountable {
       @Override
       public BinaryDocValues getBinaryDocValues(String field) {
         PerField pf = getPerField(field);
-        if (pf == null) {
+        if (pf == null || pf.fieldInfo == null) {
           return null;
         }
         if (pf.fieldInfo.getDocValuesType() == DocValuesType.BINARY) {
@@ -205,7 +205,7 @@ final class IndexingChain implements Accountable {
       @Override
       public SortedDocValues getSortedDocValues(String field) throws IOException {
         PerField pf = getPerField(field);
-        if (pf == null) {
+        if (pf == null || pf.fieldInfo == null) {
           return null;
         }
         if (pf.fieldInfo.getDocValuesType() == DocValuesType.SORTED) {
@@ -217,7 +217,7 @@ final class IndexingChain implements Accountable {
       @Override
       public SortedNumericDocValues getSortedNumericDocValues(String field) throws IOException {
         PerField pf = getPerField(field);
-        if (pf == null) {
+        if (pf == null || pf.fieldInfo == null) {
           return null;
         }
         if (pf.fieldInfo.getDocValuesType() == DocValuesType.SORTED_NUMERIC) {
@@ -229,7 +229,7 @@ final class IndexingChain implements Accountable {
       @Override
       public SortedSetDocValues getSortedSetDocValues(String field) throws IOException {
         PerField pf = getPerField(field);
-        if (pf == null) {
+        if (pf == null || pf.fieldInfo == null) {
           return null;
         }
         if (pf.fieldInfo.getDocValuesType() == DocValuesType.SORTED_SET) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexSorting.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexSorting.java
@@ -54,6 +54,8 @@ import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.FloatDocValuesField;
 import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.KeywordField;
+import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
@@ -3475,6 +3477,67 @@ public class TestIndexSorting extends LuceneTestCase {
             }
           }
         }
+      }
+    }
+  }
+
+  public void testFlushAfterInconsistentSchema() throws IOException {
+    IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));
+    if (random().nextBoolean()) {
+      Sort indexSort = new Sort(new SortField("host.name", SortField.Type.STRING));
+      iwc.setIndexSort(indexSort);
+    }
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, iwc)) {
+      Consumer<Document> addExtraFields =
+          doc -> {
+            int extraFields = random().nextInt(100);
+            for (int i = 0; i < extraFields; i++) {
+              if (random().nextBoolean()) {
+                doc.add(new NumericDocValuesField("extra-dv-" + i, i));
+              }
+              if (random().nextBoolean()) {
+                doc.add(new LongField("extra-point-" + i, i, Store.NO));
+              }
+              if (random().nextBoolean()) {
+                doc.add(
+                    new KeywordField(
+                        "extra-posting-" + i, new BytesRef(Integer.toString(i)), Store.NO));
+              }
+            }
+          };
+      // first segment
+      {
+        Document doc = new Document();
+        doc.add(new SortedDocValuesField("host.name", newBytesRef("h2")));
+        doc.add(new LongField("@timestamp", 1, Store.NO));
+        addExtraFields.accept(doc);
+        w.addDocument(doc);
+        w.commit();
+      }
+      // second segment
+      {
+        var doc = new Document();
+        doc.add(new NumericDocValuesField("@timestamp", 2));
+        addExtraFields.accept(doc);
+        doc.add(new SortedDocValuesField("host.name", newBytesRef("h1")));
+        expectThrows(IllegalArgumentException.class, () -> w.addDocument(doc));
+        w.commit();
+      }
+      try (DirectoryReader reader = DirectoryReader.open(w)) {
+        assertEquals(1, reader.numDocs());
+      }
+      // third segment
+      {
+        var doc = new Document();
+        addExtraFields.accept(doc);
+        doc.add(new LongField("@timestamp", 3, Store.NO));
+        doc.add(new SortedDocValuesField("host.name", newBytesRef("h1")));
+        w.addDocument(doc);
+        w.commit();
+      }
+      try (DirectoryReader reader = DirectoryReader.open(w)) {
+        assertEquals(2, reader.numDocs());
       }
     }
   }


### PR DESCRIPTION
If index sorts are configured and a document's schema is inconsistent with existing segments, IndexWriter may encounter a NullPointerException when building sort comparators.