### PR TITLE
Fix DocValuesRangeIterator doc ID run ends

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -404,6 +404,11 @@ Optimizations
 
 Bug Fixes
 ---------------------
+
+* GITHUB#16450: Fix DocValuesRangeIterator.docIDRunEnd() returning incorrect run boundaries,
+  causing bulk-scoring to skip or mis-score documents in range and ordinal set queries.
+  (Parker Timmins)
+
 * GITHUB#16251: Fix UpdateGraphsUtils#computeJoinSet to not request more coverage for a node than
   the node's degree. Previously nodes with a degree of 1 were always forced into the join set,
   which made the join set degenerate to the whole graph on hub-and-spoke shaped HNSW graphs.

--- a/lucene/core/src/java/org/apache/lucene/search/DocValuesRangeIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocValuesRangeIterator.java
@@ -266,7 +266,6 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
     final DocIdSetIterator disi;
     final IOBooleanSupplier predicate;
     private final float matchCost;
-    private int lastMatchingDoc = -1;
 
     private DocValuesBlockRangeIterator(
         DocIdSetIterator disi,
@@ -287,26 +286,9 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
       return disi.advance(target) == target;
     }
 
-    final boolean recordMatch(boolean matches) {
-      lastMatchingDoc = matches ? blockIterator.docID() : -1;
-      return matches;
-    }
-
-    final int confirmedDocRunEnd() {
-      int doc = blockIterator.docID();
-      return lastMatchingDoc == doc ? doc + 1 : doc;
-    }
-
     @Override
     public boolean matches() throws IOException {
-      return recordMatch(advanceDisi(blockIterator.docID()) && predicate.get());
-    }
-
-    @Override
-    public int docIDRunEnd() throws IOException {
-      // Even a YES block only proves membership in the ordinal set's bounding range, not in the
-      // potentially non-contiguous set itself.
-      return confirmedDocRunEnd();
+      return advanceDisi(blockIterator.docID()) && predicate.get();
     }
 
     @Override
@@ -333,12 +315,11 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
 
     @Override
     public final boolean matches() throws IOException {
-      return recordMatch(
-          switch (blockIterator.getMatch()) {
-            case YES -> true;
-            case YES_IF_PRESENT -> advanceDisi(blockIterator.docID());
-            case MAYBE -> advanceDisi(blockIterator.docID()) && predicate.get();
-          });
+      return switch (blockIterator.getMatch()) {
+        case YES -> true;
+        case YES_IF_PRESENT -> advanceDisi(blockIterator.docID());
+        case MAYBE -> advanceDisi(blockIterator.docID()) && predicate.get();
+      };
     }
 
     @Override
@@ -347,7 +328,7 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
       // rest of the run are actual matches.
       return switch (blockIterator.getMatch()) {
         case YES -> blockIterator.docIDRunEnd();
-        case YES_IF_PRESENT, MAYBE -> confirmedDocRunEnd();
+        case YES_IF_PRESENT, MAYBE -> blockIterator.docID();
       };
     }
 
