### PR TITLE
GITHUB#9967: document the Fields#iterator() order contract and assert it in tests

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -131,6 +131,10 @@ New Features
 
 Improvements
 ---------------------
+* GITHUB#9967: Document that Fields#iterator() must return field names in ascending order, and assert
+  it in the asserting codec so a violating PostingsFormat fails in tests rather than only in
+  CheckIndex. (Serhiy Bzhezytskyy)
+
 * GITHUB#15704: Replace LinkedList with more efficient data structure. (Renato Haeberli)
 
 * GITHUB#15682: Use ArrayDeque instead of LinkedList in CompoundWordTokenFilterBase.java. (Renato Haeberli)

--- a/lucene/core/src/java/org/apache/lucene/codecs/FieldsConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/FieldsConsumer.java
@@ -59,6 +59,8 @@ public abstract class FieldsConsumer implements Closeable {
    *   <li>The provided Fields instance is limited: you cannot call any methods that return
    *       statistics/counts; you cannot pass a non-null live docs when pulling docs/positions
    *       enums.
+   *   <li>Field names arrive in ascending natural order, as {@link Fields#iterator()} requires, so
+   *       an implementation may rely on that and must preserve it in what it writes.
    * </ul>
    */
   public abstract void write(Fields fields, NormsProducer norms) throws IOException;

--- a/lucene/core/src/java/org/apache/lucene/codecs/FieldsProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/FieldsProducer.java
@@ -24,6 +24,9 @@ import org.apache.lucene.index.MergePolicy;
 /**
  * Abstract API that produces terms, doc, freq, prox, offset and payloads postings.
  *
+ * <p>Note that {@link Fields#iterator()} must return field names in ascending natural order; see
+ * there for what relies on it and what breaks otherwise.
+ *
  * @lucene.experimental
  */
 public abstract class FieldsProducer extends Fields implements Closeable {

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -1479,7 +1479,8 @@ public final class CheckIndex implements Closeable {
     String lastField = null;
     for (String field : fields) {
 
-      // MultiFieldsEnum relies upon this order...
+      // MultiFields and PerFieldPostingsFormat merge these iterators with MergedIterator, whose
+      // behaviour is undefined unless every input is sorted; see Fields#iterator().
       if (lastField != null && field.compareTo(lastField) <= 0) {
         throw new CheckIndexException(
             "fields out of order: lastField=" + lastField + " field=" + field);

--- a/lucene/core/src/java/org/apache/lucene/index/Fields.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Fields.java
@@ -31,7 +31,17 @@ public abstract class Fields implements Iterable<String> {
   /** Sole constructor. (For invocation by subclass constructors, typically implicit.) */
   protected Fields() {}
 
-  /** Returns an iterator that will step through all fields names. This will not return null. */
+  /**
+   * Returns an iterator that will step through all fields names. This will not return null.
+   *
+   * <p><b>NOTE</b>: field names must be returned in ascending {@link String#compareTo natural
+   * order}, with no duplicates. {@link MultiFields} and {@link
+   * org.apache.lucene.codecs.perfield.PerFieldPostingsFormat} merge several of these iterators with
+   * {@link org.apache.lucene.util.MergedIterator}, whose behaviour is undefined when its inputs are
+   * not sorted, so an implementation that returns field names in another order (for instance from a
+   * {@link java.util.HashMap#keySet()}) silently produces wrong results rather than an error.
+   * {@link CheckIndex} verifies this for the fields of an index.
+   */
   @Override
   public abstract Iterator<String> iterator();
 

--- a/lucene/core/src/java/org/apache/lucene/index/Fields.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Fields.java
@@ -35,11 +35,12 @@ public abstract class Fields implements Iterable<String> {
    * Returns an iterator that will step through all fields names. This will not return null.
    *
    * <p><b>NOTE</b>: field names must be returned in ascending {@link String#compareTo natural
-   * order}, with no duplicates. {@link MultiFields} and {@link
+   * order}. {@link MultiFields} and {@link
    * org.apache.lucene.codecs.perfield.PerFieldPostingsFormat} merge several of these iterators with
    * {@link org.apache.lucene.util.MergedIterator}, whose behaviour is undefined when its inputs are
    * not sorted, so an implementation that returns field names in another order (for instance from a
-   * {@link java.util.HashMap#keySet()}) silently produces wrong results rather than an error.
+   * {@link java.util.HashMap#keySet()}) silently produces wrong results rather than an error: the
+   * merge stops deduplicating, and a name present in two sub-iterators can be returned twice.
    * {@link CheckIndex} verifies this for the fields of an index.
    */
   @Override

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldsOrder.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldsOrder.java
@@ -25,12 +25,18 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.FieldsConsumer;
 import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.MergedIterator;
 
 /**
@@ -244,5 +250,125 @@ public class TestFieldsOrder extends LuceneTestCase {
     List<String> sorted = new ArrayList<>(fields);
     sorted.sort(null);
     assertEquals(sorted, fields);
+  }
+
+  /**
+   * C4/C5 from the {@link Fields#iterator()} javadoc: when a sub-iterator is unsorted, {@link
+   * MergedIterator} stops deduplicating, and a name present in two sub-iterators comes back twice.
+   * This is the concrete harm the contract exists to prevent, so it is pinned rather than asserted
+   * in prose only.
+   */
+  public void testUnsortedInputBreaksDeduplication() throws Exception {
+    // sorted inputs: the shared name "a" is deduplicated
+    assertEquals(List.of("a", "b", "c"), merge(List.of("a", "b"), List.of("a", "c")));
+
+    // one unsorted input: "a" is returned twice, from two different sub-iterators
+    assertEquals(
+        List.of("a", "b", "a", "c", "z"), merge(List.of("b", "a", "c"), List.of("a", "z")));
+
+    // and a duplicate inside a single sub-iterator is not removed either
+    assertEquals(List.of("a", "a", "b"), merge(List.of("a", "a", "b")));
+  }
+
+  @SafeVarargs
+  @SuppressWarnings({"unchecked", "rawtypes", "varargs"})
+  private static List<String> merge(List<String>... subs) {
+    Iterator[] iterators = new Iterator[subs.length];
+    for (int i = 0; i < subs.length; i++) {
+      iterators[i] = subs[i].iterator();
+    }
+    List<String> out = new ArrayList<>();
+    // MultiFields uses the single-argument constructor, which is removeDuplicates=true
+    new MergedIterator<String>(iterators).forEachRemaining(out::add);
+    return out;
+  }
+
+  /**
+   * C3: {@link org.apache.lucene.codecs.perfield.PerFieldPostingsFormat} is the second consumer of
+   * the order. Merging two segments through it must produce every field exactly once, which is only
+   * true while the sub-iterators are sorted.
+   */
+  public void testPerFieldMergePreservesFieldsExactlyOnce() throws Exception {
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter w =
+          new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
+        for (List<String> fields : List.of(List.of("zebra", "mid"), List.of("aaa", "mid"))) {
+          Document doc = new Document();
+          for (String field : fields) {
+            doc.add(new TextField(field, "value", Field.Store.NO));
+          }
+          w.addDocument(doc);
+          w.commit();
+        }
+      }
+
+      try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+        w.forceMerge(1);
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        CodecReader leaf = (CodecReader) getOnlyLeafReader(reader);
+        List<String> merged = fieldNames(leaf.getPostingsReader());
+        // "mid" was in both segments and must appear once
+        assertEquals(List.of("aaa", "mid", "zebra"), merged);
+        assertNull(checkPostings(leaf).error);
+      }
+    }
+  }
+
+  /**
+   * C7: {@link org.apache.lucene.codecs.FieldsConsumer#write} now documents that field names arrive
+   * sorted. Pin it where the write actually happens, by observing what a real flush hands over.
+   */
+  public void testWriteSideReceivesSortedFields() throws Exception {
+    List<List<String>> observed = new ArrayList<>();
+    Codec base = TestUtil.getDefaultCodec();
+    final PostingsFormat delegateFormat = TestUtil.getDefaultPostingsFormat();
+    Codec recording =
+        new FilterCodec(base.getName(), base) {
+          @Override
+          public PostingsFormat postingsFormat() {
+            return new PostingsFormat(delegateFormat.getName()) {
+              @Override
+              public FieldsConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+                FieldsConsumer in = delegateFormat.fieldsConsumer(state);
+                return new FieldsConsumer() {
+                  @Override
+                  public void write(Fields fields, NormsProducer norms) throws IOException {
+                    observed.add(fieldNames(fields));
+                    in.write(fields, norms);
+                  }
+
+                  @Override
+                  public void close() throws IOException {
+                    in.close();
+                  }
+                };
+              }
+
+              @Override
+              public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
+                return delegateFormat.fieldsProducer(state);
+              }
+            };
+          }
+        };
+
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc =
+          new IndexWriterConfig().setCodec(recording).setMergePolicy(NoMergePolicy.INSTANCE);
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        Document doc = new Document();
+        for (String field : FIELDS) {
+          doc.add(new TextField(field, "value", Field.Store.NO));
+        }
+        w.addDocument(doc);
+      }
+    }
+
+    assertFalse("write() was never called", observed.isEmpty());
+    for (List<String> names : observed) {
+      assertAscending(names);
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldsOrder.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldsOrder.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.index;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.MergedIterator;
+
+/**
+ * Tests the ordering contract of {@link Fields#iterator()}: field names must be returned in
+ * ascending natural order. {@link MergedIterator}, which {@link MultiFields} and {@link
+ * org.apache.lucene.codecs.perfield.PerFieldPostingsFormat} use to combine several of these
+ * iterators, is documented as undefined when its inputs are not sorted, so a violation yields wrong
+ * results rather than an error and only {@link CheckIndex} detects it.
+ *
+ * <p>Note that this order is unrelated to the order in which fields were added to a document: that
+ * one is preserved in {@link FieldInfos}, while the terms dictionary sorts field names when it is
+ * opened. {@link #testOrderIsIndependentOfInsertionOrder()} pins both halves of that.
+ */
+public class TestFieldsOrder extends LuceneTestCase {
+
+  /** Deliberately neither sorted nor reverse sorted, and mixing case. */
+  private static final List<String> FIELDS = List.of("zebra", "alpha", "mid", "b", "Z");
+
+  private Directory index() throws IOException {
+    Directory dir = newDirectory();
+    try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      Document doc = new Document();
+      for (String field : FIELDS) {
+        doc.add(new TextField(field, "value", Field.Store.NO));
+      }
+      w.addDocument(doc);
+    }
+    return dir;
+  }
+
+  /** Delegates everything, but lists field names in descending order. */
+  private static FieldsProducer reversed(FieldsProducer in) {
+    return new FieldsProducer() {
+      @Override
+      public Iterator<String> iterator() {
+        List<String> fields = new ArrayList<>();
+        in.forEach(fields::add);
+        fields.sort(Comparator.reverseOrder());
+        return fields.iterator();
+      }
+
+      @Override
+      public Terms terms(String field) {
+        return in.terms(field);
+      }
+
+      @Override
+      public int size() {
+        return in.size();
+      }
+
+      @Override
+      public void checkIntegrity(MergePolicy.OneMerge merge) throws IOException {
+        in.checkIntegrity(merge);
+      }
+
+      @Override
+      public void close() throws IOException {
+        in.close();
+      }
+    };
+  }
+
+  private static CodecReader withPostings(CodecReader in, FieldsProducer postings) {
+    return new FilterCodecReader(in) {
+      @Override
+      public FieldsProducer getPostingsReader() {
+        return postings;
+      }
+
+      @Override
+      public CacheHelper getCoreCacheHelper() {
+        return in.getCoreCacheHelper();
+      }
+
+      @Override
+      public CacheHelper getReaderCacheHelper() {
+        return in.getReaderCacheHelper();
+      }
+    };
+  }
+
+  private static CheckIndex.Status.TermIndexStatus checkPostings(CodecReader reader)
+      throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    return CheckIndex.testPostings(
+        reader,
+        new PrintStream(out, false, UTF_8),
+        false,
+        CheckIndex.Level.MIN_LEVEL_FOR_INTEGRITY_CHECKS,
+        false);
+  }
+
+  /** A reader that lists fields out of order must be reported. */
+  public void testCheckIndexDetectsFieldsOutOfOrder() throws Exception {
+    try (Directory dir = index();
+        DirectoryReader reader = DirectoryReader.open(dir)) {
+      CodecReader leaf = (CodecReader) getOnlyLeafReader(reader);
+      CheckIndex.Status.TermIndexStatus status =
+          checkPostings(withPostings(leaf, reversed(leaf.getPostingsReader())));
+
+      assertNotNull("CheckIndex did not report the field order", status.error);
+      assertTrue(
+          status.error.getMessage(), status.error.getMessage().contains("fields out of order"));
+    }
+  }
+
+  /** ... and a reader that honours the contract must not be. */
+  public void testCheckIndexAcceptsSortedFields() throws Exception {
+    try (Directory dir = index();
+        DirectoryReader reader = DirectoryReader.open(dir)) {
+      CodecReader leaf = (CodecReader) getOnlyLeafReader(reader);
+      CheckIndex.Status.TermIndexStatus status = checkPostings(leaf);
+
+      assertNull(String.valueOf(status.error), status.error);
+      assertEquals(FIELDS.size(), status.termCount > 0 ? FIELDS.size() : -1);
+    }
+  }
+
+  /**
+   * The terms dictionary sorts field names regardless of the order in which they were added, and
+   * regardless of the order used by an earlier segment. {@link FieldInfos}, by contrast, keeps
+   * insertion order and field numbers assigned from it, and a merge preserves that — so the two
+   * orders are genuinely different views and only one of them is the contract.
+   */
+  public void testOrderIsIndependentOfInsertionOrder() throws Exception {
+    List<String> first = List.of("zebra", "alpha", "mid");
+    // same fields in the opposite order, plus one that sorts first but is added last
+    List<String> second = List.of("mid", "alpha", "zebra", "aaa");
+
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter w =
+          new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
+        for (List<String> fields : List.of(first, second)) {
+          Document doc = new Document();
+          for (String field : fields) {
+            doc.add(new TextField(field, "value", Field.Store.NO));
+          }
+          w.addDocument(doc);
+          w.commit();
+        }
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        assertEquals("expected one segment per commit", 2, reader.leaves().size());
+        for (LeafReaderContext ctx : reader.leaves()) {
+          CodecReader leaf = (CodecReader) ctx.reader();
+          assertAscending(fieldNames(leaf.getPostingsReader()));
+          assertNull(checkPostings(leaf).error);
+        }
+
+        // FieldInfos keeps insertion order, and the field numbers follow it: "aaa" was added last
+        // in the second segment, so it has the highest number even though it sorts first.
+        List<String> infoOrder = new ArrayList<>();
+        for (FieldInfo fi : reader.leaves().get(1).reader().getFieldInfos()) {
+          infoOrder.add(fi.name);
+        }
+        assertEquals(List.of("zebra", "alpha", "mid", "aaa"), infoOrder);
+      }
+
+      // merging does not change either view
+      try (IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+        w.forceMerge(1);
+        w.commit();
+      }
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        CodecReader leaf = (CodecReader) getOnlyLeafReader(reader);
+        assertEquals(List.of("aaa", "alpha", "mid", "zebra"), fieldNames(leaf.getPostingsReader()));
+        assertNull(checkPostings(leaf).error);
+      }
+    }
+  }
+
+  /** {@link MultiFields} is what actually depends on the order, so pin it too. */
+  public void testMultiFieldsMergesInOrder() throws Exception {
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter w =
+          new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
+        for (List<String> fields : List.of(List.of("zebra", "mid"), List.of("aaa", "alpha"))) {
+          Document doc = new Document();
+          for (String field : fields) {
+            doc.add(new TextField(field, "value", Field.Store.NO));
+          }
+          w.addDocument(doc);
+          w.commit();
+        }
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        Fields[] subs = new Fields[reader.leaves().size()];
+        ReaderSlice[] slices = new ReaderSlice[reader.leaves().size()];
+        for (int i = 0; i < reader.leaves().size(); i++) {
+          LeafReaderContext ctx = reader.leaves().get(i);
+          subs[i] = ((CodecReader) ctx.reader()).getPostingsReader();
+          slices[i] = new ReaderSlice(ctx.docBase, ctx.reader().maxDoc(), i);
+        }
+
+        List<String> merged = fieldNames(new MultiFields(subs, slices));
+        assertEquals(List.of("aaa", "alpha", "mid", "zebra"), merged);
+      }
+    }
+  }
+
+  private static List<String> fieldNames(Fields fields) {
+    List<String> names = new ArrayList<>();
+    fields.forEach(names::add);
+    return names;
+  }
+
+  private static void assertAscending(List<String> fields) {
+    List<String> sorted = new ArrayList<>(fields);
+    sorted.sort(null);
+    assertEquals(sorted, fields);
+  }
+}

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingPostingsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingPostingsFormat.java
@@ -55,19 +55,23 @@ public final class AssertingPostingsFormat extends PostingsFormat {
     return new AssertingFieldsProducer(in.fieldsProducer(state));
   }
 
