### PR TITLE
[New feature] Add an adaptive filtered strategy PathSeer for Lucene filtered HNSW search

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnCollector.java
@@ -69,6 +69,7 @@ public abstract class AbstractKnnCollector implements KnnCollector {
   @Override
   public abstract boolean collect(int docId, float similarity);
 
+  @Override
   public abstract int numCollected();
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/search/KnnCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnCollector.java
@@ -59,6 +59,16 @@ public interface KnnCollector {
   int k();
 
   /**
+   * Returns the number of results currently held by this collector.
+   *
+   * <p>The default implementation can only distinguish a full collector from a non-full one.
+   * Collectors that expose their result heap size should override this method.
+   */
+  default int numCollected() {
+    return minCompetitiveSimilarity() == Float.NEGATIVE_INFINITY ? 0 : k();
+  }
+
+  /**
    * Collect the provided docId and include in the result set.
    *
    * @param docId of the vector to collect
@@ -129,6 +139,11 @@ public interface KnnCollector {
     @Override
     public int k() {
       return collector.k();
+    }
+
+    @Override
+    public int numCollected() {
+      return collector.numCollected();
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/knn/KnnSearchStrategy.java
+++ b/lucene/core/src/java/org/apache/lucene/search/knn/KnnSearchStrategy.java
@@ -100,6 +100,21 @@ public abstract class KnnSearchStrategy {
   }
 
   /**
+   * PathSeer is a workload-adaptive strategy for filtered HNSW search. It operates on existing HNSW
+   * indexes and does not require a specialized index format.
+   *
+   * @lucene.experimental
+   */
+  public static final class PathSeer extends Hnsw {
+    public static final PathSeer INSTANCE = new PathSeer();
+
+    private PathSeer() {
+      // PathSeer does not require the filter search threshold.
+      super(0);
+    }
+  }
+
+  /**
    * A strategy for kNN search that uses a set of entry points to start the search
    *
    * @lucene.experimental

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -723,6 +723,11 @@ public class HnswGraphBuilder implements HnswBuilder {
     }
 
     @Override
+    public int numCollected() {
+      return queue.size();
+    }
+
+    @Override
     public boolean collect(int docId, float similarity) {
       return queue.insertWithOverflow(docId, similarity);
     }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -135,8 +135,18 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
       hnswStrategy = KnnSearchStrategy.Hnsw.DEFAULT;
     }
     final AbstractHnswGraphSearcher innerSearcher;
-    // First, check if we should use a filtered searcher
-    if (acceptOrds != null
+    // First, check if we should use a PathSeer searcher
+    boolean usePathSeer =
+        knnCollector.getSearchStrategy() instanceof KnnSearchStrategy.PathSeer
+            || (knnCollector.getSearchStrategy() instanceof KnnSearchStrategy.Seeded seeded
+                && seeded.originalStrategy() instanceof KnnSearchStrategy.PathSeer);
+    if (usePathSeer
+        && acceptOrds != null
+        // We can only use PathSeer search if we know the maxConn
+        && graph.maxConn() != HnswGraph.UNKNOWN_MAX_CONN
+        && filteredDocCount > 0) {
+      innerSearcher = PathSeerHnswGraphSearcher.create(knnCollector.k(), graph);
+    } else if (acceptOrds != null
         // We can only use filtered search if we know the maxConn
         && graph.maxConn() != HnswGraph.UNKNOWN_MAX_CONN
         && filteredDocCount > 0

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -145,8 +145,7 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
         // We can only use PathSeer search if we know the maxConn
         && graph.maxConn() != HnswGraph.UNKNOWN_MAX_CONN
         && filteredDocCount > 0) {
-      innerSearcher =
-          PathSeerHnswGraphSearcher.create(knnCollector.k(), graph, filteredDocCount);
+      innerSearcher = PathSeerHnswGraphSearcher.create(knnCollector.k(), graph, filteredDocCount);
     } else if (acceptOrds != null
         // We can only use filtered search if we know the maxConn
         && graph.maxConn() != HnswGraph.UNKNOWN_MAX_CONN

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java
@@ -145,7 +145,8 @@ public class HnswGraphSearcher extends AbstractHnswGraphSearcher {
         // We can only use PathSeer search if we know the maxConn
         && graph.maxConn() != HnswGraph.UNKNOWN_MAX_CONN
         && filteredDocCount > 0) {
-      innerSearcher = PathSeerHnswGraphSearcher.create(knnCollector.k(), graph);
+      innerSearcher =
+          PathSeerHnswGraphSearcher.create(knnCollector.k(), graph, filteredDocCount);
     } else if (acceptOrds != null
         // We can only use filtered search if we know the maxConn
         && graph.maxConn() != HnswGraph.UNKNOWN_MAX_CONN

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/PathSeerHnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/PathSeerHnswGraphSearcher.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util.hnsw;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+
+import java.io.IOException;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.Bits;
+
+/**
+ * A filter-aware HNSW graph searcher that operates in two phases without modifying the graph.
+ * Before the candidate frontier first reaches {@code k}, accepted second-order neighbors are added
+ * as expansion-zone candidates. In the second phase, when an expanded candidate is rejected by the
+ * filter, rejected direct neighbors are skipped without scoring.
+ *
+ * @lucene.experimental
+ */
+public final class PathSeerHnswGraphSearcher extends HnswGraphSearcher {
+  private int[] directNeighbors = new int[0];
+  private int[] toScore = new int[0];
+
+  private PathSeerHnswGraphSearcher(
+      NeighborQueue candidates, org.apache.lucene.util.BitSet visited) {
+    super(candidates, visited);
+  }
+
+  /** Creates a PathSeer searcher for the supplied graph. */
+  public static PathSeerHnswGraphSearcher create(int k, HnswGraph graph) {
+    return new PathSeerHnswGraphSearcher(
+        new NeighborQueue(k, true), HnswGraphSearcher.createBitSet(k, getGraphSize(graph)));
+  }
+
+  @Override
+  void searchLevel(
+      KnnCollector results,
+      RandomVectorScorer scorer,
+      int level,
+      int[] eps,
+      HnswGraph graph,
+      Bits acceptOrds)
+      throws IOException {
+    assert level == 0 : "PathSeer only works on the base level";
+    if (acceptOrds == null) {
+      super.searchLevel(results, scorer, level, eps, graph, null);
+      return;
+    }
+
+    candidates.clear();
+    visited.clear();
+    if (bulkScores == null || bulkScores.length < eps.length) {
+      bulkScores = new float[eps.length];
+    }
+    if (results.earlyTerminated()) {
+      return;
+    }
+    scoreEntryPoints(results, scorer, visited, eps, acceptOrds, candidates, bulkScores);
+    if (results.earlyTerminated()) {
+      return;
+    }
+
+    float minAcceptedSimilarity = Math.nextUp(results.minCompetitiveSimilarity());
+    boolean shouldExploreMinSim = true;
+    boolean candidateFrontierReachedK = false;
+    final int maxSecondOrder = Math.max(1, graph.maxConn() * 2);
+
+    while (candidates.size() > 0 && results.earlyTerminated() == false) {
+      candidateFrontierReachedK |= candidates.size() >= results.k();
+      float topCandidateSimilarity = candidates.topScore();
+      if (topCandidateSimilarity < minAcceptedSimilarity) {
+        if (shouldExploreMinSim && Math.nextUp(topCandidateSimilarity) == minAcceptedSimilarity) {
+          shouldExploreMinSim = false;
+        } else {
+          break;
+        }
+      }
+
+      int topCandidateNode = candidates.pop();
+      boolean shouldFilterRejectedNeighbors =
+          candidateFrontierReachedK && acceptOrds.get(topCandidateNode) == false;
+      graphSeek(graph, level, topCandidateNode);
+      int directCount = 0;
+      int neighbor;
+      while ((neighbor = graphNextNeighbor(graph)) != NO_MORE_DOCS) {
+        directNeighbors = ArrayUtil.grow(directNeighbors, directCount + 1);
+        directNeighbors[directCount++] = neighbor;
+      }
+
+      int scoreCount = 0;
+      for (int i = 0; i < directCount; i++) {
+        int direct = directNeighbors[i];
+        if (visited.getAndSet(direct)) {
+          continue;
+        }
+        if (shouldFilterRejectedNeighbors && acceptOrds.get(direct) == false) {
+          continue;
+        }
+        toScore = ArrayUtil.grow(toScore, scoreCount + 1);
+        toScore[scoreCount++] = direct;
+      }
+
+      if (candidateFrontierReachedK == false) {
+        int secondOrderExamined = 0;
+        outer:
+        for (int i = 0; i < directCount; i++) {
+          graphSeek(graph, level, directNeighbors[i]);
+          int secondOrder;
+          while ((secondOrder = graphNextNeighbor(graph)) != NO_MORE_DOCS) {
+            if (secondOrderExamined++ >= maxSecondOrder) {
+              break outer;
+            }
+            if (visited.get(secondOrder) || acceptOrds.get(secondOrder) == false) {
+              continue;
+            }
+            visited.set(secondOrder);
+            toScore = ArrayUtil.grow(toScore, scoreCount + 1);
+            toScore[scoreCount++] = secondOrder;
+          }
+        }
+      }
+
+      scoreCount = (int) Math.min(scoreCount, results.visitLimit() - results.visitedCount());
+      if (bulkScores.length < scoreCount) {
+        bulkScores = new float[scoreCount];
+      }
+      results.incVisitedCount(scoreCount);
+      if (scoreCount > 0
+          && scorer.bulkScore(toScore, bulkScores, scoreCount)
+              > results.minCompetitiveSimilarity()) {
+        for (int i = 0; i < scoreCount; i++) {
+          float similarity = bulkScores[i];
+          if (similarity >= minAcceptedSimilarity) {
+            int ord = toScore[i];
+            candidates.add(ord, similarity);
+            if (acceptOrds.get(ord) && results.collect(ord, similarity)) {
+              float oldMinAcceptedSimilarity = minAcceptedSimilarity;
+              minAcceptedSimilarity = Math.nextUp(results.minCompetitiveSimilarity());
+              if (minAcceptedSimilarity > oldMinAcceptedSimilarity) {
+                shouldExploreMinSim = true;
+              }
+            }
+          }
+        }
+      }
+      if (results.getSearchStrategy() != null) {
+        results.getSearchStrategy().nextVectorsBlock();
+      }
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/PathSeerHnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/PathSeerHnswGraphSearcher.java
@@ -25,25 +25,32 @@ import org.apache.lucene.util.Bits;
 
 /**
  * A filter-aware HNSW graph searcher that operates in two phases without modifying the graph.
- * Before the candidate frontier first reaches {@code k}, accepted second-order neighbors are added
+ * Before the result heap reaches its effective capacity, accepted second-order neighbors are added
  * as expansion-zone candidates. In the second phase, when an expanded candidate is rejected by the
- * filter, rejected direct neighbors are skipped without scoring.
+ * filter, rejected direct neighbors are skipped without scoring. The effective capacity is the
+ * smaller of {@code k} and the filter cardinality.
  *
  * @lucene.experimental
  */
 public final class PathSeerHnswGraphSearcher extends HnswGraphSearcher {
   private int[] directNeighbors = new int[0];
   private int[] toScore = new int[0];
+  private final int resultHeapFullAt;
 
   private PathSeerHnswGraphSearcher(
-      NeighborQueue candidates, org.apache.lucene.util.BitSet visited) {
+      NeighborQueue candidates,
+      org.apache.lucene.util.BitSet visited,
+      int resultHeapFullAt) {
     super(candidates, visited);
+    this.resultHeapFullAt = resultHeapFullAt;
   }
 
   /** Creates a PathSeer searcher for the supplied graph. */
-  public static PathSeerHnswGraphSearcher create(int k, HnswGraph graph) {
+  public static PathSeerHnswGraphSearcher create(int k, HnswGraph graph, int filteredDocCount) {
     return new PathSeerHnswGraphSearcher(
-        new NeighborQueue(k, true), HnswGraphSearcher.createBitSet(k, getGraphSize(graph)));
+        new NeighborQueue(k, true),
+        HnswGraphSearcher.createBitSet(k, getGraphSize(graph)),
+        Math.min(k, filteredDocCount));
   }
 
   @Override
@@ -76,11 +83,11 @@ public final class PathSeerHnswGraphSearcher extends HnswGraphSearcher {
 
     float minAcceptedSimilarity = Math.nextUp(results.minCompetitiveSimilarity());
     boolean shouldExploreMinSim = true;
-    boolean candidateFrontierReachedK = false;
+    boolean resultHeapIsFull = false;
     final int maxSecondOrder = Math.max(1, graph.maxConn() * 2);
 
     while (candidates.size() > 0 && results.earlyTerminated() == false) {
-      candidateFrontierReachedK |= candidates.size() >= results.k();
+      resultHeapIsFull = results.numCollected() >= resultHeapFullAt;
       float topCandidateSimilarity = candidates.topScore();
       if (topCandidateSimilarity < minAcceptedSimilarity) {
         if (shouldExploreMinSim && Math.nextUp(topCandidateSimilarity) == minAcceptedSimilarity) {
@@ -92,7 +99,7 @@ public final class PathSeerHnswGraphSearcher extends HnswGraphSearcher {
 
       int topCandidateNode = candidates.pop();
       boolean shouldFilterRejectedNeighbors =
-          candidateFrontierReachedK && acceptOrds.get(topCandidateNode) == false;
+          resultHeapIsFull && acceptOrds.get(topCandidateNode) == false;
       graphSeek(graph, level, topCandidateNode);
       int directCount = 0;
       int neighbor;
@@ -104,17 +111,17 @@ public final class PathSeerHnswGraphSearcher extends HnswGraphSearcher {
       int scoreCount = 0;
       for (int i = 0; i < directCount; i++) {
         int direct = directNeighbors[i];
-        if (visited.getAndSet(direct)) {
+        if (shouldFilterRejectedNeighbors && acceptOrds.get(direct) == false) {
           continue;
         }
-        if (shouldFilterRejectedNeighbors && acceptOrds.get(direct) == false) {
+        if (visited.getAndSet(direct)) {
           continue;
         }
         toScore = ArrayUtil.grow(toScore, scoreCount + 1);
         toScore[scoreCount++] = direct;
       }
 
-      if (candidateFrontierReachedK == false) {
+      if (resultHeapIsFull == false) {
         int secondOrderExamined = 0;
         outer:
         for (int i = 0; i < directCount; i++) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/PathSeerHnswGraphSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/PathSeerHnswGraphSearcher.java
@@ -38,9 +38,7 @@ public final class PathSeerHnswGraphSearcher extends HnswGraphSearcher {
   private final int resultHeapFullAt;
 
   private PathSeerHnswGraphSearcher(
-      NeighborQueue candidates,
-      org.apache.lucene.util.BitSet visited,
-      int resultHeapFullAt) {
+      NeighborQueue candidates, org.apache.lucene.util.BitSet visited, int resultHeapFullAt) {
     super(candidates, visited);
     this.resultHeapFullAt = resultHeapFullAt;
   }


### PR DESCRIPTION
### Description

This PR introduces [PathSeer](https://dl.acm.org/doi/10.1145/3802098), an adaptive filtered HNSW search strategy, for Lucene's filtered HNSW search.

#### Motivation

Existing filtered HNSW strategies can perform very differently across workloads. In particular, the best strategy may change with filter selectivity and query-filter correlation, making it difficult for a fixed strategy to perform consistently well across different filtering regimes.

PathSeer aims to improve this adaptivity and provide a more robust recall-performance trade-off across workloads.

#### Approach

PathSeer combines **distance-first-then-filter** traversal with **filter-first-then-distance** traversal. The key idea is to preserve the connectivity and navigability of the search subgraph while opportunistically avoiding unnecessary vector similarity computations.

Compared with the original PathSeer design described in the paper, this PR adapts the algorithm for better compatibility with Lucene's existing HNSW index. It does not modify the graph structure or on-disk index format; instead, **two-hop neighbors**, similar to those used by ACORN, are used in place of the original expanding-zone neighbors.

Since two-hop neighbors may be relatively far from the query, this version only explores them while the candidate heap is not yet full. In addition, when traversing neighbors that do not satisfy the filter, PathSeer uses only filter-first-then-distance traversal for their subsequent expansion. This helps limit unnecessary distance computations in attribute-correlated workloads.

#### Benchmark

We evaluated PathSeer in two benchmark settings: the standard **luceneutil Cohere v3 Wikipedia workload**, covering different filter selectivities and search-effort configurations, and **BEIR-based workloads**, covering different filter selectivities and query-filter correlation settings. Selected results from the BEIR-based workloads are shown below, and the complete results are provided in the attached benchmark report.

<img width="3276" height="978" alt="tput_recall_BEIR_500000_0 1_NEG" src="https://github.com/user-attachments/assets/f7ba17c7-86fd-4164-ba05-925faa129302" />
<img width="3279" height="978" alt="tput_recall_BEIR_500000_0 1_POS" src="https://github.com/user-attachments/assets/eb11f89b-d7d2-4e1a-9a7e-66a230c0ebb3" />
<img width="3276" height="978" alt="tput_recall_BEIR_500000_0 4_NEG" src="https://github.com/user-attachments/assets/12d5cabc-1d53-4ecd-a505-f6b85b875b4a" />
<img width="3279" height="978" alt="tput_recall_BEIR_500000_0 4_POS" src="https://github.com/user-attachments/assets/9989b95f-876d-4e14-9667-4b27ca631749" />

The results show that PathSeer provides a more robust recall-performance trade-off across the tested filtering regimes. Across the Cohere benchmark, PathSeer improves average throughput over all baselines by 35.19% at the 90% recall target and 39.45% at the 95% recall target. Across the BEIR workloads, the corresponding average improvements are 96.60% and 87.34%.

**Full benchmark report:**  
[pathseer_lucene_benchmark_report.pdf](https://github.com/user-attachments/files/31212091/pathseer_lucene_benchmark_report.pdf)