### PR TITLE
Do not drop strictly competitive boundary candidates in filtered HNSW search

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -226,6 +226,8 @@ Bug Fixes
 
 * Make VectorScorer#bulk default method lazily position its iterator on first use. (Michael Marshall)
 
+* GITHUB#16409: Fix filtered HNSW search boundary handling to match the general HNSW searcher. (Mingi Jeong)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14187: The query cache is now disabled by default. (Adrien Grand)

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/FilteredHnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/FilteredHnswGraphSearcher.java
@@ -131,11 +131,17 @@ public class FilteredHnswGraphSearcher extends HnswGraphSearcher {
     // A bound that holds the minimum similarity to the query vector that a candidate vector must
     // have to be considered.
     float minAcceptedSimilarity = Math.nextUp(results.minCompetitiveSimilarity());
+    // Allow one candidate equivalent to the current minimum, matching HnswGraphSearcher.
+    boolean shouldExploreMinSim = true;
     while (candidates.size() > 0 && results.earlyTerminated() == false) {
       // get the best candidate (closest or best scoring)
       float topCandidateSimilarity = candidates.topScore();
-      if (minAcceptedSimilarity > topCandidateSimilarity) {
-        break;
+      if (topCandidateSimilarity < minAcceptedSimilarity) {
+        if (shouldExploreMinSim && Math.nextUp(topCandidateSimilarity) == minAcceptedSimilarity) {
+          shouldExploreMinSim = false;
+        } else {
+          break;
+        }
       }
       int topCandidateNode = candidates.pop();
       graph.seek(level, topCandidateNode);
@@ -197,15 +203,19 @@ public class FilteredHnswGraphSearcher extends HnswGraphSearcher {
               ? scorer.bulkScore(toScore.nodes, bulkScores, toScore.size)
               : Float.NEGATIVE_INFINITY;
       results.incVisitedCount(toScore.count());
-      if (maxScore > minAcceptedSimilarity) {
+      if (maxScore > results.minCompetitiveSimilarity()) {
         for (int i = 0; i < toScore.count(); i++) {
           int idx = i + toScore.upto;
           float friendSimilarity = bulkScores[idx];
-          if (friendSimilarity > minAcceptedSimilarity) {
+          if (friendSimilarity >= minAcceptedSimilarity) {
             int ord = toScore.nodes[idx];
             candidates.add(ord, friendSimilarity);
             if (results.collect(ord, friendSimilarity)) {
+              float oldMinAcceptedSimilarity = minAcceptedSimilarity;
               minAcceptedSimilarity = Math.nextUp(results.minCompetitiveSimilarity());
+              if (minAcceptedSimilarity > oldMinAcceptedSimilarity) {
+                shouldExploreMinSim = true;
+              }
             }
           }
         }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestFilteredHnswGraphSearcher.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestFilteredHnswGraphSearcher.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+import java.io.IOException;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopKnnCollector;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.FixedBitSet;
+
+public class TestFilteredHnswGraphSearcher extends LuceneTestCase {
+
+  public void testExploresStrictlyCompetitiveBoundaryCandidate() throws IOException {
+    OnHeapHnswGraph graph = new OnHeapHnswGraph(2, 4);
+    for (int node = 0; node < 4; node++) {
+      graph.addNode(0, node);
+    }
+    assertTrue(graph.trySetNewEntryNode(0, 0));
+    graph.getNeighbors(0, 0).addInOrder(1, 1f);
+
+    float entryScore = 0.5f;
+    float betterScore = Math.nextUp(entryScore);
+    float[] scores = {entryScore, betterScore, 0.1f, 0.1f};
+    RandomVectorScorer scorer =
+        new RandomVectorScorer() {
+          @Override
+          public float score(int node) {
+            return scores[node];
+          }
+
+          @Override
+          public int maxOrd() {
+            return scores.length;
+          }
+        };
+
+    FixedBitSet acceptOrds = new FixedBitSet(4);
+    acceptOrds.set(0);
+    acceptOrds.set(1);
+    KnnCollector collector =
+        new TopKnnCollector(1, Integer.MAX_VALUE, KnnSearchStrategy.Hnsw.DEFAULT);
+
+    FilteredHnswGraphSearcher.create(collector.k(), graph, 2, acceptOrds)
+        .search(collector, scorer, graph, acceptOrds);
+
+    TopDocs results = collector.topDocs();
+    assertEquals(1, results.scoreDocs.length);
+    assertEquals(1, results.scoreDocs[0].doc);
+    assertEquals(betterScore, results.scoreDocs[0].score, 0f);
+  }
+
+  public void testAllTiedScoresBoundedVisitation() throws IOException {
+    OnHeapHnswGraph graph = new OnHeapHnswGraph(2, 6);
+    for (int node = 0; node < 6; node++) {
+      graph.addNode(0, node);
+    }
+    assertTrue(graph.trySetNewEntryNode(0, 0));
+    for (int node = 0; node < 5; node++) {
+      graph.getNeighbors(0, node).addInOrder(node + 1, 1f);
+    }
+
+    RandomVectorScorer scorer =
+        new RandomVectorScorer() {
+          @Override
+          public float score(int node) {
+            return 0.5f;
+          }
+
+          @Override
+          public int maxOrd() {
+            return 6;
+          }
+        };
+
+    FixedBitSet acceptOrds = new FixedBitSet(6);
+    for (int node = 0; node < 4; node++) {
+      acceptOrds.set(node);
+    }
+    KnnCollector collector =
+        new TopKnnCollector(1, Integer.MAX_VALUE, KnnSearchStrategy.Hnsw.DEFAULT);
+
+    FilteredHnswGraphSearcher.create(collector.k(), graph, 4, acceptOrds)
+        .search(collector, scorer, graph, acceptOrds);
+
+    // One candidate tied with the current minimum may be explored, then the search must stop
+    // instead of walking the rest of the equal-scored chain.
+    assertEquals(2, collector.visitedCount());
+    TopDocs results = collector.topDocs();
+    assertEquals(1, results.scoreDocs.length);
+    assertEquals(0, results.scoreDocs[0].doc);
+    assertEquals(0.5f, results.scoreDocs[0].score, 0f);
+  }
+}


### PR DESCRIPTION
### Description

`FilteredHnswGraphSearcher` can stop before exploring a candidate whose score is equal to the current result floor, and it rejects neighbors whose score is exactly `Math.nextUp(results.minCompetitiveSimilarity())`.

The latter score is strictly better than the current minimum and is competitive. The base `HnswGraphSearcher` already handles both boundaries:

- #14249 changed neighbor admission from `>` to `>=` because a score equal to `Math.nextUp(minCompetitiveSimilarity)` is better.
- #14366 allows one candidate equivalent to the current minimum to be explored, while preventing the degenerate equal-score case from expanding without bound.

The filtered searcher was added before those follow-ups and retained the earlier boundary behavior. This change applies the same contract to the filtered path:

- explore one candidate equivalent to the current minimum;
- admit a neighbor at `minAcceptedSimilarity`;
- gate the scored batch on `maxScore > results.minCompetitiveSimilarity()`, the same bound the base searcher uses;
- reset the one-equivalent guard when collection raises the minimum.

### Regression tests

Both tests call `FilteredHnswGraphSearcher` directly, so they do not depend on the filtered-search dispatch heuristic.

The first test uses a four-node graph with two accepted nodes and `k=1`. The entry node scores `0.5`; its accepted neighbor scores `Math.nextUp(0.5)`. Before this change, filtered HNSW returns the `0.5` entry and never considers the strictly better neighbor. After the change, it returns the neighbor.

The second test searches a chain where every node has the same score and asserts that visitation stays bounded: one candidate tied with the current minimum may be explored, then the search stops.

### Validation

- regression tests: fail on current main, pass with the change
- `./gradlew :lucene:core:check` passes: 8,534 tests, 307 skipped

Related history: #14160, #14215, #14249, #14366, #15500.
