### PR TITLE
Reject binary doc-values update on an index sort field

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -223,6 +223,9 @@ Bug Fixes
   merge-reuse generations, preventing progressive recall loss under low delete
   rates. (Ethan Baker)
 
+* GITHUB#16565: IndexWriter#updateBinaryDocValue now rejects updating a field that is part of the
+  index sort, matching IndexWriter#updateNumericDocValue. (Jim Ferenczi)
+
 * GITHUB#14049: Randomize KNN codec params in RandomCodec. Fixes scalar quantization div-by-zero
   when all values are identical. (Mike Sokolov)
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1998,6 +1998,15 @@ public class IndexWriter
     if (value == null) {
       throw new IllegalArgumentException("cannot update a field to a null value: " + field);
     }
+    // Checked before the doc-values-type check below: an index sort field is never binary, so this
+    // would otherwise surface as a less clear doc-values-type mismatch.
+    if (config.getIndexSortFields().contains(field)) {
+      throw new IllegalArgumentException(
+          "cannot update docvalues field involved in the index sort, field="
+              + field
+              + ", sort="
+              + config.getIndexSort());
+    }
     globalFieldNumberMap.verifyOrCreateDvOnlyField(field, DocValuesType.BINARY, true);
     try {
       return maybeProcessEvents(

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexSorting.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexSorting.java
@@ -2010,6 +2010,13 @@ public class TestIndexSorting extends LuceneTestCase {
     assertEquals(
         exc.getMessage(),
         "cannot update docvalues field involved in the index sort, field=foo, sort=<long: \"foo\">");
+    exc =
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> w.updateBinaryDocValue(new Term("id", "0"), "foo", newBytesRef("bar")));
+    assertEquals(
+        exc.getMessage(),
+        "cannot update docvalues field involved in the index sort, field=foo, sort=<long: \"foo\">");
     w.close();
     dir.close();
   }


### PR DESCRIPTION
`IndexWriter.updateBinaryDocValue` is missing the index-sort guard that `updateNumericDocValue` and the varargs `updateDocValues(Term, Field...)` already have: it does not reject updating a field that is part of the index sort. Updating a sort field's doc values would make the persisted sort order inconsistent with the values, so it should be rejected up front like the numeric path.

The check goes **before** `verifyOrCreateDvOnlyField` here (unlike the numeric method, which checks after). An index sort field is never backed by binary doc values, so if the check came after the type validation it would never be reached — the user would instead get a less clear doc-values-type mismatch error. Placing it first surfaces the same clear "cannot update docvalues field involved in the index sort" message the numeric path gives.

Extended `TestIndexSorting.testBadDVUpdate` to cover `updateBinaryDocValue` alongside the existing `updateNumericDocValue` and varargs assertions.
