### PR TITLE
Introduce totalHitsThresholdPerGroup parameter to TopGroupsCollector and TopGroupsCollectorManager

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -480,10 +480,11 @@ Optimizations
   LatLonDocValuesQuery, XYDocValuesPointInGeometryQuery, and
   SortedNumericDocValuesSetQuery. (Costin Leau)
 
-* GITHUB#16548: Add `exactTotalHitsPerGroup` parameter to `TopGroupsCollector` and
-  `TopGroupsCollectorManager`. When set to `false`, per-group hit counts may be reported as
-  `TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO` once `maxDocsPerGroup` hits have been collected,
-  saving the cost of exact counting. Defaults to `true` (exact counts). (Binlong Gao)
+* GITHUB#16548: Add `totalHitsThresholdPerGroup` parameter to `TopGroupsCollector` and
+  `TopGroupsCollectorManager`. When set to a value smaller than `Integer.MAX_VALUE`, per-group
+  hit counts may be reported as `TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO` once the threshold
+  is exceeded, saving the cost of exact counting. Defaults to `Integer.MAX_VALUE` (exact counts).
+  (Binlong Gao)
 
 Bug Fixes
 ---------------------

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -471,6 +471,11 @@ Optimizations
   LatLonDocValuesQuery, XYDocValuesPointInGeometryQuery, and
   SortedNumericDocValuesSetQuery. (Costin Leau)
 
+* GITHUB#XXXX: Add `exactTotalHitsPerGroup` parameter to `TopGroupsCollector` and
+  `TopGroupsCollectorManager`. When set to `false`, per-group hit counts may be reported as
+  `TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO` once `maxDocsPerGroup` hits have been collected,
+  saving the cost of exact counting. Defaults to `true` (exact counts). (Binlong Gao)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -471,7 +471,7 @@ Optimizations
   LatLonDocValuesQuery, XYDocValuesPointInGeometryQuery, and
   SortedNumericDocValuesSetQuery. (Costin Leau)
 
