### PR TITLE
Simplify array copy by ArrayUtil.copyOfSubArray() in grouping package

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -486,6 +486,8 @@ Other
 * GITHUB#16300: Reduce memory pressure in TestTermInSetQuery.testDuel stress runs.
   (Sanghun Lee)
 
+* GITHUB#16300: Simplify array copy by ArrayUtil.copyOfSubArray in grouping package (Binlong Gao)
+
 ======================= Lucene 10.5.1 =======================
 
 Bug Fixes

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -486,7 +486,7 @@ Other
 * GITHUB#16300: Reduce memory pressure in TestTermInSetQuery.testDuel stress runs.
   (Sanghun Lee)
 
-* GITHUB#16300: Simplify array copy by ArrayUtil.copyOfSubArray in grouping package (Binlong Gao)
+* GITHUB#16516: Simplify array copy by ArrayUtil.copyOfSubArray() in grouping package (Binlong Gao)
 
 ======================= Lucene 10.5.1 =======================
 

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroups.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroups.java
@@ -30,6 +30,7 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.TotalHits.Relation;
+import org.apache.lucene.util.ArrayUtil;
 
 /**
  * Represents result returned by a grouping search.
@@ -253,13 +254,9 @@ public class TopGroups<T> {
       } else if (docOffset >= mergedTopDocs.scoreDocs.length) {
         mergedScoreDocs = new ScoreDoc[0];
       } else {
-        mergedScoreDocs = new ScoreDoc[mergedTopDocs.scoreDocs.length - docOffset];
-        System.arraycopy(
-            mergedTopDocs.scoreDocs,
-            docOffset,
-            mergedScoreDocs,
-            0,
-            mergedTopDocs.scoreDocs.length - docOffset);
+        mergedScoreDocs =
+            ArrayUtil.copyOfSubArray(
+                mergedTopDocs.scoreDocs, docOffset, mergedTopDocs.scoreDocs.length);
       }
 
       final float groupScore;

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
@@ -68,6 +68,7 @@ import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.mutable.MutableValue;
 import org.apache.lucene.util.mutable.MutableValueStr;
@@ -947,8 +948,7 @@ public class TestGrouping extends LuceneTestCase {
         }
       }
 
-      final GroupDoc[] groupDocsByID = new GroupDoc[groupDocs.length];
-      System.arraycopy(groupDocs, 0, groupDocsByID, 0, groupDocs.length);
+      final GroupDoc[] groupDocsByID = ArrayUtil.copyOfSubArray(groupDocs, 0, groupDocs.length);
 
       final DirectoryReader r = w.getReader();
       w.close();


### PR DESCRIPTION
### Description

Replace manual array copy by ArrayUtil.copyOfSubArray() in grouping package.
