### PR TITLE
Address TestJavascriptCompiler.testRecursionDepth failures by compiling with a separate thread (stack size)

### DIFF
--- a/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestJavascriptCompiler.java
+++ b/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestJavascriptCompiler.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.expressions.js;
 
 import java.text.ParseException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.lucene.expressions.Expression;
@@ -316,8 +317,36 @@ public class TestJavascriptCompiler extends CompilerTestCase {
 
   /** returns the error offset for further checks */
   private int assertRecursionLimit(String src) {
-    ParseException expected = expectThrows(ParseException.class, () -> compile(src));
+    ParseException expected = expectThrows(ParseException.class, () -> compileWithLargeStack(src));
     assertTrue(expected.getMessage(), expected.getMessage().contains("Nesting level too deep"));
     return expected.getErrorOffset();
+  }
+
+  /**
+   * Compiles on a thread with a larger stack and rethrows whatever the compiler threw. The
+   * nesting-depth listener needs {@link JavascriptCompiler.DEFAULT_MAX_NESTING_DEPTH} levels of
+   * recursion before it can fire; on a default-sized stack the StackOverflowError fallback (error
+   * offset -1) can win that race depending on JIT state and instrumentation, making exact-offset
+   * assertions flaky.
+   */
+  private void compileWithLargeStack(String src) throws Throwable {
+    AtomicReference<Throwable> thrown = new AtomicReference<>();
+    Thread t =
+        new Thread(
+            null,
+            () -> {
+              try {
+                compile(src);
+              } catch (Throwable e) {
+                thrown.set(e);
+              }
+            },
+            "js-compiler-large-stack",
+            16 * 1024 * 1024);
+    t.start();
+    t.join();
+    if (thrown.get() != null) {
+      throw thrown.get();
+    }
   }
 }

--- a/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestJavascriptCompiler.java
+++ b/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestJavascriptCompiler.java
@@ -324,7 +324,7 @@ public class TestJavascriptCompiler extends CompilerTestCase {
 
   /**
    * Compiles on a thread with a larger stack and rethrows whatever the compiler threw. The
-   * nesting-depth listener needs {@link JavascriptCompiler.DEFAULT_MAX_NESTING_DEPTH} levels of
+   * nesting-depth listener needs {@link JavascriptCompiler#DEFAULT_MAX_NESTING_DEPTH} levels of
    * recursion before it can fire; on a default-sized stack the StackOverflowError fallback (error
    * offset -1) can win that race depending on JIT state and instrumentation, making exact-offset
    * assertions flaky.


### PR DESCRIPTION
The `testRecursionDepth*` tests added in #16423 assert exact error offsets from the nesting-depth listener and we've seen a number of CI errors that triggered from these methods - typically on coverage and s390x machines. This wasn't reproducing for me, but I let Claude rip through the potential causes and it found one -

```
  Root cause: two error paths race. `JavascriptNestingDepthListener` needs ~`MAX_NESTING_DEPTH`
  (1025) levels of real ANTLR parser recursion before it can throw with the exact offset; the
  `catch (StackOverflowError)` fallback in `JavascriptCompiler.compileExpression()` reports
  offset `-1`. Which one wins depends on how many bytes each `expression()` frame costs — a
  function of JIT tier, not anything the reproduce line captures. Frame sizes shift with
  compilation state: in an experiment compiling `"-".repeat(20000) + "1"` repeatedly on a 600 KB
  stack in one JVM, iteration 0 (interpreted) produced offset 1024 while iterations 1–2 (after
  C1/C2 kicked in) hit the SOE fallback and produced -1. On a default 1 MB stack the worst-case
  consumption to reach depth 1025 measured ~600 KB, so CI environments with fatter frames
  (coverage instrumentation, randomized JVM flags, different JDK builds) can cross the line.

  Deterministic repro of the CI failure before this fix:

      gradlew -p lucene/expressions test --tests "TestJavascriptCompiler.testRecursionDepth2" -Dtests.jvmargs="-Xss300k"
```

Indeed, it does reproduce the problem and is a sounds explanation of what's happening. I also like the suggested fix (to the test):

```
  Fix (test-only; the SOE fallback in production code is intentional and unchanged):
  `assertRecursionLimit` now compiles on a dedicated thread with an explicit 16 MB stack and
  rethrows whatever the compiler threw, so the depth listener deterministically wins and the
  exact-offset assertions (`1024` for depth-limited input, `0` for the depth-first case in
  `testRecursionDepth3`) remain meaningful. All five `testRecursionDepth*` tests funnel through
  the helper.
```

I don't think this can/should be fixed in the source code - it just ensures the test really hits the limit (which is high).