### PR TITLE
Clean up BytesRefHash

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -160,6 +160,8 @@ Improvements
 * GITHUB#16313: Refactored the Hunspell dictionary parser to use switch-based dispatch for affix directives,
   improving readability of the parsing logic. (Rajat Jain)
 
+* GITHUB#16499: Clean up BytesRefHash. Remove dead lastCount and unused close(), fix stale comments (neoremind)
+
 Optimizations
 ---------------------
 * GITHUB#16382: WildcardQuery.toAutomaton now collapses consecutive unescaped '*'

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
@@ -53,7 +53,6 @@ public final class BytesRefHash implements Accountable {
   // This mask is used to extract the high bits from a hashcode
   private int highMask;
   private int count;
-  private int lastCount = -1;
 
   /**
    * The <code>ids</code> array serves a dual purpose:
@@ -153,7 +152,7 @@ public final class BytesRefHash implements Accountable {
   /**
    * Populates and returns a {@link BytesRef} with the bytes for the given bytesID.
    *
-   * <p>Note: the given bytesID must be a positive integer less than the current size ({@link
+   * <p>Note: the given bytesID must be a non-negative integer less than the current size ({@link
    * #size()})
    *
    * @param bytesID the id
@@ -185,7 +184,6 @@ public final class BytesRefHash implements Accountable {
     }
     Arrays.fill(ids, count, hashSize, -1);
 
-    lastCount = count;
     return ids;
   }
 
@@ -293,28 +291,20 @@ public final class BytesRefHash implements Accountable {
 
   /** Clears the {@link BytesRef} which maps to the given {@link BytesRef} */
   public void clear(boolean resetPool) {
-    lastCount = count;
-    count = 0;
     if (resetPool) {
       pool.reset();
     }
     bytesStart = bytesStartArray.clear();
-    if (lastCount != -1 && shrink(lastCount)) {
-      // shrink clears the hash entries
-      return;
+    final boolean shrunk = shrink(count);
+    count = 0;
+    if (shrunk == false) {
+      // shrink already cleared the hash entries; otherwise clear them here
+      Arrays.fill(ids, -1);
     }
-    Arrays.fill(ids, -1);
   }
 
   public void clear() {
     clear(true);
-  }
-
-  /** Closes the BytesRefHash and releases all internally used memory */
-  public void close() {
-    clear(true);
-    ids = null;
-    bytesUsed.addAndGet(Integer.BYTES * (long) -hashSize);
   }
 
   /**
@@ -428,7 +418,7 @@ public final class BytesRefHash implements Accountable {
   }
 
   /**
-   * Called when hash is too small ({@code > 50%} occupied) or too large ({@code < 20%} occupied).
+   * Called when hash is too small ({@code > 50%} occupied) or too large ({@code < 25%} occupied).
    */
   private void rehash(final int newSize, boolean hashOnData) {
     final int newMask = newSize - 1;
@@ -560,9 +550,6 @@ public final class BytesRefHash implements Accountable {
    * instance.
    */
   public static class DirectBytesStartArray extends BytesStartArray {
-    // TODO: can't we just merge this w/
-    // TrackingDirectBytesStartArray...?  Just add a ctor
-    // that makes a private bytesUsed?
 
     protected final int initSize;
     private int[] bytesStart;

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
@@ -417,9 +417,7 @@ public final class BytesRefHash implements Accountable {
     return -(e + 1);
   }
 
-  /**
-   * Called when hash reaches {@code 50%} occupancy.
-   */
+  /** Called when hash reaches {@code 50%} occupancy. */
   private void rehash(final int newSize, boolean hashOnData) {
     final int newMask = newSize - 1;
     final int newHighMask = ~newMask;

--- a/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
+++ b/lucene/core/src/java/org/apache/lucene/util/BytesRefHash.java
@@ -418,7 +418,7 @@ public final class BytesRefHash implements Accountable {
   }
 
   /**
-   * Called when hash is too small ({@code > 50%} occupied) or too large ({@code < 25%} occupied).
+   * Called when hash reaches {@code 50%} occupancy.
    */
   private void rehash(final int newSize, boolean hashOnData) {
     final int newMask = newSize - 1;


### PR DESCRIPTION
* Remove the lastCount field as it is not in use, the `!= -1` guard in `shrink()` has been not applicable
* Remove close(): it has no callers, also `Map` data structure typically does not provide such operation
* Fix get() javadoc: valid ids are non-negative, not positive (0 is a valid id)
* Fix the rehash() comment: the shrink threshold is 25% occupancy, not 20%
* Remove a stale TODO comment in DirectBytesStartArray