### PR TITLE
Add tests for incremental doc-values updates (#16418)

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/DocValuesFieldUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocValuesFieldUpdates.java
@@ -238,8 +238,8 @@ abstract class DocValuesFieldUpdates implements Accountable {
   protected PagedMutable docs;
   protected int size;
   // true once any doc's value was reset (removed); such a buffer cannot take the sparse incremental
-  // path. Protected so
-  // subclasses that override reset() (e.g. NumericDocValuesFieldUpdates) can set it too.
+  // path. Protected so subclasses that override reset() (e.g. NumericDocValuesFieldUpdates) can set
+  // it too.
   protected boolean anyReset;
 
   protected DocValuesFieldUpdates(int maxDoc, long delGen, String field, DocValuesType type) {

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -439,8 +439,7 @@ final class ReadersAndUpdates {
                     return DocValuesFieldUpdates.Iterator.asBinaryDocValues(iterator);
                   }
                   // sparse fold merges the prior deltas (stays sparse); a dense rewrite (removal or
-                  // fold-to-dense)
-                  // merges the base column
+                  // fold-to-dense) merges the base column
                   final BinaryDocValues onDisk =
                       compact && foldToDense == false
                           ? overlayBinary(deltaProducers, fieldInfo)
@@ -503,8 +502,7 @@ final class ReadersAndUpdates {
                     return DocValuesFieldUpdates.Iterator.asNumericDocValues(iterator);
                   }
                   // sparse fold merges the prior deltas (stays sparse); a dense rewrite (removal or
-                  // fold-to-dense)
-                  // merges the base column
+                  // fold-to-dense) merges the base column
                   final NumericDocValues onDisk =
                       compact && foldToDense == false
                           ? overlayNumeric(deltaProducers, fieldInfo)

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentDocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentDocValuesProducer.java
@@ -200,8 +200,7 @@ class SegmentDocValuesProducer extends DocValuesProducer {
   }
 
   // sorted/sorted-set/sorted-numeric and skippers are never overlaid: only numeric/binary values
-  // can be updated in
-  // place, so these always have a single producer.
+  // can be updated in place, so these always have a single producer.
   private DocValuesProducer single(FieldInfo field) {
     DocValuesProducer[] producers = dvProducersByField.get(field.number);
     assert producers != null && producers.length == 1

--- a/lucene/core/src/test/org/apache/lucene/index/TestIncrementalDocValuesUpdates.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIncrementalDocValuesUpdates.java
@@ -514,7 +514,98 @@ public class TestIncrementalDocValuesUpdates extends LuceneTestCase {
           assertNumeric(reader, "d" + i, 200L + i);
         }
       }
+      TestUtil.checkIndex(dir);
     }
+  }
+
+  /**
+   * Soft deletes are numeric doc-values updates on the soft-deletes field, so they ride the overlay
+   * path too. Marking docs across many commits folds that field's overlay (and folds it to a dense
+   * column once coverage crosses the threshold); liveness and the surviving values must stay
+   * correct throughout.
+   */
+  public void testSoftDeletesOverOverlay() throws Exception {
+    String softField = "__soft_deletes";
+    int numDocs = 20;
+    try (Directory dir = newDirectory();
+        IndexWriter w =
+            new IndexWriter(
+                dir,
+                new IndexWriterConfig(new MockAnalyzer(random()))
+                    .setSoftDeletesField(softField)
+                    .setMaxDocValuesOverlays(2)
+                    .setMergePolicy(NoMergePolicy.INSTANCE))) {
+      for (int i = 0; i < numDocs; i++) {
+        Document d = new Document();
+        d.add(new StringField("id", "d" + i, StringField.Store.NO));
+        d.add(new NumericDocValuesField("val", i));
+        w.addDocument(d);
+      }
+      w.commit();
+      // Soft-delete every even doc, one commit each, so the soft-deletes field accrues deltas that
+      // fold and eventually fold to a dense column (coverage reaches half the segment).
+      for (int i = 0; i < numDocs; i += 2) {
+        w.updateDocValues(new Term("id", "d" + i), new NumericDocValuesField(softField, 1L));
+        w.commit();
+      }
+      try (DirectoryReader reader = DirectoryReader.open(w)) {
+        assertEquals(numDocs / 2, reader.numDocs());
+        for (int i = 1; i < numDocs; i += 2) {
+          assertNumeric(reader, "d" + i, i);
+        }
+      }
+      TestUtil.checkIndex(dir);
+    }
+  }
+
+  /**
+   * addIndexes(Directory...) copies segments as-is via copySegmentAsIs, so the copied segment must
+   * keep its doc-values overlay rather than flatten it the way the CodecReader path does.
+   */
+  public void testAddIndexesDirectoryCarriesOverlay() throws Exception {
+    try (Directory src = newDirectory();
+        Directory dst = newDirectory()) {
+      int numDocs = 10;
+      try (IndexWriter w =
+          new IndexWriter(src, incrementalConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
+        for (int i = 0; i < numDocs; i++) {
+          Document d = new Document();
+          d.add(new StringField("id", "d" + i, StringField.Store.NO));
+          d.add(new NumericDocValuesField("val", i));
+          w.addDocument(d);
+        }
+        w.commit();
+        for (int i = 0; i < numDocs; i++) {
+          w.updateNumericDocValue(new Term("id", "d" + i), "val", 100L + i);
+        }
+        w.commit();
+        assertTrue("source segment should carry an overlay", hasOverlay(src));
+      }
+      try (IndexWriter w =
+          new IndexWriter(
+              dst,
+              new IndexWriterConfig(new MockAnalyzer(random()))
+                  .setMergePolicy(NoMergePolicy.INSTANCE))) {
+        w.addIndexes(src);
+        w.commit();
+        assertTrue("copied segment should still carry the overlay", hasOverlay(dst));
+        try (DirectoryReader reader = DirectoryReader.open(w)) {
+          for (int i = 0; i < numDocs; i++) {
+            assertNumeric(reader, "d" + i, 100L + i);
+          }
+        }
+      }
+      TestUtil.checkIndex(dst);
+    }
+  }
+
+  private static boolean hasOverlay(Directory dir) throws IOException {
+    for (SegmentCommitInfo si : SegmentInfos.readLatestCommit(dir)) {
+      if (si.getDocValuesOverlays().isEmpty() == false) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static void assertOldReaderRejects(Directory dir) throws IOException {


### PR DESCRIPTION
Follow-up to #16418, adding a bit more test coverage for incremental doc-values updates.

Three tests for paths the original PR left uncovered:

- **Soft deletes over the overlay** — a soft delete is a set-only numeric update on the soft-deletes field, so it rides the fold lifecycle (including fold-to-dense); verifies liveness and surviving values stay correct.
- **`addIndexes(Directory)` carry-over** — exercises the `copySegmentAsIs` path that preserves the overlay, rather than the `CodecReader` path that flattens it.
- **Explicit `checkIndex`** on a deeply overlaid + folded index (the existing tests relied only on the implicit close-time check).

Second commit reflows three wrapped comments so phrases no longer break mid-line. Comment-only.