-* GITHUB#XXXX: Add `exactTotalHitsPerGroup` parameter to `TopGroupsCollector` and
+* GITHUB#16548: Add `exactTotalHitsPerGroup` parameter to `TopGroupsCollector` and
   `TopGroupsCollectorManager`. When set to `false`, per-group hit counts may be reported as
   `TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO` once `maxDocsPerGroup` hits have been collected,
   saving the cost of exact counting. Defaults to `true` (exact counts). (Binlong Gao)

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/GroupReducer.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/GroupReducer.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorable;
@@ -70,13 +71,26 @@ public abstract class GroupReducer<T, C extends Collector> {
    */
   public final void collect(T value, int doc) throws IOException {
     GroupCollector<C> collector = groups.get(value);
-    collector.leafCollector.collect(doc);
+    if (collector.leafCollector == null) {
+      return;
+    }
+    try {
+      collector.leafCollector.collect(doc);
+    } catch (CollectionTerminatedException _) {
+      // The per-group collector decided it has seen enough docs for this group in this segment
+      // (e.g. index-sort early termination). Mark as done for this segment so subsequent docs
+      // are skipped, but do NOT re-throw — the outer SecondPassGroupingCollector must keep
+      // receiving all docs to maintain a correct totalHitCount.
+      collector.leafCollector = null;
+    }
   }
 
   /** Set the Scorer on all group collectors */
   public final void setScorer(Scorable scorer) throws IOException {
     for (GroupCollector<C> collector : groups.values()) {
-      collector.leafCollector.setScorer(scorer);
+      if (collector.leafCollector != null) {
+        collector.leafCollector.setScorer(scorer);
+      }
     }
   }
 

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroups.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroups.java
@@ -29,7 +29,6 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.TotalHits;
-import org.apache.lucene.search.TotalHits.Relation;
 import org.apache.lucene.util.ArrayUtil;
 
 /**
@@ -194,6 +193,7 @@ public class TopGroups<T> {
       // Arrays.toString(shardGroups[0].groups[groupIDX].groupSortValues));
       float maxScore = Float.NaN;
       int totalHits = 0;
+      TotalHits.Relation totalHitsRelation = TotalHits.Relation.EQUAL_TO;
       double scoreSum = 0.0;
       for (int shardIDX = 0; shardIDX < shardGroups.size(); shardIDX++) {
         // System.out.println("    shard=" + shardIDX);
@@ -231,7 +231,9 @@ public class TopGroups<T> {
         if (!sortByRelevance) {
           maxScore = nonNANmax(maxScore, shardGroupDocs.maxScore());
         }
-        assert shardGroupDocs.totalHits().relation() == Relation.EQUAL_TO;
+        if (shardGroupDocs.totalHits().relation() == TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO) {
+          totalHitsRelation = TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
+        }
         totalHits += shardGroupDocs.totalHits().value();
         scoreSum += shardGroupDocs.score();
       }
@@ -283,7 +285,7 @@ public class TopGroups<T> {
           new GroupDocs<>(
               groupScore,
               maxScore,
-              new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO),
+              new TotalHits(totalHits, totalHitsRelation),
               mergedScoreDocs,
               groupValue,
               firstShardGroup.groups[groupIDX].groupSortValues());

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroupsCollector.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroupsCollector.java
@@ -67,7 +67,14 @@ public class TopGroupsCollector<T> extends SecondPassGroupingCollector<T> {
       Sort withinGroupSort,
       int maxDocsPerGroup,
       boolean getMaxScores) {
-    this(groupSelector, groups, groupSort, withinGroupSort, maxDocsPerGroup, getMaxScores, true);
+    this(
+        groupSelector,
+        groups,
+        groupSort,
+        withinGroupSort,
+        maxDocsPerGroup,
+        getMaxScores,
+        Integer.MAX_VALUE);
   }
 
   /**
@@ -79,10 +86,15 @@ public class TopGroupsCollector<T> extends SecondPassGroupingCollector<T> {
    * @param withinGroupSort the order in which documents are sorted in each group
    * @param maxDocsPerGroup the maximum number of docs to collect for each group
    * @param getMaxScores if true, record the maximum score for each group
-   * @param exactTotalHitsPerGroup if true (default), per-group hit counts are always exact; if
-   *     false, counts may be reported as {@link
-   *     org.apache.lucene.search.TotalHits.Relation#GREATER_THAN_OR_EQUAL_TO} once {@code
-   *     maxDocsPerGroup} hits have been collected, saving the cost of exact counting
+   * @param totalHitsThresholdPerGroup the threshold to control per-group hit count accuracy. If the
+   *     number of hits for a group exceeds this threshold, the hit count may be reported as {@link
+   *     org.apache.lucene.search.TotalHits.Relation#GREATER_THAN_OR_EQUAL_TO} rather than exact.
+   *     Use {@link Integer#MAX_VALUE} (the default) for exact counts, or a smaller value such as
+   *     {@code maxDocsPerGroup} to save the cost of exact counting once enough hits per group have
+   *     been collected. Note: this parameter has no effect when {@code withinGroupSort} sorts
+   *     primarily by score descending, as that case always uses exact counting to avoid incorrectly
+   *     skipping documents at the query level, which would both undercount {@code totalHitCount}
+   *     and cause other groups to miss documents.
    */
   public TopGroupsCollector(
       GroupSelector<T> groupSelector,
@@ -91,12 +103,12 @@ public class TopGroupsCollector<T> extends SecondPassGroupingCollector<T> {
       Sort withinGroupSort,
       int maxDocsPerGroup,
       boolean getMaxScores,
-      boolean exactTotalHitsPerGroup) {
+      int totalHitsThresholdPerGroup) {
     super(
         groupSelector,
         groups,
         new TopDocsReducer<>(
-            withinGroupSort, maxDocsPerGroup, getMaxScores, exactTotalHitsPerGroup));
+            withinGroupSort, maxDocsPerGroup, getMaxScores, totalHitsThresholdPerGroup));
     this.groupSort = Objects.requireNonNull(groupSort);
     this.withinGroupSort = Objects.requireNonNull(withinGroupSort);
     this.maxDocsPerGroup = maxDocsPerGroup;
@@ -155,7 +167,7 @@ public class TopGroupsCollector<T> extends SecondPassGroupingCollector<T> {
         Sort withinGroupSort,
         int maxDocsPerGroup,
         boolean getMaxScores,
-        boolean exactTotalHitsPerGroup) {
+        int totalHitsThresholdPerGroup) {
       this.needsScores = getMaxScores || withinGroupSort.needsScores();
       if (withinGroupSort == Sort.RELEVANCE) {
         supplier =
@@ -166,21 +178,17 @@ public class TopGroupsCollector<T> extends SecondPassGroupingCollector<T> {
                         .newCollector(),
                     null);
       } else {
-        // When exactTotalHitsPerGroup=false, set totalHitsThreshold=maxDocsPerGroup so that
-        // TopFieldCollector stops exact counting once it has collected enough hits per group.
-        // This is only safe when the primary sort is NOT score-descending: score-descending
-        // primary sort sets canSetMinScore=true in TopFieldCollector, which would propagate
-        // setMinCompetitiveScore() to the shared outer scorer and cause docs to be skipped at
-        // the query level before SecondPassGroupingCollector sees them, undercounting
-        // totalHitCount.
-        // For score-primary sorts we always use Integer.MAX_VALUE regardless of the flag.
+        // When the primary sort is score-descending, TopFieldCollector sets canSetMinScore=true
+        // and would call setMinCompetitiveScore() on the shared outer scorer, causing docs to
+        // be skipped at the query level before SecondPassGroupingCollector sees them. This would
+        // both undercount totalHitCount and cause other groups to miss documents, producing
+        // incorrect results. Force Integer.MAX_VALUE in that case regardless of the caller's
+        // threshold.
         SortField primarySort = withinGroupSort.getSort()[0];
         boolean primarySortByScoreDesc =
             primarySort.getType() == SortField.Type.SCORE && !primarySort.getReverse();
         int totalHitsThreshold =
-            (!exactTotalHitsPerGroup && !primarySortByScoreDesc)
-                ? maxDocsPerGroup
-                : Integer.MAX_VALUE;
+            primarySortByScoreDesc ? Integer.MAX_VALUE : totalHitsThresholdPerGroup;
         supplier =
             () -> {
               TopFieldCollector topDocsCollector =

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroupsCollector.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroupsCollector.java
@@ -30,6 +30,7 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SimpleCollector;
 import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.TopFieldCollector;
@@ -66,10 +67,36 @@ public class TopGroupsCollector<T> extends SecondPassGroupingCollector<T> {
       Sort withinGroupSort,
       int maxDocsPerGroup,
       boolean getMaxScores) {
+    this(groupSelector, groups, groupSort, withinGroupSort, maxDocsPerGroup, getMaxScores, true);
+  }
+
+  /**
+   * Create a new TopGroupsCollector
+   *
+   * @param groupSelector the group selector used to define groups
+   * @param groups the groups to collect TopDocs for
+   * @param groupSort the order in which groups are returned
+   * @param withinGroupSort the order in which documents are sorted in each group
+   * @param maxDocsPerGroup the maximum number of docs to collect for each group
+   * @param getMaxScores if true, record the maximum score for each group
+   * @param exactTotalHitsPerGroup if true (default), per-group hit counts are always exact; if
+   *     false, counts may be reported as {@link
+   *     org.apache.lucene.search.TotalHits.Relation#GREATER_THAN_OR_EQUAL_TO} once {@code
+   *     maxDocsPerGroup} hits have been collected, saving the cost of exact counting
+   */
+  public TopGroupsCollector(
+      GroupSelector<T> groupSelector,
+      Collection<SearchGroup<T>> groups,
+      Sort groupSort,
+      Sort withinGroupSort,
+      int maxDocsPerGroup,
+      boolean getMaxScores,
+      boolean exactTotalHitsPerGroup) {
     super(
         groupSelector,
         groups,
-        new TopDocsReducer<>(withinGroupSort, maxDocsPerGroup, getMaxScores));
+        new TopDocsReducer<>(
+            withinGroupSort, maxDocsPerGroup, getMaxScores, exactTotalHitsPerGroup));
     this.groupSort = Objects.requireNonNull(groupSort);
     this.withinGroupSort = Objects.requireNonNull(withinGroupSort);
     this.maxDocsPerGroup = maxDocsPerGroup;
@@ -124,7 +151,11 @@ public class TopGroupsCollector<T> extends SecondPassGroupingCollector<T> {
     private final Supplier<TopDocsAndMaxScoreCollector> supplier;
     private final boolean needsScores;
 
-    TopDocsReducer(Sort withinGroupSort, int maxDocsPerGroup, boolean getMaxScores) {
+    TopDocsReducer(
+        Sort withinGroupSort,
+        int maxDocsPerGroup,
+        boolean getMaxScores,
+        boolean exactTotalHitsPerGroup) {
       this.needsScores = getMaxScores || withinGroupSort.needsScores();
       if (withinGroupSort == Sort.RELEVANCE) {
         supplier =
@@ -135,12 +166,27 @@ public class TopGroupsCollector<T> extends SecondPassGroupingCollector<T> {
                         .newCollector(),
                     null);
       } else {
+        // When exactTotalHitsPerGroup=false, set totalHitsThreshold=maxDocsPerGroup so that
+        // TopFieldCollector stops exact counting once it has collected enough hits per group.
+        // This is only safe when the primary sort is NOT score-descending: score-descending
+        // primary sort sets canSetMinScore=true in TopFieldCollector, which would propagate
+        // setMinCompetitiveScore() to the shared outer scorer and cause docs to be skipped at
+        // the query level before SecondPassGroupingCollector sees them, undercounting
+        // totalHitCount.
+        // For score-primary sorts we always use Integer.MAX_VALUE regardless of the flag.
+        SortField primarySort = withinGroupSort.getSort()[0];
+        boolean primarySortByScoreDesc =
+            primarySort.getType() == SortField.Type.SCORE && !primarySort.getReverse();
+        int totalHitsThreshold =
+            (!exactTotalHitsPerGroup && !primarySortByScoreDesc)
+                ? maxDocsPerGroup
+                : Integer.MAX_VALUE;
         supplier =
             () -> {
               TopFieldCollector topDocsCollector =
                   new TopFieldCollectorManager(
-                          withinGroupSort, maxDocsPerGroup, null, Integer.MAX_VALUE)
-                      .newCollector(); // TODO: disable exact counts?
+                          withinGroupSort, maxDocsPerGroup, null, totalHitsThreshold)
+                      .newCollector();
               MaxScoreCollector maxScoreCollector = getMaxScores ? new MaxScoreCollector() : null;
               return new TopDocsAndMaxScoreCollector(false, topDocsCollector, maxScoreCollector);
             };

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroupsCollectorManager.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroupsCollectorManager.java
@@ -34,7 +34,7 @@ public class TopGroupsCollectorManager<T>
   private final int withinGroupOffset;
   private final int maxDocsPerGroup;
   private final boolean getMaxScores;
-  private final boolean exactTotalHitsPerGroup;
+  private final int totalHitsThresholdPerGroup;
   private final TopGroups.ScoreMergeMode scoreMergeMode;
 
   /**
@@ -64,7 +64,7 @@ public class TopGroupsCollectorManager<T>
         withinGroupOffset,
         maxDocsPerGroup,
         getMaxScores,
-        true,
+        Integer.MAX_VALUE,
         TopGroups.ScoreMergeMode.None);
   }
 
@@ -97,7 +97,7 @@ public class TopGroupsCollectorManager<T>
         withinGroupOffset,
         maxDocsPerGroup,
         getMaxScores,
-        true,
+        Integer.MAX_VALUE,
         scoreMergeMode);
   }
 
@@ -111,9 +111,15 @@ public class TopGroupsCollectorManager<T>
    * @param withinGroupOffset the offset within each group to start collecting documents
    * @param maxDocsPerGroup the maximum number of documents per group
    * @param getMaxScores whether to compute max scores
-   * @param exactTotalHitsPerGroup if true (default), per-group hit counts are always exact; if
-   *     false, counts may be approximate once {@code maxDocsPerGroup} hits have been collected,
-   *     saving exact-counting overhead
+   * @param totalHitsThresholdPerGroup the threshold to control per-group hit count accuracy. If the
+   *     number of hits for a group exceeds this threshold, the hit count may be reported as {@link
+   *     org.apache.lucene.search.TotalHits.Relation#GREATER_THAN_OR_EQUAL_TO} rather than exact.
+   *     Use {@link Integer#MAX_VALUE} (the default) for exact counts, or a smaller value such as
+   *     {@code maxDocsPerGroup} to save the cost of exact counting once enough hits per group have
+   *     been collected. Note: this parameter has no effect when {@code sortWithinGroup} sorts
+   *     primarily by score descending, as that case always uses exact counting to avoid incorrectly
+   *     skipping documents at the query level, which would both undercount {@code totalHitCount}
+   *     and cause other groups to miss documents.
    * @param scoreMergeMode the mode for merging scores across shards
    */
   public TopGroupsCollectorManager(
@@ -124,7 +130,7 @@ public class TopGroupsCollectorManager<T>
       int withinGroupOffset,
       int maxDocsPerGroup,
       boolean getMaxScores,
-      boolean exactTotalHitsPerGroup,
+      int totalHitsThresholdPerGroup,
       TopGroups.ScoreMergeMode scoreMergeMode) {
     this.groupSelectorFactory = groupSelectorFactory;
     this.searchGroups = searchGroups;
@@ -133,7 +139,7 @@ public class TopGroupsCollectorManager<T>
     this.withinGroupOffset = withinGroupOffset;
     this.maxDocsPerGroup = maxDocsPerGroup;
     this.getMaxScores = getMaxScores;
-    this.exactTotalHitsPerGroup = exactTotalHitsPerGroup;
+    this.totalHitsThresholdPerGroup = totalHitsThresholdPerGroup;
     this.scoreMergeMode = scoreMergeMode;
   }
 
@@ -146,7 +152,7 @@ public class TopGroupsCollectorManager<T>
         sortWithinGroup,
         withinGroupOffset + maxDocsPerGroup,
         getMaxScores,
-        exactTotalHitsPerGroup);
+        totalHitsThresholdPerGroup);
   }
 
   @Override

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroupsCollectorManager.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroupsCollectorManager.java
@@ -34,6 +34,7 @@ public class TopGroupsCollectorManager<T>
   private final int withinGroupOffset;
   private final int maxDocsPerGroup;
   private final boolean getMaxScores;
+  private final boolean exactTotalHitsPerGroup;
   private final TopGroups.ScoreMergeMode scoreMergeMode;
 
   /**
@@ -63,6 +64,7 @@ public class TopGroupsCollectorManager<T>
         withinGroupOffset,
         maxDocsPerGroup,
         getMaxScores,
+        true,
         TopGroups.ScoreMergeMode.None);
   }
 
@@ -87,6 +89,43 @@ public class TopGroupsCollectorManager<T>
       int maxDocsPerGroup,
       boolean getMaxScores,
       TopGroups.ScoreMergeMode scoreMergeMode) {
+    this(
+        groupSelectorFactory,
+        searchGroups,
+        groupSort,
+        sortWithinGroup,
+        withinGroupOffset,
+        maxDocsPerGroup,
+        getMaxScores,
+        true,
+        scoreMergeMode);
+  }
+
+  /**
+   * Creates a new TopGroupsCollectorManager.
+   *
+   * @param groupSelectorFactory factory to create group selectors for each collector
+   * @param searchGroups the search groups from the first pass
+   * @param groupSort the sort to use for groups
+   * @param sortWithinGroup the sort to use within each group
+   * @param withinGroupOffset the offset within each group to start collecting documents
+   * @param maxDocsPerGroup the maximum number of documents per group
+   * @param getMaxScores whether to compute max scores
+   * @param exactTotalHitsPerGroup if true (default), per-group hit counts are always exact; if
+   *     false, counts may be approximate once {@code maxDocsPerGroup} hits have been collected,
+   *     saving exact-counting overhead
+   * @param scoreMergeMode the mode for merging scores across shards
+   */
+  public TopGroupsCollectorManager(
+      Supplier<GroupSelector<T>> groupSelectorFactory,
+      Collection<SearchGroup<T>> searchGroups,
+      Sort groupSort,
+      Sort sortWithinGroup,
+      int withinGroupOffset,
+      int maxDocsPerGroup,
+      boolean getMaxScores,
+      boolean exactTotalHitsPerGroup,
+      TopGroups.ScoreMergeMode scoreMergeMode) {
     this.groupSelectorFactory = groupSelectorFactory;
     this.searchGroups = searchGroups;
     this.groupSort = groupSort;
@@ -94,6 +133,7 @@ public class TopGroupsCollectorManager<T>
     this.withinGroupOffset = withinGroupOffset;
     this.maxDocsPerGroup = maxDocsPerGroup;
     this.getMaxScores = getMaxScores;
+    this.exactTotalHitsPerGroup = exactTotalHitsPerGroup;
     this.scoreMergeMode = scoreMergeMode;
   }
 
@@ -105,7 +145,8 @@ public class TopGroupsCollectorManager<T>
         groupSort,
         sortWithinGroup,
         withinGroupOffset + maxDocsPerGroup,
-        getMaxScores);
+        getMaxScores,
+        exactTotalHitsPerGroup);
   }
 
   @Override

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
@@ -350,6 +350,179 @@ public class TestGrouping extends LuceneTestCase {
     assertTrue(result.isEmpty());
   }
 
+  public void testTotalHitsThreshold() throws Exception {
+    Directory dir = newDirectory();
+    RandomIndexWriter w =
+        new RandomIndexWriter(random(), dir, newIndexWriterConfig(new MockAnalyzer(random())));
+
+    String groupField = "author";
+    for (int i = 0; i < 5; i++) {
+      Document doc = new Document();
+      addGroupField(doc, groupField, "author1");
+      doc.add(new TextField("content", "random text", Field.Store.NO));
+      doc.add(new NumericDocValuesField("id", i));
+      w.addDocument(doc);
+    }
+    Document doc = new Document();
+    addGroupField(doc, groupField, "author2");
+    doc.add(new TextField("content", "random text", Field.Store.NO));
+    doc.add(new NumericDocValuesField("id", 99));
+    w.addDocument(doc);
+
+    DirectoryReader reader = w.getReader();
+    w.close();
+    IndexSearcher searcher = newSearcher(reader);
+    searcher.setSimilarity(new BM25Similarity());
+
+    Query query = new TermQuery(new Term("content", "random"));
+    boolean isTermGroupSelector = random().nextBoolean();
+
+    Collection<SearchGroup<BytesRef>> topGroups =
+        toByteRefSearchGroups(
+            searcher.search(
+                query,
+                createFirstPassCollectorManager(
+                    isTermGroupSelector, groupField, Sort.RELEVANCE, 0, 10)));
+    assertFalse(topGroups.isEmpty());
+
+    Sort withinGroupSort = new Sort(new SortField("id", SortField.Type.INT));
+    TopGroups<BytesRef> approxGroups =
+        toByteTopGroups(
+            searcher.search(
+                query,
+                createSecondPassCollectorManager(
+                    isTermGroupSelector,
+                    groupField,
+                    topGroups,
+                    Sort.RELEVANCE,
+                    withinGroupSort,
+                    0,
+                    1,
+                    false,
+                    false)));
+
+    assertEquals(2, approxGroups.groups.length);
+    assertEquals(6, approxGroups.totalHitCount);
+    for (GroupDocs<BytesRef> g : approxGroups.groups) {
+      assertTrue(g.totalHits().value() >= 1);
+    }
+
+    // --- exact: default threshold (Integer.MAX_VALUE) ---
+    TopGroups<BytesRef> exactGroups =
+        toByteTopGroups(
+            searcher.search(
+                query,
+                createSecondPassCollectorManager(
+                    isTermGroupSelector,
+                    groupField,
+                    topGroups,
+                    Sort.RELEVANCE,
+                    withinGroupSort,
+                    0,
+                    10,
+                    false)));
+
+    assertEquals(6, exactGroups.totalHitCount);
+    assertEquals(6, exactGroups.totalGroupedHitCount);
+    for (GroupDocs<BytesRef> g : exactGroups.groups) {
+      assertEquals(TotalHits.Relation.EQUAL_TO, g.totalHits().relation());
+      if (new BytesRef("author1").equals(g.groupValue())) {
+        assertEquals(5, g.totalHits().value());
+      } else {
+        assertEquals(1, g.totalHits().value());
+      }
+    }
+
+    reader.close();
+    dir.close();
+  }
+
+  /**
+   * Verifies that when withinGroupSort matches the index sort (searchSortPartOfIndexSort=true), a
+   * CollectionTerminatedException thrown by a per-group TopFieldCollector is caught inside
+   * GroupReducer and does NOT propagate to SecondPassGroupingCollector, so that totalHitCount
+   * remains accurate.
+   */
+  public void testIndexSortEarlyTerminationDoesNotCorruptTotalHitCount() throws Exception {
+    // Use an index sorted by "id" so that a withinGroupSort on "id" triggers
+    // searchSortPartOfIndexSort=true in TopFieldCollector, enabling CollectionTerminatedException.
+    Sort indexSort = new Sort(new SortField("id", SortField.Type.INT));
+    Directory dir = newDirectory();
+    RandomIndexWriter w =
+        new RandomIndexWriter(
+            random(),
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random())).setIndexSort(indexSort));
+
+    String groupField = "author";
+    // author1: 5 docs with ids 0-4
+    for (int i = 0; i < 5; i++) {
+      Document doc = new Document();
+      addGroupField(doc, groupField, "author1");
+      doc.add(new TextField("content", "hello", Field.Store.NO));
+      doc.add(new NumericDocValuesField("id", i));
+      w.addDocument(doc);
+    }
+    // author2: 3 docs with ids 10-12
+    for (int i = 10; i < 13; i++) {
+      Document doc = new Document();
+      addGroupField(doc, groupField, "author2");
+      doc.add(new TextField("content", "hello", Field.Store.NO));
+      doc.add(new NumericDocValuesField("id", i));
+      w.addDocument(doc);
+    }
+
+    DirectoryReader reader = w.getReader();
+    w.close();
+    IndexSearcher searcher = newSearcher(reader);
+
+    Query query = new TermQuery(new Term("content", "hello"));
+
+    // First pass: collect top groups
+    Collection<SearchGroup<BytesRef>> topGroups =
+        toByteRefSearchGroups(
+            searcher.search(
+                query, createFirstPassCollectorManager(true, groupField, Sort.RELEVANCE, 0, 10)));
+    assertEquals(2, topGroups.size());
+
+    // Second pass: withinGroupSort matches the index sort → searchSortPartOfIndexSort=true.
+    // maxDocsPerGroup=1 means the threshold fires immediately, and for the index-sorted
+    // segment CollectionTerminatedException is thrown once a group's queue is full and
+    // a non-competitive doc arrives. GroupReducer must catch it per-group so that
+    // SecondPassGroupingCollector keeps counting all 8 matching docs in totalHitCount.
+    Sort withinGroupSort = new Sort(new SortField("id", SortField.Type.INT));
+    TopGroups<BytesRef> result =
+        toByteTopGroups(
+            searcher.search(
+                query,
+                createSecondPassCollectorManager(
+                    true,
+                    groupField,
+                    topGroups,
+                    Sort.RELEVANCE,
+                    withinGroupSort,
+                    0,
+                    1,
+                    false,
+                    false)));
+
+    assertEquals(2, result.groups.length);
+
+    // totalHitCount must equal total query matches (8), not stop early due to per-group
+    // CollectionTerminatedException propagating to the outer collector.
+    assertEquals(8, result.totalHitCount);
+    assertEquals(8, result.totalGroupedHitCount);
+
+    // Each group still returns the correct top-1 doc; total hits may be approximate.
+    for (GroupDocs<BytesRef> g : result.groups) {
+      assertEquals(1, g.scoreDocs().length);
+      assertTrue(g.totalHits().value() >= 1);
+    }
+
+    reader.close();
+    dir.close();
+  }
+
   private void addGroupField(Document doc, String groupField, String value) {
     doc.add(new SortedDocValuesField(groupField, new BytesRef(value)));
   }
