### PR TITLE
Correct termBytePool reference in FreqProxTermsEnum and clarify pool sharing

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -332,6 +332,8 @@ Other
 
 * GITHUB#16170: Add JMH benchmarks for int4BitDotProduct and int4DibitDotProduct. (Vignesh)
 
+* GITHUB#16534: Correct termBytePool reference in FreqProxTermsEnum and clarify pool sharing. (neoremind)
+
 ======================= Lucene 10.6.0 =======================
 
 API Changes

--- a/lucene/core/src/java/org/apache/lucene/index/FreqProxFields.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FreqProxFields.java
@@ -129,7 +129,7 @@ class FreqProxFields extends Fields {
 
     FreqProxTermsEnum(FreqProxTermsWriterPerField terms) {
       this.terms = terms;
-      this.termsPool = new BytesRefBlockPool(terms.bytePool);
+      this.termsPool = new BytesRefBlockPool(terms.termBytePool);
       this.numTerms = terms.getNumTerms();
       sortedTermIDs = terms.getSortedTermIDs();
       assert sortedTermIDs != null;

--- a/lucene/core/src/java/org/apache/lucene/index/TermsHash.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermsHash.java
@@ -50,7 +50,14 @@ abstract class TermsHash {
     bytePool = new ByteBlockPool(byteBlockAllocator);
 
     if (nextTermsHash != null) {
-      // We are primary
+      // Two concrete writers are chained together: the primary (FreqProxTermsWriter) accumulates
+      // postings data (doc IDs, freq, pos, offsets), and the secondary
+      // (TermVectorsConsumer) accumulates per-document term vectors.
+      //
+      // Pool sharing: the primary reuses a single bytePool to store both term bytes
+      // (stored by BytesRefHash) and postings streams (doc IDs, freq, pos, offsets,
+      // payloads). The secondary also reuses this pool as its termBytePool, so term
+      // bytes are stored exactly once without duplication.
       termBytePool = bytePool;
       nextTermsHash.termBytePool = bytePool;
     }

--- a/lucene/core/src/java/org/apache/lucene/index/TermsHashPerField.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermsHashPerField.java
@@ -38,6 +38,7 @@ abstract class TermsHashPerField implements Comparable<TermsHashPerField> {
   private final TermsHashPerField nextPerField;
   private final IntBlockPool intPool;
   final ByteBlockPool bytePool;
+  final ByteBlockPool termBytePool;
   private final ByteSlicePool slicePool;
   // for each term we store an integer per stream that points into the bytePool above
   // the address is updated once data is written to the stream to point to the next free offset
@@ -73,6 +74,7 @@ abstract class TermsHashPerField implements Comparable<TermsHashPerField> {
       IndexOptions indexOptions) {
     this.intPool = intPool;
     this.bytePool = bytePool;
+    this.termBytePool = termBytePool;
     this.slicePool = new ByteSlicePool(bytePool);
     this.streamCount = streamCount;
     this.fieldName = fieldName;


### PR DESCRIPTION
FreqProxTermsEnum is the bridge between the in-memory hash+pool and the codec writer, it uses `termsPool` to retrieve real term bytes when iterating terms in lexicographical order during segment flush, but the constructor passes `terms.bytePool` where it should be `terms.termBytePool`. There is no problem now because we do pool sharing today, we use the same `ByteBlockPool` to store both term bytes and their corresponding postings data, so the two 1) `terms.bytePool` (major responsibility is to store terms' posting data in memory) and 2) `terms.termBytePool` (used to store terms' bytes) point to the same pool. Semantically speaking, FreqProxTermsEnum's constructor should use the right reference even though they refer to the same pool.

Add a bit clarification of how the in-memory things before segment flush work based on my investigation. The below class diagram shows the relationship between `TermsHash`, `BytesRefHash` and the relevant pools. 

<img width="3000" height="3517" alt="Untitled-2026-08-12-1448" src="https://github.com/user-attachments/assets/40c19ae8-87ea-4b94-ac72-48ef464c3996" />


`TermsHash` maintains three pool references:
- intPool (IntBlockPool): Stores per-term posting streams' write cursors. Each cursor tracks the offset in bytePool where the next postings write should go. For example, when we store one field's term M in doc N, the cursor directs to where term M's doc N's doc ID delta, freq, and pos should get persisted.
- bytePool (ByteBlockPool): Today we do pool sharing, it stores both term bytes and postings streams (doc ID delta, freq, pos, offsets, payloads) together in the same pool.
- termBytePool (ByteBlockPool): This points to the same bytePool above.

`BytesRefHash`:
For each term, it stores a bytesStart offset pointing into termBytePool, and supports fast hash-based find/add operations to dedup terms.
  
`IntBlockPool`:
Each 4-bytes represents a write cursor, the current position in bytePool where the next byte for that term's stream posting data should be written to.
  
`ByteBlockPool`:
We interleave term bytes and their respective postings data in this single pool now. The postings data for each term forms a linked list of growing slices. For frequent terms like "the", "a", "and", the linked list grows long, span multiple slices, they are not contiguous, usually hop. For rare terms, usually just the term length prefix + term bytes + a 5-byte first postings slice.
 