### PR TITLE
Pattern replace keywords

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceFilter.java
@@ -68,7 +68,8 @@ public final class PatternReplaceFilter extends TokenFilter {
    * @param ignoreKeywords if true, tokens with KeywordAttribute set to true will not be processed
    * @see Matcher#quoteReplacement
    */
-  public PatternReplaceFilter(TokenStream in, Pattern p, String replacement, boolean all, boolean ignoreKeywords) {
+  public PatternReplaceFilter(
+      TokenStream in, Pattern p, String replacement, boolean all, boolean ignoreKeywords) {
     super(in);
     this.replacement = (null == replacement) ? "" : replacement;
     this.all = all;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceFilter.java
@@ -53,7 +53,8 @@ public final class PatternReplaceFilter extends TokenFilter {
    * @param ignoreKeywords if true, tokens with KeywordAttribute set to true will not be processed
    * @see Matcher#quoteReplacement
    */
-  public PatternReplaceFilter(TokenStream in, Pattern p, String replacement, boolean all, boolean ignoreKeywords) {
+  public PatternReplaceFilter(
+      TokenStream in, Pattern p, String replacement, boolean all, boolean ignoreKeywords) {
     super(in);
     this.replacement = (null == replacement) ? "" : replacement;
     this.all = all;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceFilter.java
@@ -50,21 +50,6 @@ public final class PatternReplaceFilter extends TokenFilter {
    *     Note that this is not the literal string that will be used, '$' and '\' have special
    *     meaning.
    * @param all if true, all matches will be replaced otherwise just the first match.
-   * @see Matcher#quoteReplacement
-   */
-  public PatternReplaceFilter(TokenStream in, Pattern p, String replacement, boolean all) {
-    this(in, p, replacement, all, false);
-  }
-
-  /**
-   * Constructs an instance to replace either the first, or all occurrences
-   *
-   * @param in the TokenStream to process
-   * @param p the patterm to apply to each Token
-   * @param replacement the "replacement string" to substitute, if null a blank string will be used.
-   *     Note that this is not the literal string that will be used, '$' and '\' have special
-   *     meaning.
-   * @param all if true, all matches will be replaced otherwise just the first match.
    * @param ignoreKeywords if true, tokens with KeywordAttribute set to true will not be processed
    * @see Matcher#quoteReplacement
    */

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceFilter.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.KeywordAttribute;
 
 /**
  * A TokenFilter which applies a Pattern to each token in the stream, replacing match occurrences
@@ -35,7 +36,9 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 public final class PatternReplaceFilter extends TokenFilter {
   private final String replacement;
   private final boolean all;
+  private final boolean ignoreKeywords;
   private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+  private final KeywordAttribute keywordAtt = addAttribute(KeywordAttribute.class);
   private final Matcher m;
 
   /**
@@ -50,15 +53,36 @@ public final class PatternReplaceFilter extends TokenFilter {
    * @see Matcher#quoteReplacement
    */
   public PatternReplaceFilter(TokenStream in, Pattern p, String replacement, boolean all) {
+    this(in, p, replacement, all, false);
+  }
+
+  /**
+   * Constructs an instance to replace either the first, or all occurrences
+   *
+   * @param in the TokenStream to process
+   * @param p the patterm to apply to each Token
+   * @param replacement the "replacement string" to substitute, if null a blank string will be used.
+   *     Note that this is not the literal string that will be used, '$' and '\' have special
+   *     meaning.
+   * @param all if true, all matches will be replaced otherwise just the first match.
+   * @param ignoreKeywords if true, tokens with KeywordAttribute set to true will not be processed
+   * @see Matcher#quoteReplacement
+   */
+  public PatternReplaceFilter(TokenStream in, Pattern p, String replacement, boolean all, boolean ignoreKeywords) {
     super(in);
     this.replacement = (null == replacement) ? "" : replacement;
     this.all = all;
+    this.ignoreKeywords = ignoreKeywords;
     this.m = p.matcher(termAtt);
   }
 
   @Override
   public boolean incrementToken() throws IOException {
     if (!input.incrementToken()) return false;
+
+    if (ignoreKeywords && keywordAtt.isKeyword()) {
+      return true;
+    }
 
     m.reset();
     if (m.find()) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceFilterFactory.java
@@ -46,6 +46,7 @@ public class PatternReplaceFilterFactory extends TokenFilterFactory {
   final Pattern pattern;
   final String replacement;
   final boolean replaceAll;
+  final boolean ignoreKeywords;
 
   /** Creates a new PatternReplaceFilterFactory */
   public PatternReplaceFilterFactory(Map<String, String> args) {
@@ -53,6 +54,7 @@ public class PatternReplaceFilterFactory extends TokenFilterFactory {
     pattern = getPattern(args, "pattern");
     replacement = get(args, "replacement");
     replaceAll = "all".equals(get(args, "replace", Arrays.asList("all", "first"), "all"));
+    ignoreKeywords = getBoolean(args, "ignoreKeywords", false);
     if (!args.isEmpty()) {
       throw new IllegalArgumentException("Unknown parameters: " + args);
     }
@@ -65,6 +67,6 @@ public class PatternReplaceFilterFactory extends TokenFilterFactory {
 
   @Override
   public PatternReplaceFilter create(TokenStream input) {
-    return new PatternReplaceFilter(input, pattern, replacement, replaceAll);
+    return new PatternReplaceFilter(input, pattern, replacement, replaceAll, ignoreKeywords);
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
@@ -22,6 +22,8 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
+import org.apache.lucene.analysis.miscellaneous.KeywordMarkerFilter;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 
@@ -107,5 +109,78 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
         };
     checkOneTerm(a, "", "");
     a.close();
+  }
+
+  public void testIgnoreKeywords() throws Exception {
+    Analyzer a =
+        new Analyzer() {
+          @Override
+          protected TokenStreamComponents createComponents(String fieldName) {
+            Tokenizer tokenizer = new MockTokenizer(MockTokenizer.WHITESPACE, false);
+            KeywordMarkerFilter keywordFilter =
+                new KeywordMarkerFilter(tokenizer) {
+                  private final CharTermAttribute term = addAttribute(CharTermAttribute.class);
+
+                  @Override
+                  public boolean isKeyword() {
+                    // Mark terms starting with 'k' as keywords
+                    return term.toString().startsWith("k");
+                  }
+                };
+            return new TokenStreamComponents(
+                tokenizer,
+                new PatternReplaceFilter(keywordFilter, Pattern.compile("a"), "X", true, true));
+          }
+        };
+
+    // Without ignoreKeywords=true, both terms would have 'a' replaced with 'X'
+    // With ignoreKeywords=true, only non-keyword terms should be modified
+    assertAnalyzesTo(
+        a,
+        "banana kappa alpha",
+        new String[] {"bXnXnX", "kappa", "XlphX"}, // kappa unchanged, others modified
+        new int[] {0, 7, 13},
+        new int[] {6, 12, 18},
+        null,
+        new int[] {1, 1, 1},
+        null,
+        false);
+
+    a.close();
+
+    // Test with ignoreKeywords=false for comparison
+    Analyzer b =
+        new Analyzer() {
+          @Override
+          protected TokenStreamComponents createComponents(String fieldName) {
+            Tokenizer tokenizer = new MockTokenizer(MockTokenizer.WHITESPACE, false);
+            KeywordMarkerFilter keywordFilter =
+                new KeywordMarkerFilter(tokenizer) {
+                  private final CharTermAttribute term = addAttribute(CharTermAttribute.class);
+
+                  @Override
+                  public boolean isKeyword() {
+                    return term.toString().startsWith("k");
+                  }
+                };
+            return new TokenStreamComponents(
+                tokenizer,
+                new PatternReplaceFilter(keywordFilter, Pattern.compile("a"), "X", true, false));
+          }
+        };
+
+    // With ignoreKeywords=false, all terms should be modified regardless of keyword status
+    assertAnalyzesTo(
+        b,
+        "banana kappa alpha",
+        new String[] {"bXnXnX", "kXppX", "XlphX"}, // all terms modified
+        new int[] {0, 7, 13},
+        new int[] {6, 12, 18},
+        null,
+        new int[] {1, 1, 1},
+        null,
+        false);
+
+    b.close();
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
@@ -117,24 +117,12 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
     assertAnalyzesTo(
         keywordTestAnalyzer(true),
         "banana kappa alpha",
-        new String[] {"bXnXnX", "kappa", "XlphX"}, // kappa unchanged, others modified
-        new int[] {0, 7, 13},
-        new int[] {6, 12, 18},
-        null,
-        new int[] {1, 1, 1},
-        null,
-        false);
+        new String[] {"bXnXnX", "kappa", "XlphX"});
 
     assertAnalyzesTo(
         keywordTestAnalyzer(false),
         "banana kappa alpha",
-        new String[] {"bXnXnX", "kXppX", "XlphX"}, // all terms modified
-        new int[] {0, 7, 13},
-        new int[] {6, 12, 18},
-        null,
-        new int[] {1, 1, 1},
-        null,
-        false);
+        new String[] {"bXnXnX", "kXppX", "XlphX"});
   }
 
   private Analyzer keywordTestAnalyzer(boolean ignoreKeywords) throws Exception {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
@@ -115,9 +115,7 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
 
   public void testKeywordFilter() throws Exception {
     assertAnalyzesTo(
-        keywordTestAnalyzer(true),
-        "banana kappa alpha",
-        new String[] {"bXnXnX", "kappa", "XlphX"});
+        keywordTestAnalyzer(true), "banana kappa alpha", new String[] {"bXnXnX", "kappa", "XlphX"});
 
     assertAnalyzesTo(
         keywordTestAnalyzer(false),

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
@@ -111,32 +111,9 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
     a.close();
   }
 
-  public void testIgnoreKeywords() throws Exception {
-    Analyzer a =
-        new Analyzer() {
-          @Override
-          protected TokenStreamComponents createComponents(String fieldName) {
-            Tokenizer tokenizer = new MockTokenizer(MockTokenizer.WHITESPACE, false);
-            KeywordMarkerFilter keywordFilter =
-                new KeywordMarkerFilter(tokenizer) {
-                  private final CharTermAttribute term = addAttribute(CharTermAttribute.class);
-
-                  @Override
-                  public boolean isKeyword() {
-                    // Mark terms starting with 'k' as keywords
-                    return term.toString().startsWith("k");
-                  }
-                };
-            return new TokenStreamComponents(
-                tokenizer,
-                new PatternReplaceFilter(keywordFilter, Pattern.compile("a"), "X", true, true));
-          }
-        };
-
-    // Without ignoreKeywords=true, both terms would have 'a' replaced with 'X'
-    // With ignoreKeywords=true, only non-keyword terms should be modified
+  public void testKeywordFilter() throws Exception {
     assertAnalyzesTo(
-        a,
+        keywordTestAnalyzer(true),
         "banana kappa alpha",
         new String[] {"bXnXnX", "kappa", "XlphX"}, // kappa unchanged, others modified
         new int[] {0, 7, 13},
@@ -146,32 +123,8 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
         null,
         false);
 
-    a.close();
-
-    // Test with ignoreKeywords=false for comparison
-    Analyzer b =
-        new Analyzer() {
-          @Override
-          protected TokenStreamComponents createComponents(String fieldName) {
-            Tokenizer tokenizer = new MockTokenizer(MockTokenizer.WHITESPACE, false);
-            KeywordMarkerFilter keywordFilter =
-                new KeywordMarkerFilter(tokenizer) {
-                  private final CharTermAttribute term = addAttribute(CharTermAttribute.class);
-
-                  @Override
-                  public boolean isKeyword() {
-                    return term.toString().startsWith("k");
-                  }
-                };
-            return new TokenStreamComponents(
-                tokenizer,
-                new PatternReplaceFilter(keywordFilter, Pattern.compile("a"), "X", true, false));
-          }
-        };
-
-    // With ignoreKeywords=false, all terms should be modified regardless of keyword status
     assertAnalyzesTo(
-        b,
+        keywordTestAnalyzer(false),
         "banana kappa alpha",
         new String[] {"bXnXnX", "kXppX", "XlphX"}, // all terms modified
         new int[] {0, 7, 13},
@@ -180,7 +133,28 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
         new int[] {1, 1, 1},
         null,
         false);
+  }
 
-    b.close();
+  private Analyzer keywordTestAnalyzer(boolean ignoreKeywords) throws Exception {
+    return new Analyzer() {
+      @Override
+      protected TokenStreamComponents createComponents(String fieldName) {
+        Tokenizer tokenizer = new MockTokenizer(MockTokenizer.WHITESPACE, false);
+        KeywordMarkerFilter keywordFilter =
+            new KeywordMarkerFilter(tokenizer) {
+              private final CharTermAttribute term = addAttribute(CharTermAttribute.class);
+
+              @Override
+              public boolean isKeyword() {
+                // Mark terms starting with 'k' as keywords
+                return term.toString().startsWith("k");
+              }
+            };
+        return new TokenStreamComponents(
+            tokenizer,
+            new PatternReplaceFilter(
+                keywordFilter, Pattern.compile("a"), "X", true, ignoreKeywords));
+      }
+    };
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
@@ -113,32 +113,9 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
     a.close();
   }
 
-  public void testIgnoreKeywords() throws Exception {
-    Analyzer a =
-        new Analyzer() {
-          @Override
-          protected TokenStreamComponents createComponents(String fieldName) {
-            Tokenizer tokenizer = new MockTokenizer(MockTokenizer.WHITESPACE, false);
-            KeywordMarkerFilter keywordFilter =
-                new KeywordMarkerFilter(tokenizer) {
-                  private final CharTermAttribute term = addAttribute(CharTermAttribute.class);
-
-                  @Override
-                  public boolean isKeyword() {
-                    // Mark terms starting with 'k' as keywords
-                    return term.toString().startsWith("k");
-                  }
-                };
-            return new TokenStreamComponents(
-                tokenizer,
-                new PatternReplaceFilter(keywordFilter, Pattern.compile("a"), "X", true, true));
-          }
-        };
-
-    // Without ignoreKeywords=true, both terms would have 'a' replaced with 'X'
-    // With ignoreKeywords=true, only non-keyword terms should be modified
+  public void testKeywordFilter() throws Exception {
     assertAnalyzesTo(
-        a,
+        keywordTestAnalyzer(true),
         "banana kappa alpha",
         new String[] {"bXnXnX", "kappa", "XlphX"}, // kappa unchanged, others modified
         new int[] {0, 7, 13},
@@ -148,32 +125,8 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
         null,
         false);
 
-    a.close();
-
-    // Test with ignoreKeywords=false for comparison
-    Analyzer b =
-        new Analyzer() {
-          @Override
-          protected TokenStreamComponents createComponents(String fieldName) {
-            Tokenizer tokenizer = new MockTokenizer(MockTokenizer.WHITESPACE, false);
-            KeywordMarkerFilter keywordFilter =
-                new KeywordMarkerFilter(tokenizer) {
-                  private final CharTermAttribute term = addAttribute(CharTermAttribute.class);
-
-                  @Override
-                  public boolean isKeyword() {
-                    return term.toString().startsWith("k");
-                  }
-                };
-            return new TokenStreamComponents(
-                tokenizer,
-                new PatternReplaceFilter(keywordFilter, Pattern.compile("a"), "X", true, false));
-          }
-        };
-
-    // With ignoreKeywords=false, all terms should be modified regardless of keyword status
     assertAnalyzesTo(
-        b,
+        keywordTestAnalyzer(false),
         "banana kappa alpha",
         new String[] {"bXnXnX", "kXppX", "XlphX"}, // all terms modified
         new int[] {0, 7, 13},
@@ -182,7 +135,28 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
         new int[] {1, 1, 1},
         null,
         false);
+  }
 
-    b.close();
+  private Analyzer keywordTestAnalyzer(boolean ignoreKeywords) throws Exception {
+    return new Analyzer() {
+      @Override
+      protected TokenStreamComponents createComponents(String fieldName) {
+        Tokenizer tokenizer = new MockTokenizer(MockTokenizer.WHITESPACE, false);
+        KeywordMarkerFilter keywordFilter =
+            new KeywordMarkerFilter(tokenizer) {
+              private final CharTermAttribute term = addAttribute(CharTermAttribute.class);
+
+              @Override
+              public boolean isKeyword() {
+                // Mark terms starting with 'k' as keywords
+                return term.toString().startsWith("k");
+              }
+            };
+        return new TokenStreamComponents(
+            tokenizer,
+            new PatternReplaceFilter(
+                keywordFilter, Pattern.compile("a"), "X", true, ignoreKeywords));
+      }
+    };
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
@@ -115,24 +115,12 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
     assertAnalyzesTo(
         keywordTestAnalyzer(true),
         "banana kappa alpha",
-        new String[] {"bXnXnX", "kappa", "XlphX"}, // kappa unchanged, others modified
-        new int[] {0, 7, 13},
-        new int[] {6, 12, 18},
-        null,
-        new int[] {1, 1, 1},
-        null,
-        false);
+        new String[] {"bXnXnX", "kappa", "XlphX"});
 
     assertAnalyzesTo(
         keywordTestAnalyzer(false),
         "banana kappa alpha",
-        new String[] {"bXnXnX", "kXppX", "XlphX"}, // all terms modified
-        new int[] {0, 7, 13},
-        new int[] {6, 12, 18},
-        null,
-        new int[] {1, 1, 1},
-        null,
-        false);
+        new String[] {"bXnXnX", "kXppX", "XlphX"});
   }
 
   private Analyzer keywordTestAnalyzer(boolean ignoreKeywords) throws Exception {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
@@ -22,6 +22,8 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
+import org.apache.lucene.analysis.miscellaneous.KeywordMarkerFilter;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.tests.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 
@@ -109,5 +111,78 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
         };
     checkOneTerm(a, "", "");
     a.close();
+  }
+
+  public void testIgnoreKeywords() throws Exception {
+    Analyzer a =
+        new Analyzer() {
+          @Override
+          protected TokenStreamComponents createComponents(String fieldName) {
+            Tokenizer tokenizer = new MockTokenizer(MockTokenizer.WHITESPACE, false);
+            KeywordMarkerFilter keywordFilter =
+                new KeywordMarkerFilter(tokenizer) {
+                  private final CharTermAttribute term = addAttribute(CharTermAttribute.class);
+
+                  @Override
+                  public boolean isKeyword() {
+                    // Mark terms starting with 'k' as keywords
+                    return term.toString().startsWith("k");
+                  }
+                };
+            return new TokenStreamComponents(
+                tokenizer,
+                new PatternReplaceFilter(keywordFilter, Pattern.compile("a"), "X", true, true));
+          }
+        };
+
+    // Without ignoreKeywords=true, both terms would have 'a' replaced with 'X'
+    // With ignoreKeywords=true, only non-keyword terms should be modified
+    assertAnalyzesTo(
+        a,
+        "banana kappa alpha",
+        new String[] {"bXnXnX", "kappa", "XlphX"}, // kappa unchanged, others modified
+        new int[] {0, 7, 13},
+        new int[] {6, 12, 18},
+        null,
+        new int[] {1, 1, 1},
+        null,
+        false);
+
+    a.close();
+
+    // Test with ignoreKeywords=false for comparison
+    Analyzer b =
+        new Analyzer() {
+          @Override
+          protected TokenStreamComponents createComponents(String fieldName) {
+            Tokenizer tokenizer = new MockTokenizer(MockTokenizer.WHITESPACE, false);
+            KeywordMarkerFilter keywordFilter =
+                new KeywordMarkerFilter(tokenizer) {
+                  private final CharTermAttribute term = addAttribute(CharTermAttribute.class);
+
+                  @Override
+                  public boolean isKeyword() {
+                    return term.toString().startsWith("k");
+                  }
+                };
+            return new TokenStreamComponents(
+                tokenizer,
+                new PatternReplaceFilter(keywordFilter, Pattern.compile("a"), "X", true, false));
+          }
+        };
+
+    // With ignoreKeywords=false, all terms should be modified regardless of keyword status
+    assertAnalyzesTo(
+        b,
+        "banana kappa alpha",
+        new String[] {"bXnXnX", "kXppX", "XlphX"}, // all terms modified
+        new int[] {0, 7, 13},
+        new int[] {6, 12, 18},
+        null,
+        new int[] {1, 1, 1},
+        null,
+        false);
+
+    b.close();
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
@@ -113,9 +113,7 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
 
   public void testKeywordFilter() throws Exception {
     assertAnalyzesTo(
-        keywordTestAnalyzer(true),
-        "banana kappa alpha",
-        new String[] {"bXnXnX", "kappa", "XlphX"});
+        keywordTestAnalyzer(true), "banana kappa alpha", new String[] {"bXnXnX", "kappa", "XlphX"});
 
     assertAnalyzesTo(
         keywordTestAnalyzer(false),

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
@@ -30,7 +30,8 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
   public void testReplaceAll() throws Exception {
     String input = "aabfooaabfooabfoob ab caaaaaaaaab";
     TokenStream ts =
-        new PatternReplaceFilter(whitespaceMockTokenizer(input), Pattern.compile("a*b"), "-", true, false);
+        new PatternReplaceFilter(
+            whitespaceMockTokenizer(input), Pattern.compile("a*b"), "-", true, false);
     assertTokenStreamContents(ts, new String[] {"-foo-foo-foo-", "-", "c-"});
   }
 
@@ -102,7 +103,8 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
           protected TokenStreamComponents createComponents(String fieldName) {
             Tokenizer tokenizer = new KeywordTokenizer();
             return new TokenStreamComponents(
-                tokenizer, new PatternReplaceFilter(tokenizer, Pattern.compile("a"), "b", true, false));
+                tokenizer,
+                new PatternReplaceFilter(tokenizer, Pattern.compile("a"), "b", true, false));
           }
         };
     checkOneTerm(a, "", "");

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/pattern/TestPatternReplaceFilter.java
@@ -30,7 +30,7 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
   public void testReplaceAll() throws Exception {
     String input = "aabfooaabfooabfoob ab caaaaaaaaab";
     TokenStream ts =
-        new PatternReplaceFilter(whitespaceMockTokenizer(input), Pattern.compile("a*b"), "-", true);
+        new PatternReplaceFilter(whitespaceMockTokenizer(input), Pattern.compile("a*b"), "-", true, false);
     assertTokenStreamContents(ts, new String[] {"-foo-foo-foo-", "-", "c-"});
   }
 
@@ -38,7 +38,7 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
     String input = "aabfooaabfooabfoob ab caaaaaaaaab";
     TokenStream ts =
         new PatternReplaceFilter(
-            whitespaceMockTokenizer(input), Pattern.compile("a*b"), "-", false);
+            whitespaceMockTokenizer(input), Pattern.compile("a*b"), "-", false, false);
     assertTokenStreamContents(ts, new String[] {"-fooaabfooabfoob", "-", "c-"});
   }
 
@@ -46,7 +46,7 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
     String input = "aabfooaabfooabfoob ab caaaaaaaaab";
     TokenStream ts =
         new PatternReplaceFilter(
-            whitespaceMockTokenizer(input), Pattern.compile("a*b"), null, false);
+            whitespaceMockTokenizer(input), Pattern.compile("a*b"), null, false, false);
     assertTokenStreamContents(ts, new String[] {"fooaabfooabfoob", "", "c"});
   }
 
@@ -54,7 +54,7 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
     String input = "aabfooaabfooabfoob ab caaaaaaaaab";
     TokenStream ts =
         new PatternReplaceFilter(
-            whitespaceMockTokenizer(input), Pattern.compile("a*b"), null, true);
+            whitespaceMockTokenizer(input), Pattern.compile("a*b"), null, true, false);
     assertTokenStreamContents(ts, new String[] {"foofoofoo", "", "c"});
   }
 
@@ -62,7 +62,7 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
     String input = "aabfooaabfooabfoob ab caaaaaaaaab";
     TokenStream ts =
         new PatternReplaceFilter(
-            whitespaceMockTokenizer(input), Pattern.compile("(a*)b"), "$1\\$", true);
+            whitespaceMockTokenizer(input), Pattern.compile("(a*)b"), "$1\\$", true, false);
     assertTokenStreamContents(ts, new String[] {"aa$fooaa$fooa$foo$", "a$", "caaaaaaaaa$"});
   }
 
@@ -74,7 +74,7 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
           protected TokenStreamComponents createComponents(String fieldName) {
             Tokenizer tokenizer = new MockTokenizer(MockTokenizer.WHITESPACE, false);
             TokenStream filter =
-                new PatternReplaceFilter(tokenizer, Pattern.compile("a"), "b", false);
+                new PatternReplaceFilter(tokenizer, Pattern.compile("a"), "b", false, false);
             return new TokenStreamComponents(tokenizer, filter);
           }
         };
