### PR TITLE
Restore HNSW graph reuse during merges under per-field vectors formats

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -89,6 +89,10 @@ Bug Fixes
 
 * GITHUB#15125: Handle inconsistent schema on flush with index sorts (Nhat Nguyen)
 
+* GITHUB#16400: Restore HNSW graph reuse during merges under per-field vectors formats,
+  including the default codec. Since 10.4.0 the merger tested the per-field wrapper instead
+  of the unwrapped reader, so every merge rebuilt the graph from scratch. (Jeho Jeong)
+
 Other
 ---------------------
 * GITHUB#16266: Remove deprecated search(Query, Collector) calls in QueryUtils by replacing

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/IncrementalHnswGraphMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/IncrementalHnswGraphMerger.java
@@ -108,7 +108,7 @@ public class IncrementalHnswGraphMerger implements HnswGraphMerger {
     if (reader instanceof PerFieldKnnVectorsFormat.FieldsReader candidateReader) {
       currKnnVectorsReader = candidateReader.getFieldReader(fieldInfo.name);
     }
-    if (!(reader instanceof HnswGraphProvider)) {
+    if (!(currKnnVectorsReader instanceof HnswGraphProvider)) {
       return this;
     }
     HnswGraph graph = ((HnswGraphProvider) currKnnVectorsReader).getGraph(fieldInfo.name);
@@ -125,7 +125,7 @@ public class IncrementalHnswGraphMerger implements HnswGraphMerger {
     int candidateVectorCount = countLiveVectors(liveDocs, knnVectorValues);
     int graphSize = graph.size();
 
-    GraphReader graphReader = new GraphReader(reader, docMap, graphSize);
+    GraphReader graphReader = new GraphReader(currKnnVectorsReader, docMap, graphSize);
 
     int deletePct = ((graphSize - candidateVectorCount) * 100) / graphSize;
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestHnswGraphReuse.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestHnswGraphReuse.java
@@ -20,9 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnFloatVectorField;
-import org.apache.lucene.document.StringField;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
@@ -55,11 +53,9 @@ public class TestHnswGraphReuse extends LuceneTestCase {
       cfg.setMergePolicy(NoMergePolicy.INSTANCE);
       try (IndexWriter w = new IndexWriter(dir, cfg)) {
         Random r = random();
-        int id = 0;
         for (int s = 0; s < SEGMENTS; s++) {
-          for (int i = 0; i < DOCS_PER_SEGMENT; i++, id++) {
+          for (int i = 0; i < DOCS_PER_SEGMENT; i++) {
             Document doc = new Document();
-            doc.add(new StringField("id", Integer.toString(id), Field.Store.NO));
             float[] v = new float[DIM];
             for (int j = 0; j < DIM; j++) {
               v[j] = r.nextFloat();
@@ -69,7 +65,6 @@ public class TestHnswGraphReuse extends LuceneTestCase {
           }
           w.flush();
         }
-        w.commit();
       }
 
       List<String> hnswMessages = new ArrayList<>();

--- a/lucene/core/src/test/org/apache/lucene/index/TestHnswGraphReuse.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestHnswGraphReuse.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.index;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.InfoStream;
+
+/**
+ * Tests that merging deletion-free segments under the default codec reuses their existing HNSW
+ * graphs instead of rebuilding the merged graph from scratch. The default codec wires vector
+ * readers through {@code PerFieldKnnVectorsFormat.FieldsReader}, the wrapper that {@code
+ * IncrementalHnswGraphMerger#addReader} must unwrap for reuse to trigger.
+ *
+ * <p>The assertion keys on the InfoStream message of {@code MergingHnswGraphBuilder}, used by the
+ * single threaded merger that the default format selects ({@code numMergeWorkers} is 1).
+ */
+public class TestHnswGraphReuse extends LuceneTestCase {
+
+  private static final int DIM = 8;
+  private static final int SEGMENTS = 2;
+
+  /**
+   * Above the tiny-segment cutoff of {@code Lucene99HnswVectorsWriter#shouldCreateGraph} (about 650
+   * vectors at the default threshold), so graphs are built at both flush and merge time.
+   */
+  private static final int DOCS_PER_SEGMENT = 1500;
+
+  public void testMergeReusesGraphsUnderDefaultCodec() throws Exception {
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig cfg = new IndexWriterConfig();
+      cfg.setCodec(TestUtil.getDefaultCodec());
+      cfg.setMergePolicy(NoMergePolicy.INSTANCE);
+      try (IndexWriter w = new IndexWriter(dir, cfg)) {
+        Random r = random();
+        int id = 0;
+        for (int s = 0; s < SEGMENTS; s++) {
+          for (int i = 0; i < DOCS_PER_SEGMENT; i++, id++) {
+            Document doc = new Document();
+            doc.add(new StringField("id", Integer.toString(id), Field.Store.NO));
+            float[] v = new float[DIM];
+            for (int j = 0; j < DIM; j++) {
+              v[j] = r.nextFloat();
+            }
+            doc.add(new KnnFloatVectorField("v", v));
+            w.addDocument(doc);
+          }
+          w.flush();
+        }
+        w.commit();
+      }
+
+      List<String> hnswMessages = new ArrayList<>();
+      InfoStream capturing =
+          new InfoStream() {
+            @Override
+            public void message(String component, String message) {
+              if ("HNSW".equals(component)) {
+                synchronized (hnswMessages) {
+                  hnswMessages.add(message);
+                }
+              }
+            }
+
+            @Override
+            public boolean isEnabled(String component) {
+              return "HNSW".equals(component);
+            }
+
+            @Override
+            public void close() {}
+          };
+
+      IndexWriterConfig cfg2 = new IndexWriterConfig();
+      cfg2.setCodec(TestUtil.getDefaultCodec());
+      cfg2.setInfoStream(capturing);
+      try (IndexWriter w2 = new IndexWriter(dir, cfg2)) {
+        w2.forceMerge(1);
+      }
+
+      synchronized (hnswMessages) {
+        assertTrue(
+            "expected the merged graph to be built by joining the "
+                + SEGMENTS
+                + " deletion-free source graphs, but HNSW messages were: "
+                + hnswMessages,
+            hnswMessages.stream().anyMatch(m -> m.startsWith("build graph from merging")));
+      }
+    }
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/index/TestHnswGraphReuseDuringMerge.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestHnswGraphReuseDuringMerge.java
@@ -35,7 +35,7 @@ import org.apache.lucene.util.InfoStream;
  * <p>The assertion keys on the InfoStream message of {@code MergingHnswGraphBuilder}, used by the
  * single threaded merger that the default format selects ({@code numMergeWorkers} is 1).
  */
-public class TestHnswGraphReuse extends LuceneTestCase {
+public class TestHnswGraphReuseDuringMerge extends LuceneTestCase {
 
   private static final int DIM = 8;
   private static final int SEGMENTS = 2;

--- a/lucene/core/src/test/org/apache/lucene/index/TestHnswGraphReuseDuringMerge.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestHnswGraphReuseDuringMerge.java
@@ -16,24 +16,28 @@
  */
 package org.apache.lucene.index;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.document.StringField;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.InfoStream;
 
 /**
- * Tests that merging deletion-free segments under the default codec reuses their existing HNSW
- * graphs instead of rebuilding the merged graph from scratch. The default codec wires vector
- * readers through {@code PerFieldKnnVectorsFormat.FieldsReader}, the wrapper that {@code
- * IncrementalHnswGraphMerger#addReader} must unwrap for reuse to trigger.
+ * Tests that merging segments under the default codec reuses their existing HNSW graphs instead of
+ * rebuilding the merged graph from scratch, both when the source segments are deletion-free and
+ * when the base segment carries deletions below the delete percentage threshold. The default codec
+ * wires vector readers through {@code PerFieldKnnVectorsFormat.FieldsReader}, the wrapper that
+ * {@code IncrementalHnswGraphMerger#addReader} must unwrap for reuse to trigger.
  *
- * <p>The assertion keys on the InfoStream message of {@code MergingHnswGraphBuilder}, used by the
- * single threaded merger that the default format selects ({@code numMergeWorkers} is 1).
+ * <p>The assertions key on the InfoStream message of {@code MergingHnswGraphBuilder}, used by the
+ * single-threaded merger that the default format selects ({@code numMergeWorkers} is 1).
  */
 public class TestHnswGraphReuseDuringMerge extends LuceneTestCase {
 
@@ -52,45 +56,16 @@ public class TestHnswGraphReuseDuringMerge extends LuceneTestCase {
       cfg.setCodec(TestUtil.getDefaultCodec());
       cfg.setMergePolicy(NoMergePolicy.INSTANCE);
       try (IndexWriter w = new IndexWriter(dir, cfg)) {
-        Random r = random();
         for (int s = 0; s < SEGMENTS; s++) {
-          for (int i = 0; i < DOCS_PER_SEGMENT; i++) {
-            Document doc = new Document();
-            float[] v = new float[DIM];
-            for (int j = 0; j < DIM; j++) {
-              v[j] = r.nextFloat();
-            }
-            doc.add(new KnnFloatVectorField("v", v));
-            w.addDocument(doc);
-          }
+          addVectorDocs(w, DOCS_PER_SEGMENT, null);
           w.flush();
         }
       }
 
       List<String> hnswMessages = new ArrayList<>();
-      InfoStream capturing =
-          new InfoStream() {
-            @Override
-            public void message(String component, String message) {
-              if ("HNSW".equals(component)) {
-                synchronized (hnswMessages) {
-                  hnswMessages.add(message);
-                }
-              }
-            }
-
-            @Override
-            public boolean isEnabled(String component) {
-              return "HNSW".equals(component);
-            }
-
-            @Override
-            public void close() {}
-          };
-
       IndexWriterConfig cfg2 = new IndexWriterConfig();
       cfg2.setCodec(TestUtil.getDefaultCodec());
-      cfg2.setInfoStream(capturing);
+      cfg2.setInfoStream(hnswInfoStream(hnswMessages));
       try (IndexWriter w2 = new IndexWriter(dir, cfg2)) {
         w2.forceMerge(1);
       }
@@ -101,8 +76,97 @@ public class TestHnswGraphReuseDuringMerge extends LuceneTestCase {
                 + SEGMENTS
                 + " deletion-free source graphs, but HNSW messages were: "
                 + hnswMessages,
-            hnswMessages.stream().anyMatch(m -> m.startsWith("build graph from merging")));
+            hnswMessages.stream()
+                .anyMatch(m -> m.startsWith("build graph from merging " + SEGMENTS + " graphs")));
       }
     }
+  }
+
+  /**
+   * A graph with deletions below the delete percentage threshold of {@code
+   * IncrementalHnswGraphMerger} is still selected as the base graph, so the merged graph is built
+   * by joining both source graphs rather than rebuilding from scratch.
+   */
+  public void testMergeReusesBaseGraphWithDeletions() throws Exception {
+    // enough docs that the base segment's live count after the deletions still exceeds the
+    // other segment's, keeping it the base graph
+    int baseSegmentDocs = 2000;
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig cfg = new IndexWriterConfig();
+      cfg.setCodec(TestUtil.getDefaultCodec());
+      cfg.setMergePolicy(NoMergePolicy.INSTANCE);
+      try (IndexWriter w = new IndexWriter(dir, cfg)) {
+        addVectorDocs(w, baseSegmentDocs, "d");
+        w.flush();
+        addVectorDocs(w, DOCS_PER_SEGMENT, null);
+        w.flush();
+      }
+
+      List<String> hnswMessages = new ArrayList<>();
+      IndexWriterConfig cfg2 = new IndexWriterConfig();
+      cfg2.setCodec(TestUtil.getDefaultCodec());
+      cfg2.setInfoStream(hnswInfoStream(hnswMessages));
+      try (IndexWriter w2 = new IndexWriter(dir, cfg2)) {
+        // delete 20% of the base segment, below the 40% delete percentage threshold
+        for (int i = 0; i < baseSegmentDocs; i += 5) {
+          w2.deleteDocuments(new Term("id", "d" + i));
+        }
+        w2.forceMerge(1);
+      }
+
+      // ensure the deletions actually applied, otherwise this degenerates into the clean case
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        assertEquals(
+            "deletions were not applied",
+            baseSegmentDocs - baseSegmentDocs / 5 + DOCS_PER_SEGMENT,
+            reader.numDocs());
+      }
+
+      synchronized (hnswMessages) {
+        assertTrue(
+            "expected the merged graph to be built by joining the base graph with deletions and"
+                + " the clean graph, but HNSW messages were: "
+                + hnswMessages,
+            hnswMessages.stream().anyMatch(m -> m.startsWith("build graph from merging 2 graphs")));
+      }
+    }
+  }
+
+  private static void addVectorDocs(IndexWriter w, int numDocs, String idPrefix)
+      throws IOException {
+    Random r = random();
+    for (int i = 0; i < numDocs; i++) {
+      Document doc = new Document();
+      float[] v = new float[DIM];
+      for (int j = 0; j < DIM; j++) {
+        v[j] = r.nextFloat();
+      }
+      doc.add(new KnnFloatVectorField("v", v));
+      if (idPrefix != null) {
+        doc.add(new StringField("id", idPrefix + i, Field.Store.NO));
+      }
+      w.addDocument(doc);
+    }
+  }
+
+  private static InfoStream hnswInfoStream(List<String> sink) {
+    return new InfoStream() {
+      @Override
+      public void message(String component, String message) {
+        if ("HNSW".equals(component)) {
+          synchronized (sink) {
+            sink.add(message);
+          }
+        }
+      }
+
+      @Override
+      public boolean isEnabled(String component) {
+        return "HNSW".equals(component);
+      }
+
+      @Override
+      public void close() {}
+    };
   }
 }


### PR DESCRIPTION
Fixes #16400.

The guard in `IncrementalHnswGraphMerger.addReader` tests the per-field wrapper instead of the unwrapped reader, so under per-field vectors formats reuse never triggers and every merge rebuilds the graph. Details are in the issue.

The fix tests the unwrapped reader and stores it in `GraphReader`, because `createBuilder` later casts `GraphReader#reader` to `HnswGraphProvider`.

`TestHnswGraphReuse` asserts that merging deletion-free segments under the default codec takes the graph reuse path.
