### PR TITLE
GITHUB#7820: report which segment's .si could not be read

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -131,6 +131,10 @@ New Features
 
 Improvements
 ---------------------
+* GITHUB#7820: CheckIndex now reports which segment's .si file could not be read, rather than only that
+  a commit point was unreadable. SegmentInfos throws CorruptSegmentInfoException, carrying the segment
+  name and the underlying failure. (Gokul Manoj, Serhiy Bzhezytskyy)
+
 * GITHUB#15704: Replace LinkedList with more efficient data structure. (Renato Haeberli)
 
 * GITHUB#15682: Use ArrayDeque instead of LinkedList in CompoundWordTokenFilterBase.java. (Renato Haeberli)

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -133,6 +133,13 @@ public final class CheckIndex implements Closeable {
     /** True if we were unable to locate and load the segments_N file. */
     public boolean missingSegments;
 
+    /**
+     * Name of the segment whose {@code .si} file could not be read, when that is why {@link
+     * #missingSegments} is set; null when the commit point itself could not be parsed far enough to
+     * name a segment.
+     */
+    public String brokenSegmentName;
+
     /** Name of latest segments_N file in the index. */
     public String segmentsFileName;
 
@@ -676,16 +683,27 @@ public final class CheckIndex implements Closeable {
           throw IOUtils.rethrowAlways(t);
         }
 
+        String which = isLastCommit ? "latest" : "old (not latest)";
         String message;
 
-        if (isLastCommit) {
+        if (t instanceof CorruptSegmentInfoException corrupt) {
+          // The commit point itself parsed far enough to name the segment, so say which one.
+          result.brokenSegmentName = corrupt.getSegmentName();
           message =
-              "ERROR: could not read latest commit point from segments file \""
+              "ERROR: could not read segment \""
+                  + corrupt.getSegmentName()
+                  + "\" referenced by the "
+                  + which
+                  + " commit point in segments file \""
                   + fileName
-                  + "\" in directory";
+                  + "\": its "
+                  + corrupt.getSegmentName()
+                  + ".si is missing or corrupt";
         } else {
           message =
-              "ERROR: could not read old (not latest) commit point segments file \""
+              "ERROR: could not read "
+                  + which
+                  + " commit point from segments file \""
                   + fileName
                   + "\" in directory";
         }

--- a/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CheckIndex.java
@@ -991,7 +991,7 @@ public final class CheckIndex implements Closeable {
 
     final Version version = info.info.getVersion();
     if (info.info.maxDoc() <= 0) {
-      throw new CheckIndexException(" illegal number of documents: maxDoc=" + info.info.maxDoc());
+      throw new CheckIndexException("illegal number of documents: maxDoc=" + info.info.maxDoc());
     }
 
     int toLoseDocCount = info.info.maxDoc();

--- a/lucene/core/src/java/org/apache/lucene/index/CorruptSegmentInfoException.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CorruptSegmentInfoException.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.index;
+
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+
+/**
+ * This exception is thrown when Lucene is unable to read a SegmentInfo file _N.si (When it is
+ * missing or corrupt)
+ */
+public class CorruptSegmentInfoException extends CorruptIndexException {
+
+  // The segment name of the missing .si file is always stored for accurate error reporting
+  String segmentName;
+
+  /** Create exception with the segmentName and message only */
+  public CorruptSegmentInfoException(String segmentName, String message, DataInput input) {
+    super(message, input);
+    this.segmentName = segmentName;
+  }
+
+  /** Create exception with the segmentName and message only */
+  public CorruptSegmentInfoException(String segmentName, String message, DataOutput output) {
+    super(message, output);
+    this.segmentName = segmentName;
+  }
+
+  /** Create exception with the segmentName, message and root cause. */
+  public CorruptSegmentInfoException(
+      String segmentName, String message, DataInput input, Throwable cause) {
+    super(message, input, cause);
+    this.segmentName = segmentName;
+  }
+
+  /** Create exception with the segmentName, message and root cause. */
+  public CorruptSegmentInfoException(
+      String segmentName, String message, DataOutput output, Throwable cause) {
+    super(message, output, cause);
+    this.segmentName = segmentName;
+  }
+
+  /** Create exception with the segmentName and message only */
+  public CorruptSegmentInfoException(
+      String segmentName, String message, String resourceDescription) {
+    super(message, resourceDescription);
+    this.segmentName = segmentName;
+  }
+
+  /** Create exception with the segmentName, message and root cause. */
+  public CorruptSegmentInfoException(
+      String segmentName, String message, String resourceDescription, Throwable cause) {
+    super(message, resourceDescription, cause);
+    this.segmentName = segmentName;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/index/CorruptSegmentInfoException.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CorruptSegmentInfoException.java
@@ -16,55 +16,41 @@
  */
 package org.apache.lucene.index;
 
+import java.util.Objects;
 import org.apache.lucene.store.DataInput;
-import org.apache.lucene.store.DataOutput;
 
 /**
- * This exception is thrown when Lucene is unable to read a SegmentInfo file _N.si (When it is
- * missing or corrupt)
+ * Thrown when a single segment's {@code _N.si} file cannot be read, because it is missing or
+ * corrupt, while the commit point that references it parsed far enough to name the segment.
+ *
+ * <p>Unlike a plain {@link CorruptIndexException}, this carries the {@link #getSegmentName() name
+ * of the affected segment}, so a caller such as {@link CheckIndex} can report which segment is
+ * broken rather than only that something was. The root cause is always attached, since it is what
+ * names the file on disk.
+ *
+ * @lucene.internal
  */
 public class CorruptSegmentInfoException extends CorruptIndexException {
 
-  // The segment name of the missing .si file is always stored for accurate error reporting
-  String segmentName;
+  /** Name of the segment whose {@code .si} file could not be read. */
+  private final String segmentName;
 
-  /** Create exception with the segmentName and message only */
-  public CorruptSegmentInfoException(String segmentName, String message, DataInput input) {
-    super(message, input);
-    this.segmentName = segmentName;
-  }
-
-  /** Create exception with the segmentName and message only */
-  public CorruptSegmentInfoException(String segmentName, String message, DataOutput output) {
-    super(message, output);
-    this.segmentName = segmentName;
-  }
-
-  /** Create exception with the segmentName, message and root cause. */
+  /**
+   * Create an exception naming the segment whose {@code .si} could not be read.
+   *
+   * @param segmentName name of the affected segment, must not be null
+   * @param message description of what went wrong
+   * @param input the input being read when the failure was detected
+   * @param cause the underlying failure, must not be null
+   */
   public CorruptSegmentInfoException(
       String segmentName, String message, DataInput input, Throwable cause) {
-    super(message, input, cause);
-    this.segmentName = segmentName;
+    super(message, input, Objects.requireNonNull(cause));
+    this.segmentName = Objects.requireNonNull(segmentName);
   }
 
-  /** Create exception with the segmentName, message and root cause. */
-  public CorruptSegmentInfoException(
-      String segmentName, String message, DataOutput output, Throwable cause) {
-    super(message, output, cause);
-    this.segmentName = segmentName;
-  }
-
-  /** Create exception with the segmentName and message only */
-  public CorruptSegmentInfoException(
-      String segmentName, String message, String resourceDescription) {
-    super(message, resourceDescription);
-    this.segmentName = segmentName;
-  }
-
-  /** Create exception with the segmentName, message and root cause. */
-  public CorruptSegmentInfoException(
-      String segmentName, String message, String resourceDescription, Throwable cause) {
-    super(message, resourceDescription, cause);
-    this.segmentName = segmentName;
+  /** Returns the name of the segment whose {@code .si} file could not be read. */
+  public String getSegmentName() {
+    return segmentName;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -389,12 +389,13 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
     }
 
     long totalDocs = 0;
-    SegmentInfo info;
+
     for (int seg = 0; seg < numSegments; seg++) {
       String segName = input.readString();
       byte[] segmentID = new byte[StringHelper.ID_LENGTH];
       input.readBytes(segmentID, 0, segmentID.length);
       Codec codec = readCodec(input);
+      final SegmentInfo info;
       try {
         info = codec.segmentInfoFormat().read(directory, segName, segmentID, IOContext.READONCE);
       } catch (ThreadInterruptedException e) {

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -45,6 +45,7 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.ThreadInterruptedException;
 import org.apache.lucene.util.Version;
 
 /**
@@ -388,14 +389,25 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
     }
 
     long totalDocs = 0;
-
+    SegmentInfo info;
     for (int seg = 0; seg < numSegments; seg++) {
       String segName = input.readString();
       byte[] segmentID = new byte[StringHelper.ID_LENGTH];
       input.readBytes(segmentID, 0, segmentID.length);
       Codec codec = readCodec(input);
-      SegmentInfo info =
-          codec.segmentInfoFormat().read(directory, segName, segmentID, IOContext.READONCE);
+      try {
+        info = codec.segmentInfoFormat().read(directory, segName, segmentID, IOContext.READONCE);
+      } catch (ThreadInterruptedException e) {
+        throw e;
+      } catch (Exception | AssertionError e) {
+        // Corruption in a .si file can surface as almost anything the codec's reader happens to do
+        // with the bad bytes, so catch broadly, but keep the root cause: it is what names the file.
+        throw new CorruptSegmentInfoException(
+            segName,
+            "segment info file: " + segName + ".si cannot be read - it may be missing or corrupt",
+            input,
+            e);
+      }
       info.setCodec(codec);
       totalDocs += info.maxDoc();
       long delGen = CodecUtil.readBELong(input);

--- a/lucene/core/src/test/org/apache/lucene/index/TestCheckIndex.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestCheckIndex.java
@@ -19,7 +19,10 @@ package org.apache.lucene.index;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.NoSuchFileException;
 import java.util.List;
 import org.apache.lucene.document.BinaryPoint;
 import org.apache.lucene.document.Document;
@@ -34,6 +37,9 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.tests.analysis.CannedTokenStream;
 import org.apache.lucene.tests.analysis.Token;
 import org.apache.lucene.tests.index.BaseTestCheckIndex;
@@ -291,6 +297,79 @@ public class TestCheckIndex extends BaseTestCheckIndex {
         CheckIndex.Status checkIndexStatus = checkers.checkIndex();
         assertFalse(checkIndexStatus.clean);
       }
+    }
+  }
+
+  public void testCorruptSegmentInfoNamesTheSegment() throws Exception {
+    for (String corruption : List.of("delete-si", "truncate-si")) {
+      try (MockDirectoryWrapper dir = newMockDirectory()) {
+        // this test intentionally leaves a broken index behind
+        dir.setCheckIndexOnClose(false);
+
+        IndexWriterConfig iwc = new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE);
+        try (IndexWriter iw = new IndexWriter(dir, iwc)) {
+          for (int seg = 0; seg < 2; seg++) {
+            Document doc = new Document();
+            doc.add(new StringField("id", "d" + seg, Field.Store.NO));
+            iw.addDocument(doc);
+            iw.commit();
+          }
+        }
+
+        // NOTE: relying on precise file naming, as testPriorBrokenCommitPoint above already does.
+        if (corruption.equals("delete-si")) {
+          dir.deleteFile("_1.si");
+        } else {
+          truncate(dir, "_1.si");
+        }
+
+        // Reading the commit point names the segment whose .si could not be read, and keeps the
+        // root cause: it is what names the file on disk.
+        CorruptSegmentInfoException e =
+            expectThrows(
+                CorruptSegmentInfoException.class,
+                () ->
+                    SegmentInfos.readCommit(
+                        dir, SegmentInfos.getLastCommitSegmentsFileName(dir), 0));
+        assertEquals(corruption, "_1", e.getSegmentName());
+        // the root cause must be the codec's own failure, since that is what names the file on disk
+        Throwable cause = e.getCause();
+        assertNotNull(corruption, cause);
+        if (corruption.equals("delete-si")) {
+          assertTrue(
+              corruption + ": " + cause,
+              cause instanceof NoSuchFileException || cause instanceof FileNotFoundException);
+        } else {
+          assertTrue(corruption + ": " + cause, cause instanceof IOException);
+        }
+        assertTrue(corruption + ": " + cause, cause.toString().contains("_1.si"));
+
+        // ... and CheckIndex reports it rather than only that something was unreadable
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (CheckIndex checker = new CheckIndex(dir)) {
+          checker.setInfoStream(new PrintStream(out, false, UTF_8), false);
+          CheckIndex.Status status = checker.checkIndex();
+
+          assertFalse(corruption, status.clean);
+          assertTrue(corruption, status.missingSegments);
+          assertEquals(corruption, "_1", status.brokenSegmentName);
+        }
+        assertTrue(
+            out.toString(UTF_8), out.toString(UTF_8).contains("could not read segment \"_1\""));
+      }
+    }
+  }
+
+  /** Rewrites {@code name} keeping only its first 70% of bytes. */
+  private static void truncate(Directory dir, String name) throws IOException {
+    byte[] bytes;
+    try (IndexInput in = dir.openInput(name, IOContext.READONCE)) {
+      bytes = new byte[(int) (in.length() * 0.7)];
+      in.readBytes(bytes, 0, bytes.length);
+    }
+    dir.deleteFile(name);
+    try (IndexOutput out = dir.createOutput(name, IOContext.DEFAULT)) {
+      out.writeBytes(bytes, bytes.length);
     }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestTransactions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTransactions.java
@@ -207,7 +207,7 @@ public class TestTransactions extends LuceneTestCase {
           // can be rethrown as RuntimeException if it happens during a close listener
           if (!e.getMessage().contains("on purpose")) {
             // Caught "on-purpose" IOException can be rethrown as CorruptSegmentInfoException
-            if (!(e instanceof CorruptSegmentInfoException)) {
+            if (e instanceof CorruptSegmentInfoException == false) {
               throw e;
             }
           }

--- a/lucene/core/src/test/org/apache/lucene/index/TestTransactions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTransactions.java
@@ -206,7 +206,10 @@ public class TestTransactions extends LuceneTestCase {
         } catch (Exception e) {
           // can be rethrown as RuntimeException if it happens during a close listener
           if (!e.getMessage().contains("on purpose")) {
-            throw e;
+            // Caught "on-purpose" IOException can be rethrown as CorruptSegmentInfoException
+            if (!(e instanceof CorruptSegmentInfoException)) {
+              throw e;
+            }
           }
           // release resources
           IOUtils.closeWhileHandlingException(r1, r2);


### PR DESCRIPTION
### Description

`CheckIndex` reports that a commit point could not be read, but not *which* segment is at fault:

```
ERROR: could not read latest commit point from segments file "segments_3" in directory
```

The information exists at the point of failure — a deleted `.si` arrives as a `NoSuchFileException` carrying the full path, a truncated one as a suppressed `EOFException` naming the `MemorySegmentIndexInput` — but `SegmentInfos#parseSegmentInfos` lets the codec's exception propagate untyped, so nothing downstream can tell which segment it was. This is the November 2023 comment on #7820:

> the exception "does not make it clear which segment(s) are broken"

After this change:

```
ERROR: could not read segment "_1" referenced by the latest commit point in segments file
"segments_3": its _1.si is missing or corrupt
```

### Changes

The first commit is @gokaai's from #12872, rebased onto `main` with authorship intact. It introduces `CorruptSegmentInfoException` and throws it from `SegmentInfos` when a segment's `.si` cannot be read. Two hunks needed adjusting for `main`: `IOContext.READ` became `IOContext.READONCE`, and the wildcard import was replaced with explicit ones, which the ecj lint requires.

The second commit finishes the two things asked for in that PR's review but not done there:

- **The root cause was dropped.** The throw site caught the codec's failure and called the three-argument constructor, discarding it. @mikemccand asked on the PR: *"Can we somehow return the root cause exception here and include it in `CheckIndexException`"*. It is now passed, and the catch is `Exception | AssertionError` rather than `Exception`, per the same review: *"Corruption in `.si` can result in exotic exceptions"*.
- **`segmentName` was unreachable.** It was package-private with no accessor, so nothing outside `org.apache.lucene.index` could read the name the exception exists to carry, and no test could assert on it. `getSegmentName()` is added, the six constructors are reduced to the one that is used, and both arguments are `Objects.requireNonNull`.

On top of that, `CheckIndex` records the name in `Status#brokenSegmentName` and puts it in the message, and `TestCheckIndex#testCorruptSegmentInfoNamesTheSegment` covers a deleted and a truncated `.si`, asserting the segment name, the cause's type, and that the cause names `_1.si`. #12872 had no test for the exception it added.

### Relationship to #12872 and #16474

#12872 has been open since 2023-12 and is no longer mergeable; the last human comment there is from 2024-02, after a `git` digression, and @mikemccand's *"I'll try to review soon!"* never got a follow-up. The pain it addresses is still there, so this carries it forward rather than leaving it. If @gokaai would rather finish it there, close this one — the point is the fix landing, not where.

#16474 is the other half of the same thread: `exorciseIndex` throws `NullPointerException` instead of refusing when `Status.newSegments` is null. That is the piece @gokaai explicitly deferred:

> Will create a new commit (or issue?) to add in fixes and unit tests for `exorciseIndex`

The two are independent and can land in either order.

### Verification

- `testCorruptSegmentInfoNamesTheSegment` fails without the fix, and fails again if the root cause is replaced with a synthetic one — so it checks the cause rather than just its presence
- `:lucene:core:test` for `TestCheckIndex`, `TestTransactions`, `SegmentInfos*` and `IndexWriter*` passes (362 tests)
- `:lucene:core:check` and `tidy` pass

Verified on `main` only.
