### PR TITLE
Store doc values disi data into a separate file

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -349,11 +349,7 @@ Improvements
 
 Optimizations
 ---------------------
-* GITHUB#16298: Store the IndexedDISI (presence) structure for sparse doc-values fields in a
-  dedicated .dvp file instead of interleaving it with packed values in .dvd, improving locality for
-  presence-only access patterns (e.g. FieldExistsQuery and YES_IF_PRESENT range blocks). The
-  per-field .dvp region uses self-describing, length-prefixed entries so future presence data can be
-  added without a format version bump. (Sagar Upadhyaya)
+* GITHUB#16298: Store doc values DISI data into a separate file. (Sagar Upadhyaya)
 
 * GITHUB#16394: Add DocIdSetIterator#intoArray, which DisjunctionDISIApproximation implements by
   loading a window of doc IDs through #intoBitSet rather than one nextDoc() call per match.

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -349,6 +349,12 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#16298: Store the IndexedDISI (presence) structure for sparse doc-values fields in a
+  dedicated .dvp file instead of interleaving it with packed values in .dvd, improving locality for
+  presence-only access patterns (e.g. FieldExistsQuery and YES_IF_PRESENT range blocks). The
+  per-field .dvp region uses self-describing, length-prefixed entries so future presence data can be
+  added without a format version bump. (Sagar Upadhyaya)
+
 * GITHUB#16394: Add DocIdSetIterator#intoArray, which DisjunctionDISIApproximation implements by
   loading a window of doc IDs through #intoBitSet rather than one nextDoc() call per match.
   ConstantScoreScorer#nextDocsAndScores now builds on it, which avoids a priority-queue update per

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -333,6 +333,8 @@ New Features
 Improvements
 ---------------------
 
+* GITHUB#16298: Store doc values DISI data into a separate file. (Sagar Upadhyaya)
+
 * GITHUB#16247: Introduce CachingCollectorManager to parallelize search when using CachingCollector.
                 Remove experimental GroupingSearch constructor that takes a GroupSelector as argument
                 in favour of providing a GroupSelector supplier. (Binlong Gao)
@@ -349,8 +351,6 @@ Improvements
 
 Optimizations
 ---------------------
-* GITHUB#16298: Store doc values DISI data into a separate file. (Sagar Upadhyaya)
-
 * GITHUB#16394: Add DocIdSetIterator#intoArray, which DisjunctionDISIApproximation implements by
   loading a window of doc IDs through #intoBitSet rather than one nextDoc() call per match.
   ConstantScoreScorer#nextDocsAndScores now builds on it, which avoids a priority-queue update per

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
@@ -64,7 +64,7 @@ import org.apache.lucene.util.packed.DirectWriter;
 /** writer for {@link Lucene90DocValuesFormat} */
 final class Lucene90DocValuesConsumer extends DocValuesConsumer {
 
-  IndexOutput data, meta, skipIndex;
+  IndexOutput data, meta, skipIndex, disiData;
   final int maxDoc;
   private byte[] termsDictBuffer;
   private final int skipIndexIntervalSize;
@@ -78,7 +78,9 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
       String metaCodec,
       String metaExtension,
       String skipIndexCodec,
-      String skipIndexExtension)
+      String skipIndexExtension,
+      String disiCodec,
+      String disiExtension)
       throws IOException {
     this.termsDictBuffer = new byte[1 << 14];
     try {
@@ -112,6 +114,16 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
           Lucene90DocValuesFormat.VERSION_CURRENT,
           state.segmentInfo.getId(),
           state.segmentSuffix);
+      String disiName =
+          IndexFileNames.segmentFileName(
+              state.segmentInfo.name, state.segmentSuffix, disiExtension);
+      disiData = state.directory.createOutput(disiName, state.context);
+      CodecUtil.writeIndexHeader(
+          disiData,
+          disiCodec,
+          Lucene90DocValuesFormat.VERSION_CURRENT,
+          state.segmentInfo.getId(),
+          state.segmentSuffix);
       maxDoc = state.segmentInfo.maxDoc();
       this.skipIndexIntervalSize = skipIndexIntervalSize;
     } catch (Throwable t) {
@@ -134,14 +146,48 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
         if (skipIndex != null) {
           CodecUtil.writeFooter(skipIndex); // write checksum
         }
+        if (disiData != null) {
+          CodecUtil.writeFooter(disiData); // write checksum
+        }
       } catch (Throwable t) {
-        IOUtils.closeWhileSuppressingExceptions(t, data, meta, skipIndex);
+        IOUtils.closeWhileSuppressingExceptions(t, data, meta, skipIndex, disiData);
         throw t;
       }
