### PR TITLE
Remove JVMCI checks and update assertions for Java 25 

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -136,18 +136,12 @@ public abstract class VectorizationProvider {
   // visible for tests
   static VectorizationProvider lookup(boolean testMode) {
     final int runtimeVersion = Runtime.version().feature();
-    assert runtimeVersion >= 21;
+    assert runtimeVersion >= 25;
     if (runtimeVersion <= UPPER_JAVA_FEATURE_VERSION) {
       // only use vector module with Hotspot VM
       if (!Constants.IS_HOTSPOT_VM) {
         LOG.warning(
             "Java runtime is not using Hotspot VM; Java vector incubator API can't be enabled.");
-        return new DefaultVectorizationProvider();
-      }
-      // don't use vector module with JVMCI (it does not work)
-      if (Constants.IS_JVMCI_VM && Runtime.version().feature() < 25) {
-        LOG.warning(
-            "Java runtime is using JVMCI Compiler; Java vector incubator API can't be enabled.");
         return new DefaultVectorizationProvider();
       }
       // is the incubator module present and readable (JVM providers may to exclude them or it is

--- a/lucene/core/src/java/org/apache/lucene/util/Constants.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Constants.java
@@ -67,10 +67,6 @@ public final class Constants {
   /** True iff the Java VM is based on Hotspot and has the Hotspot MX bean readable by Lucene. */
   public static final boolean IS_HOTSPOT_VM = HotspotVMOptions.IS_HOTSPOT_VM;
 
-  /** True if jvmci is enabled (e.g. graalvm) */
-  public static final boolean IS_JVMCI_VM =
-      HotspotVMOptions.get("UseJVMCICompiler").map(Boolean::valueOf).orElse(false);
-
   /** True iff running on a 64bit JVM */
   public static final boolean JRE_IS_64BIT = (ValueLayout.ADDRESS.byteSize() == Long.BYTES);
 


### PR DESCRIPTION
### Description
Following the discussion with @uschindler in #16497, this PR cleans up legacy code in the main branch to reflect the recent Java 25 baseline migration:

1. Removes Constants.IS_JVMCI_VM and its associated fallback block in VectorizationProvider.java.

2.Updates the stale assertion assert runtimeVersion >= 21 to >= 25.

(Note: The UPPER_JAVA_FEATURE_VERSION check remains unchanged).

### Testing
Ran :lucene:core:test --tests "*VectorUtil*" locally under Oracle GraalVM 25 (25+37.1).

- All 348 vector utility tests passed cleanly.

- Confirmed jdk.incubator.vector module was loaded during execution.