### PR TITLE
fix: prevent HNSW node degree decay across merge generations by adding absolute M-based threshold

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
@@ -257,7 +257,8 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
         }
 
         // Mark as disconnected if node lost more than the acceptable threshold of neighbors
-        if (newNeighbors.size() < oldNeighbourCount * DISCONNECTED_NODE_FACTOR) {
+        if (newNeighbors.size() < oldNeighbourCount * DISCONNECTED_NODE_FACTOR
+            || newNeighbors.size() < M * DISCONNECTED_NODE_FACTOR) {
           disconnectedNodes.add(newOrd);
         }
       }


### PR DESCRIPTION
## Fix

This PR fixes a progressive recall degradation issue in `IncrementalHnswGraphMerger` when merging HNSW graphs across multiple merge generations.

## Root Cause

In `InitializedHnswGraphBuilder.copyGraphStructure()`, a surviving node's neighbor list is copied verbatim minus its deleted neighbors. The node is flagged for repair only if it lost more than 15% of its neighbors in that single merge (`DISCONNECTED_NODE_FACTOR = 0.85`).

The threshold is relative to the node's **current** (potentially already thinned) degree at the start of each merge, not its target or original degree. Therefore, nodes that lose only a small fraction of their neighbors (<15%) stay above the threshold every time, and are never flagged and repaired, so their degree decays silently across merge generations with no re-diversification.

## Fix

This fix adds an absolute `M-based` threshold as a second condition: if a node's remaining neighbor count is below `M * DISCONNECTED_NODE_FACTOR`, it is also flagged for repair regardless of the proportional loss. This prevents the silent progressive decay of connectivity across multiple merge generations.

## Changes

- `lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java`: Added absolute M-based threshold in `copyGraphStructure()` alongside the existing proportional threshold.

## Related

Fixes #16552