### PR TITLE
GITHUB#14399: decide index-sort early termination per segment in TopFieldCollector

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,9 +7,6 @@ http://s.apache.org/luceneversions
 
 API Changes
 ---------------------
-* GITHUB#14399: Add a default LeafFieldComparator#disableSkipping method so document skipping can be
-  disabled per segment. (Serhiy Bzhezytskyy)
-
 * GITHUB#15929: Rename CollectionStatistics to FieldStats and TermStatistics to TermStats. (Zhou Hui)
 
 * GITHUB#15763: Deprecate Operations.complement() method. This operation can be slow and is not
@@ -196,10 +193,6 @@ Optimizations
 
 Bug Fixes
 ---------------------
-* GITHUB#14399: TopFieldCollector now decides per segment whether the search sort is a prefix of the
-  index sort, instead of caching the decision from the first segment. This fixes incorrect results
-  when searching a MultiReader that combines indexes with different index sorts. (Serhiy Bzhezytskyy)
-
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
   when all values are identical. (Mike Sokolov)
 
@@ -326,6 +319,9 @@ Other
 API Changes
 ---------------------
 
+* GITHUB#14399: Add a default LeafFieldComparator#disableSkipping method so document skipping can be
+  disabled per segment. (Serhiy Bzhezytskyy)
+
 * GITHUB#16286: Introduce BinaryDocValues#binaryValues to help speed up the
   retrieval of many binary doc values at once. (Costin Leau)
 
@@ -417,6 +413,10 @@ Bug Fixes
 * GITHUB#16450: Fix DocValuesRangeIterator.docIDRunEnd() returning incorrect run boundaries,
   causing bulk-scoring to skip or mis-score documents in range and ordinal set queries.
   (Parker Timmins)
+
+* GITHUB#14399: TopFieldCollector now decides per segment whether the search sort is a prefix of the
+  index sort, instead of caching the decision from the first segment. This fixes incorrect results
+  when searching a MultiReader that combines indexes with different index sorts. (Serhiy Bzhezytskyy)
 
 * GITHUB#16251: Fix UpdateGraphsUtils#computeJoinSet to not request more coverage for a node than
   the node's degree. Previously nodes with a degree of 1 were always forced into the join set,

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,6 +7,9 @@ http://s.apache.org/luceneversions
 
 API Changes
 ---------------------
+* GITHUB#14399: Add a default LeafFieldComparator#disableSkipping method so document skipping can be
+  disabled per segment. (Serhiy Bzhezytskyy)
+
 * GITHUB#15929: Rename CollectionStatistics to FieldStats and TermStatistics to TermStats. (Zhou Hui)
 
 * GITHUB#15763: Deprecate Operations.complement() method. This operation can be slow and is not
@@ -193,6 +196,10 @@ Optimizations
 
 Bug Fixes
 ---------------------
+* GITHUB#14399: TopFieldCollector now decides per segment whether the search sort is a prefix of the
+  index sort, instead of caching the decision from the first segment. This fixes incorrect results
+  when searching a MultiReader that combines indexes with different index sorts. (Serhiy Bzhezytskyy)
+
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
   when all values are identical. (Mike Sokolov)
 

--- a/lucene/core/src/java/org/apache/lucene/search/LeafFieldComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LeafFieldComparator.java
@@ -111,4 +111,13 @@ public interface LeafFieldComparator {
    * collector when hits threshold is reached.
    */
   default void setHitsThresholdReached() throws IOException {}
+
+  /**
+   * Informs this leaf comparator that document skipping should be disabled for this segment. Called
+   * by {@link TopFieldCollector} when the search sort is a prefix of <em>this segment's</em> index
+   * sort, so the collector can already terminate early and any extra skipping work in the
+   * comparator is redundant. This is a per-segment decision: a {@link
+   * org.apache.lucene.index.MultiReader} may combine segments with different index sorts.
+   */
+  default void disableSkipping() {}
 }

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
@@ -45,20 +45,18 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
 
     final LeafFieldComparator comparator;
     final int reverseMul;
