### PR TITLE
Omit computing max score when sorting by score primarily in TopGroupsCollector

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -477,7 +477,7 @@ Optimizations
   LatLonDocValuesQuery, XYDocValuesPointInGeometryQuery, and
   SortedNumericDocValuesSetQuery. (Costin Leau)
 
-* GITHUB#XXXX: In `TopGroupsCollector`, omit `MaxScoreCollector` when `withinGroupSort` has score
+* GITHUB#16569: In `TopGroupsCollector`, omit `MaxScoreCollector` when `withinGroupSort` has score
   as the primary field. The group max score is instead derived from `FieldDoc.fields[0]` (set by
   `RelevanceComparator`), avoiding the overhead of a parallel score-tracking collector. (Binlong Gao)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -477,6 +477,10 @@ Optimizations
   LatLonDocValuesQuery, XYDocValuesPointInGeometryQuery, and
   SortedNumericDocValuesSetQuery. (Costin Leau)
 
+* GITHUB#XXXX: In `TopGroupsCollector`, omit `MaxScoreCollector` when `withinGroupSort` has score
+  as the primary field. The group max score is instead derived from `FieldDoc.fields[0]` (set by
+  `RelevanceComparator`), avoiding the overhead of a parallel score-tracking collector. (Binlong Gao)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroupsCollector.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroupsCollector.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.function.Supplier;
+import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.FilterCollector;
 import org.apache.lucene.search.MultiCollector;
 import org.apache.lucene.search.Scorable;
@@ -30,6 +31,7 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SimpleCollector;
 import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.TopFieldCollector;
@@ -135,14 +137,19 @@ public class TopGroupsCollector<T> extends SecondPassGroupingCollector<T> {
                         .newCollector(),
                     null);
       } else {
+        SortField primarySort = withinGroupSort.getSort()[0];
+        boolean primarySortByScoreDesc =
+            primarySort.getType() == SortField.Type.SCORE && !primarySort.getReverse();
         supplier =
             () -> {
               TopFieldCollector topDocsCollector =
                   new TopFieldCollectorManager(
                           withinGroupSort, maxDocsPerGroup, null, Integer.MAX_VALUE)
                       .newCollector(); // TODO: disable exact counts?
-              MaxScoreCollector maxScoreCollector = getMaxScores ? new MaxScoreCollector() : null;
-              return new TopDocsAndMaxScoreCollector(false, topDocsCollector, maxScoreCollector);
+              MaxScoreCollector maxScoreCollector =
+                  (getMaxScores && !primarySortByScoreDesc) ? new MaxScoreCollector() : null;
+              return new TopDocsAndMaxScoreCollector(
+                  primarySortByScoreDesc && getMaxScores, topDocsCollector, maxScoreCollector);
             };
       }
     }