@@ -356,7 +337,7 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
       while (blockIterator.docID() < upTo) {
         int blockStart = blockIterator.docID();
         SkipBlockRangeIterator.Match match = blockIterator.getMatch();
-        int blockEnd = blockEnd(upTo, match);
+        int blockEnd = blockEnd(upTo);
         switch (match) {
           case YES -> bitSet.set(blockStart - offset, blockEnd - offset);
           case YES_IF_PRESENT -> {
@@ -379,12 +360,8 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
     abstract void intoMaybeBlock(int blockStart, int blockEnd, FixedBitSet bitSet, int offset)
         throws IOException;
 
-    // For MAYBE blocks docIDRunEnd() only describes a previously confirmed current doc, so use the
-    // full block boundary to evaluate/classify the whole block at once.
-    private int blockEnd(int upTo, SkipBlockRangeIterator.Match match) throws IOException {
-      return match == SkipBlockRangeIterator.Match.MAYBE
-          ? Math.min(upTo, blockIterator.blockEnd())
-          : Math.min(upTo, blockIterator.docIDRunEnd());
+    private int blockEnd(int upTo) throws IOException {
+      return Math.min(upTo, blockIterator.docIDRunEnd());
     }
 
     @Override
@@ -399,7 +376,7 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
           bitSet.clear(cursor - offset, blockStart - offset);
         }
         SkipBlockRangeIterator.Match match = blockIterator.getMatch();
-        int blockEnd = blockEnd(upTo, match);
+        int blockEnd = blockEnd(upTo);
 
         if (match != SkipBlockRangeIterator.Match.YES
             && bitSet.nextSetBit(blockStart - offset, blockEnd - offset)

--- a/lucene/core/src/java/org/apache/lucene/search/DocValuesRangeIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocValuesRangeIterator.java
@@ -266,6 +266,7 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
     final DocIdSetIterator disi;
     final IOBooleanSupplier predicate;
     private final float matchCost;
+    private int lastMatchingDoc = -1;
 
     private DocValuesBlockRangeIterator(
         DocIdSetIterator disi,
@@ -286,14 +287,26 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
       return disi.advance(target) == target;
     }
 
+    final boolean recordMatch(boolean matches) {
+      lastMatchingDoc = matches ? blockIterator.docID() : -1;
+      return matches;
+    }
+
+    final int confirmedDocRunEnd() {
+      int doc = blockIterator.docID();
+      return lastMatchingDoc == doc ? doc + 1 : doc;
+    }
+
     @Override
     public boolean matches() throws IOException {
-      return advanceDisi(blockIterator.docID()) && predicate.get();
+      return recordMatch(advanceDisi(blockIterator.docID()) && predicate.get());
     }
 
     @Override
     public int docIDRunEnd() throws IOException {
-      return blockIterator.docID() + 1;
+      // Even a YES block only proves membership in the ordinal set's bounding range, not in the
+      // potentially non-contiguous set itself.
+      return confirmedDocRunEnd();
     }
 
     @Override
@@ -320,16 +333,22 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
 
     @Override
     public final boolean matches() throws IOException {
-      return switch (blockIterator.getMatch()) {
-        case YES -> true;
-        case YES_IF_PRESENT -> advanceDisi(blockIterator.docID());
-        case MAYBE -> advanceDisi(blockIterator.docID()) && predicate.get();
-      };
+      return recordMatch(
+          switch (blockIterator.getMatch()) {
+            case YES -> true;
+            case YES_IF_PRESENT -> advanceDisi(blockIterator.docID());
+            case MAYBE -> advanceDisi(blockIterator.docID()) && predicate.get();
+          });
     }
 
     @Override
     public final int docIDRunEnd() throws IOException {
-      return blockIterator.docIDRunEnd();
+      // docIDRunEnd() may be called on non-matches, so only YES proves that the current doc and the
+      // rest of the run are actual matches.
+      return switch (blockIterator.getMatch()) {
+        case YES -> blockIterator.docIDRunEnd();
+        case YES_IF_PRESENT, MAYBE -> confirmedDocRunEnd();
+      };
     }
 
     @Override
@@ -360,8 +379,8 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
     abstract void intoMaybeBlock(int blockStart, int blockEnd, FixedBitSet bitSet, int offset)
         throws IOException;
 
-    // For MAYBE blocks docIDRunEnd() is conservative (doc+1), so use the full block boundary to
-    // evaluate/classify the whole block at once.
+    // For MAYBE blocks docIDRunEnd() only describes a previously confirmed current doc, so use the
+    // full block boundary to evaluate/classify the whole block at once.
     private int blockEnd(int upTo, SkipBlockRangeIterator.Match match) throws IOException {
       return match == SkipBlockRangeIterator.Match.MAYBE
           ? Math.min(upTo, blockIterator.blockEnd())

--- a/lucene/core/src/java/org/apache/lucene/search/DocValuesRangeIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DocValuesRangeIterator.java
@@ -360,6 +360,8 @@ public abstract sealed class DocValuesRangeIterator extends TwoPhaseIterator {
     abstract void intoMaybeBlock(int blockStart, int blockEnd, FixedBitSet bitSet, int offset)
         throws IOException;
 
+    // For MAYBE/YES_IF_PRESENT blocks this is the block boundary; for YES blocks it may extend
+    // further via multi-level run expansion.
     private int blockEnd(int upTo) throws IOException {
       return Math.min(upTo, blockIterator.docIDRunEnd());
     }

--- a/lucene/core/src/java/org/apache/lucene/search/SkipBlockRangeIterator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SkipBlockRangeIterator.java
@@ -113,9 +113,8 @@ public class SkipBlockRangeIterator extends AbstractDocIdSetIterator {
 
   /**
    * Returns the exclusive end of the current skip block (the actual block boundary from the
-   * skipper), regardless of match state. Unlike {@link #docIDRunEnd()} which returns {@code doc+1}
-   * for MAYBE blocks, this always returns the full block boundary so callers can bulk-evaluate the
-   * entire block at once.
+   * skipper), regardless of match state. {@link #docIDRunEnd()} returns the same boundary for MAYBE
+   * and YES_IF_PRESENT blocks, but may extend beyond it for YES blocks.
    */
   public int blockEnd() {
     return skipper.maxDocID(0) + 1;
@@ -123,18 +122,17 @@ public class SkipBlockRangeIterator extends AbstractDocIdSetIterator {
 
   @Override
   public int docIDRunEnd() throws IOException {
-    if (match != Match.YES) {
-      return doc + 1;
-    }
     int maxDoc = skipper.maxDocID(0);
-    int nextLevel = 1;
-    while (nextLevel < skipper.numLevels()
-        && skipper.minValue(nextLevel) >= minValue
-        && skipper.maxValue(nextLevel) <= maxValue
-        && skipper.maxDocID(nextLevel) - skipper.minDocID(nextLevel)
-            == skipper.docCount(nextLevel) - 1) {
-      maxDoc = skipper.maxDocID(nextLevel);
-      nextLevel++;
+    if (match == Match.YES) {
+      int nextLevel = 1;
+      while (nextLevel < skipper.numLevels()
+          && skipper.minValue(nextLevel) >= minValue
+          && skipper.maxValue(nextLevel) <= maxValue
+          && skipper.maxDocID(nextLevel) - skipper.minDocID(nextLevel)
+              == skipper.docCount(nextLevel) - 1) {
+        maxDoc = skipper.maxDocID(nextLevel);
+        nextLevel++;
+      }
     }
     return maxDoc + 1;
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalRangeIterator.java
@@ -252,8 +252,15 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     approx.advance(64);
     assertEquals(128, iter.docIDRunEnd());
 
+    // MAYBE block, no match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(512);
-    assertEquals(513, iter.docIDRunEnd());
+    assertFalse(iter.matches());
+    assertEquals(512, iter.docIDRunEnd());
+
+    // MAYBE block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    approx.advance(514);
+    assertTrue(iter.matches());
+    assertEquals(515, iter.docIDRunEnd());
 
     // YES block in second repetition (dense up to DENSE_END=1088)
     approx.advance(1024);
@@ -531,9 +538,17 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     approx.advance(64);
     assertEquals(128, iter.docIDRunEnd());
 
+    // MAYBE block, match: docIDRunEnd returns docID + 1 for a single-doc run.
     approx.advance(512);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
+    assertTrue(iter.matches());
     assertEquals(513, iter.docIDRunEnd());
+
+    // MAYBE block, no match: docIDRunEnd returns docID to signal an empty run.
+    approx.advance(516);
+    assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
+    assertFalse(iter.matches());
+    assertEquals(516, iter.docIDRunEnd());
 
     // YES block in second repetition (dense up to DENSE_END=1088)
     approx.advance(1024);

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalRangeIterator.java
@@ -267,9 +267,16 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
     assertEquals(1088, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID + 1 for a single-doc run.
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertTrue(iter.matches());
+    assertEquals(1089, iter.docIDRunEnd());
+
+    // YES_IF_PRESENT block, no match: docIDRunEnd returns docID to signal an empty run.
+    approx.advance(1089);
+    assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertFalse(iter.matches());
     assertEquals(1089, iter.docIDRunEnd());
   }
 
@@ -555,9 +562,16 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
     assertEquals(1088, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID + 1 for a single-doc run.
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertTrue(iter.matches());
+    assertEquals(1089, iter.docIDRunEnd());
+
+    // YES_IF_PRESENT block, no match: docIDRunEnd returns docID to signal an empty run.
+    approx.advance(1089);
+    assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertFalse(iter.matches());
     assertEquals(1089, iter.docIDRunEnd());
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalRangeIterator.java
@@ -257,21 +257,21 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     assertFalse(iter.matches());
     assertEquals(512, iter.docIDRunEnd());
 
-    // MAYBE block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    // MAYBE block, match: docIDRunEnd returns docID (empty run).
     approx.advance(514);
     assertTrue(iter.matches());
-    assertEquals(515, iter.docIDRunEnd());
+    assertEquals(514, iter.docIDRunEnd());
 
     // YES block in second repetition (dense up to DENSE_END=1088)
     approx.advance(1024);
     assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
     assertEquals(1088, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID (empty run).
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertTrue(iter.matches());
-    assertEquals(1089, iter.docIDRunEnd());
+    assertEquals(1088, iter.docIDRunEnd());
 
     // YES_IF_PRESENT block, no match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(1089);
@@ -545,11 +545,11 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     approx.advance(64);
     assertEquals(128, iter.docIDRunEnd());
 
-    // MAYBE block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    // MAYBE block, match: docIDRunEnd returns docID (empty run).
     approx.advance(512);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
     assertTrue(iter.matches());
-    assertEquals(513, iter.docIDRunEnd());
+    assertEquals(512, iter.docIDRunEnd());
 
     // MAYBE block, no match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(516);
@@ -562,11 +562,11 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
     assertEquals(1088, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID (empty run).
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertTrue(iter.matches());
-    assertEquals(1089, iter.docIDRunEnd());
+    assertEquals(1088, iter.docIDRunEnd());
 
     // YES_IF_PRESENT block, no match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(1089);

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalRangeIterator.java
@@ -257,7 +257,7 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     assertFalse(iter.matches());
     assertEquals(512, iter.docIDRunEnd());
 
-    // MAYBE block, match: docIDRunEnd returns docID (empty run).
+    // MAYBE block, match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(514);
     assertTrue(iter.matches());
     assertEquals(514, iter.docIDRunEnd());
@@ -267,7 +267,7 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
     assertEquals(1088, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block, match: docIDRunEnd returns docID (empty run).
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertTrue(iter.matches());
@@ -545,7 +545,7 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     approx.advance(64);
     assertEquals(128, iter.docIDRunEnd());
 
-    // MAYBE block, match: docIDRunEnd returns docID (empty run).
+    // MAYBE block, match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(512);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
     assertTrue(iter.matches());
@@ -562,7 +562,7 @@ public class TestDocValuesOrdinalRangeIterator extends BaseDocValuesSkipperTests
     assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
     assertEquals(1088, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block, match: docIDRunEnd returns docID (empty run).
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertTrue(iter.matches());

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
@@ -24,9 +24,9 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.ImpactsEnum;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.index.ImpactsEnum;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
@@ -783,7 +783,8 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
         w.forceMerge(1);
       }
       try (DirectoryReader reader = DirectoryReader.open(dir)) {
-        // Non-contiguous ordinal set {aaa=0, ccc=2}: gap at bbb=1 forces DocValuesBlockRangeIterator.
+        // Non-contiguous ordinal set {aaa=0, ccc=2}: gap at bbb=1 forces
+        // DocValuesBlockRangeIterator.
         Query setQuery =
             SortedDocValuesField.newSlowSetQuery(
                 "field", List.of(new BytesRef("aaa"), new BytesRef("ccc")));

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
@@ -400,11 +400,11 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     DocValuesRangeIterator iter = createSortedDocValuesIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
-    // YES block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    // YES block, match: docIDRunEnd returns docID (empty run).
     approx.advance(0);
     assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
     assertTrue(iter.matches());
-    assertEquals(1, iter.docIDRunEnd());
+    assertEquals(0, iter.docIDRunEnd());
 
     // YES block, no match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(1);
@@ -418,17 +418,17 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     assertFalse(iter.matches());
     assertEquals(512, iter.docIDRunEnd());
 
-    // MAYBE block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    // MAYBE block, match: docIDRunEnd returns docID (empty run).
     approx.advance(516);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
     assertTrue(iter.matches());
-    assertEquals(517, iter.docIDRunEnd());
+    assertEquals(516, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID (empty run).
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertTrue(iter.matches());
-    assertEquals(1089, iter.docIDRunEnd());
+    assertEquals(1088, iter.docIDRunEnd());
 
     // YES_IF_PRESENT block, no match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(1089);
@@ -649,11 +649,11 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     DocValuesRangeIterator iter = createSortedSetDocValuesIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
-    // YES block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    // YES block, match: docIDRunEnd returns docID (empty run).
     approx.advance(0);
     assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
     assertTrue(iter.matches());
-    assertEquals(1, iter.docIDRunEnd());
+    assertEquals(0, iter.docIDRunEnd());
 
     // YES block, no match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(1);
@@ -661,11 +661,11 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     assertFalse(iter.matches());
     assertEquals(1, iter.docIDRunEnd());
 
-    // MAYBE block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    // MAYBE block, match: docIDRunEnd returns docID (empty run).
     approx.advance(512);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
     assertTrue(iter.matches());
-    assertEquals(513, iter.docIDRunEnd());
+    assertEquals(512, iter.docIDRunEnd());
 
     // MAYBE block, no match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(516);
@@ -673,11 +673,11 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     assertFalse(iter.matches());
     assertEquals(516, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID (empty run).
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertTrue(iter.matches());
-    assertEquals(1089, iter.docIDRunEnd());
+    assertEquals(1088, iter.docIDRunEnd());
 
     // YES_IF_PRESENT block, no match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(1089);

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
@@ -400,7 +400,7 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     DocValuesRangeIterator iter = createSortedDocValuesIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
-    // YES block, match: docIDRunEnd returns docID (empty run).
+    // YES block, match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(0);
     assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
     assertTrue(iter.matches());
@@ -418,13 +418,13 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     assertFalse(iter.matches());
     assertEquals(512, iter.docIDRunEnd());
 
-    // MAYBE block, match: docIDRunEnd returns docID (empty run).
+    // MAYBE block, match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(516);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
     assertTrue(iter.matches());
     assertEquals(516, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block, match: docIDRunEnd returns docID (empty run).
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertTrue(iter.matches());
@@ -649,7 +649,7 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     DocValuesRangeIterator iter = createSortedSetDocValuesIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
-    // YES block, match: docIDRunEnd returns docID (empty run).
+    // YES block, match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(0);
     assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
     assertTrue(iter.matches());
@@ -661,7 +661,7 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     assertFalse(iter.matches());
     assertEquals(1, iter.docIDRunEnd());
 
-    // MAYBE block, match: docIDRunEnd returns docID (empty run).
+    // MAYBE block, match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(512);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
     assertTrue(iter.matches());
@@ -673,7 +673,7 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     assertFalse(iter.matches());
     assertEquals(516, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block, match: docIDRunEnd returns docID (empty run).
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertTrue(iter.matches());

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
@@ -168,7 +168,8 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
       return (int) (QUERY_MIN - 1);
     } else {
       return switch ((d / 2) % 3) {
-        // Include values in the ord set, values outside the range, and values in the range but not in the ord set.
+        // Include values in the ord set, values outside the range, and values in the range but not
+        // in the ord set.
         case 0 -> (int) QUERY_MAX;
         case 1 -> (int) (QUERY_MAX + 1);
         case 2 -> (int) GAP_ORD;

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
@@ -156,21 +156,18 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
   // SortedDocValues (single-valued ordinals with a set)
   // ==========================================================================
 
-  /**
-   * Single ordinal per doc. Uses ordinal 14 (in the set) for the in-range region, and ordinal 15
-   * (in the gap) for the mixed region's case 2.
-   */
+  /** Single ordinal per doc. The in-range region alternates between a set member and a gap. */
   private static int singleOrdinal(int doc) {
     int d = doc % 1024;
     if (d < 128) {
-      return 14;
+      return (doc & 1) == 0 ? 14 : (int) GAP_ORD;
     } else if (d < 256) {
       return (int) (QUERY_MAX + 1);
     } else if (d < 512) {
       return (int) (QUERY_MIN - 1);
     } else {
       return switch ((d / 2) % 3) {
-        case 0 -> (int) (QUERY_MIN - 1);
+        case 0 -> (int) QUERY_MAX;
         case 1 -> (int) (QUERY_MAX + 1);
         case 2 -> (int) GAP_ORD;
         default -> throw new AssertionError();
@@ -390,39 +387,50 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     approx.advance(0);
     assertFalse(iter.matches());
 
-    // The key signal: docIDRunEnd must collapse to doc+1 because the set is not contiguous and
-    // every doc still needs per-doc predicate confirmation.
-    assertEquals(1, iter.docIDRunEnd());
+    // No match: docIDRunEnd returns docID to signal an empty run.
+    assertEquals(0, iter.docIDRunEnd());
   }
 
   // --- SortedDocValues: docIdRunEnd is conservative with ordinal sets ---
 
-  public void testSortedDocValuesDocIdRunEndAlwaysDocPlusOne() throws IOException {
+  public void testSortedDocValuesDocIdRunEnd() throws IOException {
     DocValuesRangeIterator iter = createSortedDocValuesIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
-    // Even in a YES block, docIdRunEnd returns doc+1 because ordinal sets
-    // may have gaps that the block-level check cannot detect.
+    // YES block, match: docIDRunEnd returns docID + 1 for a single-doc run.
     approx.advance(0);
     assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
+    assertTrue(iter.matches());
     assertEquals(1, iter.docIDRunEnd());
 
-    approx.advance(64);
-    assertEquals(65, iter.docIDRunEnd());
+    // YES block, no match: docIDRunEnd returns docID to signal an empty run.
+    approx.advance(1);
+    assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
+    assertFalse(iter.matches());
+    assertEquals(1, iter.docIDRunEnd());
 
-    // MAYBE block: same behavior as forOrdinalRange
+    // MAYBE block, no match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(512);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
-    assertEquals(513, iter.docIDRunEnd());
+    assertFalse(iter.matches());
+    assertEquals(512, iter.docIDRunEnd());
 
-    // YES block in second repetition (dense up to DENSE_END=1088): also doc+1
-    approx.advance(1024);
-    assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
-    assertEquals(1025, iter.docIDRunEnd());
+    // MAYBE block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    approx.advance(516);
+    assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
+    assertTrue(iter.matches());
+    assertEquals(517, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block: also doc+1
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID + 1 for a single-doc run.
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertTrue(iter.matches());
+    assertEquals(1089, iter.docIDRunEnd());
+
+    // YES_IF_PRESENT block, no match: docIDRunEnd returns docID to signal an empty run.
+    approx.advance(1089);
+    assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertFalse(iter.matches());
     assertEquals(1089, iter.docIDRunEnd());
   }
 
@@ -442,7 +450,7 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
   private static long[] ordinalPair(int doc) {
     int d = doc % 1024;
     if (d < 128) {
-      return new long[] {QUERY_MIN, QUERY_MAX};
+      return (doc & 1) == 0 ? new long[] {QUERY_MIN, QUERY_MAX} : new long[] {GAP_ORD, GAP_ORD};
     } else if (d < 256) {
       return new long[] {QUERY_MAX + 1, QUERY_MAX + 1};
     } else if (d < 512) {
@@ -633,26 +641,44 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
 
   // --- SortedSetDocValues: docIdRunEnd ---
 
-  public void testSortedSetDocIdRunEndAlwaysDocPlusOne() throws IOException {
+  public void testSortedSetDocIdRunEnd() throws IOException {
     DocValuesRangeIterator iter = createSortedSetDocValuesIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
+    // YES block, match: docIDRunEnd returns docID + 1 for a single-doc run.
     approx.advance(0);
     assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
+    assertTrue(iter.matches());
     assertEquals(1, iter.docIDRunEnd());
 
+    // YES block, no match: docIDRunEnd returns docID to signal an empty run.
+    approx.advance(1);
+    assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
+    assertFalse(iter.matches());
+    assertEquals(1, iter.docIDRunEnd());
+
+    // MAYBE block, match: docIDRunEnd returns docID + 1 for a single-doc run.
     approx.advance(512);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
+    assertTrue(iter.matches());
     assertEquals(513, iter.docIDRunEnd());
 
-    // YES block in second repetition (dense up to DENSE_END=1088)
-    approx.advance(1024);
-    assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
-    assertEquals(1025, iter.docIDRunEnd());
+    // MAYBE block, no match: docIDRunEnd returns docID to signal an empty run.
+    approx.advance(516);
+    assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
+    assertFalse(iter.matches());
+    assertEquals(516, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID + 1 for a single-doc run.
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertTrue(iter.matches());
+    assertEquals(1089, iter.docIDRunEnd());
+
+    // YES_IF_PRESENT block, no match: docIDRunEnd returns docID to signal an empty run.
+    approx.advance(1089);
+    assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertFalse(iter.matches());
     assertEquals(1089, iter.docIDRunEnd());
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
@@ -19,13 +19,20 @@ package org.apache.lucene.search;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.ImpactsEnum;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.TermState;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOBooleanSupplier;
@@ -754,5 +761,50 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
     approx.advance(1089);
     // Odd doc has no value → no match
     assertFalse(iter.matches());
+  }
+
+  /**
+   * Regression test: {@code DocValuesBlockRangeIterator.docIDRunEnd()} previously returned {@code
+   * doc+1} unconditionally, causing {@code DenseConjunctionBulkScorer} to collect false positives
+   * in the trailing single-doc window of a {@code WINDOW_SIZE+1}-doc segment.
+   */
+  public void testOrdinalSetDocIDRunEndFalsePositive() throws IOException {
+    int maxDoc = DenseConjunctionBulkScorer.WINDOW_SIZE + 1;
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = new IndexWriterConfig().setCodec(new Lucene104Codec());
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        for (int i = 0; i < maxDoc; i++) {
+          Document doc = new Document();
+          // Last doc gets "bbb" (ord 1): inside the bounding range [0,2] but not in the set {0,2}.
+          String val = (i == maxDoc - 1) ? "bbb" : (i % 100 == 0 ? "ccc" : "aaa");
+          doc.add(SortedDocValuesField.indexedField("field", new BytesRef(val)));
+          w.addDocument(doc);
+        }
+        w.forceMerge(1);
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        // Non-contiguous ordinal set {aaa=0, ccc=2}: gap at bbb=1 forces DocValuesBlockRangeIterator.
+        Query setQuery =
+            SortedDocValuesField.newSlowSetQuery(
+                "field", List.of(new BytesRef("aaa"), new BytesRef("ccc")));
+        // Range [aaa,ccc] matches all docs. A two-clause FILTER conjunction causes
+        // BooleanScorerSupplier to use DenseConjunctionBulkScorer.of(), which extracts the set
+        // query's DocValuesBlockRangeIterator as a TwoPhaseIterator — the production code path.
+        Query rangeQuery =
+            SortedDocValuesField.newSlowRangeQuery(
+                "field", new BytesRef("aaa"), new BytesRef("ccc"), true, true);
+        Query q =
+            new BooleanQuery.Builder()
+                .add(setQuery, BooleanClause.Occur.FILTER)
+                .add(rangeQuery, BooleanClause.Occur.FILTER)
+                .build();
+
+        IndexSearcher searcher = new IndexSearcher(reader);
+        // Disable cache: the test framework's LRUQueryCache may cache a clause as a plain
+        // DocIdSetIterator, bypassing the TwoPhaseIterator and preventing the bug from triggering.
+        searcher.setQueryCache(null);
+        assertEquals(maxDoc - 1, searcher.count(q));
+      }
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesOrdinalSetIterator.java
@@ -160,6 +160,7 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
   private static int singleOrdinal(int doc) {
     int d = doc % 1024;
     if (d < 128) {
+      // 14 and 15 (GAP_ORD) are in range, but 15 is not in the matching ordinal set
       return (doc & 1) == 0 ? 14 : (int) GAP_ORD;
     } else if (d < 256) {
       return (int) (QUERY_MAX + 1);
@@ -167,6 +168,7 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
       return (int) (QUERY_MIN - 1);
     } else {
       return switch ((d / 2) % 3) {
+        // Include values in the ord set, values outside the range, and values in the range but not in the ord set.
         case 0 -> (int) QUERY_MAX;
         case 1 -> (int) (QUERY_MAX + 1);
         case 2 -> (int) GAP_ORD;
@@ -450,6 +452,7 @@ public class TestDocValuesOrdinalSetIterator extends BaseDocValuesSkipperTests {
   private static long[] ordinalPair(int doc) {
     int d = doc % 1024;
     if (d < 128) {
+      // All values are in range, but GAP_ORD is not in the ord set
       return (doc & 1) == 0 ? new long[] {QUERY_MIN, QUERY_MAX} : new long[] {GAP_ORD, GAP_ORD};
     } else if (d < 256) {
       return new long[] {QUERY_MAX + 1, QUERY_MAX + 1};

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRangeIterator.java
@@ -272,23 +272,33 @@ public class TestDocValuesRangeIterator extends BaseDocValuesSkipperTests {
     DocValuesRangeIterator iter = createIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
-    // MAYBE blocks cannot guarantee all docs match, so docIdRunEnd = doc + 1
+    // MAYBE block, no match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(512);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
-    assertEquals(513, iter.docIDRunEnd());
+    assertFalse(iter.matches());
+    assertEquals(512, iter.docIDRunEnd());
 
-    approx.advance(800);
+    // MAYBE block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    approx.advance(514);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
-    assertEquals(801, iter.docIDRunEnd());
+    assertTrue(iter.matches());
+    assertEquals(515, iter.docIDRunEnd());
   }
 
   public void testDocIdRunEndYesIfPresentBlock() throws IOException {
     DocValuesRangeIterator iter = createIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
-    // YES_IF_PRESENT blocks have gaps, so docIdRunEnd = doc + 1
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID + 1 for a single-doc run.
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertTrue(iter.matches());
+    assertEquals(1089, iter.docIDRunEnd());
+
+    // YES_IF_PRESENT block, no match: docIDRunEnd returns docID to signal an empty run.
+    approx.advance(1089);
+    assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertFalse(iter.matches());
     assertEquals(1089, iter.docIDRunEnd());
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRangeIterator.java
@@ -278,22 +278,22 @@ public class TestDocValuesRangeIterator extends BaseDocValuesSkipperTests {
     assertFalse(iter.matches());
     assertEquals(512, iter.docIDRunEnd());
 
-    // MAYBE block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    // MAYBE block, match: docIDRunEnd returns docID (empty run).
     approx.advance(514);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
     assertTrue(iter.matches());
-    assertEquals(515, iter.docIDRunEnd());
+    assertEquals(514, iter.docIDRunEnd());
   }
 
   public void testDocIdRunEndYesIfPresentBlock() throws IOException {
     DocValuesRangeIterator iter = createIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
-    // YES_IF_PRESENT block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID (empty run).
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertTrue(iter.matches());
-    assertEquals(1089, iter.docIDRunEnd());
+    assertEquals(1088, iter.docIDRunEnd());
 
     // YES_IF_PRESENT block, no match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(1089);

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesRangeIterator.java
@@ -278,7 +278,7 @@ public class TestDocValuesRangeIterator extends BaseDocValuesSkipperTests {
     assertFalse(iter.matches());
     assertEquals(512, iter.docIDRunEnd());
 
-    // MAYBE block, match: docIDRunEnd returns docID (empty run).
+    // MAYBE block, match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(514);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
     assertTrue(iter.matches());
@@ -289,7 +289,7 @@ public class TestDocValuesRangeIterator extends BaseDocValuesSkipperTests {
     DocValuesRangeIterator iter = createIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
-    // YES_IF_PRESENT block, match: docIDRunEnd returns docID (empty run).
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertTrue(iter.matches());

--- a/lucene/core/src/test/org/apache/lucene/search/TestSkipBlockRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSkipBlockRangeIterator.java
@@ -31,14 +31,17 @@ public class TestSkipBlockRangeIterator extends BaseDocValuesSkipperTests {
     assertEquals(128, it.docIDRunEnd());
     assertEquals(100, it.advance(100));
     assertEquals(512, it.advance(300));
-    assertEquals(513, it.docIDRunEnd());
+    assertEquals(SkipBlockRangeIterator.Match.MAYBE, it.getMatch());
+    assertEquals(576, it.docIDRunEnd());
     // Block [1024,1087] is dense YES, but level-1 [1024,1151] is sparse: can't expand
     assertEquals(1024, it.advance(1024));
     assertEquals(1088, it.docIDRunEnd());
     assertEquals(1100, it.advance(1100));
-    assertEquals(1101, it.docIDRunEnd());
+    assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, it.getMatch());
+    assertEquals(1152, it.docIDRunEnd());
     assertEquals(1536, it.advance(1500));
-    assertEquals(1537, it.docIDRunEnd());
+    assertEquals(SkipBlockRangeIterator.Match.MAYBE, it.getMatch());
+    assertEquals(1600, it.docIDRunEnd());
     assertEquals(DocIdSetIterator.NO_MORE_DOCS, it.advance(2050));
   }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortedNumericDocValuesRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortedNumericDocValuesRangeIterator.java
@@ -382,7 +382,7 @@ public class TestSortedNumericDocValuesRangeIterator extends BaseDocValuesSkippe
     DocValuesRangeIterator iter = createIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
-    // MAYBE block, match: docIDRunEnd returns docID (empty run).
+    // MAYBE block, match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(512);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
     assertTrue(iter.matches());
@@ -405,7 +405,7 @@ public class TestSortedNumericDocValuesRangeIterator extends BaseDocValuesSkippe
     assertTrue(iter.matches());
     assertEquals(1088, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block, match: docIDRunEnd returns docID (empty run).
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertTrue(iter.matches());

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortedNumericDocValuesRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortedNumericDocValuesRangeIterator.java
@@ -382,11 +382,11 @@ public class TestSortedNumericDocValuesRangeIterator extends BaseDocValuesSkippe
     DocValuesRangeIterator iter = createIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
-    // MAYBE block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    // MAYBE block, match: docIDRunEnd returns docID (empty run).
     approx.advance(512);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
     assertTrue(iter.matches());
-    assertEquals(513, iter.docIDRunEnd());
+    assertEquals(512, iter.docIDRunEnd());
 
     // MAYBE block, no match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(516);
@@ -405,11 +405,11 @@ public class TestSortedNumericDocValuesRangeIterator extends BaseDocValuesSkippe
     assertTrue(iter.matches());
     assertEquals(1088, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT block, match: docIDRunEnd returns docID + 1 for a single-doc run.
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID (empty run).
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
     assertTrue(iter.matches());
-    assertEquals(1089, iter.docIDRunEnd());
+    assertEquals(1088, iter.docIDRunEnd());
 
     // YES_IF_PRESENT block, no match: docIDRunEnd returns docID to signal an empty run.
     approx.advance(1089);

--- a/lucene/core/src/test/org/apache/lucene/search/TestSortedNumericDocValuesRangeIterator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSortedNumericDocValuesRangeIterator.java
@@ -382,13 +382,17 @@ public class TestSortedNumericDocValuesRangeIterator extends BaseDocValuesSkippe
     DocValuesRangeIterator iter = createIterator(true);
     SkipBlockRangeIterator approx = (SkipBlockRangeIterator) iter.approximation();
 
+    // MAYBE block, match: docIDRunEnd returns docID + 1 for a single-doc run.
     approx.advance(512);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
+    assertTrue(iter.matches());
     assertEquals(513, iter.docIDRunEnd());
 
-    approx.advance(800);
+    // MAYBE block, no match: docIDRunEnd returns docID to signal an empty run.
+    approx.advance(516);
     assertEquals(SkipBlockRangeIterator.Match.MAYBE, approx.getMatch());
-    assertEquals(801, iter.docIDRunEnd());
+    assertFalse(iter.matches());
+    assertEquals(516, iter.docIDRunEnd());
   }
 
   public void testDocIdRunEndYesIfPresentBlock() throws IOException {
@@ -398,11 +402,19 @@ public class TestSortedNumericDocValuesRangeIterator extends BaseDocValuesSkippe
     // YES block in second repetition (dense up to DENSE_END=1088)
     approx.advance(1024);
     assertEquals(SkipBlockRangeIterator.Match.YES, approx.getMatch());
+    assertTrue(iter.matches());
     assertEquals(1088, iter.docIDRunEnd());
 
-    // YES_IF_PRESENT blocks have gaps, so docIdRunEnd = doc + 1
+    // YES_IF_PRESENT block, match: docIDRunEnd returns docID + 1 for a single-doc run.
     approx.advance(1088);
     assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertTrue(iter.matches());
+    assertEquals(1089, iter.docIDRunEnd());
+
+    // YES_IF_PRESENT block, no match: docIDRunEnd returns docID to signal an empty run.
+    approx.advance(1089);
+    assertEquals(SkipBlockRangeIterator.Match.YES_IF_PRESENT, approx.getMatch());
+    assertFalse(iter.matches());
     assertEquals(1089, iter.docIDRunEnd());
   }
 


### PR DESCRIPTION
`DocValuesRangeIterator` uses `SkipBlockRangeIterator` as a two-phase approximation. Docs in `MAYBE` and `YES_IF_PRESENT` blocks belong to the approximation, but are not necessarily query matches. `docIDRunEnd()` could previously expose these approximation runs as actual matching runs. Consumers could then treat unconfirmed docs as matches. 

This change modifies the `docIDRunEnd` implementations in `DocValuesBlockRangeIterator` and `BulkBlockRangeIterator` to avoid returning too large of a set from `docIDRunEnd`. This means instead of returning `approximation.docID + 1`, which implies that the current docId is a match, we return `approximation.docID`. This means the run is empty. Always returning `approximation.docID` would be correct, but is overly conservative. Thus we store the last matching docID. If it is the same docID as `approximation.docID`, we return `docID+1` meaning docID was match. Otherwise, we return `docID`, meaning the run is empty.

This change also makes the `SkipBlockRangeIterator.docIDRunEnd` less conservative. It had previously returned `docID+1` for MAYBE and YES_IF_PRESENT blocks. But the `SkipBlockRangeIterator` is a set of docID's that are either YES, YES_IF_PRESENT, or MAYBE. That is, from the perspective of `SkipBlockRangeIterator`, docIDs with MAYBE are valid members of it's DISI set. Thus `docIDRunEnd` should treat a MAYBE doc as a match. This means `docIDRunEnd` can be extended to the end of MAYBE blocks. (This differs from `DocValuesBlockRangeIterator` and `BulkBlockRangeIterator`  which are two phase iterators. The set they expose has to remove the MAYBEs, thus should not include them in `docIDRunEnd`.)


