### PR TITLE
Update CHANGES.txt entry for fp16 vector encoding support

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -126,6 +126,8 @@ New Features
 
 * GITHUB#15818: Add BM25 k3 query-term frequency saturation to BM25Similarity. (Sagar Upadhyaya)
 
+* GITHUB#16383: Add fp16 vector encoding support. (Pulkit Gupta)
+
 Improvements
 ---------------------
 * GITHUB#15704: Replace LinkedList with more efficient data structure. (Renato Haeberli)
@@ -327,8 +329,6 @@ New Features
 * GITHUB#16243: Add StableTflSimilarity, a similarity that estimates term rarity from term length
   and document length instead of corpus statistics such as document frequency. It also supports k3
   query-term frequency saturation. (Tianxiao Wei)
-
-* GITHUB#16383: Add fp16 vector encoding support. (Pulkit Gupta)
 
 Improvements
 ---------------------


### PR DESCRIPTION
We realized that the fp16 encoding support: (comment [link](https://github.com/apache/lucene/pull/16383#issuecomment-5116436447)) #16383 should be released in Lucene 11 instead of Lucene 10.6. Hence changing the entry in CHANGES.txt file.