### PR TITLE
Gradle WrapperDownloader: move URL & sha into properties

### DIFF
--- a/.github/actions/prepare-for-build/action.yml
+++ b/.github/actions/prepare-for-build/action.yml
@@ -35,7 +35,7 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: gradle/wrapper/gradle-wrapper.jar
-        key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.jar.sha256') }}
+        key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
     # This includes "smart" caching of gradle dependencies.
     - name: Set up Gradle

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -21,6 +21,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Reader;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -28,6 +29,7 @@ import java.lang.annotation.Target;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -86,7 +88,7 @@ public class WrapperDownloader {
     }
 
     Properties properties = new Properties();
-    try (InputStream in = Files.newInputStream(wrapperProperties)) {
+    try (Reader in = Files.newBufferedReader(wrapperProperties, StandardCharsets.UTF_8)) {
       properties.load(in);
     }
     String wrapperUrl = requireProperty(properties, wrapperProperties, "wrapperUrl");

--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java
@@ -28,17 +28,14 @@ import java.lang.annotation.Target;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
-import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
-import java.util.regex.Pattern;
 
 /**
  * Standalone class used to download the {@code gradle-wrapper.jar}.
@@ -81,48 +78,6 @@ public class WrapperDownloader {
   }
 
   public void run(Path destination) throws IOException, NoSuchAlgorithmException {
-    var expectedFileName = destination.getFileName().toString();
-    Path checksumPath = destination.resolveSibling(expectedFileName + ".sha256");
-    if (!Files.exists(checksumPath)) {
-      throw new IOException("Checksum file not found: " + checksumPath);
-    }
-
-    String expectedChecksum;
-    try (var lines = Files.lines(checksumPath, StandardCharsets.UTF_8)) {
-      expectedChecksum =
-          lines
-              .map(
-                  line -> {
-                    // "The default mode is to print a line with: checksum, a space,
-                    // a character indicating input mode  ('*' for binary, ' ' for text
-                    // or where binary is insignificant), and name for each FILE."
-                    var spaceIndex = line.indexOf(" ");
-                    if (spaceIndex != -1 && spaceIndex + 2 < line.length()) {
-                      var mode = line.charAt(spaceIndex + 1);
-                      String fileName = line.substring(spaceIndex + 2);
-                      if (mode == '*' && fileName.equals(expectedFileName)) {
-                        return line.substring(0, spaceIndex);
-                      }
-                    }
-
-                    Logger.getLogger(WrapperDownloader.class.getName())
-                        .warning(
-                            "Something is wrong with the checksum file. Regenerate with "
-                                + "'sha256sum -b gradle-wrapper.jar > gradle-wrapper.jar.sha256'");
-                    return null;
-                  })
-              .filter(Objects::nonNull)
-              .findFirst()
-              .orElse(null);
-
-      if (expectedChecksum == null) {
-        throw new IOException(
-            "The checksum file did not contain the expected checksum for '"
-                + expectedFileName
-                + "'?");
-      }
-    }
-
     Path wrapperProperties =
         destination.resolveSibling(
             destination.getFileName().toString().replace(".jar", ".properties"));
@@ -130,21 +85,12 @@ public class WrapperDownloader {
       throw new IOException("Wrapper property file not found: " + wrapperProperties);
     }
 
-    Pattern versionPattern = Pattern.compile("gradle-(?<version>.+?)-bin.zip");
-    String wrapperVersion =
-        Files.readAllLines(wrapperProperties, StandardCharsets.UTF_8).stream()
-            .map(
-                line -> {
-                  var matcher = versionPattern.matcher(line);
-                  if (matcher.find()) {
-                    return matcher.group("version");
-                  } else {
-                    return null;
-                  }
-                })
-            .filter(Objects::nonNull)
-            .findAny()
-            .orElseThrow();
+    Properties properties = new Properties();
+    try (InputStream in = Files.newInputStream(wrapperProperties)) {
+      properties.load(in);
+    }
+    String wrapperUrl = requireProperty(properties, wrapperProperties, "wrapperUrl");
+    String expectedChecksum = requireProperty(properties, wrapperProperties, "wrapperSha256");
 
     MessageDigest digest = MessageDigest.getInstance("SHA-256");
 
@@ -159,12 +105,7 @@ public class WrapperDownloader {
       }
     }
 
-    URL url =
-        URI.create(
-                "https://raw.githubusercontent.com/gradle/gradle/v"
-                    + wrapperVersion
-                    + "/gradle/wrapper/gradle-wrapper.jar")
-            .toURL();
+    URL url = URI.create(wrapperUrl).toURL();
     System.err.println("Downloading gradle-wrapper.jar from " + url);
 
     // Zero-copy save the jar to a temp file
@@ -240,6 +181,15 @@ public class WrapperDownloader {
         Files.deleteIfExists(temp);
       }
     }
+  }
+
+  private static String requireProperty(Properties properties, Path source, String key)
+      throws IOException {
+    String value = properties.getProperty(key);
+    if (value == null || value.isBlank()) {
+      throw new IOException("Missing required property '" + key + "' in " + source);
+    }
+    return value.trim();
   }
 
   @SuppressForbidden(reason = "Valid use of thread.sleep.")

--- a/gradle/wrapper/gradle-wrapper.jar.sha256
+++ b/gradle/wrapper/gradle-wrapper.jar.sha256
@@ -1,1 +1,0 @@
-497c8c2a7e5031f6aa847f88104aa80a93532ec32ee17bdb8d1d2f67a194a9c7 *gradle-wrapper.jar

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -7,3 +7,8 @@ retryBackOffMs=500
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+
+# Read by Lucene's WrapperDownloader (not by the actual wrapper) to bootstrap gradle-wrapper.jar.
+wrapperSha256=497c8c2a7e5031f6aa847f88104aa80a93532ec32ee17bdb8d1d2f67a194a9c7
+wrapperUrl=https\://raw.githubusercontent.com/gradle/gradle/v9.6.1/gradle/wrapper/gradle-wrapper.jar
+#   To self download, try %> curl -Lo gradle/wrapper/gradle-wrapper.jar <wrapperUrl>  (from the repo root)

--- a/gradlew
+++ b/gradlew
@@ -211,18 +211,13 @@ if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
 fi
 DEFAULT_JVM_OPTS="$DEFAULT_JVM_OPTS \"-Djava.io.tmpdir=$GRADLE_TEMPDIR\""
 
-# LUCENE-9266: verify and download the gradle wrapper jar if we don't have one.
+# LUCENE-9266: download the gradle wrapper jar if we don't have one.
 if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
 fi
 
 GRADLE_WRAPPER_JAR="$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
-if "$darwin"; then
-    shasumcmd=shasum
-else
-    shasumcmd=sha256sum
-fi
-if [ ! -e "$GRADLE_WRAPPER_JAR" ] || ! ( cd "$APP_HOME/gradle/wrapper" && "$shasumcmd" --status -c "${GRADLE_WRAPPER_JAR}.sha256" ); then
+if [ ! -e "$GRADLE_WRAPPER_JAR" ]; then
     "$JAVACMD" $JAVA_OPTS "$APP_HOME/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java" "$GRADLE_WRAPPER_JAR"
     WRAPPER_STATUS=$?
     if [ "$WRAPPER_STATUS" -eq 1 ]; then

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -77,20 +77,10 @@ SET GRADLE_TEMPDIR=%DIRNAME%\.gradle\tmp
 IF NOT EXIST "%GRADLE_TEMPDIR%" MKDIR "%GRADLE_TEMPDIR%"
 SET DEFAULT_JVM_OPTS=%DEFAULT_JVM_OPTS% "-Djava.io.tmpdir=%GRADLE_TEMPDIR%"
 
-@rem LUCENE-9266: verify and download the gradle wrapper jar if we don't have one.
+@rem LUCENE-9266: download the gradle wrapper jar if we don't have one.
 set GRADLE_WRAPPER_JAR=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
-set GRADLE_WRAPPER_CHECKSUM=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar.sha256
 
-@rem Read the expected hash from .sha256 file
-for /f "tokens=1 usebackq" %%A in ("%GRADLE_WRAPPER_CHECKSUM%") do (
-    set "EXPECTED=%%A"
-)
-@rem Get actual SHA-256 hash using certutil
-for /f "tokens=* delims=" %%H in ('certutil -hashfile "%GRADLE_WRAPPER_JAR%" SHA256 ^| findstr /R /B /I /X "[0-9a-f]*"') do (
-    set "ACTUAL=%%H"
-)
-
-if /i "%ACTUAL%" NEQ "%EXPECTED%" (
+IF NOT EXIST "%GRADLE_WRAPPER_JAR%" (
   "%JAVA_EXE%" -XX:TieredStopAtLevel=1 %JAVA_OPTS% "%APP_HOME%/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/WrapperDownloader.java" "%GRADLE_WRAPPER_JAR%"
   IF %ERRORLEVEL% EQU 1 goto failWithJvmMessage
   IF %ERRORLEVEL% NEQ 0 goto exitWithErrorLevel


### PR DESCRIPTION
And don't bother checking if the wrapper jar is out-of-date.

Goal: (1) Allow configuration of the wrapper location.  (2) simpler; easier to maintain

Can replace #16483 