### PR TITLE
Don't rely on .cost() to provide the number of docs with a value (SimpleText uses a heuristic)

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -35,6 +35,7 @@ import org.apache.lucene.codecs.DocValuesConsumer;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldInfosFormat;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FlushInfo;
 import org.apache.lucene.store.IOContext;
@@ -389,10 +390,13 @@ final class ReadersAndUpdates {
                     Long.toString(gen, Character.MAX_RADIX));
             DocValuesProducer p = dvFormat.fieldsProducer(srs);
             deltaProducers.add(p);
+            // Count docs-with-value by iteration: cost() is only an estimate (SimpleText reports
+            // maxDoc for sparse columns) and deltas are small by construction.
             deltaCoverage +=
-                type == DocValuesType.BINARY
-                    ? p.getBinary(fieldInfo).cost()
-                    : p.getNumeric(fieldInfo).cost();
+                docsWithValueCount(
+                    type == DocValuesType.BINARY
+                        ? p.getBinary(fieldInfo)
+                        : p.getNumeric(fieldInfo));
           }
         } catch (Throwable t) {
           // The try-with-resources below owns the normal close; close here if opening a delta fails
@@ -578,6 +582,15 @@ final class ReadersAndUpdates {
       assert !fieldFiles.containsKey(fieldInfo.number);
       fieldFiles.put(fieldInfo.number, trackingDir.getCreatedFiles());
     }
+  }
+
+  /** Exact number of docs with a value; the iterator is consumed. */
+  private static long docsWithValueCount(DocIdSetIterator it) throws IOException {
+    long count = 0;
+    while (it.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+      count++;
+    }
+    return count;
   }
 
   /**


### PR DESCRIPTION
This failure: https://jenkins.thetaphi.de/job/Lucene-MMAPv2-Linux/5940/console reproduces:
```
gradlew :lucene:core:test --tests "org.apache.lucene.index.TestIncrementalDocValuesUpdates.testSparseFoldOverDenseBase" -Ptests.asserts=false -Ptests.directory=MMapDirectory -Ptests.file.encoding=ISO-8859-1 -Ptests.gui=true -Ptests.haltonfailure=false -Ptests.jvmargs= -Ptests.jvms=6 -Ptests.multiplier=3 -Ptests.seed=1524CDD7264C1732 -Ptests.vectorsize=default
```

Here is the analysis from an LLM. I've added an explicit doc count instead of relyong on .cost in that test.

---

  testSparseFoldOverDenseBase runs with maxDocValuesOverlays=1 on a 10-doc segment. After the second full-corpus update round folds the column to a dense generation, it
  updates only d0 twice more and asserts the final fold stays a sparse overlay over the dense base. Instead the overlay comes back empty.

  The decision it's testing lives in ReadersAndUpdates.handleDVUpdates. When a fold is due (compact == true), the code estimates how much of the segment the prior delta
  generations cover by summing the iterator cost of each delta (ReadersAndUpdates.java:392-395):

  deltaCoverage += type == BINARY ? p.getBinary(fieldInfo).cost() : p.getNumeric(fieldInfo).cost();

  and folds to a dense column — clearing the overlay — when deltaCoverage >= maxDoc * FOLD_TO_DENSE_COVERAGE_RATIO (0.5), at ReadersAndUpdates.java:406-407.

  The problem: SimpleText's numeric doc-values iterator reports cost() == maxDoc unconditionally (SimpleTextDocValuesReader.java:343-345 — the docsWithField iterator just
  returns maxDoc), no matter how many docs actually have a value in that generation. So the fourth update's fold sees a prior delta containing one doc (d0) but measures
  its coverage as 10; 10 ≥ 10 × 0.5, so foldToDense becomes true, the writer does a full-column rewrite, and clears the overlay (newOverlays.put(fieldInfo.number, new
  long[]{-1}) at line 575) — exactly the degradation the test is guarding against.

  Assessment

  DocIdSetIterator.cost() is documented as an estimate, and SimpleText's "cost = maxDoc" is a legal implementation of that contract (the comment at
  ReadersAndUpdates.java:376 even concedes the sum is >= distinct). Fold-to-dense is still value-correct, so this is a heuristic misfire, not data corruption — but it
  means the "stay sparse over a dense base" behavior silently never happens under any codec with pessimistic cost estimates, and the test's structural assertion only
  holds for codecs with exact costs.
