### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/run-checks-gradle-upgrade.yml
+++ b/.github/workflows/run-checks-gradle-upgrade.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: 'temurin'
           java-version: 11

--- a/.github/workflows/run-nightly-smoketester.yml
+++ b/.github/workflows/run-nightly-smoketester.yml
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup java
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: 'temurin'
           java-package: jdk


### PR DESCRIPTION
### Description

Upgrade all active `actions/setup-java` workflow references from v5.6.0 to v6.0.0. This preserves Lucene's SHA-pinned action style and updates the accompanying version comments.

Validation: reviewed all active `.github/workflows/*.yml` and `.yaml` files and confirmed no older `actions/setup-java` references remain.