### PR TITLE
Fix stale block size comments in Lucene104 postings reader/writer

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104PostingsReader.java
@@ -602,7 +602,7 @@ public final class Lucene104PostingsReader extends PostingsReaderBase {
         int numLongs;
         if (bitsPerValue == 0) {
           // 0 is used to record that all 256 docs in the block are consecutive
-          numLongs = BLOCK_SIZE / Long.SIZE; // 2
+          numLongs = BLOCK_SIZE / Long.SIZE; // 4
           docBitSet.set(0, BLOCK_SIZE);
         } else {
           numLongs = -bitsPerValue;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104PostingsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104PostingsWriter.java
@@ -451,7 +451,7 @@ public class Lucene104PostingsWriter extends PushPostingsWriterBase {
           spareBitSet.set(s);
         }
         // We never use the bit set encoding when it requires more than Integer.SIZE=32 bits per
-        // value. So the bit set cannot have more than BLOCK_SIZE * Integer.SIZE / Long.SIZE = 64
+        // value. So the bit set cannot have more than BLOCK_SIZE * Integer.SIZE / Long.SIZE = 128
         // longs, which fits on a byte.
         assert numBitSetLongs <= BLOCK_SIZE / 2;
         level0Output.writeByte((byte) -numBitSetLongs);
@@ -483,7 +483,7 @@ public class Lucene104PostingsWriter extends PushPostingsWriterBase {
       level0FreqNormAccumulator.clear();
     }
 
-    if ((docCount & LEVEL1_MASK) == 0) { // true every 32 blocks (4,096 docs)
+    if ((docCount & LEVEL1_MASK) == 0) { // true every 32 blocks (8,192 docs)
       writeLevel1SkipData();
       level1LastDocID = docID;
       level1CompetitiveFreqNormAccumulator.clear();


### PR DESCRIPTION
Fixes #15670.

BLOCK_SIZE went from 128 to 256 in 10.4, but a few comments still spell out
values computed with the old block size:

- Lucene104PostingsWriter: level 1 skip data is written every 32 blocks, which
  is 8,192 docs, not 4,096.
- Lucene104PostingsWriter: BLOCK_SIZE * Integer.SIZE / Long.SIZE is 128, not 64.
  The assert on the next line already uses BLOCK_SIZE / 2.
- Lucene104PostingsReader: BLOCK_SIZE / Long.SIZE is 4, not 2.

This is a follow-up to #15672, where the question was raised whether other
comments needed the same fix. I went through the lucene104 package looking
for comments that hard-code values derived from BLOCK_SIZE, and these three
are the only ones left. The version history in package-info.java is correct
as is, since it describes the 9.12 format where BLOCK_SIZE was still 128.

Documentation only, no change in behaviour, so no CHANGES.txt entry.
