### PR TITLE
feat: Add Executor support to Monitor for concurrent search (issue #16198)

### DIFF
--- a/lucene/monitor/src/java/org/apache/lucene/monitor/Monitor.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/Monitor.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.LeafReader;
@@ -47,6 +48,8 @@ public class Monitor implements Closeable {
   private final QueryIndex queryIndex;
 
   private final long commitBatchSize;
+
+  private final Executor executor;
 
   /**
    * Create a non-persistent Monitor instance with the default term-filtering Presearcher
@@ -96,6 +99,7 @@ public class Monitor implements Closeable {
     }
 
     this.commitBatchSize = configuration.getQueryUpdateBufferSize();
+    this.executor = configuration.getExecutor();
   }
 
   /**
@@ -219,7 +223,9 @@ public class Monitor implements Closeable {
       Document[] docs, MatcherFactory<T> factory) throws IOException {
     try (DocumentBatch batch = DocumentBatch.of(analyzer, docs)) {
       LeafReader reader = batch.get();
-      CandidateMatcher<T> matcher = factory.createMatcher(new IndexSearcher(batch.get()));
+      IndexSearcher indexSearcher =
+          (executor != null) ? new IndexSearcher(reader, executor) : new IndexSearcher(reader);
+      CandidateMatcher<T> matcher = factory.createMatcher(indexSearcher);
       StandardQueryCollector<T> collector = new StandardQueryCollector<>(matcher);
       long buildTime = queryIndex.search(t -> presearcher.buildQuery(reader, t), collector);
       return matcher.finish(buildTime, collector.queryCount);
@@ -318,7 +324,8 @@ public class Monitor implements Closeable {
       Document[] docs, MatcherFactory<T> factory) throws IOException {
     try (DocumentBatch batch = DocumentBatch.of(analyzer, docs)) {
       LeafReader reader = batch.get();
-      IndexSearcher searcher = new IndexSearcher(reader);
+      IndexSearcher searcher =
+          (executor != null) ? new IndexSearcher(reader, executor) : new IndexSearcher(reader);
       searcher.setQueryCache(null);
       PresearcherQueryCollector<T> collector =
           new PresearcherQueryCollector<>(factory.createMatcher(searcher));

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/MonitorConfiguration.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/MonitorConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.lucene.monitor;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.index.IndexWriter;
@@ -39,6 +40,7 @@ public class MonitorConfiguration {
   private MonitorQuerySerializer serializer;
   private boolean readOnly = false;
   private IOSupplier<Directory> directoryProvider = () -> new ByteBuffersDirectory();
+  private Executor executor = null;
 
   private static IndexWriterConfig defaultIndexWriterConfig() {
     IndexWriterConfig iwc = new IndexWriterConfig(new KeywordAnalyzer());
@@ -164,5 +166,26 @@ public class MonitorConfiguration {
    */
   public int getQueryUpdateBufferSize() {
     return queryUpdateBufferSize;
+  }
+
+  /**
+   * Set the Executor to use for concurrent search.
+   *
+   * <p>If set, the Monitor will pass this Executor to the IndexSearcher it creates internally,
+   * allowing for inter-segment concurrency in search operations.
+   *
+   * @param executor the Executor to use for concurrent search
+   * @return the current configuration
+   */
+  public MonitorConfiguration setExecutor(Executor executor) {
+    this.executor = executor;
+    return this;
+  }
+
+  /**
+   * @return the Executor used for concurrent search, or null if not set
+   */
+  public Executor getExecutor() {
+    return executor;
   }
 }


### PR DESCRIPTION
## Summary

This PR adds support for passing an Executor to the Monitor for inter-segment concurrency in search operations.

## Changes

- Added `Executor` field to `MonitorConfiguration` with getter/setter methods
- Modified `Monitor` constructor to store the Executor from configuration
- Updated `match()` and `debug()` methods to use the Executor when creating `IndexSearcher` instances

## Usage

Users can now configure concurrent search in Monitor:

```java
MonitorConfiguration config = new MonitorConfiguration();
config.setExecutor(executor);
Monitor monitor = new Monitor(analyzer, config);
```

## Related

Fixes #16198

🤖 Generated with [Claude Code](https://claude.com/claude-code)