### PR TITLE
Reconnect HNSW nodes whose out-degree decays across successive merge-reuse generations

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -217,6 +217,10 @@ Optimizations
 
 Bug Fixes
 ---------------------
+* GITHUB#16552: Reconnect HNSW nodes whose out-degree decays across successive
+  merge-reuse generations, preventing progressive recall loss under low delete
+  rates. (Ethan Baker)
+
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
   when all values are identical. (Mike Sokolov)
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
@@ -46,10 +46,11 @@ import org.apache.lucene.util.BitSet;
  *   <li>Allows incremental addition of new nodes while preserving initialized nodes
  * </ul>
  *
- * <p><b>Disconnected Node Detection:</b> A node is considered disconnected if it retains less than
- * {@link #DISCONNECTED_NODE_FACTOR} of its original neighbor count from the source graph. This
- * typically occurs when many of the node's neighbors were deleted documents that couldn't be
- * remapped.
+ * <p><b>Disconnected Node Detection:</b> A node that lost neighbors this merge is flagged for
+ * repair if it either kept less than {@link #DISCONNECTED_NODE_FACTOR} of its neighbors from the
+ * source graph, or fell below {@link #CUMULATIVE_DEGREE_FLOOR_FACTOR} of the level's connection
+ * budget. The first catches a large loss in a single merge; the second catches slow decay across
+ * many merges.
  *
  * @lucene.experimental
  */
@@ -77,6 +78,15 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
    * search performance.
    */
   private final double DISCONNECTED_NODE_FACTOR = 0.85;
+
+  /**
+   * The cumulative disconnection threshold. A node is disconnected when its out-degree falls below
+   * this fraction of the level's connection budget ({@code M} on upper levels, {@code 2*M} at level
+   * 0). Because the budget is fixed, the check holds a node to the same target on every merge, so
+   * it catches out-degree that drifts down gradually across many merges rather than in a single
+   * one.
+   */
+  private final double CUMULATIVE_DEGREE_FLOOR_FACTOR = 0.5;
 
   // Tracks if the graph has deletes
   private boolean hasDeletes = false;
@@ -201,13 +211,16 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
    * Copies the graph structure from the initializer graph, applying ordinal remapping and
    * identifying nodes that have lost neighbors.
    *
-   * <p>A node is considered disconnected if it retains less than {@link #DISCONNECTED_NODE_FACTOR}
-   * of its original neighbors. This happens when many neighbors were deleted documents that
-   * couldn't be remapped (indicated by -1 in newOrdMap).
+   * <p>Deleted neighbors show up as -1 in newOrdMap and are dropped. A node that loses any this way
+   * is flagged for repair when it crosses one of the two thresholds ({@link
+   * #DISCONNECTED_NODE_FACTOR} and {@link #CUMULATIVE_DEGREE_FLOOR_FACTOR}); flagged nodes are
+   * repaired afterwards.
    *
-   * <p><b>Example:</b> With DISCONNECTED_NODE_FACTOR = 0.9, if a node had 20 neighbors in the
-   * source graph but only 17 remain after remapping (17/20 = 0.85 < 0.9), it's marked as
-   * disconnected and will be repaired.
+   * <p><b>Example:</b> at level 0 with {@code M=16} (budget {@code 2*M = 32}), a node that kept 16
+   * of 20 neighbors is flagged by the per-merge check ({@code 16/20 = 0.8 <
+   * DISCONNECTED_NODE_FACTOR = 0.85}); a node that has drifted to 15 neighbors is flagged by the
+   * cumulative check ({@code 15 < 32 * CUMULATIVE_DEGREE_FLOOR_FACTOR = 16}) even if it lost only
+   * one this merge.
    *
    * @param initializerGraph the source graph to copy from
    * @param newOrdMap maps old ordinals to new ordinals; -1 indicates deleted documents
@@ -256,8 +269,11 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
           }
         }
 
-        // Mark as disconnected if node lost more than the acceptable threshold of neighbors
-        if (newNeighbors.size() < oldNeighbourCount * DISCONNECTED_NODE_FACTOR) {
+        // Flag a node that lost neighbors and crossed either disconnection threshold.
+        int maxConnOnLevel = newNeighbors.maxSize() - 1; // M on upper levels, 2*M on level 0
+        if (newNeighbors.size() < oldNeighbourCount * DISCONNECTED_NODE_FACTOR
+            || (newNeighbors.size() < oldNeighbourCount
+                && newNeighbors.size() < maxConnOnLevel * CUMULATIVE_DEGREE_FLOOR_FACTOR)) {
           disconnectedNodes.add(newOrd);
         }
       }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
@@ -19,6 +19,7 @@ package org.apache.lucene.util.hnsw;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import java.io.IOException;
+import java.util.Random;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.FloatVectorValues;
@@ -66,6 +67,54 @@ public class TestHnswFloatVectorGraph extends HnswGraphTestCase<float[]> {
   @Override
   MockVectorValues vectorValues(float[][] values) {
     return MockVectorValues.fromValues(values);
+  }
+
+  public void testReconnectsNodeDecayedBelowFloorDuringMerge() throws IOException {
+    // Pin vectors, both graph seeds, and similarity so the merged graph is identical every run.
+    long savedRandSeed = HnswGraphBuilder.randSeed;
+    try {
+      HnswGraphBuilder.randSeed = 42;
+      similarityFunction = VectorSimilarityFunction.EUCLIDEAN;
+      int M = 16;
+      int beamWidth = 100;
+      int size = 128;
+      int dim = 16;
+      MockVectorValues vectors =
+          MockVectorValues.fromValues(createRandomFloatVectors(size, dim, new Random(42)));
+      RandomVectorScorerSupplier supplier = buildScorerSupplier(vectors);
+      OnHeapHnswGraph graph = HnswGraphBuilder.create(supplier, M, beamWidth, 42).build(size);
+
+      int entry = graph.entryNode();
+      int target = entry == 0 ? 1 : 0;
+
+      // Degree 10, below the floor (0.5 * 2M = 16). Deleting one neighbor leaves 9: too small a
+      // loss for the per-merge check, but below the floor, so only the cumulative check flags it.
+      int degreeBefore = 10;
+      NeighborArray targetNeighbors = graph.getNeighbors(0, target);
+      targetNeighbors.clear();
+      for (int node = 0, added = 0; added < degreeBefore; node++) {
+        if (node != target && node != entry) {
+          targetNeighbors.addOutOfOrder(node, Float.NaN);
+          added++;
+        }
+      }
+      int deleted = targetNeighbors.nodes()[0];
+      int[] newOrdMap = new int[size];
+      for (int i = 0; i < size; i++) {
+        newOrdMap[i] = i;
+      }
+      newOrdMap[deleted] = -1;
+
+      OnHeapHnswGraph merged =
+          InitializedHnswGraphBuilder.initGraph(graph, newOrdMap, size, beamWidth, supplier);
+
+      // Old per-merge-only check leaves the target at 9; the cumulative check reconnects it.
+      assertTrue(
+          "target below the cumulative floor should be reconnected during merge",
+          merged.getNeighbors(0, target).size() >= degreeBefore);
+    } finally {
+      HnswGraphBuilder.randSeed = savedRandSeed;
+    }
   }
 
   @Override


### PR DESCRIPTION
### Description

When `IncrementalHnswGraphMerger` reuses an existing segment's HNSW graph as the base for a merged segment (#15003), a surviving node's neighbor list is copied minus its deleted neighbors. The node is then repaired only if it lost more than 15% of its neighbors *in that single merge* (`DISCONNECTED_NODE_FACTOR = 0.85`). That threshold resets every merge, so a node that sheds only a small fraction each time never trips it. Its out-degree decays across successive merges and approximate-search recall drops with it. The effect is worst under continuous low-rate deletes, where an index accumulates a few percent of deletions between merges.

This adds a second, cumulative check in `InitializedHnswGraphBuilder.copyGraphStructure`: a node that lost at least one neighbor this merge and whose out-degree has fallen below `CUMULATIVE_DEGREE_FLOOR_FACTOR` (0.5) of the level's connection budget (`2*M` at level 0, `M` above) is flagged for repair. Anchoring on the fixed per-level budget lets the check see decay that accumulates across merges, which the existing prior-degree-relative check cannot. Gating on an actual neighbor loss means a node that is simply sparse and lost nothing is never touched, so healthy graphs are unaffected and unnecessary work is not done. The repair path itself is unchanged.

### Benchmarks

**Setup:** luceneutil, GloVe-100, `M=32`, `beamWidth=250`, 2% deletes per generation, 100 generations, deterministic base. 

"current" is `main`; "rebuild" is the same build with reuse disabled (`DELETE_PCT_THRESHOLD=-1`), i.e. a full rebuild every merge, which is the ground truth the reused graph is measured against. 

Recall is reported as Δ vs rebuild on the identical per-generation live set; out-degree is the level-0 mean.

**Delete-only** (each generation deletes 2% of the live docs, 100k starting docs, ~13k ending docs):

| `CUMULATIVE_DEGREE_FLOOR_FACTOR` | Δ recall@100 (gen 50 / gen 100) | L0 out-degree (gen 100) | force-merge time / gen |
|---|---|---|---|
| current (`main`) | −7.0 / −5.6 pp | 15.5 | 2.0 s |
| 0.35 | −1.6 / −0.3 | 26.2 | 8.1 s |
| 0.40 | −1.1 / +0.2 | 28.0 | 9.3 s |
| 0.45 | −0.8 / +0.5 | 29.5 | 11.2 s |
| **0.50** | **−0.4 / +0.7** | **30.7** | **12.4 s** |
| 0.55 | +0.1 / +0.9 | 32.0 | 14.7 s |
| 0.60 | +0.4 / +0.9 | 32.8 | 16.0 s |
| 0.85 | +0.7 / +1.3 | 34.7 | 21.2 s |
| rebuild (control) | 0 | 34.7 | 41.8 s |

**Churn** (each generation deletes 2% and re-adds the same count randomly, holding the corpus at 100k, so each gen is full-scale):

| `CUMULATIVE_DEGREE_FLOOR_FACTOR` | Δ recall@100 (gen 50 / gen 100) | L0 out-degree (gen 100) |
|---|---|---|
| current (`main`) | −2.7 / −2.9 pp | 14.3 |
| 0.40 | −0.1 / −0.2 | 21.8 |
| **0.50** | **+0.3 / +0.2** | **23.2** |
| rebuild (control) | 0 | 26.5 |

Reuse-on out-degree decays geometrically (28 → 15 delete-only), and recall diverges from the full-rebuild graph as merges accumulate. Recall recovers as the floor rises and saturates around 0.5; higher floors add merge cost for no further recall. At 0.5 the merged graph matches full-rebuild recall on both workloads while merging at roughly a third of a full rebuild's cost. The small positive Δ values are within run-to-run noise, since the rebuild graph is itself approximate.

### Visual

<img width="2009" height="1430" alt="16552-benchmarks" src="https://github.com/user-attachments/assets/c9d53086-258e-46f9-9c8d-751e40b86dd3" />

### Tuning

`CUMULATIVE_DEGREE_FLOOR_FACTOR = 0.5` was chosen in part due to benchmarking results, but also due to intuition about the distribution of the nodes by neighbor connections. 

The results show that `0.5` is the point which best balances the tradeoff between recall and merge cost, the below table shows the 'Kneedle score', which finds the perpendicular distance of each point above the endpoint chord of the (merge cost, recall) curve on min-max-normalized axes. The point with the highest score is the knee, which balances the tradeoff with the least diminishing returns. 

| FLOOR | 0.35 | 0.4 | 0.45 | **0.5** | 0.55 | 0.6 | 0.65 | 0.85 |
|---|---|---|---|---|---|---|---|---|
| Δ recall vs rebuild (pp) | −1.38 | −0.64 | −0.57 | **−0.04** | +0.15 | +0.19 | +0.60 | +0.70 |
| merge cost (s, full corpus) | 8.1 | 9.3 | 11.2 | **12.4** | 14.7 | 16.0 | 18.1 | 21.2 |
| Kneedle score | 0.000 | 0.188 | 0.109 | **0.225** | 0.166 | 0.109 | 0.136 | 0.000 |

These results make sense intuitively when we consider the insertion heuristic, which targets up to M connections per node on the upper levels and 2M at level 0: measured against that level-0 budget of 2M, a factor of 0.5 places the repair trigger at exactly M, the graph's per-node connection target. 

A node whose degree has decayed below M across successive merges has fallen beneath the connectivity the builder aims for, so repairing there restores it to a natural degree. Going lower waits until nodes are badly starved before acting (recall keeps sliding), while going higher spends merge cost re-connecting nodes that are still within the range the build naturally produces.

### Testing

`./gradlew check` passes. Adds `TestHnswFloatVectorGraph#testReconnectsNodeDecayedBelowFloorDuringMerge`, a deterministic (fixed-seed) test that drives a single reuse-merge on a node engineered to sit just below the cumulative floor. It fails on the pre-fix builder (the node stays thinned) and passes with the fix (the node is reconnected).

Closes #16552