@@ -384,6 +557,30 @@ public class TestGrouping extends LuceneTestCase {
       int maxDocsPerGroup,
       boolean getMaxScores)
       throws IOException {
+    return createSecondPassCollectorManager(
+        isTermGroupSelector,
+        groupField,
+        searchGroups,
+        groupSort,
+        sortWithinGroup,
+        withinGroupOffset,
+        maxDocsPerGroup,
+        getMaxScores,
+        false);
+  }
+
+  // Basically converts searchGroups from MutableValue to BytesRef if grouping by ValueSource
+  private TopGroupsCollectorManager<?> createSecondPassCollectorManager(
+      boolean isTermGroupSelector,
+      String groupField,
+      Collection<SearchGroup<BytesRef>> searchGroups,
+      Sort groupSort,
+      Sort sortWithinGroup,
+      int withinGroupOffset,
+      int maxDocsPerGroup,
+      boolean getMaxScores,
+      boolean exactTotalHitsPerGroup)
+      throws IOException {
     if (isTermGroupSelector) {
       return new TopGroupsCollectorManager<>(
           () -> new TermGroupSelector(groupField),
@@ -392,7 +589,9 @@ public class TestGrouping extends LuceneTestCase {
           sortWithinGroup,
           withinGroupOffset,
           maxDocsPerGroup,
-          getMaxScores);
+          getMaxScores,
+          exactTotalHitsPerGroup,
+          TopGroups.ScoreMergeMode.None);
     } else {
       ValueSource vs = new BytesRefFieldSource(groupField);
       List<SearchGroup<MutableValue>> mvalSearchGroups = new ArrayList<>(searchGroups.size());
@@ -415,7 +614,9 @@ public class TestGrouping extends LuceneTestCase {
           sortWithinGroup,
           withinGroupOffset,
           maxDocsPerGroup,
-          getMaxScores);
+          getMaxScores,
+          exactTotalHitsPerGroup,
+          TopGroups.ScoreMergeMode.None);
     }
   }
 

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
@@ -386,6 +386,8 @@ public class TestGrouping extends LuceneTestCase {
     assertFalse(topGroups.isEmpty());
 
     Sort withinGroupSort = new Sort(new SortField("id", SortField.Type.INT));
+    // totalHitsThresholdPerGroup=1 (=maxDocsPerGroup): per-group hit counts may be
+    // reported as GREATER_THAN_OR_EQUAL_TO once the threshold fires.
     TopGroups<BytesRef> approxGroups =
         toByteTopGroups(
             searcher.search(
@@ -399,7 +401,7 @@ public class TestGrouping extends LuceneTestCase {
                     0,
                     1,
                     false,
-                    false)));
+                    1)));
 
     assertEquals(2, approxGroups.groups.length);
     assertEquals(6, approxGroups.totalHitCount);