@@ -87,7 +87,7 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
           protected TokenStreamComponents createComponents(String fieldName) {
             Tokenizer tokenizer = new MockTokenizer(MockTokenizer.WHITESPACE, false);
             TokenStream filter =
-                new PatternReplaceFilter(tokenizer, Pattern.compile("a"), "b", true);
+                new PatternReplaceFilter(tokenizer, Pattern.compile("a"), "b", true, false);
             return new TokenStreamComponents(tokenizer, filter);
           }
         };
@@ -102,7 +102,7 @@ public class TestPatternReplaceFilter extends BaseTokenStreamTestCase {
           protected TokenStreamComponents createComponents(String fieldName) {
             Tokenizer tokenizer = new KeywordTokenizer();
             return new TokenStreamComponents(
-                tokenizer, new PatternReplaceFilter(tokenizer, Pattern.compile("a"), "b", true));
+                tokenizer, new PatternReplaceFilter(tokenizer, Pattern.compile("a"), "b", true, false));
           }
         };
     checkOneTerm(a, "", "");


### PR DESCRIPTION
### Description

Add an ignoreKeywords flag to PatternReplaceFilter similar to WordDelimiterGraphFilter. We use PatternReplaceFilter for some custom spelling normalization and minimal stemming and would like to use the existing mechanism to protect keywords.

### Disclaimers

This pull request was created using aider and Claude Sonnet 4.

We don't use Lucene directly (I plan to do a follow up pull request for elasticsearch) so I could not yet check this changes besides the generated new tests. Please tell me if anything is missing.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