+    // Whether the search sort is a prefix of this segment's index sort (decided per segment).
+    final boolean searchSortPartOfIndexSort;
     Scorable scorer;
     boolean collectedAllCompetitiveHits = false;
 
     TopFieldLeafCollector(FieldValueHitQueue<Entry> queue, Sort sort, LeafReaderContext context)
         throws IOException {
-      // as all segments are sorted in the same way, enough to check only the 1st segment for
-      // indexSort
-      if (searchSortPartOfIndexSort == null) {
-        final Sort indexSort = context.reader().getMetaData().sort();
-        searchSortPartOfIndexSort = canEarlyTerminate(sort, indexSort);
-        if (searchSortPartOfIndexSort) {
-          firstComparator.disableSkipping();
-        }
-      }
+      // Whether the search sort is a prefix of the index sort is decided per segment: a MultiReader
+      // may combine segments with different index sorts, so this cannot be cached across leaves
+      // (GITHUB#14399).
+      final Sort indexSort = context.reader().getMetaData().sort();
+      searchSortPartOfIndexSort = canEarlyTerminate(sort, indexSort);
       LeafFieldComparator[] comparators = queue.getComparators(context);
       int[] reverseMuls = queue.getReverseMul();
       if (comparators.length == 1) {
@@ -67,6 +65,12 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
       } else {
         this.reverseMul = 1;
         this.comparator = new MultiLeafFieldComparator(comparators, reverseMuls);
+      }
+      if (searchSortPartOfIndexSort) {
+        // Early termination handles this segment; skipping work in the comparator is redundant.
+        for (LeafFieldComparator comparator : comparators) {
+          comparator.disableSkipping();
+        }
       }
     }
 
@@ -303,8 +307,6 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
   final int totalHitsThreshold;
   final FieldComparator<?> firstComparator;
   final boolean canSetMinScore;
