### PR TITLE
ByteBuffersDataInput: throw EOFException when random-access reads go past the limit

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataInput.java
@@ -220,8 +220,9 @@ public final class ByteBuffersDataInput extends DataInput
       while (len > 0) {
         ByteBuffer block = blocks[blockIndex(absPos)];
         int blockPosition = blockOffset(absPos);
-        int chunk = Math.min(len, block.capacity() - blockPosition);
-        if (chunk == 0) {
+        // Use block's limit to bound the read as the last block may only be partially filled.
+        int chunk = Math.min(len, block.limit() - blockPosition);
+        if (chunk <= 0) {
           throw new EOFException();
         }
 

--- a/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDataInput.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestByteBuffersDataInput.java
@@ -227,6 +227,26 @@ public final class TestByteBuffersDataInput extends LuceneTestCase {
         });
   }
 
+  public void testEofOnRandomAccessReadPastBufferSize() throws Exception {
+    ByteBuffersDataOutput dst = new ByteBuffersDataOutput();
+    byte[] data = new byte[10];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = (byte) i;
+    }
+    dst.writeBytes(data);
+
+    // Assert that we know throw EOFException
+    LuceneTestCase.expectThrows(
+        EOFException.class, () -> dst.toDataInput().readBytes(5L, new byte[100], 0, 100));
+
+    // A valid random-access read that ends exactly at the last (partial) block's limit must still
+    // succeed and return the right bytes.
+    ByteBuffersDataInput in = dst.toDataInput();
+    byte[] tail = new byte[5];
+    in.readBytes(5L, tail, 0, 5);
+    assertArrayEquals(new byte[] {5, 6, 7, 8, 9}, tail);
+  }
+
   // https://issues.apache.org/jira/browse/LUCENE-8625
   public void testSlicingLargeBuffers() throws IOException {
     // Simulate a "large" (> 4GB) input by duplicating


### PR DESCRIPTION
### Description

ByteBuffersDataInput's random-access `readBytes(long, byte[], int, int)` used the block's `capacity()` to figure out how many bytes were left, but `capacity()` might include the unused tail of the last block. So reading past the end we throw `IndexOutOfBoundsException` which seems wrong to me, instead should be `EOFException`. This PR uses `limit()` instead of a `capacity()`



<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
