### PR TITLE
LUCENE-13829: don't enforce the sysout limit when tests.iters >1

### DIFF
--- a/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleLimitSysouts.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/tests/util/TestRuleLimitSysouts.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.tests.util;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
+import com.carrotsearch.randomizedtesting.SysGlobals;
 import com.carrotsearch.randomizedtesting.rules.TestRuleAdapter;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -248,6 +249,7 @@ public class TestRuleLimitSysouts extends TestRuleAdapter {
 
     if (LuceneTestCase.VERBOSE
         || LuceneTestCase.INFOSTREAM
+        || isRepeatingTestCases()
         || target.isAnnotationPresent(Monster.class)
         || target.isAnnotationPresent(SuppressSysoutChecks.class)) {
       return false;
@@ -258,6 +260,11 @@ public class TestRuleLimitSysouts extends TestRuleAdapter {
     }
 
     return true;
+  }
+
+  /** Whether the runner repeats test cases, via {@code tests.iters}. */
+  private static boolean isRepeatingTestCases() {
+    return RandomizedTest.systemPropertyAsInt(SysGlobals.SYSPROP_ITERATIONS(), 1) > 1;
   }
 
   /**

--- a/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestSysoutsLimits.java
+++ b/lucene/test-framework/src/test/org/apache/lucene/tests/util/TestSysoutsLimits.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.tests.util;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
+import com.carrotsearch.randomizedtesting.SysGlobals;
 import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -76,6 +77,21 @@ public class TestSysoutsLimits extends WithNestedTests {
             .collect(Collectors.joining("\n"));
 
     Assert.assertTrue(msg, msg.contains("The test or suite printed 10 bytes"));
+  }
+
+  @Test
+  public void testNotEnforcedWhenRepeatingTestCases() {
+    String iters = SysGlobals.SYSPROP_ITERATIONS();
+    try {
+      // Still apply limit for single iter.
+      System.setProperty(iters, "1");
+      Assert.assertEquals(1, new JUnitCore().run(OverSoftLimit.class).getFailureCount());
+
+      System.setProperty(iters, "3");
+      Assert.assertEquals(0, new JUnitCore().run(OverSoftLimit.class).getFailureCount());
+    } finally {
+      System.clearProperty(iters);
+    }
   }
 
   @TestRuleLimitSysouts.Limit(bytes = 10)


### PR DESCRIPTION
Addresses https://github.com/apache/lucene/issues/13829

Context lifted from the issue: `Some tests fail when tests.iters is set to a highish value (like 20) because stdout grows above the allowed threshold. `

No changes.txt needed.
For Lucene 10.6.