@@ -496,15 +498,7 @@ public class TestGrouping extends LuceneTestCase {
             searcher.search(
                 query,
                 createSecondPassCollectorManager(
-                    true,
-                    groupField,
-                    topGroups,
-                    Sort.RELEVANCE,
-                    withinGroupSort,
-                    0,
-                    1,
-                    false,
-                    false)));
+                    true, groupField, topGroups, Sort.RELEVANCE, withinGroupSort, 0, 1, false, 1)));
 
     assertEquals(2, result.groups.length);
 
@@ -566,7 +560,7 @@ public class TestGrouping extends LuceneTestCase {
         withinGroupOffset,
         maxDocsPerGroup,
         getMaxScores,
-        false);
+        Integer.MAX_VALUE);
   }
 
   // Basically converts searchGroups from MutableValue to BytesRef if grouping by ValueSource
@@ -579,7 +573,7 @@ public class TestGrouping extends LuceneTestCase {
       int withinGroupOffset,
       int maxDocsPerGroup,
       boolean getMaxScores,
-      boolean exactTotalHitsPerGroup)
+      int totalHitsThresholdPerGroup)
       throws IOException {
     if (isTermGroupSelector) {
       return new TopGroupsCollectorManager<>(
@@ -590,7 +584,7 @@ public class TestGrouping extends LuceneTestCase {
           withinGroupOffset,
           maxDocsPerGroup,
           getMaxScores,
-          exactTotalHitsPerGroup,
+          totalHitsThresholdPerGroup,
           TopGroups.ScoreMergeMode.None);
     } else {
       ValueSource vs = new BytesRefFieldSource(groupField);
@@ -615,7 +609,7 @@ public class TestGrouping extends LuceneTestCase {
           withinGroupOffset,
           maxDocsPerGroup,
           getMaxScores,
-          exactTotalHitsPerGroup,
+          totalHitsThresholdPerGroup,
           TopGroups.ScoreMergeMode.None);
     }
   }


### PR DESCRIPTION
### Description
Resolve a [TODO](https://github.com/apache/lucene/blob/d85fc27bb36be862130a602984f5c7e244503457/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroupsCollector.java#L143) in TopGroupsCollector.

Add `totalHitsThresholdPerGroup` parameter to `TopGroupsCollector` and `TopGroupsCollectorManager`. When set to a value less than Integer.MAX_VALUE, per-group hit counts may be reported as `TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO` once `totalHitsThresholdPerGroup` hits have been collected, saving the cost of exact counting. Defaults to `true` (exact counts).

Benchark on wikimedium1m with set `totalHitsThresholdPerGroup` to `maxDocsPerGroup`(10):

                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                    TermGroup100      109.06     (29.0%)      110.12     (31.7%)    1.0% ( -46% -   86%) 0.903
                     TermGroup1M       83.43     (21.7%)       85.24     (21.9%)    2.2% ( -34% -   58%) 0.705
                    TermGroup10K      119.36     (11.6%)      123.38     (12.0%)    3.4% ( -18% -   30%) 0.277