### PR TITLE
Correct the code not to rely on wall clock 1 second in waiter.join.

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestControlledRealTimeReopenThread.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestControlledRealTimeReopenThread.java
@@ -403,11 +403,8 @@ public class TestControlledRealTimeReopenThread extends ThreadedIndexingAndSearc
         };
     waiter.start();
     manager.maybeRefresh();
-    waiter.join(1000);
-    if (!finished.get()) {
-      waiter.interrupt();
-      fail("thread deadlocked on waitForGeneration");
-    }
+    waiter.join();
+    assertTrue("waiter thread terminated abnormally", finished.get());
     thread.close();
     thread.join();
     writer.close();


### PR DESCRIPTION
CI run error https://ci-builds.apache.org/job/Lucene/job/Lucene-Check-main%20(s390x%20big%20endian)/1328/consoleFull

This is 99.9% caused by slow VM and thread.join(1 second) just falling through, with subsequent assertions and checks being noise. 

I replaced it with an indefinite join(). If the code hangs, the framework will terminate it on a suite timeout.