### PR TITLE
Fix seed-dependent failure in TestTrackingTmpOutputDirectoryWrapper

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/index/TestTrackingTmpOutputDirectoryWrapper.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTrackingTmpOutputDirectoryWrapper.java
@@ -18,12 +18,15 @@
 package org.apache.lucene.index;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.FilterIndexInput;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.tests.mockfile.ExtrasFS;
 import org.apache.lucene.tests.util.LuceneTestCase;
 
 public class TestTrackingTmpOutputDirectoryWrapper extends LuceneTestCase {
@@ -78,8 +81,8 @@ public class TestTrackingTmpOutputDirectoryWrapper extends LuceneTestCase {
           wrapper.getTemporaryFiles().containsKey("dest"));
       assertEquals(
           "temp file must be deleted from backing dir after failed copyFrom",
-          0,
-          backing.listAll().length);
+          List.of(),
+          Arrays.stream(backing.listAll()).filter(f -> ExtrasFS.isExtra(f) == false).toList());
     }
   }
 }


### PR DESCRIPTION
`TestTrackingTmpOutputDirectoryWrapper#testCopyFromCleansUpOnFailure`, added in #16530, fails on some seeds. Reported by @javanna on #16530, seen on  [Lucene-main-Linux #66586](https://jenkins.thetaphi.de/job/Lucene-main-Linux/66586/):

  ```
  gradlew test --tests TestTrackingTmpOutputDirectoryWrapper.testCopyFromCleansUpOnFailure -Dtests.seed=FEF8B573E1CF44D1 -Dtests.locale=en-IN
  -Dtests.timezone=Mexico/BajaNorte -Dtests.asserts=false -Dtests.file.encoding=UTF-8
  ```
  ```
  java.lang.AssertionError: temp file must be deleted from backing dir after failed copyFrom expected:<0> but was:<1>
  ```

  Test bug, not a production one — the leftover file is `extra0`, planted by `ExtrasFS` and passed through by `MockDirectoryWrapper#listAll()`, so `listAll().length ==  0` is the wrong assertion. `copyFrom` deletes the temp file correctly.  Fixed by filtering extras before asserting, as in `TestSegmentInfos`.