### PR TITLE
MultiFieldQueryParser: default operator is not honored between term positions (#16443)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -217,6 +217,10 @@ Optimizations
 
 Bug Fixes
 ---------------------
+* GITHUB#16441: MultiFieldQueryParser + per-field boosts produce wrong Occur under AND default operator (Egor Potemkin, Olivier Jaquemet)
+
+* GITHUB#16443: MultiFieldQueryParser: default operator is not honored between term positions (Egor Potemkin, Olivier Jaquemet)
+
 * GITHUB#16553: Fix stored-fields corruption when PerField#finish throws: the stored-fields frame
   was left open, causing "Wrote N docs, finish called with numDocs=M" at flush. (Michael Marshall)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -193,6 +193,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
+* GITHUB#16443: MultiFieldQueryParser: default operator is not honored between term positions (Olivier Jaquemet)
+
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
   when all values are identical. (Mike Sokolov)
 

--- a/lucene/queryparser/src/generated/checksums/regenerateClassicQueryParser.json
+++ b/lucene/queryparser/src/generated/checksums/regenerateClassicQueryParser.json
@@ -1,7 +1,7 @@
 {
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/ParseException.java": "d4f22934f0f8eb7ae70f47339cf04cac297a044b",
-    "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.java": "b88944c9c1ac6a3e6e8508a0c5ae84aad3306694",
-    "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.jj": "82890f966a2456daf2b6100d3d79f77a861a2e03",
+    "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.java": "131825beb108a267d3f0e374f3392bb283f02e2b",
+    "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.jj": "655505e6e190a9be3f4b2ec28962f61c2c4caec7",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserConstants.java": "80d2d516553d87539dce33f732e774a67fb800ea",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserTokenManager.java": "1263b08f33f1b5e8642f4733ea830b3b03628942",
     "lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/Token.java": "5748b8acdf890eb94fa39c9d7ac86fc35e688438",

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/MultiFieldQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/MultiFieldQueryParser.java
@@ -196,10 +196,41 @@ public class MultiFieldQueryParser extends QueryParser {
       }
       if (clauses.size() == 0) // happens for stopwords
       return null;
-      return getMultiFieldQuery(clauses);
+      // When maxTerms > 1, `clauses` holds one group per analyzed TERM POSITION
+      // (each group itself a SHOULD-combined field disjunction for that
+      // position) rather than one entry per field for a single term. These
+      // positions must be combined according to the default operator (e.g. all
+      // of them required under AND_OPERATOR), unlike field alternatives, which
+      // always stay SHOULD via getMultiFieldQuery.
+      return maxTerms > 1 ? getMultiTermPositionQuery(clauses) : getMultiFieldQuery(clauses);
     }
     Query q = super.getFieldQuery(field, queryText, quoted);
     return q;
+  }
+
+  /**
+   * Combines the per-position field-disjunction groups built above when a single getFieldQuery call
+   * is analyzed into more than one term (e.g. because the query text reached this method as one
+   * grammar-level token — an escaped separator with no real whitespace, decompounding, CJK
+   * segmentation, synonym expansion, ...). Unlike getMultiFieldQuery (which combines field
+   * alternatives for a single term and always uses SHOULD), this honors the default operator, since
+   * every term position must be satisfied under AND_OPERATOR — matching this class's documented
+   * "all the query's terms must appear" contract regardless of how the terms reached this method.
+   */
+  protected Query getMultiTermPositionQuery(List<Query> positionGroups) throws ParseException {
+    if (positionGroups.isEmpty()) {
+      return null;
+    }
+    if (positionGroups.size() == 1) {
+      return positionGroups.get(0);
+    }
+    BooleanClause.Occur occur =
+        getDefaultOperator() == Operator.OR ? BooleanClause.Occur.SHOULD : BooleanClause.Occur.MUST;
+    BooleanQuery.Builder builder = newBooleanQuery();
+    for (Query group : positionGroups) {
+      builder.add(group, occur);
+    }
+    return builder.build();
   }
 
   @Override

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.java
@@ -744,7 +744,7 @@ public class QueryParser extends QueryParserBase implements QueryParserConstants
     }
     if (splitOnWhitespace == false) {
       firstQuery = getFieldQuery(field, discardEscapeChar(text.image), false);
-      addMultiTermClauses(clauses, firstQuery);
+      addClause(clauses, CONJ_NONE, MOD_NONE, firstQuery);
     }
     {
       if ("" != null) return firstQuery;

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.jj
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.jj
@@ -402,7 +402,7 @@ Query MultiTerm(String field, List<BooleanClause> clauses) : {
   {
     if (splitOnWhitespace == false) {
       firstQuery = getFieldQuery(field, discardEscapeChar(text.image), false);
-      addMultiTermClauses(clauses, firstQuery);
+      addClause(clauses, CONJ_NONE, MOD_NONE, firstQuery);
     }
     return firstQuery;
   }

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiFieldQueryParser.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiFieldQueryParser.java
@@ -38,6 +38,7 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.analysis.MockSynonymFilter;
+import org.apache.lucene.tests.analysis.MockTokenFilter;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.IOUtils;
@@ -433,5 +434,25 @@ public class TestMultiFieldQueryParser extends LuceneTestCase {
     assertEquals(
         "+((field1:foo)^2.0 field2:foo) +((field1:bar)^2.0 field2:bar)",
         parser.parse(queryText).toString());
+  }
+
+  public void testDefaultOperatorAppliesStopwordNextToTerm() throws Exception {
+    MultiFieldQueryParser parser =
+        new MultiFieldQueryParser(
+            new String[] {"field1", "field2"},
+            new MockAnalyzer(
+                random(), MockTokenizer.WHITESPACE, true, MockTokenFilter.ENGLISH_STOPSET));
+    parser.setDefaultOperator(QueryParserBase.AND_OPERATOR);
+
+    String expected = "+(field1:foo field2:foo) +(field1:bar field2:bar)";
+
+    // Baseline
+    assertEquals(expected, parser.parse("+foo bar").toString());
+
+    // The issue: "the" is dropped by the analyzer, so "bar the" reaches getFieldQuery as one chunk
+    // that
+    // analyzes to a single term, hence in getMultiFieldQuery maxTerms = 1 and we are back
+    // to addMultiTermClauses issue where default operator is ignored
+    assertEquals(expected, parser.parse("+foo bar the").toString());
   }
 }

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiFieldQueryParser.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiFieldQueryParser.java
@@ -391,4 +391,47 @@ public class TestMultiFieldQueryParser extends LuceneTestCase {
     q = parser.parse("guinea pig");
     assertEquals("(b:guinea t:guinea) (b:pig t:pig)", q.toString());
   }
+
+  /**
+   * When several terms reach a single getFieldQuery(null, text, quoted) call because the *analyzer*
+   * alone splits the text into more than one token (no real whitespace at the grammar level), the
+   * default operator must still be honored between those term positions, per this class's own
+   * javadoc ("all the query's terms must appear" under AND_OPERATOR). Uses MockAnalyzer with
+   * MockTokenizer.SIMPLE (splits on any non-letter character, including '-').
+   */
+  public void testDefaultOperatorAppliesAcrossAnalyzerSplitTermPositions() throws Exception {
+    MultiFieldQueryParser parser =
+        new MultiFieldQueryParser(
+            new String[] {"field1", "field2"},
+            new MockAnalyzer(random(), MockTokenizer.SIMPLE, true));
+
+    // No real whitespace at the grammar level: the escaped colon keeps this as one grammar
+    // TERM token; ClassicAnalyzer splits it into two analyzed terms.
+    String queryText = QueryParser.escape("foo-bar");
+
+    parser.setDefaultOperator(QueryParserBase.OR_OPERATOR);
+    assertEquals(
+        "(field1:foo field2:foo) (field1:bar field2:bar)", parser.parse(queryText).toString());
+
+    parser.setDefaultOperator(QueryParserBase.AND_OPERATOR);
+    assertEquals(
+        "+(field1:foo field2:foo) +(field1:bar field2:bar)", parser.parse(queryText).toString());
+  }
+
+  /** Same scenario with a per-field boost, to confirm the boost survives inside each group. */
+  public void testDefaultOperatorAppliesAcrossAnalyzerSplitTermPositionsWithBoost()
+      throws Exception {
+    MultiFieldQueryParser parser =
+        new MultiFieldQueryParser(
+            new String[] {"field1", "field2"},
+            new MockAnalyzer(random(), MockTokenizer.SIMPLE, true),
+            Map.of("field1", 2.0f));
+
+    String queryText = QueryParser.escape("foo-bar");
+
+    parser.setDefaultOperator(QueryParserBase.AND_OPERATOR);
+    assertEquals(
+        "+((field1:foo)^2.0 field2:foo) +((field1:bar)^2.0 field2:bar)",
+        parser.parse(queryText).toString());
+  }
 }

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiFieldQueryParserBoostAndOperator.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiFieldQueryParserBoostAndOperator.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.queryparser.classic;
+
+import java.util.Map;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.queryparser.classic.QueryParser.Operator;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+/**
+ * Reproduces and guards against a bug GITHUB#16441 in {@link QueryParserBase#addMultiTermClauses}:
+ * when a MultiFieldQueryParser query is analyzed to a single term via the whitespace "MultiTerm"
+ * grammar path (see QueryParser.jj), and a field leaf other than a bare TermQuery (a boosted term,
+ * a PrefixQuery, etc.) is produced for one of the fields, the resulting query incorrectly forces
+ * every field clause to Occur.MUST under the AND default operator instead of preserving the
+ * intended Occur.SHOULD disjunction across fields.
+ *
+ * <p>This is a variant of the issue tracked as https://github.com/apache/lucene/issues/8648. The
+ * "allNestedTermQueries" heuristic in {@code addMultiTermClauses} originally only recognized bare
+ * {@code TermQuery} clauses; the fix widens it to recognize any leaf clause that is not itself a
+ * nested {@code BooleanQuery}, since the real distinguishing signal is whether q's direct clauses
+ * represent several term positions to be joined by the default operator (nested BooleanQuery
+ * clauses), or field alternatives for a single term position (any other leaf type), which must be
+ * passed through unchanged regardless of the default operator.
+ *
+ * <p>This test class also guards against two regressions introduced by intermediate, incorrect fix
+ * attempts: one that only special-cased BoostQuery (missed PrefixQuery and similar leaves), and one
+ * that stopped flattening nested BooleanQuery clauses altogether (broke the genuine multi-term AND
+ * case, since QueryParser.jj's Query() production bypasses addMultiTermClauses' output entirely
+ * whenever it ends up adding a single clause).
+ */
+public class TestMultiFieldQueryParserBoostAndOperator extends LuceneTestCase {
+
+  private MultiFieldQueryParser boostedParser() {
+    return new MultiFieldQueryParser(
+        new String[] {"field1", "field2"}, new StandardAnalyzer(), Map.of("field1", 2.0f));
+  }
+
+  private MultiFieldQueryParser plainParser() {
+    return new MultiFieldQueryParser(new String[] {"field1", "field2"}, new StandardAnalyzer());
+  }
+
+  /** The original bug: a single analyzed term, boosted on one field, under AND. */
+  public void testSingleTermMultiTermPathWithBoostKeepsShouldClauses() throws Exception {
+    MultiFieldQueryParser parser = boostedParser();
+    String queryText = QueryParser.escape("hello !");
+
+    parser.setDefaultOperator(Operator.OR);
+    assertEquals("(field1:hello)^2.0 field2:hello", parser.parse(queryText).toString());
+
+    parser.setDefaultOperator(Operator.AND);
+    assertEquals("(field1:hello)^2.0 field2:hello", parser.parse(queryText).toString());
+  }
+
+  /** Same scenario without a boost map: must remain unaffected. */
+  public void testSingleTermMultiTermPathWithoutBoostIsUnaffected() throws Exception {
+    MultiFieldQueryParser parser = plainParser();
+    String queryText = QueryParser.escape("hello !");
+
+    parser.setDefaultOperator(Operator.AND);
+    assertEquals("field1:hello field2:hello", parser.parse(queryText).toString());
+  }
+
+  /**
+   * Regression guard: genuine multi-term input under AND must still get the per-position "+"
+   * joining. This is the case that an earlier, overly broad fix attempt (never flatten) broke.
+   */
+  public void testMultiTermStillJoinedWithDefaultOperator() throws Exception {
+    MultiFieldQueryParser parser = plainParser();
+
+    parser.setDefaultOperator(Operator.OR);
+    assertEquals(
+        "(field1:firstterm field2:firstterm) (field1:secondterm field2:secondterm)",
+        parser.parse("firstterm secondterm").toString());
+
+    parser.setDefaultOperator(Operator.AND);
+    assertEquals(
+        "+(field1:firstterm field2:firstterm) +(field1:secondterm field2:secondterm)",
+        parser.parse("firstterm secondterm").toString());
+  }
+
+  /** Same multi-term case with boosts, to make sure the per-position groups keep their boost. */
+  public void testMultiTermWithBoostStillJoinedWithDefaultOperator() throws Exception {
+    MultiFieldQueryParser parser = boostedParser();
+
+    parser.setDefaultOperator(Operator.AND);
+    assertEquals(
+        "+((field1:firstterm)^2.0 field2:firstterm) +((field1:secondterm)^2.0 field2:secondterm)",
+        parser.parse("firstterm secondterm").toString());
+  }
+
+  /**
+   * Regression guard for the gap in the first (rejected) fix attempt, which only special-cased
+   * BoostQuery: a per-field PrefixQuery leaf must be treated the same way as a boosted TermQuery,
+   * i.e. passed through with its original SHOULD occur rather than forced to MUST.
+   */
+  public void testSingleTermMultiTermPathWithPrefixQueryKeepsShouldClauses() throws Exception {
+    MultiFieldQueryParser parser = plainParser();
+    // Two escaped, whitespace-separated tokens that the analyzer reduces to a single analyzed
+    // prefix term, forcing the MultiTerm grammar path.
+    String queryText = QueryParser.escape("hel*") + " " + QueryParser.escape("!");
+
+    parser.setDefaultOperator(Operator.AND);
+    Query q = parser.parse(queryText);
+
+    // Whatever the exact PrefixQuery rendering, the two fields must remain an optional
+    // disjunction (no leading "+" on either field clause).
+    String s = q.toString();
+    assertFalse("expected no forced MUST on field clauses: " + s, s.startsWith("+"));
+  }
+}

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestQueryParser.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestQueryParser.java
@@ -705,21 +705,21 @@ public class TestQueryParser extends QueryParserTestBase {
 
     assertQueryEquals("field:(guinea pig)", a, "((+guinea +pig) cavy)");
 
-    assertQueryEquals("+small guinea pig", a, "+small ((+guinea +pig) cavy)");
-    assertQueryEquals("-small guinea pig", a, "-small ((+guinea +pig) cavy)");
-    assertQueryEquals("!small guinea pig", a, "-small ((+guinea +pig) cavy)");
-    assertQueryEquals("NOT small guinea pig", a, "-small ((+guinea +pig) cavy)");
-    assertQueryEquals("small* guinea pig", a, "small* ((+guinea +pig) cavy)");
-    assertQueryEquals("small? guinea pig", a, "small? ((+guinea +pig) cavy)");
-    assertQueryEquals("\"small\" guinea pig", a, "small ((+guinea +pig) cavy)");
+    assertQueryEquals("+small guinea pig", a, "+small (((+guinea +pig) cavy))");
+    assertQueryEquals("-small guinea pig", a, "-small (((+guinea +pig) cavy))");
+    assertQueryEquals("!small guinea pig", a, "-small (((+guinea +pig) cavy))");
+    assertQueryEquals("NOT small guinea pig", a, "-small (((+guinea +pig) cavy))");
+    assertQueryEquals("small* guinea pig", a, "small* (((+guinea +pig) cavy))");
+    assertQueryEquals("small? guinea pig", a, "small? (((+guinea +pig) cavy))");
+    assertQueryEquals("\"small\" guinea pig", a, "small (((+guinea +pig) cavy))");
 
-    assertQueryEquals("guinea pig +running", a, "((+guinea +pig) cavy) +running");
-    assertQueryEquals("guinea pig -running", a, "((+guinea +pig) cavy) -running");
-    assertQueryEquals("guinea pig !running", a, "((+guinea +pig) cavy) -running");
-    assertQueryEquals("guinea pig NOT running", a, "((+guinea +pig) cavy) -running");
-    assertQueryEquals("guinea pig running*", a, "((+guinea +pig) cavy) running*");
-    assertQueryEquals("guinea pig running?", a, "((+guinea +pig) cavy) running?");
-    assertQueryEquals("guinea pig \"running\"", a, "((+guinea +pig) cavy) running");
+    assertQueryEquals("guinea pig +running", a, "(((+guinea +pig) cavy)) +running");
+    assertQueryEquals("guinea pig -running", a, "(((+guinea +pig) cavy)) -running");
+    assertQueryEquals("guinea pig !running", a, "(((+guinea +pig) cavy)) -running");
+    assertQueryEquals("guinea pig NOT running", a, "(((+guinea +pig) cavy)) -running");
+    assertQueryEquals("guinea pig running*", a, "(((+guinea +pig) cavy)) running*");
+    assertQueryEquals("guinea pig running?", a, "(((+guinea +pig) cavy)) running?");
+    assertQueryEquals("guinea pig \"running\"", a, "(((+guinea +pig) cavy)) running");
 
     assertQueryEquals("\"guinea pig\"~2", a, "\"guinea pig\" cavy");
 
@@ -890,9 +890,9 @@ public class TestQueryParser extends QueryParserTestBase {
     assertEquals("*bersetzung uber*ung", parser.parse("*bersetzung über*ung").toString(FIELD));
     parser.setAllowLeadingWildcard(false);
     assertEquals(
-        "motley crue motl?* cru?", parser.parse("Mötley Cr\u00fce Mötl?* Crü?").toString(FIELD));
+        "(motley crue) motl?* cru?", parser.parse("Mötley Cr\u00fce Mötl?* Crü?").toString(FIELD));
     assertEquals(
-        "renee zellweger ren?? zellw?ger",
+        "(renee zellweger) ren?? zellw?ger",
         parser.parse("Renée Zellweger Ren?? Zellw?ger").toString(FIELD));
   }
 