-  static class AssertingFieldsProducer extends FieldsProducer {
-    private final FieldsProducer in;
+  /**
+   * Checks the {@link Fields#iterator()} contract, and nothing else, so it is safe on both sides of
+   * the codec: a {@link FieldsProducer} being read, and the {@link Fields} handed to {@link
+   * FieldsConsumer#write}.
+   *
+   * <p>It deliberately does not wrap {@link Terms}. On the write side the consumer pulls a {@link
+   * PostingsEnum} straight from the incoming {@link Fields} and drives it with different
+   * expectations from a reader, so wrapping terms there trips the read-side assertions in {@link
+   * AssertingLeafReader} (three tests in {@code BasePostingsFormatTestCase} fail on {@code assert
+   * super.docID() == nextDoc}). {@link AssertingReadFields} adds that wrapping for the read side
+   * only.
+   */
+  static class AssertingFields extends Fields {
+    protected final Fields in;
 
-    AssertingFieldsProducer(FieldsProducer in) {
+    AssertingFields(Fields in) {
       this.in = in;
-      // do a few simple checks on init
-      assert toString() != null;
-    }
-
-    @Override
-    public void close() throws IOException {
-      in.close();
-      in.close(); // close again
     }
 
     @Override
@@ -78,10 +82,17 @@ public final class AssertingPostingsFormat extends PostingsFormat {
     }
 
     /**
-     * Wraps {@code in} so that it fails if field names do not arrive in ascending natural order, as
-     * {@link Fields#iterator()} requires. Nothing else detects a violation: {@link
+     * Wraps {@code in} so that it fails if field names do not arrive in ascending natural order
+     * with no duplicates, as {@link Fields#iterator()} requires.
+     *
+     * <p>Nothing in production code detects a violation: {@link
      * org.apache.lucene.util.MergedIterator}, which is what relies on the order, is documented as
-     * undefined rather than checked, so an unsorted producer silently returns wrong results.
+     * undefined for unsorted input rather than checking it, so an offending implementation silently
+     * returns wrong results — the merge stops deduplicating and a name present in two sub-iterators
+     * can be returned twice. Only {@code CheckIndex} catches it, and only after the fact.
+     *
+     * <p>The comparison is strict, matching both the check in {@code CheckIndex#checkFields} and
+     * the one that {@link AssertingFieldsConsumer#write} has applied to the write side since 2013.
      */
     private static Iterator<String> assertSorted(Iterator<String> in) {
       return new Iterator<>() {
@@ -95,7 +106,6 @@ public final class AssertingPostingsFormat extends PostingsFormat {
         @Override
         public String next() {
           String field = in.next();
-          assert field != null : "Fields.iterator() must not return null field names";
           assert last == null || last.compareTo(field) < 0
               : "Fields.iterator() must return field names in ascending order with no duplicates,"
                   + " but saw \""
@@ -111,13 +121,63 @@ public final class AssertingPostingsFormat extends PostingsFormat {
 
     @Override
     public Terms terms(String field) {
-      Terms terms = in.terms(field);
-      return terms == null ? null : new AssertingLeafReader.AssertingTerms(terms);
+      return in.terms(field);
     }
 
     @Override
     public int size() {
       return in.size();
+    }
+
+    @Override
+    public String toString() {
+      return getClass().getSimpleName() + "(" + in.toString() + ")";
+    }
+  }
+
+  /** Adds the read-side {@link Terms} assertions on top of the {@link Fields} contract. */
+  static class AssertingReadFields extends AssertingFields {
+    AssertingReadFields(Fields in) {
+      super(in);
+    }
+
+    @Override
+    public Terms terms(String field) {
+      Terms terms = in.terms(field);
+      return terms == null ? null : new AssertingLeafReader.AssertingTerms(terms);
+    }
+  }
+
+  static class AssertingFieldsProducer extends FieldsProducer {
+    private final FieldsProducer in;
+    private final AssertingFields asserting;
+
+    AssertingFieldsProducer(FieldsProducer in) {
+      this.in = in;
+      this.asserting = new AssertingReadFields(in);
+      // do a few simple checks on init
+      assert toString() != null;
+    }
+
+    @Override
+    public void close() throws IOException {
+      in.close();
+      in.close(); // close again
+    }
+
+    @Override
+    public Iterator<String> iterator() {
+      return asserting.iterator();
+    }
+
+    @Override
+    public Terms terms(String field) {
+      return asserting.terms(field);
+    }
+
+    @Override
+    public int size() {
+      return asserting.size();
     }
 
     @Override
@@ -147,23 +207,25 @@ public final class AssertingPostingsFormat extends PostingsFormat {
 
     @Override
     public void write(Fields fields, NormsProducer norms) throws IOException {
-      in.write(fields, norms);
+      // Wrap the incoming Fields, so the contract is checked on the way in and not only when a
+      // FieldsProducer reads the result back. The delegate sees the wrapper, so a violation fails
+      // during the write that caused it rather than in a later reader or in CheckIndex.
+      Fields asserting = new AssertingFields(fields);
+      in.write(asserting, norms);
 
       // TODO: more asserts?  can we somehow run a
-      // "limited" CheckIndex here???  Or ... can we improve
-      // AssertingFieldsProducer and us it also to wrap the
-      // incoming Fields here?
+      // "limited" CheckIndex here???
 
       String lastField = null;
 
-      for (String field : fields) {
+      for (String field : asserting) {
 
         FieldInfo fieldInfo = writeState.fieldInfos.fieldInfo(field);
         assert fieldInfo != null;
         assert lastField == null || lastField.compareTo(field) < 0;
         lastField = field;
 
-        Terms terms = fields.terms(field);
+        Terms terms = asserting.terms(field);
         if (terms == null) {
           continue;
         }

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingPostingsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingPostingsFormat.java
@@ -74,7 +74,39 @@ public final class AssertingPostingsFormat extends PostingsFormat {
     public Iterator<String> iterator() {
       Iterator<String> iterator = in.iterator();
       assert iterator != null;
-      return iterator;
+      return assertSorted(iterator);
+    }
+
+    /**
+     * Wraps {@code in} so that it fails if field names do not arrive in ascending natural order, as
+     * {@link Fields#iterator()} requires. Nothing else detects a violation: {@link
+     * org.apache.lucene.util.MergedIterator}, which is what relies on the order, is documented as
+     * undefined rather than checked, so an unsorted producer silently returns wrong results.
+     */
+    private static Iterator<String> assertSorted(Iterator<String> in) {
+      return new Iterator<>() {
+        String last;
+
+        @Override
+        public boolean hasNext() {
+          return in.hasNext();
+        }
+
+        @Override
+        public String next() {
+          String field = in.next();
+          assert field != null : "Fields.iterator() must not return null field names";
+          assert last == null || last.compareTo(field) < 0
+              : "Fields.iterator() must return field names in ascending order with no duplicates,"
+                  + " but saw \""
+                  + last
+                  + "\" followed by \""
+                  + field
+                  + "\"";
+          last = field;
+          return field;
+        }
+      };
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingPostingsFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/codecs/asserting/AssertingPostingsFormat.java
@@ -67,10 +67,10 @@ public final class AssertingPostingsFormat extends PostingsFormat {
    * super.docID() == nextDoc}). {@link AssertingReadFields} adds that wrapping for the read side
    * only.
    */
-  static class AssertingFields extends Fields {
+  static class OrderCheckingFields extends Fields {
     protected final Fields in;
 
-    AssertingFields(Fields in) {
+    OrderCheckingFields(Fields in) {
       this.in = in;
     }
 
@@ -78,45 +78,7 @@ public final class AssertingPostingsFormat extends PostingsFormat {
     public Iterator<String> iterator() {
       Iterator<String> iterator = in.iterator();
       assert iterator != null;
-      return assertSorted(iterator);
-    }
-
-    /**
-     * Wraps {@code in} so that it fails if field names do not arrive in ascending natural order
-     * with no duplicates, as {@link Fields#iterator()} requires.
-     *
-     * <p>Nothing in production code detects a violation: {@link
-     * org.apache.lucene.util.MergedIterator}, which is what relies on the order, is documented as
-     * undefined for unsorted input rather than checking it, so an offending implementation silently
-     * returns wrong results — the merge stops deduplicating and a name present in two sub-iterators
-     * can be returned twice. Only {@code CheckIndex} catches it, and only after the fact.
-     *
-     * <p>The comparison is strict, matching both the check in {@code CheckIndex#checkFields} and
-     * the one that {@link AssertingFieldsConsumer#write} has applied to the write side since 2013.
-     */
-    private static Iterator<String> assertSorted(Iterator<String> in) {
-      return new Iterator<>() {
-        String last;
-
-        @Override
-        public boolean hasNext() {
-          return in.hasNext();
-        }
-
-        @Override
-        public String next() {
-          String field = in.next();
-          assert last == null || last.compareTo(field) < 0
-              : "Fields.iterator() must return field names in ascending order with no duplicates,"
-                  + " but saw \""
-                  + last
-                  + "\" followed by \""
-                  + field
-                  + "\"";
-          last = field;
-          return field;
-        }
-      };
+      return AssertingLeafReader.AssertingFields.assertFieldOrder(iterator);
     }
 
     @Override
@@ -136,7 +98,7 @@ public final class AssertingPostingsFormat extends PostingsFormat {
   }
 
   /** Adds the read-side {@link Terms} assertions on top of the {@link Fields} contract. */
-  static class AssertingReadFields extends AssertingFields {
+  static class AssertingReadFields extends OrderCheckingFields {
     AssertingReadFields(Fields in) {
       super(in);
     }
@@ -150,7 +112,7 @@ public final class AssertingPostingsFormat extends PostingsFormat {
 
   static class AssertingFieldsProducer extends FieldsProducer {
     private final FieldsProducer in;
-    private final AssertingFields asserting;
+    private final OrderCheckingFields asserting;
 
     AssertingFieldsProducer(FieldsProducer in) {
       this.in = in;
@@ -210,7 +172,7 @@ public final class AssertingPostingsFormat extends PostingsFormat {
       // Wrap the incoming Fields, so the contract is checked on the way in and not only when a
       // FieldsProducer reads the result back. The delegate sees the wrapper, so a violation fails
       // during the write that caused it rather than in a later reader or in CheckIndex.
-      Fields asserting = new AssertingFields(fields);
+      Fields asserting = new OrderCheckingFields(fields);
       in.write(asserting, norms);
 
       // TODO: more asserts?  can we somehow run a

--- a/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/index/AssertingLeafReader.java
@@ -186,7 +186,45 @@ public class AssertingLeafReader extends FilterLeafReader {
       assertThread("Fields", creationThread);
       Iterator<String> iterator = super.iterator();
       assert iterator != null;
-      return iterator;
+      return assertFieldOrder(iterator);
+    }
+
+    /**
+     * Wraps {@code in} so that it fails if field names do not arrive in ascending natural order
+     * with no duplicates, as {@link Fields#iterator()} requires.
+     *
+     * <p>Nothing in production code detects a violation: {@link
+     * org.apache.lucene.util.MergedIterator}, which is what relies on the order, is documented as
+     * undefined for unsorted input rather than checking it, so an offending implementation silently
+     * returns wrong results — the merge stops deduplicating and a name present in two sub-iterators
+     * can be returned twice. Only {@code CheckIndex} catches it, and only after the fact.
+     *
+     * <p>The comparison is strict, matching the check in {@code CheckIndex#checkFields} and the one
+     * applied to the write side of {@code AssertingPostingsFormat} since 2013.
+     */
+    public static Iterator<String> assertFieldOrder(Iterator<String> in) {
+      return new Iterator<>() {
+        String last;
+
+        @Override
+        public boolean hasNext() {
+          return in.hasNext();
+        }
+
+        @Override
+        public String next() {
+          String field = in.next();
+          assert last == null || last.compareTo(field) < 0
+              : "Fields.iterator() must return field names in ascending order with no duplicates,"
+                  + " but saw \""
+                  + last
+                  + "\" followed by \""
+                  + field
+                  + "\"";
+          last = field;
+          return field;
+        }
+      };
     }
 
     @Override

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/codecs/asserting/TestAssertingPostingsFormat.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/codecs/asserting/TestAssertingPostingsFormat.java
@@ -16,7 +16,15 @@
  */
 package org.apache.lucene.tests.codecs.asserting;
 
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.tests.codecs.asserting.AssertingPostingsFormat.AssertingFieldsProducer;
 import org.apache.lucene.tests.index.BasePostingsFormatTestCase;
 
 /** Test AssertingPostingsFormat directly */
@@ -31,5 +39,79 @@ public class TestAssertingPostingsFormat extends BasePostingsFormatTestCase {
   @Override
   protected boolean isPostingsEnumReuseImplemented() {
     return false;
+  }
+
+  /** A producer that lists exactly the given field names, in the given order. */
+  private static FieldsProducer producing(List<String> fields) {
+    return new FieldsProducer() {
+      @Override
+      public Iterator<String> iterator() {
+        // a fresh iterator per call, as every real FieldsProducer does
+        return List.copyOf(fields).iterator();
+      }
+
+      @Override
+      public Terms terms(String field) {
+        return null;
+      }
+
+      @Override
+      public int size() {
+        return fields.size();
+      }
+
+      @Override
+      public void checkIntegrity(MergePolicy.OneMerge merge) {}
+
+      @Override
+      public void close() {}
+    };
+  }
+
+  private static void drain(Fields fields) {
+    Iterator<String> it = fields.iterator();
+    while (it.hasNext()) {
+      it.next();
+    }
+  }
+
+  /**
+   * {@link Fields#iterator()} requires ascending order, but nothing in production code checks it:
+   * {@link org.apache.lucene.util.MergedIterator}, which is what relies on the order, is documented
+   * as undefined for unsorted input, so a violating {@link FieldsProducer} silently yields wrong
+   * results. The asserting codec is where the whole test suite gets to catch that.
+   */
+  public void testRejectsUnsortedFields() throws IOException {
+    try (FieldsProducer producer =
+        new AssertingFieldsProducer(producing(List.of("zebra", "mid", "alpha")))) {
+      AssertionError e = expectThrows(AssertionError.class, () -> drain(producer));
+      assertTrue(e.getMessage(), e.getMessage().contains("ascending order"));
+      assertTrue(e.getMessage(), e.getMessage().contains("\"zebra\" followed by \"mid\""));
+    }
+  }
+
+  public void testRejectsDuplicateFields() throws IOException {
+    try (FieldsProducer producer =
+        new AssertingFieldsProducer(producing(List.of("alpha", "alpha")))) {
+      AssertionError e = expectThrows(AssertionError.class, () -> drain(producer));
+      assertTrue(e.getMessage(), e.getMessage().contains("no duplicates"));
+    }
+  }
+
+  public void testAcceptsSortedFields() throws IOException {
+    try (FieldsProducer producer =
+        new AssertingFieldsProducer(producing(List.of("Z", "alpha", "mid", "zebra")))) {
+      drain(producer);
+    }
+  }
+
+  /** Each call to {@link Fields#iterator()} must track order independently. */
+  public void testIteratorsDoNotShareState() throws IOException {
+    try (FieldsProducer producer =
+        new AssertingFieldsProducer(producing(List.of("alpha", "mid")))) {
+      drain(producer);
+      // a second pass starts from scratch rather than comparing "alpha" against the previous "mid"
+      drain(producer);
+    }
   }
 }

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/codecs/asserting/TestAssertingPostingsFormat.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/codecs/asserting/TestAssertingPostingsFormat.java
@@ -93,10 +93,10 @@ public class TestAssertingPostingsFormat extends BasePostingsFormatTestCase {
 
   /**
    * Duplicates are rejected, matching the check that {@code CheckIndex#checkFields} has applied to
-   * the read side since 2012 and the one {@link AssertingPostingsFormat.AssertingFieldsConsumer}
-   * has applied to the write side since 2013. {@link org.apache.lucene.util.MergedIterator} would
-   * merely fail to deduplicate them, but every implementation in the repository builds its iterator
-   * from a map's key set, so a duplicate means something is already wrong.
+   * the read side since 2012 and the one {@code AssertingFieldsConsumer} has applied to the write
+   * side since 2013. {@link org.apache.lucene.util.MergedIterator} would merely fail to deduplicate
+   * them, but every implementation in the repository builds its iterator from a map's key set, so a
+   * duplicate means something is already wrong.
    */
   public void testRejectsDuplicateFields() throws IOException {
     assumeTrue("Test designed to work only with assertions enabled.", TEST_ASSERTS_ENABLED);

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/codecs/asserting/TestAssertingPostingsFormat.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/codecs/asserting/TestAssertingPostingsFormat.java
@@ -82,6 +82,7 @@ public class TestAssertingPostingsFormat extends BasePostingsFormatTestCase {
    * results. The asserting codec is where the whole test suite gets to catch that.
    */
   public void testRejectsUnsortedFields() throws IOException {
+    assumeTrue("Test designed to work only with assertions enabled.", TEST_ASSERTS_ENABLED);
     try (FieldsProducer producer =
         new AssertingFieldsProducer(producing(List.of("zebra", "mid", "alpha")))) {
       AssertionError e = expectThrows(AssertionError.class, () -> drain(producer));
@@ -90,9 +91,17 @@ public class TestAssertingPostingsFormat extends BasePostingsFormatTestCase {
     }
   }
 
+  /**
+   * Duplicates are rejected, matching the check that {@code CheckIndex#checkFields} has applied to
+   * the read side since 2012 and the one {@link AssertingPostingsFormat.AssertingFieldsConsumer}
+   * has applied to the write side since 2013. {@link org.apache.lucene.util.MergedIterator} would
+   * merely fail to deduplicate them, but every implementation in the repository builds its iterator
+   * from a map's key set, so a duplicate means something is already wrong.
+   */
   public void testRejectsDuplicateFields() throws IOException {
+    assumeTrue("Test designed to work only with assertions enabled.", TEST_ASSERTS_ENABLED);
     try (FieldsProducer producer =
-        new AssertingFieldsProducer(producing(List.of("alpha", "alpha")))) {
+        new AssertingFieldsProducer(producing(List.of("alpha", "alpha", "beta")))) {
       AssertionError e = expectThrows(AssertionError.class, () -> drain(producer));
       assertTrue(e.getMessage(), e.getMessage().contains("no duplicates"));
     }

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/index/TestAssertingLeafReader.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/index/TestAssertingLeafReader.java
@@ -16,14 +16,19 @@
  */
 package org.apache.lucene.tests.index;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.index.Terms;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.IOUtils;
@@ -68,5 +73,67 @@ public class TestAssertingLeafReader extends LuceneTestCase {
     thread.join();
 
     IOUtils.close(r, dir);
+  }
+
+  /**
+   * {@link AssertingLeafReader.AssertingFields} wraps the {@link org.apache.lucene.index.Fields}
+   * that term vectors expose, so it must reject a field iteration order that {@link
+   * org.apache.lucene.index.Fields#iterator()} forbids. This path is separate from the one {@code
+   * AssertingPostingsFormat} covers.
+   */
+  public void testAssertingFieldsRejectsUnsortedFieldNames() throws Exception {
+    assumeTrue("Test designed to work only with assertions enabled.", TEST_ASSERTS_ENABLED);
+    Fields unsorted =
+        new Fields() {
+          @Override
+          public Iterator<String> iterator() {
+            return List.of("zebra", "mid", "alpha").iterator();
+          }
+
+          @Override
+          public Terms terms(String field) {
+            return null;
+          }
+
+          @Override
+          public int size() {
+            return 3;
+          }
+        };
+
+    AssertionError e =
+        expectThrows(
+            AssertionError.class,
+            () -> {
+              Iterator<String> it = new AssertingLeafReader.AssertingFields(unsorted).iterator();
+              while (it.hasNext()) {
+                it.next();
+              }
+            });
+    assertTrue(e.getMessage(), e.getMessage().contains("ascending order"));
+  }
+
+  public void testAssertingFieldsAcceptsSortedFieldNames() throws Exception {
+    Fields sorted =
+        new Fields() {
+          @Override
+          public Iterator<String> iterator() {
+            return List.of("alpha", "mid", "zebra").iterator();
+          }
+
+          @Override
+          public Terms terms(String field) {
+            return null;
+          }
+
+          @Override
+          public int size() {
+            return 3;
+          }
+        };
+
+    List<String> seen = new ArrayList<>();
+    new AssertingLeafReader.AssertingFields(sorted).forEach(seen::add);
+    assertEquals(List.of("alpha", "mid", "zebra"), seen);
   }
 }


### PR DESCRIPTION
### Description

`CheckIndex` rejects a reader whose `Fields#iterator()` returns field names out of order, but the requirement is stated nowhere and checked nowhere else.

What relies on the order is `MergedIterator`, used by `MultiFields#iterator` and by `PerFieldPostingsFormat#merge`. It documents *"the behavior is undefined if the iterators are not actually sorted"* rather than checking, so an unsorted producer yields wrong results with no error anywhere. Measured, with `removeDuplicates=true` as both callers use:

| input | result |
|---|---|
| `[a,b]` + `[a,c]` — sorted | `[a, b, c]` — the shared name is deduplicated |
| `[b,a,c]` + `[a,z]` — one unsorted | **`[a, b, a, c, z]`** — `a` twice, from two different sub-iterators |

Meanwhile:

- `Fields#iterator()` said only *"Returns an iterator that will step through all fields names"*.
- `FieldsConsumer#write` has a `Notes` list of what an implementation must do and may assume, and did not mention the order, although `Lucene103BlockTreeTermsWriter` relies on it and `AssertingFieldsConsumer` has asserted it since 2013.
- `FieldsProducer`, which every postings reader extends, had no mention either.
- The comment on the `CheckIndex` check cites `MultiFieldsEnum`, which no longer exists.

So a new `PostingsFormat` — a public extension point — can return `HashMap#keySet()`, pass the whole test suite, and only be caught later by `CheckIndex`, if anyone runs it.

All thirteen `Fields` implementations in the repository do honour the order today, but by four different means: a `TreeMap` in four of them, an explicit sort on the way out in two, and in `FreqProxFields` a `LinkedHashMap` plus a comment relying on the caller having sorted first.

### Changes

- `Fields#iterator()`, `FieldsConsumer#write` and `FieldsProducer` state the requirement, and `Fields#iterator()` also says what breaks without it.
- `AssertingLeafReader.AssertingFields` asserts it. That class already wrapped the `Fields` that term vectors expose, so the check covers that path too; `AssertingPostingsFormat` calls the same helper rather than carrying a second copy.
- `AssertingFieldsConsumer#write` now wraps the incoming `Fields`, so a violation fails during the write that caused it rather than in a later reader. This is part of the TODO that has sat in that method since 2013 (`017a3bf6281`).
- The `CheckIndex` comment names `MultiFields` and `MergedIterator`.

Doing the TODO's last part literally does not work, which is worth recording: `AssertingFieldsProducer` wraps `Terms` in `AssertingLeafReader.AssertingTerms`, which encodes read-side expectations, and on the write side the consumer pulls a `PostingsEnum` straight out of the incoming `Fields` and drives it differently. Reusing the producer trips `assert super.docID() == nextDoc` in `AssertingPostingsEnum` and fails three tests in `BasePostingsFormatTestCase`. So the wrapper is split: one class checks only the `iterator()` contract and is safe on both sides, a subclass adds the `Terms` wrapping for the read side. The *"limited CheckIndex"* half of the TODO is left in place, unaddressed.

### Relationship to #9967

That issue asks whether the order check can be removed from `CheckIndex`. It cannot: `MultiFields` still exists and still merges these iterators, so @jpountz's 2019 answer — *"We rely on the order for merging, see MultiFields"* — still holds. But the follow-up question in the same thread was never answered:

> Should we make this more explicit and robust then? For E.g., since we do not explicitly maintain a sort order but rely on the key set to do the right thing, a change from `Collections.unModifiableSet` to `Set.copyOf` breaks this assertion in checkIndex

This is an attempt at that. The check stays; the contract behind it is now written down and enforced where a codec author will see it.

### Verification

Every claim the javadoc makes is pinned by a test, since a documented invariant that no test exercises is how the stale `MultiFieldsEnum` comment survived for thirteen years:

| claim | test |
|---|---|
| ascending order from a real reader | `testCheckIndexAcceptsSortedFields` |
| `CheckIndex` verifies it | `testCheckIndexDetectsFieldsOutOfOrder` |
| `MultiFields` merges with `MergedIterator` | `testMultiFieldsMergesInOrder` |
| `PerFieldPostingsFormat` does too | `testPerFieldMergePreservesFieldsExactlyOnce` |
| unsorted input stops deduplicating | `testUnsortedInputBreaksDeduplication` |
| the write side receives sorted names | `testWriteSideReceivesSortedFields` |
| the order is not the insertion order | `testOrderIsIndependentOfInsertionOrder` |
| the assertion fires, and only on violations | `TestAssertingPostingsFormat`, `TestAssertingLeafReader` |

Each was mutation-checked: inverting the expectation, removing the `CheckIndex` check, bypassing the assertion, or reversing the names the recording consumer observes makes the corresponding test fail.

`:lucene:core:test`, `:lucene:test-framework:test`, `:lucene:codecs:test`, `:lucene:backward-codecs:test`, `:lucene:memory:test` pass (11,452 tests), as do `:lucene:core:check` and `tidy`. Also run with `-Ptests.nightly=true -Ptests.iters=3 -Ptests.asserts=true` on the postings tests.

### One thing worth flagging

The assertion is in `test-framework`, so a third-party `PostingsFormat` that violates the contract will start failing its own tests. That is what the assertion is for, but it is a behavioural change for downstream, so it is worth a deliberate decision rather than slipping in.

I checked what is reachable: Solr has no `Fields` implementation of its own (`SchemaCodecFactory` only resolves format names through SPI). Of the implementations in Elasticsearch and OpenSearch, `DelegatingBloomFilterFieldsProducer` inherits its delegate's order, `TSDBSyntheticIdFieldsProducer` exposes a single field, and `Lucene40BlockTreeTermsReader` sorts explicitly. Two places have no guarantee either way — `XPerFieldMergeState`'s `new ArrayList<>(filterFields)`, and `TermVectorsFields` backed by a `HashMap` from `StreamInput#readMap`, though that one is on the term-vectors path. This is from reading their code, not from running their tests.
