### PR TITLE
GITHUB#12370: early-terminate string sort when field is missing from the whole index

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -166,12 +166,6 @@ Optimizations
   wildcards into a single any-string automaton, avoiding a quadratic blow-up in
   automaton size for patterns with many repeated asterisks. (Vismay Tiwari)
 
-* GITHUB#12370: Sorting on a string field no longer scans every document when the top-N queue fills
-  with missing values -- whether because the field is missing from the whole index, or because
-  sort-missing-first put missing values at the top. When the sort has no tie breaker, a further
-  missing value cannot displace one already in the queue, so the rest can be skipped.
-  (Serhiy Bzhezytskyy)
-
 * GITHUB#16307: ReqExclBulkScorer now skips runs of excluded docs via
   TwoPhaseIterator#docIDRunEnd for two-phase excluded clauses (e.g. a doc-values
   not-equals filter), instead of advancing one doc at a time. (Jim Ferenczi)
@@ -409,6 +403,12 @@ Optimizations
   sort field is empty or only contains a single value. (Alan Woodward)
 
 * GITHUB#16180: Add bulk intoBitSet for SortedDocValues ordinal ranges. (Prithvi S)
+
+* GITHUB#12370: Sorting on a string field no longer scans every document when the top-N queue fills
+  with missing values -- whether because the field is missing from the whole index, or because
+  sort-missing-first put missing values at the top. When the sort has no tie breaker, a further
+  missing value cannot displace one already in the queue, so the rest can be skipped.
+  (Serhiy Bzhezytskyy)
 
 Bug Fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -166,6 +166,10 @@ Optimizations
   wildcards into a single any-string automaton, avoiding a quadratic blow-up in
   automaton size for patterns with many repeated asterisks. (Vismay Tiwari)
 
+* GITHUB#12370: Sorting on a string field that is missing from the whole index no longer scans every
+  document. When the sort has no tie breaker, all documents tie on the missing value, so once the
+  top-N queue is full the remaining documents can be skipped. (Serhiy Bzhezytskyy)
+
 * GITHUB#16307: ReqExclBulkScorer now skips runs of excluded docs via
   TwoPhaseIterator#docIDRunEnd for two-phase excluded clauses (e.g. a doc-values
   not-equals filter), instead of advancing one doc at a time. (Jim Ferenczi)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -166,9 +166,11 @@ Optimizations
   wildcards into a single any-string automaton, avoiding a quadratic blow-up in
   automaton size for patterns with many repeated asterisks. (Vismay Tiwari)
 
