### PR TITLE
Remove HnswUtil TODO about measuring strong connectivity

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswUtil.java
@@ -202,8 +202,8 @@ public class HnswUtil {
    * In graph theory, "connected components" are really defined only for undirected (ie
    * bidirectional) graphs. Our graphs are directed, because of pruning, but they are *mostly*
    * undirected. In this case we compute components starting from a single node so what we are
-   * really measuring is whether the graph is a "rooted graph". TODO: measure whether the graph is
-   * "strongly connected" ie there is a path from every node to every other node.
+   * really measuring is whether the graph is a "rooted graph", not whether it is "strongly
+   * connected".
    */
   public static boolean graphIsRooted(IndexReader reader, String vectorField) throws IOException {
     for (LeafReaderContext ctx : reader.leaves()) {


### PR DESCRIPTION
Strong connectivity can now be measured by KnnGraphTester in luceneutil, see https://github.com/mikemccand/luceneutil/pull/608

Closes https://github.com/apache/lucene/issues/13687


Milestone: Lucene 10.6.0.
No changes.txt needed.