-      IOUtils.close(data, meta, skipIndex);
+      IOUtils.close(data, meta, skipIndex, disiData);
     } finally {
-      meta = data = skipIndex = null;
+      meta = data = skipIndex = disiData = null;
     }
+  }
+
+  /**
+   * Writes a sparse field's {@link IndexedDISI} to the {@code .dvp} file and records its region
+   * offset and length in the metadata.
+   *
+   * <p>Each {@code .dvp} per-field region is a sequence of {@code [1B type tag][vlong length][entry
+   * payload]} entries. This writes one {@link Lucene90DocValuesFormat#DISI_TYPE_INDEXED} entry with
+   * payload {@code [short jumpTableEntryCount][byte denseRankPower][IndexedDISI bytes]}. Future
+   * entry types can be appended with no version bump since readers skip unknown tags by their
+   * length.
+   */
+  private void writeDISI(DocIdSetIterator values) throws IOException {
+    final long disiOffset = disiData.getFilePointer();
+    meta.writeLong(disiOffset); // docsWithFieldOffset (into .dvp)
+    // Buffer the IndexedDISI so we can length-prefix the entry. Its jump-table offsets are relative
+    // to the start of the bytes, so buffering then copying keeps them valid. Freed after this
+    // field.
+    final ByteBuffersDataOutput blob = new ByteBuffersDataOutput();
+    final short jumpTableEntryCount;
+    try (ByteBuffersIndexOutput blobOut = new ByteBuffersIndexOutput(blob, "disi", "disi")) {
+      jumpTableEntryCount =
+          IndexedDISI.writeBitSet(values, blobOut, IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+    }
+    final long entryLength = Short.BYTES + Byte.BYTES + blob.size();
+    disiData.writeByte(Lucene90DocValuesFormat.DISI_TYPE_INDEXED);
+    disiData.writeVLong(entryLength);
+    disiData.writeShort(jumpTableEntryCount);
+    disiData.writeByte(IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+    blob.copyTo(disiData);
+    meta.writeLong(disiData.getFilePointer() - disiOffset); // docsWithFieldLength (region in .dvp)
   }
 
   @Override
@@ -433,22 +479,12 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
     if (numDocsWithValue == 0) { // meta[-2, 0]: No documents with values
       meta.writeLong(-2); // docsWithFieldOffset
       meta.writeLong(0L); // docsWithFieldLength
-      meta.writeShort((short) -1); // jumpTableEntryCount
-      meta.writeByte((byte) -1); // denseRankPower
     } else if (numDocsWithValue == maxDoc) { // meta[-1, 0]: All documents has values
       meta.writeLong(-1); // docsWithFieldOffset
       meta.writeLong(0L); // docsWithFieldLength
-      meta.writeShort((short) -1); // jumpTableEntryCount
-      meta.writeByte((byte) -1); // denseRankPower
-    } else { // meta[data.offset, data.length]: IndexedDISI structure for documents with values
-      long offset = data.getFilePointer();
-      meta.writeLong(offset); // docsWithFieldOffset
+    } else { // meta[disi.offset, disi.length]: IndexedDISI region in .dvp for documents with values
       values = valuesProducer.getSortedNumeric(field);
-      final short jumpTableEntryCount =
-          IndexedDISI.writeBitSet(values, data, IndexedDISI.DEFAULT_DENSE_RANK_POWER);
-      meta.writeLong(data.getFilePointer() - offset); // docsWithFieldLength
-      meta.writeShort(jumpTableEntryCount);
-      meta.writeByte(IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+      writeDISI(values);
     }
 
     meta.writeLong(numValues);
@@ -625,22 +661,12 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
     if (numDocsWithField == 0) {
       meta.writeLong(-2); // docsWithFieldOffset
       meta.writeLong(0L); // docsWithFieldLength
-      meta.writeShort((short) -1); // jumpTableEntryCount
-      meta.writeByte((byte) -1); // denseRankPower
     } else if (numDocsWithField == maxDoc) {
       meta.writeLong(-1); // docsWithFieldOffset
       meta.writeLong(0L); // docsWithFieldLength
-      meta.writeShort((short) -1); // jumpTableEntryCount
-      meta.writeByte((byte) -1); // denseRankPower
     } else {
-      long offset = data.getFilePointer();
-      meta.writeLong(offset); // docsWithFieldOffset
       values = valuesProducer.getBinary(field);
-      final short jumpTableEntryCount =
-          IndexedDISI.writeBitSet(values, data, IndexedDISI.DEFAULT_DENSE_RANK_POWER);
-      meta.writeLong(data.getFilePointer() - offset); // docsWithFieldLength
-      meta.writeShort(jumpTableEntryCount);
-      meta.writeByte(IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+      writeDISI(values);
     }
 
     meta.writeInt(numDocsWithField);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
@@ -160,34 +160,17 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
   }
 
   /**
-   * Writes a sparse field's {@link IndexedDISI} to the {@code .dvp} file and records its region
-   * offset and length in the metadata.
-   *
-   * <p>Each {@code .dvp} per-field region is a sequence of {@code [1B type tag][vlong length][entry
-   * payload]} entries. This writes one {@link Lucene90DocValuesFormat#DISI_TYPE_INDEXED} entry with
-   * payload {@code [short jumpTableEntryCount][byte denseRankPower][IndexedDISI bytes]}. Future
-   * entry types can be appended with no version bump since readers skip unknown tags by their
-   * length.
+   * Writes a sparse field's {@link IndexedDISI} to the {@code .dvp} file and records its offset,
+   * length and shape in the metadata.
    */
   private void writeDISI(DocIdSetIterator values) throws IOException {
-    final long disiOffset = disiData.getFilePointer();
-    meta.writeLong(disiOffset); // docsWithFieldOffset (into .dvp)
-    // Buffer the IndexedDISI so we can length-prefix the entry. Its jump-table offsets are relative
-    // to the start of the bytes, so buffering then copying keeps them valid. Freed after this
-    // field.
-    final ByteBuffersDataOutput blob = new ByteBuffersDataOutput();
-    final short jumpTableEntryCount;
-    try (ByteBuffersIndexOutput blobOut = new ByteBuffersIndexOutput(blob, "disi", "disi")) {
-      jumpTableEntryCount =
-          IndexedDISI.writeBitSet(values, blobOut, IndexedDISI.DEFAULT_DENSE_RANK_POWER);
-    }
-    final long entryLength = Short.BYTES + Byte.BYTES + blob.size();
-    disiData.writeByte(Lucene90DocValuesFormat.DISI_TYPE_INDEXED);
-    disiData.writeVLong(entryLength);
-    disiData.writeShort(jumpTableEntryCount);
-    disiData.writeByte(IndexedDISI.DEFAULT_DENSE_RANK_POWER);
-    blob.copyTo(disiData);
-    meta.writeLong(disiData.getFilePointer() - disiOffset); // docsWithFieldLength (region in .dvp)
+    final long offset = disiData.getFilePointer();
+    meta.writeLong(offset); // docsWithFieldOffset (into .dvp)
+    final short jumpTableEntryCount =
+        IndexedDISI.writeBitSet(values, disiData, IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+    meta.writeLong(disiData.getFilePointer() - offset); // docsWithFieldLength (region in .dvp)
+    meta.writeShort(jumpTableEntryCount);
+    meta.writeByte(IndexedDISI.DEFAULT_DENSE_RANK_POWER);
   }
 
   @Override
@@ -479,9 +462,13 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
     if (numDocsWithValue == 0) { // meta[-2, 0]: No documents with values
       meta.writeLong(-2); // docsWithFieldOffset
       meta.writeLong(0L); // docsWithFieldLength
+      meta.writeShort((short) -1); // jumpTableEntryCount
+      meta.writeByte((byte) -1); // denseRankPower
     } else if (numDocsWithValue == maxDoc) { // meta[-1, 0]: All documents has values
       meta.writeLong(-1); // docsWithFieldOffset
       meta.writeLong(0L); // docsWithFieldLength
+      meta.writeShort((short) -1); // jumpTableEntryCount
+      meta.writeByte((byte) -1); // denseRankPower
     } else { // meta[disi.offset, disi.length]: IndexedDISI region in .dvp for documents with values
       values = valuesProducer.getSortedNumeric(field);
       writeDISI(values);
@@ -661,9 +648,13 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
     if (numDocsWithField == 0) {
       meta.writeLong(-2); // docsWithFieldOffset
       meta.writeLong(0L); // docsWithFieldLength
+      meta.writeShort((short) -1); // jumpTableEntryCount
+      meta.writeByte((byte) -1); // denseRankPower
     } else if (numDocsWithField == maxDoc) {
       meta.writeLong(-1); // docsWithFieldOffset
       meta.writeLong(0L); // docsWithFieldLength
+      meta.writeShort((short) -1); // jumpTableEntryCount
+      meta.writeByte((byte) -1); // denseRankPower
     } else {
       values = valuesProducer.getBinary(field);
       writeDISI(values);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesFormat.java
@@ -133,6 +133,8 @@ import org.apache.lucene.util.packed.DirectWriter;
  *   <li><code>.dvd</code>: DocValues data
  *   <li><code>.dvm</code>: DocValues metadata
  *   <li><code>.dvs</code>: DocValues skip index (since version 1)
+ *   <li><code>.dvp</code>: DocValues presence, i.e. the {@link IndexedDISI} for sparse fields
+ *       (since version 3)
  * </ol>
  *
  * @lucene.experimental
@@ -166,7 +168,9 @@ public final class Lucene90DocValuesFormat extends DocValuesFormat {
         META_CODEC,
         META_EXTENSION,
         SKIP_INDEX_CODEC,
-        SKIP_INDEX_EXTENSION);
+        SKIP_INDEX_EXTENSION,
+        DISI_CODEC,
+        DISI_EXTENSION);
   }
 
   @Override
@@ -178,7 +182,9 @@ public final class Lucene90DocValuesFormat extends DocValuesFormat {
         META_CODEC,
         META_EXTENSION,
         SKIP_INDEX_CODEC,
-        SKIP_INDEX_EXTENSION);
+        SKIP_INDEX_EXTENSION,
+        DISI_CODEC,
+        DISI_EXTENSION);
   }
 
   static final String DATA_CODEC = "Lucene90DocValuesData";
@@ -187,10 +193,17 @@ public final class Lucene90DocValuesFormat extends DocValuesFormat {
   static final String META_EXTENSION = "dvm";
   static final String SKIP_INDEX_CODEC = "Lucene90DocValuesSkipIndex";
   static final String SKIP_INDEX_EXTENSION = "dvs";
+  static final String DISI_CODEC = "Lucene90DocValuesDISI";
+  static final String DISI_EXTENSION = "dvp";
   static final int VERSION_START = 0;
   static final int VERSION_SKIPPER_SEPARATE_FILE = 1;
   static final int VERSION_SKIPPER_MAX_VALUE_COUNT = 2;
-  static final int VERSION_CURRENT = VERSION_SKIPPER_MAX_VALUE_COUNT;
+  // Moves the sparse-field IndexedDISI from .dvd into a dedicated .dvp file. The .dvp per-field
+  // region uses self-describing entries (see DISI_TYPE_*), so new presence data needs a new tag,
+  // not
+  // a version bump. Meant to be the last version bump this format needs for presence changes.
+  static final int VERSION_DISI_EXTENSIBLE_FILE = 3;
+  static final int VERSION_CURRENT = VERSION_DISI_EXTENSIBLE_FILE;
 
   // indicates docvalues type
   static final byte NUMERIC = 0;
@@ -198,6 +211,10 @@ public final class Lucene90DocValuesFormat extends DocValuesFormat {
   static final byte SORTED = 2;
   static final byte SORTED_SET = 3;
   static final byte SORTED_NUMERIC = 4;
+
+  // Entry type tags for the .dvp per-field region. The reader dispatches on the tag and skips
+  // unknown entries using their stored byte length, so new tags need no version bump.
+  static final byte DISI_TYPE_INDEXED = 0x01;
 
   static final int DIRECT_MONOTONIC_BLOCK_SHIFT = 16;
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesFormat.java
@@ -198,12 +198,9 @@ public final class Lucene90DocValuesFormat extends DocValuesFormat {
   static final int VERSION_START = 0;
   static final int VERSION_SKIPPER_SEPARATE_FILE = 1;
   static final int VERSION_SKIPPER_MAX_VALUE_COUNT = 2;
-  // Moves the sparse-field IndexedDISI from .dvd into a dedicated .dvp file. The .dvp per-field
-  // region uses self-describing entries (see DISI_TYPE_*), so new presence data needs a new tag,
-  // not
-  // a version bump. Meant to be the last version bump this format needs for presence changes.
-  static final int VERSION_DISI_EXTENSIBLE_FILE = 3;
-  static final int VERSION_CURRENT = VERSION_DISI_EXTENSIBLE_FILE;
+  // Moves the sparse-field IndexedDISI from .dvd into a dedicated .dvp file.
+  static final int VERSION_DISI_SEPARATE_FILE = 3;
+  static final int VERSION_CURRENT = VERSION_DISI_SEPARATE_FILE;
 
   // indicates docvalues type
   static final byte NUMERIC = 0;
@@ -211,10 +208,6 @@ public final class Lucene90DocValuesFormat extends DocValuesFormat {
   static final byte SORTED = 2;
   static final byte SORTED_SET = 3;
   static final byte SORTED_NUMERIC = 4;
-
-  // Entry type tags for the .dvp per-field region. The reader dispatches on the tag and skips
-  // unknown entries using their stored byte length, so new tags need no version bump.
-  static final byte DISI_TYPE_INDEXED = 0x01;
 
   static final int DIRECT_MONOTONIC_BLOCK_SHIFT = 16;
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -69,6 +69,9 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
   private final IntObjectHashMap<DocValuesSkipperEntry> skippers;
   private final IndexInput data;
   private final IndexInput skipIndexData;
+  // Sparse-field presence (IndexedDISI) file. Null for pre-VERSION_DISI_EXTENSIBLE_FILE segments,
+  // which still keep the IndexedDISI in .dvd.
+  private final IndexInput disiData;
   private final int maxDoc;
   private int version = -1;
   private final boolean merging;
@@ -81,7 +84,9 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
       String metaCodec,
       String metaExtension,
       String skipIndexCodec,
-      String skipIndexExtension)
+      String skipIndexExtension,
+      String disiCodec,
+      String disiExtension)
       throws IOException {
     String metaName =
         IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, metaExtension);
@@ -178,6 +183,35 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     } else {
       this.skipIndexData = null;
     }
+
+    if (version >= Lucene90DocValuesFormat.VERSION_DISI_EXTENSIBLE_FILE) {
+      IndexInput disiIn = null;
+      try {
+        String disiName =
+            IndexFileNames.segmentFileName(
+                state.segmentInfo.name, state.segmentSuffix, disiExtension);
+        disiIn = state.directory.openInput(disiName, state.context.withHints(FileTypeHint.DATA));
+        final int disiVersion =
+            CodecUtil.checkIndexHeader(
+                disiIn,
+                disiCodec,
+                Lucene90DocValuesFormat.VERSION_DISI_EXTENSIBLE_FILE,
+                Lucene90DocValuesFormat.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix);
+        if (version != disiVersion) {
+          throw new CorruptIndexException(
+              "Format versions mismatch: meta=" + version + ", disi=" + disiVersion, disiIn);
+        }
+        CodecUtil.retrieveChecksum(disiIn);
+      } catch (Throwable t) {
+        IOUtils.closeWhileSuppressingExceptions(t, data, skipIndexData, disiIn);
+        throw t;
+      }
+      this.disiData = disiIn;
+    } else {
+      this.disiData = null;
+    }
   }
 
   // Used for cloning
@@ -190,6 +224,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
       IntObjectHashMap<DocValuesSkipperEntry> skippers,
       IndexInput data,
       IndexInput skipIndexData,
+      IndexInput disiData,
       int maxDoc,
       int version,
       boolean merging) {
@@ -201,6 +236,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     this.skippers = skippers;
     this.data = data.clone();
     this.skipIndexData = skipIndexData != null ? skipIndexData.clone() : null;
+    this.disiData = disiData != null ? disiData.clone() : null;
     this.maxDoc = maxDoc;
     this.version = version;
     this.merging = merging;
@@ -217,9 +253,59 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
         skippers,
         data,
         skipIndexData,
+        disiData,
         maxDoc,
         version,
         true);
+  }
+
+  /**
+   * Builds a sparse field's {@link IndexedDISI}.
+   *
+   * <p>Since {@link Lucene90DocValuesFormat#VERSION_DISI_EXTENSIBLE_FILE} the bytes live in {@code
+   * .dvp} as {@code [1B type tag][vlong length][payload]} entries. This scans that region, skips
+   * unknown tags by their length, and decodes the {@link Lucene90DocValuesFormat#DISI_TYPE_INDEXED}
+   * payload {@code [short jumpTableEntryCount][byte denseRankPower][IndexedDISI bytes]}.
+   *
+   * <p>For older segments the bytes are inline in {@code .dvd} and {@code jumpTableEntryCount} /
+   * {@code denseRankPower} were read from the metadata.
+   */
+  private IndexedDISI newIndexedDISI(
+      long docsWithFieldOffset,
+      long docsWithFieldLength,
+      short jumpTableEntryCount,
+      byte denseRankPower,
+      long numValues)
+      throws IOException {
+    if (disiData == null) {
+      return new IndexedDISI(
+          data,
+          docsWithFieldOffset,
+          docsWithFieldLength,
+          jumpTableEntryCount,
+          denseRankPower,
+          numValues);
+    }
+    final long regionEnd = docsWithFieldOffset + docsWithFieldLength;
+    final IndexInput entries = disiData.clone();
+    entries.seek(docsWithFieldOffset);
+    while (entries.getFilePointer() < regionEnd) {
+      final byte type = entries.readByte();
+      final long entryLength = entries.readVLong();
+      final long payloadStart = entries.getFilePointer();
+      if (type == Lucene90DocValuesFormat.DISI_TYPE_INDEXED) {
+        final short jump = entries.readShort();
+        final byte rank = entries.readByte();
+        final long blobOffset = entries.getFilePointer();
+        final long blobLength = payloadStart + entryLength - blobOffset;
+        return new IndexedDISI(disiData, blobOffset, blobLength, jump, rank, numValues);
+      }
+      // Unknown tag: skip by stored length.
+      entries.seek(payloadStart + entryLength);
+    }
+    throw new CorruptIndexException(
+        "Missing " + Lucene90DocValuesFormat.DISI_TYPE_INDEXED + " entry in presence file",
+        disiData);
   }
 
   private void inferMaxValueCounts(FieldInfos fieldInfos) {
@@ -324,8 +410,12 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
   private void readNumeric(IndexInput meta, NumericEntry entry) throws IOException {
     entry.docsWithFieldOffset = meta.readLong();
     entry.docsWithFieldLength = meta.readLong();
-    entry.jumpTableEntryCount = meta.readShort();
-    entry.denseRankPower = meta.readByte();
+    if (version < Lucene90DocValuesFormat.VERSION_DISI_EXTENSIBLE_FILE) {
+      // Pre-.dvp: IndexedDISI shape and bytes live inline in .dvd.
+      entry.jumpTableEntryCount = meta.readShort();
+      entry.denseRankPower = meta.readByte();
+    }
+    // Otherwise these are read lazily from the .dvp entry.
     entry.numValues = meta.readLong();
     int tableSize = meta.readInt();
     if (tableSize > 256) {
@@ -356,8 +446,12 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     entry.dataLength = meta.readLong();
     entry.docsWithFieldOffset = meta.readLong();
     entry.docsWithFieldLength = meta.readLong();
-    entry.jumpTableEntryCount = meta.readShort();
-    entry.denseRankPower = meta.readByte();
+    if (version < Lucene90DocValuesFormat.VERSION_DISI_EXTENSIBLE_FILE) {
+      // Pre-.dvp: IndexedDISI shape and bytes live inline in .dvd.
+      entry.jumpTableEntryCount = meta.readShort();
+      entry.denseRankPower = meta.readByte();
+    }
+    // Otherwise these are read lazily from the .dvp entry.
     entry.numDocsWithField = meta.readInt();
     entry.minLength = meta.readInt();
     entry.maxLength = meta.readInt();
@@ -447,7 +541,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
 
   @Override
   public void close() throws IOException {
-    IOUtils.close(data, skipIndexData);
+    IOUtils.close(data, skipIndexData, disiData);
   }
 
   private record DocValuesSkipperEntry(
@@ -1020,8 +1114,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     } else {
       // sparse
       final IndexedDISI disi =
-          new IndexedDISI(
-              data,
+          newIndexedDISI(
               entry.docsWithFieldOffset,
               entry.docsWithFieldLength,
               entry.jumpTableEntryCount,
@@ -1359,8 +1452,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     } else {
       // sparse
       final IndexedDISI disi =
-          new IndexedDISI(
-              data,
+          newIndexedDISI(
               entry.docsWithFieldOffset,
               entry.docsWithFieldLength,
               entry.jumpTableEntryCount,
@@ -1497,8 +1589,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
         };
       } else if (ordsEntry.docsWithFieldOffset >= 0) { // sparse but non-empty
         final IndexedDISI disi =
-            new IndexedDISI(
-                data,
+            newIndexedDISI(
                 ordsEntry.docsWithFieldOffset,
                 ordsEntry.docsWithFieldLength,
                 ordsEntry.jumpTableEntryCount,
@@ -2086,8 +2177,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     } else {
       // sparse
       final IndexedDISI disi =
-          new IndexedDISI(
-              data,
+          newIndexedDISI(
               entry.docsWithFieldOffset,
               entry.docsWithFieldLength,
               entry.jumpTableEntryCount,
@@ -2323,8 +2413,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
         };
       } else if (ordsEntry.docsWithFieldOffset >= 0) { // sparse but non-empty
         final IndexedDISI disi =
-            new IndexedDISI(
-                data,
+            newIndexedDISI(
                 ordsEntry.docsWithFieldOffset,
                 ordsEntry.docsWithFieldLength,
                 ordsEntry.jumpTableEntryCount,

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -69,7 +69,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
   private final IntObjectHashMap<DocValuesSkipperEntry> skippers;
   private final IndexInput data;
   private final IndexInput skipIndexData;
-  // Sparse-field presence (IndexedDISI) file. Null for pre-VERSION_DISI_EXTENSIBLE_FILE segments,
+  // Sparse-field presence (IndexedDISI) file. Null for pre-VERSION_DISI_SEPARATE_FILE segments,
   // which still keep the IndexedDISI in .dvd.
   private final IndexInput disiData;
   private final int maxDoc;
@@ -184,18 +184,18 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
       this.skipIndexData = null;
     }
 
-    if (version >= Lucene90DocValuesFormat.VERSION_DISI_EXTENSIBLE_FILE) {
+    if (version >= Lucene90DocValuesFormat.VERSION_DISI_SEPARATE_FILE) {
       IndexInput disiIn = null;
       try {
         String disiName =
             IndexFileNames.segmentFileName(
                 state.segmentInfo.name, state.segmentSuffix, disiExtension);
-        disiIn = state.directory.openInput(disiName, state.context.withHints(FileTypeHint.DATA));
+        disiIn = state.directory.openInput(disiName, state.context.withHints(FileTypeHint.INDEX));
         final int disiVersion =
             CodecUtil.checkIndexHeader(
                 disiIn,
                 disiCodec,
-                Lucene90DocValuesFormat.VERSION_DISI_EXTENSIBLE_FILE,
+                Lucene90DocValuesFormat.VERSION_DISI_SEPARATE_FILE,
                 Lucene90DocValuesFormat.VERSION_CURRENT,
                 state.segmentInfo.getId(),
                 state.segmentSuffix);
@@ -262,13 +262,9 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
   /**
    * Builds a sparse field's {@link IndexedDISI}.
    *
-   * <p>Since {@link Lucene90DocValuesFormat#VERSION_DISI_EXTENSIBLE_FILE} the bytes live in {@code
-   * .dvp} as {@code [1B type tag][vlong length][payload]} entries. This scans that region, skips
-   * unknown tags by their length, and decodes the {@link Lucene90DocValuesFormat#DISI_TYPE_INDEXED}
-   * payload {@code [short jumpTableEntryCount][byte denseRankPower][IndexedDISI bytes]}.
-   *
-   * <p>For older segments the bytes are inline in {@code .dvd} and {@code jumpTableEntryCount} /
-   * {@code denseRankPower} were read from the metadata.
+   * <p>Since {@link Lucene90DocValuesFormat#VERSION_DISI_SEPARATE_FILE} the bytes live in the
+   * {@code .dvp} file; for older segments they are inline in {@code .dvd}. The offset, length and
+   * shape are read from the metadata in both cases.
    */
   private IndexedDISI newIndexedDISI(
       long docsWithFieldOffset,
@@ -277,35 +273,14 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
       byte denseRankPower,
       long numValues)
       throws IOException {
-    if (disiData == null) {
-      return new IndexedDISI(
-          data,
-          docsWithFieldOffset,
-          docsWithFieldLength,
-          jumpTableEntryCount,
-          denseRankPower,
-          numValues);
-    }
-    final long regionEnd = docsWithFieldOffset + docsWithFieldLength;
-    final IndexInput entries = disiData.clone();
-    entries.seek(docsWithFieldOffset);
-    while (entries.getFilePointer() < regionEnd) {
-      final byte type = entries.readByte();
-      final long entryLength = entries.readVLong();
-      final long payloadStart = entries.getFilePointer();
-      if (type == Lucene90DocValuesFormat.DISI_TYPE_INDEXED) {
-        final short jump = entries.readShort();
-        final byte rank = entries.readByte();
-        final long blobOffset = entries.getFilePointer();
-        final long blobLength = payloadStart + entryLength - blobOffset;
-        return new IndexedDISI(disiData, blobOffset, blobLength, jump, rank, numValues);
-      }
-      // Unknown tag: skip by stored length.
-      entries.seek(payloadStart + entryLength);
-    }
-    throw new CorruptIndexException(
-        "Missing " + Lucene90DocValuesFormat.DISI_TYPE_INDEXED + " entry in presence file",
-        disiData);
+    final IndexInput in = disiData != null ? disiData : data;
+    return new IndexedDISI(
+        in,
+        docsWithFieldOffset,
+        docsWithFieldLength,
+        jumpTableEntryCount,
+        denseRankPower,
+        numValues);
   }
 
   private void inferMaxValueCounts(FieldInfos fieldInfos) {
@@ -410,12 +385,8 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
   private void readNumeric(IndexInput meta, NumericEntry entry) throws IOException {
     entry.docsWithFieldOffset = meta.readLong();
     entry.docsWithFieldLength = meta.readLong();
-    if (version < Lucene90DocValuesFormat.VERSION_DISI_EXTENSIBLE_FILE) {
-      // Pre-.dvp: IndexedDISI shape and bytes live inline in .dvd.
-      entry.jumpTableEntryCount = meta.readShort();
-      entry.denseRankPower = meta.readByte();
-    }
-    // Otherwise these are read lazily from the .dvp entry.
+    entry.jumpTableEntryCount = meta.readShort();
+    entry.denseRankPower = meta.readByte();
     entry.numValues = meta.readLong();
     int tableSize = meta.readInt();
     if (tableSize > 256) {
@@ -446,12 +417,8 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     entry.dataLength = meta.readLong();
     entry.docsWithFieldOffset = meta.readLong();
     entry.docsWithFieldLength = meta.readLong();
-    if (version < Lucene90DocValuesFormat.VERSION_DISI_EXTENSIBLE_FILE) {
-      // Pre-.dvp: IndexedDISI shape and bytes live inline in .dvd.
-      entry.jumpTableEntryCount = meta.readShort();
-      entry.denseRankPower = meta.readByte();
-    }
-    // Otherwise these are read lazily from the .dvp entry.
+    entry.jumpTableEntryCount = meta.readShort();
+    entry.denseRankPower = meta.readByte();
     entry.numDocsWithField = meta.readInt();
     entry.minLength = meta.readInt();
     entry.maxLength = meta.readInt();
@@ -2545,6 +2512,9 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     CodecUtil.checksumEntireFile(data, merge);
     if (skipIndexData != null) {
       CodecUtil.checksumEntireFile(skipIndexData, merge);
+    }
+    if (disiData != null) {
+      CodecUtil.checksumEntireFile(disiData, merge);
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90DocValuesFormat.java
@@ -435,6 +435,68 @@ public class TestLucene90DocValuesFormat extends BaseCompressingDocValuesFormatT
     dir.close();
   }
 
+  public void testSparseDISIStoredInSeparateFile() throws Exception {
+    // A .dvp always gets a header + footer, so just checking it exists proves nothing. Instead
+    // compare a sparse field against a dense-only baseline: only the sparse one should write an
+    // IndexedDISI, so its .dvp must be bigger.
+    final int numDocs = 512;
+
+    // Dense baseline: no IndexedDISI, so .dvp is just header + footer.
+    final long denseDvpBytes;
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig conf =
+          new IndexWriterConfig(new MockAnalyzer(random()))
+              .setMergeScheduler(new SerialMergeScheduler())
+              .setUseCompoundFile(false); // keep .dvp visible in the listing
+      try (IndexWriter writer = new IndexWriter(dir, conf)) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          doc.add(new NumericDocValuesField("dv", i)); // every doc -> dense
+          writer.addDocument(doc);
+        }
+        writer.forceMerge(1);
+      }
+      denseDvpBytes = totalBytes(dir, Lucene90DocValuesFormat.DISI_EXTENSION);
+      assertTrue("a segment with doc values should always have a .dvp", denseDvpBytes > 0);
+    }
+
+    // Sparse field: only some docs have a value, so we expect an IndexedDISI in .dvp.
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig conf =
+          new IndexWriterConfig(new MockAnalyzer(random()))
+              .setMergeScheduler(new SerialMergeScheduler())
+              .setUseCompoundFile(false);
+      try (IndexWriter writer = new IndexWriter(dir, conf)) {
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          if (i % 2 == 0) { // only even docs -> sparse
+            doc.add(new NumericDocValuesField("dv", i));
+          }
+          writer.addDocument(doc);
+        }
+        writer.forceMerge(1);
+      }
+      final long sparseDvpBytes = totalBytes(dir, Lucene90DocValuesFormat.DISI_EXTENSION);
+      assertTrue(
+          "sparse IndexedDISI should live in .dvp (sparse="
+              + sparseDvpBytes
+              + "B, dense="
+              + denseDvpBytes
+              + "B)",
+          sparseDvpBytes > denseDvpBytes);
+    }
+  }
+
+  private static long totalBytes(Directory dir, String extension) throws IOException {
+    long total = 0;
+    for (String file : dir.listAll()) {
+      if (file.endsWith("." + extension)) {
+        total += dir.fileLength(file);
+      }
+    }
+    return total;
+  }
+
   private void doTestSparseDocValuesVsStoredFields() throws Exception {
     final long[] values = new long[TestUtil.nextInt(random(), 1, 500)];
     for (int i = 0; i < values.length; ++i) {


### PR DESCRIPTION
### Description

This moves out the doc values disi data (used to store sparse data) into a separate file so that we can prefetch and keep it hot in the cache if needed.

Closes - https://github.com/apache/lucene/issues/16298

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