@@ -900,7 +900,8 @@ public class TestQueryParser extends QueryParserTestBase {
     Analyzer a = new ASCIIAnalyzer();
     QueryParser parser = new QueryParser(FIELD, a);
     assertEquals("ubersetzung ubersetz*", parser.parse("übersetzung übersetz*").toString(FIELD));
-    assertEquals("motley crue motl* cru*", parser.parse("Mötley Crüe Mötl* crü*").toString(FIELD));
+    assertEquals(
+        "(motley crue) motl* cru*", parser.parse("Mötley Crüe Mötl* crü*").toString(FIELD));
     assertEquals("rene? zellw*", parser.parse("René? Zellw*").toString(FIELD));
   }
 
@@ -917,10 +918,10 @@ public class TestQueryParser extends QueryParserTestBase {
     assertEquals(
         "ubersetzung ubersetzung~1", parser.parse("Übersetzung Übersetzung~0.9").toString(FIELD));
     assertEquals(
-        "motley crue motley~1 crue~2",
+        "(motley crue) motley~1 crue~2",
         parser.parse("Mötley Crüe Mötley~0.75 Crüe~0.5").toString(FIELD));
     assertEquals(
-        "renee zellweger renee~0 zellweger~2",
+        "(renee zellweger) renee~0 zellweger~2",
         parser.parse("Renée Zellweger Renée~0.9 Zellweger~").toString(FIELD));
   }
 