@@ -176,8 +183,16 @@ public class TopGroupsCollector<T> extends SecondPassGroupingCollector<T> {
       final float groupMaxScore;
       if (collector.sortedByScore) {
         TopDocs allTopDocs = collector.topDocsCollector.topDocs();
-        groupMaxScore =
-            allTopDocs.scoreDocs.length == 0 ? Float.NaN : allTopDocs.scoreDocs[0].score;
+        if (allTopDocs.scoreDocs.length == 0) {
+          groupMaxScore = Float.NaN;
+        } else if (allTopDocs.scoreDocs[0] instanceof FieldDoc fieldDoc) {
+          // TopFieldCollector with score-primary sort: score is in FieldDoc.fields[0]
+          // (set by RelevanceComparator), not in FieldDoc.score (which is always NaN).
+          groupMaxScore = (float) fieldDoc.fields[0];
+        } else {
+          // TopScoreDocCollector: score is in ScoreDoc.score directly.
+          groupMaxScore = allTopDocs.scoreDocs[0].score;
+        }
         if (allTopDocs.scoreDocs.length <= withinGroupOffset) {
           topDocs = new TopDocs(allTopDocs.totalHits, new ScoreDoc[0]);
         } else {

--- a/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
+++ b/lucene/grouping/src/test/org/apache/lucene/search/grouping/TestGrouping.java
@@ -350,6 +350,97 @@ public class TestGrouping extends LuceneTestCase {
     assertTrue(result.isEmpty());
   }
 
+  /**
+   * When withinGroupSort has score as the primary field (but is not Sort.RELEVANCE),
+   * MaxScoreCollector is omitted — the group max score is derived from FieldDoc.fields[0] (stored
+   * by RelevanceComparator) of the top-ranked doc, avoiding the overhead of a parallel
+   * score-tracking collector.
+   */
+  public void testScorePrimaryWithinGroupSortOmitsMaxScoreCollector() throws Exception {
+    Directory dir = newDirectory();
+    RandomIndexWriter w =
+        new RandomIndexWriter(random(), dir, newIndexWriterConfig(new MockAnalyzer(random())));
+
+    String groupField = "author";
+    for (int i = 0; i < 3; i++) {
+      Document doc = new Document();
+      addGroupField(doc, groupField, "author1");
+      doc.add(new TextField("content", "word", Field.Store.NO));
+      doc.add(new NumericDocValuesField("id", i));
+      w.addDocument(doc);
+    }
+    for (int i = 0; i < 2; i++) {
+      Document doc = new Document();
+      addGroupField(doc, groupField, "author2");
+      doc.add(new TextField("content", "word", Field.Store.NO));
+      doc.add(new NumericDocValuesField("id", 10 + i));
+      w.addDocument(doc);
+    }
+
+    DirectoryReader reader = w.getReader();
+    w.close();
+    IndexSearcher searcher = newSearcher(reader);
+
+    Query query = new TermQuery(new Term("content", "word"));
+
+    Collection<SearchGroup<BytesRef>> topGroups =
+        toByteRefSearchGroups(
+            searcher.search(
+                query, createFirstPassCollectorManager(true, groupField, Sort.RELEVANCE, 0, 10)));
+    assertEquals(2, topGroups.size());
+
+    // withinGroupSort: score desc primary + id tiebreak — NOT Sort.RELEVANCE.
+    // MaxScoreCollector is omitted; max score is read from FieldDoc.fields[0].
+    Sort withinGroupSort = new Sort(SortField.FIELD_SCORE, new SortField("id", SortField.Type.INT));
+
+    // getMaxScores=false: MaxScoreCollector omitted, groupMaxScore=NaN
+    TopGroups<BytesRef> resultNoMaxScores =
+        toByteTopGroups(
+            searcher.search(
+                query,
+                new TopGroupsCollectorManager<>(
+                    () -> new TermGroupSelector(groupField),
+                    topGroups,
+                    Sort.RELEVANCE,
+                    withinGroupSort,
+                    0,
+                    10,
+                    false)));
+    assertEquals(2, resultNoMaxScores.groups.length);
+    assertEquals(5, resultNoMaxScores.totalHitCount);
+    for (GroupDocs<BytesRef> g : resultNoMaxScores.groups) {
+      assertTrue("group must have hits", g.scoreDocs().length > 0);
+      assertTrue("groupMaxScore should be NaN when getMaxScores=false", Float.isNaN(g.maxScore()));
+    }
+
+    // getMaxScores=true: MaxScoreCollector still omitted, but max score is derived from
+    // FieldDoc.fields[0] of the top doc — should be a valid positive score.
+    TopGroups<BytesRef> resultWithMaxScores =
+        toByteTopGroups(
+            searcher.search(
+                query,
+                new TopGroupsCollectorManager<>(
+                    () -> new TermGroupSelector(groupField),
+                    topGroups,
+                    Sort.RELEVANCE,
+                    withinGroupSort,
+                    0,
+                    10,
+                    true)));
+    assertEquals(2, resultWithMaxScores.groups.length);
+    assertEquals(5, resultWithMaxScores.totalHitCount);
+    for (GroupDocs<BytesRef> g : resultWithMaxScores.groups) {
+      assertTrue("group must have hits", g.scoreDocs().length > 0);
+      assertFalse(
+          "groupMaxScore should not be NaN when getMaxScores=true (derived from FieldDoc.fields[0])",
+          Float.isNaN(g.maxScore()));
+      assertTrue("groupMaxScore must be positive", g.maxScore() > 0f);
+    }
+
+    reader.close();
+    dir.close();
+  }
+
   private void addGroupField(Document doc, String groupField, String value) {
     doc.add(new SortedDocValuesField(groupField, new BytesRef(value)));
   }


### PR DESCRIPTION
### Description

In `TopGroupsCollector`, omit `MaxScoreCollector` when `withinGroupSort` has score as the primary field. The group max score is instead derived from `FieldDoc.fields[0]` (set by `RelevanceComparator`), avoiding the overhead of a parallel score-tracking collector.

This helps improve the performance of grouping search, benchmark on wikimedium1m:

                            TaskQPS baseline      StdDevQPS my_modified_version      StdDev                Pct diff p-value
                    TermGroup10K      124.24     (12.3%)      126.94     (11.5%)    2.2% ( -19% -   29%) 0.480
                    TermGroup100      117.89     (31.3%)      120.88     (26.7%)    2.5% ( -42% -   88%) 0.736
                     TermGroup1M      118.59     (10.9%)      122.83     (13.8%)    3.6% ( -19% -   31%) 0.265
