### PR TITLE
Remove unintended CHANGES.txt entry for #16383

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -331,8 +331,6 @@ New Features
   and document length instead of corpus statistics such as document frequency. It also supports k3
   query-term frequency saturation. (Tianxiao Wei)
 
-* GITHUB#16383: Add fp16 vector encoding support. (Pulkit Gupta)
-
 * GITHUB#16371, GITHUB#14389: Add CaseFoldingFilter for Unicode simple case folding without
   requiring the ICU analysis plugin. Uses a generated switch for fold exceptions with
   Character.toLowerCase() as the default fallback. (Robert Muir, Costin Leau)


### PR DESCRIPTION
The `CHANGES.txt` entry for #16383 was moved from Lucene 10.6 to Lucene 11 in #16432, but the 10.6 entry was added back by mistake in #16371.

Removing that extra entry^