-* GITHUB#12370: Sorting on a string field that is missing from the whole index no longer scans every
-  document. When the sort has no tie breaker, all documents tie on the missing value, so once the
-  top-N queue is full the remaining documents can be skipped. (Serhiy Bzhezytskyy)
+* GITHUB#12370: Sorting on a string field no longer scans every document when the top-N queue fills
+  with missing values -- whether because the field is missing from the whole index, or because
+  sort-missing-first put missing values at the top. When the sort has no tie breaker, a further
+  missing value cannot displace one already in the queue, so the rest can be skipped.
+  (Serhiy Bzhezytskyy)
 
 * GITHUB#16307: ReqExclBulkScorer now skips runs of excluded docs via
   TwoPhaseIterator#docIDRunEnd for two-phase excluded clauses (e.g. a doc-values

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
@@ -434,6 +434,13 @@ public class TermOrdValComparator extends FieldComparator<BytesRef> {
           }
         } else if (sortMissingLast || dense) {
           minOrd = 0;
+        } else if (bottomValue == null && singleSort) {
+          // The worst entry in the queue is itself a missing value and there is no tie breaker, so
+          // another missing value can no longer compete: missing values are no longer competitive.
+          // (bottomValue==null is stronger than bottomOrd==missingOrd, which can also be produced
+          // by
+          // a real value that maps before ord 0 in this segment.)
+          minOrd = 0;
         } else {
           // Missing values are still competitive.
           minOrd = -1;

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
@@ -297,8 +297,10 @@ public class TermOrdValComparator extends FieldComparator<BytesRef> {
       if (dense || topValue != null) {
         return true;
       } else if (reverse == sortMissingLast) {
-        // Missing values are always competitive, we can never skip
-        return false;
+        // Missing values sort best here, so they stay competitive for as long as the queue is not
+        // full of them. With no tie breaker they stop competing once it is, so skipping is still
+        // worth enabling; updateCompetitiveIterator decides when it can actually start.
+        return singleSort;
       } else {
         return true;
       }

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -1239,6 +1239,47 @@ public class TestSortOptimization extends LuceneTestCase {
     dir.close();
   }
 
+  /**
+   * GITHUB#12370: when the sort field is missing from the whole index (not just one segment) and
+   * the sort has no tie breaker, all documents tie on the missing value, so once the top-N queue is
+   * full the remaining documents are non-competitive and must be skipped rather than fully
+   * collected.
+   */
+  public void testStringSortOptimizationFieldMissingInWholeIndex() throws IOException {
+    final Directory dir = newDirectory();
+    final IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig());
+
+    // None of the documents index the sort field, so it is absent from every segment's FieldInfos.
+    final int numDocs = atLeast(10000);
+    for (int i = 0; i < numDocs; i++) {
+      final Document doc = new Document();
+      doc.add(new StringField("other", Integer.toString(i), Field.Store.NO));
+      writer.addDocument(doc);
+    }
+
+    final DirectoryReader reader = DirectoryReader.open(writer);
+    writer.close();
+
+    final int numHits = 5;
+
+    { // ascending, sort-missing-first (the default for SortedSetSortField): missing is the best
+      // value, but with no tie breaker a second missing value can never displace one already in the
+      // queue, so the tail should be skipped.
+      SortField sortField = new SortedSetSortField("field_does_not_exist", false);
+      TopDocs topDocs = assertSearchHits(reader, new Sort(sortField), numHits, null);
+      assertNonCompetitiveHitsAreSkipped(topDocs.totalHits.value(), numDocs);
+    }
+
+    { // descending, sort-missing-first
+      SortField sortField = new SortedSetSortField("field_does_not_exist", true);
+      TopDocs topDocs = assertSearchHits(reader, new Sort(sortField), numHits, null);
+      assertNonCompetitiveHitsAreSkipped(topDocs.totalHits.value(), numDocs);
+    }
+
+    reader.close();
+    dir.close();
+  }
+
   private void doTestStringSortOptimization(DirectoryReader reader) throws IOException {
     final int numDocs = reader.numDocs();
     final int numHits = 5;

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortOptimization.java
@@ -1280,6 +1280,83 @@ public class TestSortOptimization extends LuceneTestCase {
     dir.close();
   }
 
+  /**
+   * GITHUB#12370: every document carries the SAME single value for the sort field, so with no tie
+   * breaker they all compare equal and the tail is non-competitive once the queue is full, exactly
+   * as when the field is missing from every segment.
+   */
+  public void testStringSortOptimizationSingleValueInWholeIndex() throws IOException {
+    final Directory dir = newDirectory();
+    final IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig());
+
+    final int numDocs = atLeast(10000);
+    for (int i = 0; i < numDocs; i++) {
+      final Document doc = new Document();
+      doc.add(new SortedDocValuesField("field", new BytesRef("the only value")));
+      doc.add(new StringField("field", "the only value", Field.Store.NO));
+      doc.add(new StringField("other", Integer.toString(i), Field.Store.NO));
+      writer.addDocument(doc);
+    }
+
+    final DirectoryReader reader = DirectoryReader.open(writer);
+    writer.close();
+
+    final int numHits = 5;
+
+    { // ascending
+      SortField sortField = new SortField("field", SortField.Type.STRING, false);
+      TopDocs topDocs = assertSearchHits(reader, new Sort(sortField), numHits, null);
+      assertNonCompetitiveHitsAreSkipped(topDocs.totalHits.value(), numDocs);
+    }
+
+    { // descending
+      SortField sortField = new SortField("field", SortField.Type.STRING, true);
+      TopDocs topDocs = assertSearchHits(reader, new Sort(sortField), numHits, null);
+      assertNonCompetitiveHitsAreSkipped(topDocs.totalHits.value(), numDocs);
+    }
+
+    reader.close();
+    dir.close();
+  }
+
+  /**
+   * GITHUB#12370, the remaining case: the sort field DOES exist and some documents have a value,
+   * but with sort-missing-first the top-N queue fills entirely with missing values. With no tie
+   * breaker a further missing value cannot displace one already in the queue, so the tail must be
+   * skipped.
+   */
+  public void testStringSortOptimizationQueueAllMissingSortMissingFirst() throws IOException {
+    final Directory dir = newDirectory();
+    final IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig());
+
+    // Most documents lack the sort field, a few carry a value, so the field is present in
+    // FieldInfos but not dense -- unlike the missing-from-the-whole-index case above.
+    final int numDocs = atLeast(10000);
+    for (int i = 0; i < numDocs; i++) {
+      final Document doc = new Document();
+      if (i % 1000 == 0) {
+        doc.add(new SortedDocValuesField("field", new BytesRef("value" + i)));
+        doc.add(new StringField("field", "value" + i, Field.Store.NO));
+      }
+      doc.add(new StringField("other", Integer.toString(i), Field.Store.NO));
+      writer.addDocument(doc);
+    }
+
+    final DirectoryReader reader = DirectoryReader.open(writer);
+    writer.close();
+
+    final int numHits = 5;
+
+    // sortMissingFirst ascending: missing sorts best, so the queue is all-missing once full.
+    SortField sortField =
+        new SortField("field", SortField.Type.STRING, false, SortField.STRING_FIRST);
+    TopDocs topDocs = assertSearchHits(reader, new Sort(sortField), numHits, null);
+    assertNonCompetitiveHitsAreSkipped(topDocs.totalHits.value(), numDocs);
+
+    reader.close();
+    dir.close();
+  }
+
   private void doTestStringSortOptimization(DirectoryReader reader) throws IOException {
     final int numDocs = reader.numDocs();
     final int numHits = 5;


### PR DESCRIPTION
Closes #12370.

### Description

Sorting on a string field that is **missing from the whole index** currently scans every document instead of early-terminating.

When the sort field doesn't exist anywhere in the segment, every document ties on the "missing" value. With no tie-breaker, once the top-N priority queue is full, all remaining documents are non-competitive and can be skipped — but `TermOrdValComparator` didn't recognize this case, so it visited every doc.

### Fix

`TermOrdValComparator` now mirrors the existing `singleSort` competitive-iterator recognition to the `minOrd` path, gated on `bottomValue == null` (i.e. the field is missing from the segment). This lets the comparator signal non-competitiveness and skip once the queue is full, exactly as it already does for present fields.

Correctness is unchanged — results are identical; this is purely an optimization (so it's filed under Optimizations in CHANGES.txt).

### Tests

Added a regression test to `TestSortOptimization` that asserts early termination happens (non-vacuous — it fails without the fix). `./gradlew :lucene:core:test --tests TestSortOptimization` → 29 tests, all green on current main.
