### PR TITLE
Fix empty range collection in RangeBulkScorer

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -217,8 +217,6 @@ Optimizations
 
 Bug Fixes
 ---------------------
-* GITHUB#16546: Prevent RangeBulkScorer from passing empty ranges to LeafCollector. (jxy)
-
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
   when all values are identical. (Mike Sokolov)
 
@@ -475,6 +473,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
+
+* GITHUB#16546: Prevent RangeBulkScorer from passing empty ranges to LeafCollector. (jxy)
 
 * GITHUB#16450: Fix DocValuesRangeIterator.docIDRunEnd() returning incorrect run boundaries,
   causing bulk-scoring to skip or mis-score documents in range and ordinal set queries.

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -217,6 +217,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
+* GITHUB#16546: Prevent RangeBulkScorer from passing empty ranges to LeafCollector. (jxy)
+
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
   when all values are identical. (Mike Sokolov)
 

--- a/lucene/core/src/java/org/apache/lucene/document/RangeBulkScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/document/RangeBulkScorer.java
@@ -75,7 +75,9 @@ final class RangeBulkScorer extends BulkScorer {
       final int filteredMax = Math.min(max, maxDocID);
       iterator.advance(filteredMin);
       if (acceptDocs == null) {
-        collector.collectRange(filteredMin, filteredMax);
+        if (filteredMin < filteredMax) {
+          collector.collectRange(filteredMin, filteredMax);
+        }
       } else {
         int rangeStart = -1;
         for (int doc = filteredMin; doc < filteredMax; doc++) {

--- a/lucene/core/src/test/org/apache/lucene/document/TestRangeFilteredBulkScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestRangeFilteredBulkScorer.java
@@ -51,6 +51,14 @@ public class TestRangeFilteredBulkScorer extends LuceneTestCase {
     assertEquals(DocIdSetIterator.NO_MORE_DOCS, next);
   }
 
+  public void testEmptyScoringWindowInsideRange() throws Exception {
+    BulkScorer bs = newBulkScorer(20, 80);
+    var collector = new RangeRecordingCollector();
+    int next = bs.score(collector, null, 40, 40);
+    assertTrue(collector.ranges.isEmpty());
+    assertEquals(40, next);
+  }
+
   public void testCost() {
     assertEquals(30L, newBulkScorer(10, 40).cost());
   }


### PR DESCRIPTION
### Description

Prevent `RangeBulkScorer` from passing an empty range to `LeafCollector.collectRange` when it receives an empty scoring window. `ReqExclBulkScorer` uses such windows to obtain the next-match estimate, while `LeafCollector.collectRange` requires `max` to be greater than `min`.

Add regression coverage for an empty scoring window inside the scorer's query interval.

Closes #16546.

### Tests

- Confirmed the new test fails before the production change.
- `./gradlew :lucene:core:test --tests org.apache.lucene.document.TestRangeFilteredBulkScorer --tests org.apache.lucene.search.TestReqExclBulkScorer`
- `./gradlew tidy`
- `./gradlew :lucene:core:check` (`8677` tests passed, `320` skipped)