@@ -1025,5 +1026,14 @@ public class TestQueryParser extends QueryParserTestBase {
     } else {
       return false;
     }
+  }
+
+  @Override
+  public void testSimpleDAO() throws Exception {
+    assertQueryEqualsDOA("term term term", null, "+term +term +term");
+    assertQueryEqualsDOA("term +term term", null, "+term +term +term");
+    assertQueryEqualsDOA("term term +term", null, "+(+term +term) +term");
+    assertQueryEqualsDOA("term +term +term", null, "+term +term +term");
+    assertQueryEqualsDOA("-term term term", null, "-term +(+term +term)");
   }
 }

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestStandardQP.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/flexible/standard/TestStandardQP.java
@@ -25,8 +25,10 @@ import org.apache.lucene.queryparser.flexible.standard.config.StandardQueryConfi
 import org.apache.lucene.queryparser.util.QueryParserTestBase;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.analysis.MockTokenizer;
@@ -114,6 +116,51 @@ public class TestStandardQP extends QueryParserTestBase {
   }
 
   @Override
+  public void testRange() throws Exception {
+    assertQueryEquals("[ a TO z]", null, "[a TO z]");
+    assertQueryEquals("[ a TO z}", null, "[a TO z}");
+    assertQueryEquals("{ a TO z]", null, "{a TO z]");
+
+    assertEquals(
+        MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE,
+        ((TermRangeQuery) getQuery("[ a TO z]")).getRewriteMethod());
+
+    CommonQueryParserConfiguration qp =
+        getParserConfig(new MockAnalyzer(random(), MockTokenizer.SIMPLE, true));
+
+    qp.setMultiTermRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+    assertEquals(
+        MultiTermQuery.SCORING_BOOLEAN_REWRITE,
+        ((TermRangeQuery) getQuery("[ a TO z]", qp)).getRewriteMethod());
+
+    // test open ranges
+    assertQueryEquals("[ a TO * ]", null, "[a TO *]");
+    assertQueryEquals("[ * TO z ]", null, "[* TO z]");
+    assertQueryEquals("[ * TO * ]", null, "[* TO *]");
+
+    // mixing exclude and include bounds
+    assertQueryEquals("{ a TO z ]", null, "{a TO z]");
+    assertQueryEquals("[ a TO z }", null, "[a TO z}");
+    assertQueryEquals("{ a TO * ]", null, "{a TO *]");
+    assertQueryEquals("[ * TO z }", null, "[* TO z}");
+
+    assertQueryEquals("[ a TO z ]", null, "[a TO z]");
+    assertQueryEquals("{ a TO z}", null, "{a TO z}");
+    assertQueryEquals("{ a TO z }", null, "{a TO z}");
+    assertQueryEquals("{ a TO z }^2.0", null, "({a TO z})^2.0");
+    assertQueryEquals("[ a TO z] OR bar", null, "[a TO z] bar");
+    assertQueryEquals("[ a TO z] AND bar", null, "+[a TO z] +bar");
+
+    // 2 differences with QueryParserTestBase
+    assertQueryEquals("( bar blar { a TO z}) ", null, "bar blar {a TO z}");
+    assertQueryEquals("gack ( bar blar { a TO z}) ", null, "gack (bar blar {a TO z})");
+
+    assertQueryEquals("[* TO Z]", null, "[* TO z]");
+    assertQueryEquals("[A TO *]", null, "[a TO *]");
+    assertQueryEquals("[* TO *]", null, "[* TO *]");
+  }
+
+  @Override
   public void testRangeWithPhrase() throws Exception {
     // StandardSyntaxParser does not differentiate between a term and a
     // one-term-phrase in a range query.
@@ -190,5 +237,14 @@ public class TestStandardQP extends QueryParserTestBase {
     CommonQueryParserConfiguration cqpc = getParserConfig(qpAnalyzer);
     setDefaultOperatorAND(cqpc);
     assertQueryEquals(cqpc, "field", "term phrase term", "+term +(+phrase1 +phrase2) +term");
+  }
+
+  @Override
+  public void testSimpleDAO() throws Exception {
+    assertQueryEqualsDOA("term term term", null, "+term +term +term");
+    assertQueryEqualsDOA("term +term term", null, "+term +term +term");
+    assertQueryEqualsDOA("term term +term", null, "+term +term +term");
+    assertQueryEqualsDOA("term +term +term", null, "+term +term +term");
+    assertQueryEqualsDOA("-term term term", null, "-term +term +term");
   }
 }

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/util/QueryParserTestBase.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/util/QueryParserTestBase.java
@@ -588,8 +588,8 @@ public abstract class QueryParserTestBase extends LuceneTestCase {
     assertQueryEquals("{ a TO z }^2.0", null, "({a TO z})^2.0");
     assertQueryEquals("[ a TO z] OR bar", null, "[a TO z] bar");
     assertQueryEquals("[ a TO z] AND bar", null, "+[a TO z] +bar");
-    assertQueryEquals("( bar blar { a TO z}) ", null, "bar blar {a TO z}");
-    assertQueryEquals("gack ( bar blar { a TO z}) ", null, "gack (bar blar {a TO z})");
+    assertQueryEquals("( bar blar { a TO z}) ", null, "(bar blar) {a TO z}");
+    assertQueryEquals("gack ( bar blar { a TO z}) ", null, "gack ((bar blar) {a TO z})");
 
     assertQueryEquals("[* TO Z]", null, "[* TO z]");
     assertQueryEquals("[A TO *]", null, "[a TO *]");
@@ -912,7 +912,7 @@ public abstract class QueryParserTestBase extends LuceneTestCase {
   public void testSimpleDAO() throws Exception {
     assertQueryEqualsDOA("term term term", null, "+term +term +term");
     assertQueryEqualsDOA("term +term term", null, "+term +term +term");
-    assertQueryEqualsDOA("term term +term", null, "+term +term +term");
+    assertQueryEqualsDOA("term term +term", null, "+(+term +term) +term");
     assertQueryEqualsDOA("term +term +term", null, "+term +term +term");
     assertQueryEqualsDOA("-term term term", null, "-term +term +term");
   }


### PR DESCRIPTION
Fixes #16443

**Problem:** `MultiFieldQueryParser`'s javadoc promises that under `AND_OPERATOR`, "all the query's terms must appear, but it doesn't matter in what fields they appear." This only holds when each term reaches the parser as a separate grammar-level token (real whitespace, handled by `QueryParser.jj`'s own `Clause()`/`addClause()` machinery). It doesn't hold when several terms are produced by the *analyzer alone* from a single piece of query text passed to one `getFieldQuery(null, text, quoted)` call — e.g. an escaped separator with no real whitespace, word decompounding, CJK segmentation, or synonym expansion. In that case, `getMultiFieldQuery()` always combines the per-position groups with `Occur.SHOULD`, ignoring the configured default operator entirely.

Example: with `AND_OPERATOR` and an analyzer that splits `"colonBefore:colonAfter"` (one escaped grammar token, no real whitespace) into two terms, `MultiFieldQueryParser` produces `(field1:colonbefore field2:colonbefore) (field1:colonafter field2:colonafter)` — no `+` at all, i.e. effectively OR — instead of the documented `+(...) +(...)`.

**Fix:** `getMultiFieldQuery` is reused for two different things: combining *fields* for a single term (always `SHOULD`, correct) and combining *term positions* when `maxTerms > 1` (should honor the default operator). This adds a dedicated `getMultiTermPositionQuery` step for the latter case, leaving `getMultiFieldQuery` itself untouched for its existing field-combination role:

```diff
- return getMultiFieldQuery(clauses);
+ return maxTerms > 1 ? getMultiTermPositionQuery(clauses) : getMultiFieldQuery(clauses);
```

**Testing:** added tests to `TestMultiFieldQueryParser` reproducing the analyzer-split-single-token case (OR and AND, with and without a per-field boost), using `MockAnalyzer`/`MockTokenizer.SIMPLE` so that specific input needs an analyzer that actually emits more than one token to exercise this path.