-
-  Boolean searchSortPartOfIndexSort = null; // shows if Search Sort if a part of the Index Sort
 
   // an accumulator that maintains the maximum of the segment's minimum competitive scores
   final MaxScoreAccumulator minScoreAcc;

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -98,12 +98,20 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
   public abstract class NumericLeafComparator implements LeafFieldComparator {
     private final LeafReaderContext context;
     protected final NumericDocValues docValues;
-    private final CompetitiveDISIBuilder competitiveDISIBuilder;
+    private CompetitiveDISIBuilder competitiveDISIBuilder;
 
     public NumericLeafComparator(LeafReaderContext context) throws IOException {
       this.context = context;
       this.docValues = getNumericDocValues(context, field);
       this.competitiveDISIBuilder = buildCompetitiveDISIBuilder();
+    }
+
+    @Override
+    public void disableSkipping() {
+      // Drop the competitive iterator so this segment is scanned without skipping; the collector
+      // has determined the search sort is a prefix of this segment's index sort and will terminate
+      // early on its own.
+      this.competitiveDISIBuilder = null;
     }
 
     protected CompetitiveDISIBuilder buildCompetitiveDISIBuilder() throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java
@@ -214,7 +214,7 @@ public class TermOrdValComparator extends FieldComparator<BytesRef> {
     /** Which ordinal to use for a missing value. */
     final int missingOrd;
 
-    private final CompetitiveState competitiveState;
+    private CompetitiveState competitiveState;
 
     private final boolean dense;
 
@@ -489,6 +489,13 @@ public class TermOrdValComparator extends FieldComparator<BytesRef> {
       assert minOrd >= 0;
       assert maxOrd < termsIndex.getValueCount();
       competitiveState.update(minOrd, maxOrd);
+    }
+
+    @Override
+    public void disableSkipping() {
+      // Drop the competitive iterator so this segment is scanned without skipping; the collector
+      // will terminate early on its own because the search sort is a prefix of this segment's sort.
+      competitiveState = null;
     }
 
     @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollectorEarlyTermination.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollectorEarlyTermination.java
@@ -285,7 +285,6 @@ public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
     // calls disableSkipping().
     Directory dirA = newDirectory();
     IndexWriterConfig iwcA = newIndexWriterConfig().setIndexSort(ascSort);
-    iwcA.setMergeScheduler(new SerialMergeScheduler());
     try (RandomIndexWriter w = new RandomIndexWriter(random(), dirA, iwcA)) {
       for (int i = 0; i < 20; i++) {
         Document doc = new Document();
@@ -305,7 +304,6 @@ public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
     IndexWriterConfig iwcB =
         newIndexWriterConfig()
             .setIndexSort(new Sort(new SortField("ndv", SortField.Type.LONG, true)));
-    iwcB.setMergeScheduler(new SerialMergeScheduler());
     try (RandomIndexWriter w = new RandomIndexWriter(random(), dirB, iwcB)) {
       for (int i = 0; i < 20; i++) {
         Document doc = new Document();

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollectorEarlyTermination.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollectorEarlyTermination.java
@@ -270,19 +270,19 @@ public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
   }
 
   /**
-   * GITHUB#14399: TopFieldCollector caches whether the search sort is a prefix of the index sort
-   * after inspecting only the first leaf. That is safe for a single index (IndexWriter enforces one
-   * index sort), but a MultiReader can span indexes with different index sorts. Here the first
-   * index is sorted so the search sort IS a prefix (early termination is eligible) while the second
-   * index is sorted the opposite way (it is NOT). The cached "yes" wrongly early-terminates the
-   * second leaf and drops results that should rank first.
+   * GITHUB#14399: whether the search sort is a prefix of the index sort must be decided per
+   * segment. A single index has one index sort (IndexWriter enforces it), but a MultiReader can
+   * span indexes sorted differently: here the first index is sorted so the search sort IS a prefix
+   * (early termination is eligible) while the second is sorted the opposite way (it is NOT).
+   * Deciding once from the first leaf answers "yes" for both, which early-terminates the second
+   * leaf and drops the result that should rank first.
    */
   public void testMultiReaderWithDifferentIndexSorts() throws IOException {
     final Sort ascSort = new Sort(new SortField("ndv", SortField.Type.LONG));
 
     // Index A: sorted ndv ASC, many docs with a moderate value (50). Under an ASC search sort this
-    // leaf is prefix-sorted, so the collector caches "search sort is part of index sort" = true and
-    // calls disableSkipping().
+    // leaf is prefix-sorted, so the collector decides "search sort is part of index sort" = true
+    // for it and calls disableSkipping().
     Directory dirA = newDirectory();
     IndexWriterConfig iwcA = newIndexWriterConfig().setIndexSort(ascSort);
     try (RandomIndexWriter w = new RandomIndexWriter(random(), dirA, iwcA)) {
@@ -296,10 +296,8 @@ public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
 
     // Index B: sorted ndv DESC (a DIFFERENT index sort). Its most competitive doc for an ASC search
     // (value 1) is written LAST, so in docid order the leaf is [90, 90, ..., 1]. If leaf B is
-    // wrongly
-    // treated as prefix-sorted (leaf A's cached decision), collection terminates in docid order
-    // after
-    // the threshold and never reaches the trailing value 1 -- the true top result is dropped.
+    // wrongly treated as prefix-sorted, collection terminates in docid order after the threshold
+    // and never reaches the trailing value 1 -- the true top result is dropped.
     Directory dirB = newDirectory();
     IndexWriterConfig iwcB =
         newIndexWriterConfig()
@@ -322,8 +320,8 @@ public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
     // eligible for early termination); the B leaf is DESC-sorted (not a prefix).
     MultiReader multiReader = new MultiReader(readerA, readerB);
     try {
-      // Force both leaves into a single slice so one collector (with one shared
-      // searchSortPartOfIndexSort cache) sees both the ASC-sorted and DESC-sorted leaves.
+      // Force both leaves into a single slice so one collector sees both the ASC-sorted and the
+      // DESC-sorted leaf.
       IndexSearcher searcher =
           new IndexSearcher(multiReader) {
             @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollectorEarlyTermination.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollectorEarlyTermination.java
@@ -27,8 +27,11 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.SerialMergeScheduler;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher.LeafReaderContextPartition;
@@ -41,6 +44,7 @@ import org.apache.lucene.tests.search.CheckHits;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.IOUtils;
 
 public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
 
@@ -263,5 +267,89 @@ public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
             new Sort(
                 new SortField("c", SortField.Type.LONG),
                 new SortField("b", SortField.Type.STRING))));
+  }
+
+  /**
+   * GITHUB#14399: TopFieldCollector caches whether the search sort is a prefix of the index sort
+   * after inspecting only the first leaf. That is safe for a single index (IndexWriter enforces one
+   * index sort), but a MultiReader can span indexes with different index sorts. Here the first
+   * index is sorted so the search sort IS a prefix (early termination is eligible) while the second
+   * index is sorted the opposite way (it is NOT). The cached "yes" wrongly early-terminates the
+   * second leaf and drops results that should rank first.
+   */
+  public void testMultiReaderWithDifferentIndexSorts() throws IOException {
+    final Sort ascSort = new Sort(new SortField("ndv", SortField.Type.LONG));
+
+    // Index A: sorted ndv ASC, many docs with a moderate value (50). Under an ASC search sort this
+    // leaf is prefix-sorted, so the collector caches "search sort is part of index sort" = true and
+    // calls disableSkipping().
+    Directory dirA = newDirectory();
+    IndexWriterConfig iwcA = newIndexWriterConfig().setIndexSort(ascSort);
+    iwcA.setMergeScheduler(new SerialMergeScheduler());
+    try (RandomIndexWriter w = new RandomIndexWriter(random(), dirA, iwcA)) {
+      for (int i = 0; i < 20; i++) {
+        Document doc = new Document();
+        doc.add(new NumericDocValuesField("ndv", 50L));
+        w.addDocument(doc);
+      }
+      w.forceMerge(1);
+    }
+
+    // Index B: sorted ndv DESC (a DIFFERENT index sort). Its most competitive doc for an ASC search
+    // (value 1) is written LAST, so in docid order the leaf is [90, 90, ..., 1]. If leaf B is
+    // wrongly
+    // treated as prefix-sorted (leaf A's cached decision), collection terminates in docid order
+    // after
+    // the threshold and never reaches the trailing value 1 -- the true top result is dropped.
+    Directory dirB = newDirectory();
+    IndexWriterConfig iwcB =
+        newIndexWriterConfig()
+            .setIndexSort(new Sort(new SortField("ndv", SortField.Type.LONG, true)));
+    iwcB.setMergeScheduler(new SerialMergeScheduler());
+    try (RandomIndexWriter w = new RandomIndexWriter(random(), dirB, iwcB)) {
+      for (int i = 0; i < 20; i++) {
+        Document doc = new Document();
+        doc.add(new NumericDocValuesField("ndv", 90L));
+        w.addDocument(doc);
+      }
+      Document winner = new Document();
+      winner.add(new NumericDocValuesField("ndv", 1L)); // the smallest value overall
+      w.addDocument(winner);
+      w.forceMerge(1);
+    }
+
+    DirectoryReader readerA = DirectoryReader.open(dirA);
+    DirectoryReader readerB = DirectoryReader.open(dirB);
+    // MultiReader with A first, so the first leaf is the ASC-sorted one (search sort is a prefix ->
+    // eligible for early termination); the B leaf is DESC-sorted (not a prefix).
+    MultiReader multiReader = new MultiReader(readerA, readerB);
+    try {
+      // Force both leaves into a single slice so one collector (with one shared
+      // searchSortPartOfIndexSort cache) sees both the ASC-sorted and DESC-sorted leaves.
+      IndexSearcher searcher =
+          new IndexSearcher(multiReader) {
+            @Override
+            protected LeafSlice[] slices(List<LeafReaderContext> leaves) {
+              List<LeafReaderContextPartition> partitions = new ArrayList<>();
+              for (LeafReaderContext ctx : leaves) {
+                partitions.add(LeafReaderContextPartition.createForEntireSegment(ctx));
+              }
+              return new LeafSlice[] {new LeafSlice(partitions)};
+            }
+          };
+      // numHits=1, threshold=1: want the single smallest value overall, which is 1 (last docid of
+      // leaf B). Correct answer is 1; the bug drops it and returns 50 (from leaf A).
+      TopFieldCollectorManager manager = new TopFieldCollectorManager(ascSort, 1, null, 1);
+      TopFieldDocs td = searcher.search(new MatchAllDocsQuery(), manager);
+
+      assertEquals(1, td.scoreDocs.length);
+      long topValue = (long) ((FieldDoc) td.scoreDocs[0]).fields[0];
+      assertEquals("the smallest value (1, trailing docid of leaf B) must win", 1L, topValue);
+    } finally {
+      multiReader.close();
+      readerA.close();
+      readerB.close();
+      IOUtils.close(dirA, dirB);
+    }
   }
 }


### PR DESCRIPTION
Fixes #14399.

`TopFieldCollector` decided whether the search sort is a prefix of the index sort by inspecting only the **first** segment, then cached that decision for the whole search:

```java
// as all segments are sorted in the same way, enough to check only the 1st segment for indexSort
if (searchSortPartOfIndexSort == null) {
  final Sort indexSort = context.reader().getMetaData().sort();
  searchSortPartOfIndexSort = canEarlyTerminate(sort, indexSort);
  ...
}
```

The premise holds for a single index — `IndexWriter` enforces one index sort — but not for a `MultiReader`, which can combine indexes sorted differently. The cached decision is then wrong for later segments, and early termination drops documents that should have ranked first.

**This is a wrong-results bug, not only a missed optimisation.** The added test builds a `MultiReader` over two indexes sorted in *opposite* directions (`ndv` ascending and `ndv` descending) and searches with `ndv` ascending. The competitive document sits at the end of the second segment's docid order, so the decision cached from the first segment early-terminates the second one and discards it. Without the fix:

```
AssertionError: the smallest value (1, trailing docid of leaf B) must win expected:<1> but was:<50>
```

### The fix

Decide it per segment, inside `TopFieldLeafCollector`, rather than caching across leaves.

That change requires one adjustment: the old code called `disableSkipping()` on the shared `FieldComparator`, which is the wrong scope once the decision is per segment. `disableSkipping()` is now a default method on `LeafFieldComparator` and is called on that segment's leaf comparators; `NumericComparator` and `TermOrdValComparator` override it to drop their competitive iterator. This is close to what @jpountz suggested on the issue, except that the method moves to `LeafFieldComparator` rather than being removed from `FieldComparator` — the leaf is the object whose lifetime matches the decision.

### Verification

- The new test fails on unmodified `main` with the assertion above, and passes with the fix. Checked both ways rather than only the passing direction.
- `TestTopFieldCollector*`, `TestSortOptimization`, `TestSearchAfter` and the `comparators` package pass.
- `./gradlew check -x test` is green.
