### PR TITLE
Allow Java Panama vector API on GraalVM for JDK 25+ (#16317)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -356,6 +356,8 @@ Improvements
   The new code allows to add a hard limit for nesting (default is 1024) and no longer
   throws virtual machine errors.  (Uwe Schindler, Seth Kraft)
 
+* GITHUB#16497: Allow Java Panama vector API on GraalVM for JDK 25+. (Abhinav Chinnala)
+
 Optimizations
 ---------------------
 * GITHUB#16394: Add DocIdSetIterator#intoArray, which DisjunctionDISIApproximation implements by

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -145,7 +145,7 @@ public abstract class VectorizationProvider {
         return new DefaultVectorizationProvider();
       }
       // don't use vector module with JVMCI (it does not work)
-      if (Constants.IS_JVMCI_VM) {
+      if (Constants.IS_JVMCI_VM && Runtime.version().feature() < 25) {
         LOG.warning(
             "Java runtime is using JVMCI Compiler; Java vector incubator API can't be enabled.");
         return new DefaultVectorizationProvider();


### PR DESCRIPTION
### Description
GraalVM fully supports the Panama Vector API starting with JDK 25 (via oracle/graal#10285). Currently, `VectorizationProvider.java` unconditionally disables the vector incubator module when running on JVMCI (`Constants.IS_JVMCI_VM`).

This PR updates the JVMCI check to evaluate `Runtime.version().feature() < 25`, allowing GraalVM JDK 25+ runtimes to utilize hardware-accelerated vectorization instead of falling back to the scalar `DefaultVectorizationProvider`.

### Testing
Ran `:lucene:core:test --tests "*VectorUtil*"` locally under Oracle GraalVM 25 (`25+37.1`).
* All 348 vector utility tests passed cleanly.
* Confirmed `jdk.incubator.vector` module was loaded during execution.

Closes #16317
