### PR TITLE
Stop buffering doc-values updates in heap during merges

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -4576,7 +4576,7 @@ public class IndexWriter
       infoStream.message("IW", msg);
     }
 
-    assert assertCarryOverReconstructibleFromDisk(merge, docMaps, mappedDVUpdates);
+    assert assertCarryOverReconstructibleFromDisk(merge, docMaps, mappedDVUpdates, minGen);
 
     merge.info.setBufferedDeletesGen(minGen);
 
@@ -4589,19 +4589,208 @@ public class IndexWriter
   /**
    * Assertion-only invariant check backing the removal of {@code ReadersAndUpdates.mergingDVUpdates}:
    * the doc-values-update carry-over accumulated in heap for the whole merge is redundant with what
-   * the source segments already persist. This recomputes the carry-over purely from each source
-   * segment's current on-disk state (relative to the merge-reader baseline) plus the residual
-   * still-pending updates, and asserts it matches the {@code mappedDVUpdates} produced from
-   * {@code mergingDVUpdates}. Read-only; changes no behavior.
+   * the source segments already persist. Rebuilds the mapped carry-over purely from disk via
+   * {@link #buildMappedDVUpdatesFromDisk} and asserts it has the same effect (newest value per merged
+   * doc) as {@code mappedDVUpdates} produced from {@code mergingDVUpdates}. Read-only.
    */
   private boolean assertCarryOverReconstructibleFromDisk(
       MergePolicy.OneMerge merge,
       MergeState.DocMap[] docMaps,
-      Map<String, LongObjectHashMap<DocValuesFieldUpdates>> mappedDVUpdates)
+      Map<String, LongObjectHashMap<DocValuesFieldUpdates>> mappedDVUpdates,
+      long minGen)
       throws IOException {
-    // expected: field -> merged docID -> value (Long | BytesRef | DV_NO_VALUE), newest delGen wins.
-    Map<String, Map<Integer, Object>> expected = new HashMap<>();
-    for (Map.Entry<String, LongObjectHashMap<DocValuesFieldUpdates>> e : mappedDVUpdates.entrySet()) {
+    Map<String, Map<Integer, Object>> expected = effectiveMap(mappedDVUpdates);
+    Map<String, Map<Integer, Object>> actual =
+        effectiveMap(buildMappedDVUpdatesFromDisk(merge, docMaps, minGen));
+    assert dvCarryOverEquals(expected, actual)
+        : "DV-update carry-over not reconstructible from disk:\n expected=" + expected + "\n actual=" + actual;
+    return true;
+  }
+
+  /**
+   * Reconstructs the doc-values-update merge carry-over purely from the source segments' on-disk
+   * state plus their residual (finished but not-yet-written) pending updates, remapping to merged
+   * docIDs. This is the replacement for consuming {@code ReadersAndUpdates.mergingDVUpdates}: nothing
+   * is retained in heap for the merge duration. Returns {@code field -> delGen -> updates}, matching
+   * the shape the merged {@link ReadersAndUpdates} consumes.
+   *
+   * <p>Per source segment and updated field, the already-flushed changes (the bulk) are read back
+   * from disk (current-vs-baseline diff) and collapsed into a single packet; the still-pending
+   * updates keep their real delGens. Because flushing is a monotonic prefix by {@code
+   * completedDelGen}, every residual delGen is strictly greater than any flushed one, so the
+   * collapsed packet is given {@code minResidualDelGen - 1} (or {@code completedDelGen} when there is
+   * no residual) — a slot below all residual/still-running gens and above {@code minGen}, so
+   * newest-wins ordering on the merged segment is preserved.
+   */
+  private Map<String, LongObjectHashMap<DocValuesFieldUpdates>> buildMappedDVUpdatesFromDisk(
+      MergePolicy.OneMerge merge, MergeState.DocMap[] docMaps, long minGen) throws IOException {
+    final int mergedMaxDoc = merge.info.info.maxDoc();
+    Map<String, LongObjectHashMap<DocValuesFieldUpdates>> mapped = new HashMap<>();
+    for (int i = 0; i < merge.segments.size(); i++) {
+      SegmentCommitInfo info = merge.segments.get(i);
+      final ReadersAndUpdates rld = getPooledInstance(info, false);
+      final MergeState.DocMap segDocMap = docMaps[i];
+      final CodecReader baseline = merge.getMergeReader().get(i).codecReader;
+      final SegmentReader current = rld.getReader(IOContext.DEFAULT);
+      try {
+        // Residual finished-but-unflushed updates for this segment, per field, skipping any packet
+        // still globally running (those re-resolve against the merged segment).
+        Map<String, List<DocValuesFieldUpdates>> residualByField = new HashMap<>();
+        for (Map.Entry<String, List<DocValuesFieldUpdates>> e :
+            rld.getPendingDVUpdatesForAssert().entrySet()) {
+          List<DocValuesFieldUpdates> keep = new ArrayList<>();
+          for (DocValuesFieldUpdates u : e.getValue()) {
+            if (bufferedUpdatesStream.stillRunning(u.delGen) == false) {
+              keep.add(u);
+            }
+          }
+          if (keep.isEmpty() == false) {
+            residualByField.put(e.getKey(), keep);
+          }
+        }
+        // Updated fields = those whose on-disk DV generation advanced vs the merge-reader baseline
+        // (gen advances for both classic and overlay writes), plus any field with residual updates.
+        Set<String> updatedFields = new HashSet<>(residualByField.keySet());
+        FieldInfos baseFieldInfos = baseline.getFieldInfos();
+        for (FieldInfo fi : current.getFieldInfos()) {
+          DocValuesType t = fi.getDocValuesType();
+          if (t != DocValuesType.NUMERIC && t != DocValuesType.BINARY) {
+            continue;
+          }
+          FieldInfo baseFi = baseFieldInfos.fieldInfo(fi.name);
+          if (baseFi == null || baseFi.getDocValuesGen() != fi.getDocValuesGen()) {
+            updatedFields.add(fi.name);
+          }
+        }
+
+        for (String field : updatedFields) {
+          FieldInfo fi = current.getFieldInfos().fieldInfo(field);
+          if (fi == null) {
+            continue;
+          }
+          List<DocValuesFieldUpdates> residual = residualByField.getOrDefault(field, List.of());
+          long minResidual = Long.MAX_VALUE;
+          for (DocValuesFieldUpdates u : residual) {
+            minResidual = Math.min(minResidual, u.delGen);
+          }
+          final long diskDelGen =
+              minResidual != Long.MAX_VALUE
+                  ? minResidual - 1
+                  : bufferedUpdatesStream.getCompletedDelGen();
+          LongObjectHashMap<DocValuesFieldUpdates> byGen =
+              mapped.computeIfAbsent(field, _ -> new LongObjectHashMap<>());
+
+          // (A) flushed changes since baseline, collapsed at diskDelGen.
+          addDiskDiffToPacket(fi, baseline, current, segDocMap, diskDelGen, mergedMaxDoc, byGen);
+          assert byGen.containsKey(diskDelGen) == false || diskDelGen > minGen
+              : "diskDelGen " + diskDelGen + " <= minGen " + minGen;
+
+          // (B) residual updates at their real delGens.
+          for (DocValuesFieldUpdates u : residual) {
+            DocValuesFieldUpdates.Iterator it = u.iterator();
+            int doc;
+            while ((doc = it.nextDoc()) != NO_MORE_DOCS) {
+              int md = segDocMap.get(doc);
+              if (md == -1) {
+                continue;
+              }
+              DocValuesFieldUpdates p = getOrCreatePacket(byGen, u.delGen, fi, mergedMaxDoc);
+              if (it.hasValue()) {
+                p.add(md, it);
+              } else {
+                p.reset(md);
+              }
+            }
+          }
+        }
+      } finally {
+        current.decRef();
+      }
+    }
+    for (LongObjectHashMap<DocValuesFieldUpdates> byGen : mapped.values()) {
+      for (ObjectCursor<DocValuesFieldUpdates> c : byGen.values()) {
+        c.value.finish();
+      }
+    }
+    return mapped;
+  }
+
+  /** Current value under a {@link DocValuesFieldUpdates.Iterator}: Long, BytesRef, or DV_NO_VALUE. */
+  private static Object dvUpdateValue(DocValuesType type, DocValuesFieldUpdates.Iterator it) {
+    if (it.hasValue() == false) {
+      return DV_NO_VALUE;
+    }
+    return type == DocValuesType.BINARY
+        ? BytesRef.deepCopyOf(it.binaryValue())
+        : Long.valueOf(it.longValue());
+  }
+
+  private static DocValuesFieldUpdates getOrCreatePacket(
+      LongObjectHashMap<DocValuesFieldUpdates> byGen, long delGen, FieldInfo fi, int mergedMaxDoc) {
+    DocValuesFieldUpdates p = byGen.get(delGen);
+    if (p == null) {
+      p =
+          fi.getDocValuesType() == DocValuesType.BINARY
+              ? new BinaryDocValuesFieldUpdates(delGen, fi.name, mergedMaxDoc)
+              : new NumericDocValuesFieldUpdates(delGen, fi.name, mergedMaxDoc);
+      byGen.put(delGen, p);
+    }
+    return p;
+  }
+
+  /**
+   * Emits, into a single {@code diskDelGen} packet, each merged doc of {@code fi} whose current
+   * on-disk value differs from the merge-reader baseline (i.e. an update flushed during the merge),
+   * remapping source docIDs to merged docIDs.
+   */
+  private static void addDiskDiffToPacket(
+      FieldInfo fi,
+      CodecReader baseline,
+      CodecReader current,
+      MergeState.DocMap segDocMap,
+      long diskDelGen,
+      int mergedMaxDoc,
+      LongObjectHashMap<DocValuesFieldUpdates> byGen)
+      throws IOException {
+    final int maxDoc = current.maxDoc();
+    final boolean binary = fi.getDocValuesType() == DocValuesType.BINARY;
+    BinaryDocValues curB = binary ? current.getBinaryDocValues(fi.name) : null;
+    BinaryDocValues baseB = binary ? baseline.getBinaryDocValues(fi.name) : null;
+    NumericDocValues curN = binary ? null : current.getNumericDocValues(fi.name);
+    NumericDocValues baseN = binary ? null : baseline.getNumericDocValues(fi.name);
+    for (int doc = 0; doc < maxDoc; doc++) {
+      int md = segDocMap.get(doc);
+      if (md == -1) {
+        continue;
+      }
+      Object curVal;
+      Object baseVal;
+      if (binary) {
+        curVal = (curB != null && curB.advanceExact(doc)) ? BytesRef.deepCopyOf(curB.binaryValue()) : DV_NO_VALUE;
+        baseVal = (baseB != null && baseB.advanceExact(doc)) ? BytesRef.deepCopyOf(baseB.binaryValue()) : DV_NO_VALUE;
+      } else {
+        curVal = (curN != null && curN.advanceExact(doc)) ? Long.valueOf(curN.longValue()) : DV_NO_VALUE;
+        baseVal = (baseN != null && baseN.advanceExact(doc)) ? Long.valueOf(baseN.longValue()) : DV_NO_VALUE;
+      }
+      if (dvEquals(curVal, baseVal)) {
+        continue;
+      }
+      DocValuesFieldUpdates p = getOrCreatePacket(byGen, diskDelGen, fi, mergedMaxDoc);
+      if (curVal == DV_NO_VALUE) {
+        p.reset(md);
+      } else if (binary) {
+        ((BinaryDocValuesFieldUpdates) p).add(md, (BytesRef) curVal);
+      } else {
+        ((NumericDocValuesFieldUpdates) p).add(md, (Long) curVal);
+      }
+    }
+  }
+
+  /** Collapses {@code field -> delGen -> updates} to {@code field -> merged doc -> value}, newest delGen wins. */
+  private static Map<String, Map<Integer, Object>> effectiveMap(
+      Map<String, LongObjectHashMap<DocValuesFieldUpdates>> mapped) {
+    Map<String, Map<Integer, Object>> out = new HashMap<>();
+    for (Map.Entry<String, LongObjectHashMap<DocValuesFieldUpdates>> e : mapped.entrySet()) {
       Map<Integer, Object> byDoc = new HashMap<>();
       List<DocValuesFieldUpdates> packets = new ArrayList<>();
       for (ObjectCursor<DocValuesFieldUpdates> c : e.getValue().values()) {
@@ -4615,111 +4804,11 @@ public class IndexWriter
           byDoc.put(d, dvUpdateValue(u.type, it));
         }
       }
-      expected.put(e.getKey(), byDoc);
-    }
-
-    // actual: reconstruct the same map from disk (current-vs-baseline per source segment) + residual
-    // still-pending updates.
-    Map<String, Map<Integer, Object>> actual = new HashMap<>();
-    for (int i = 0; i < merge.segments.size(); i++) {
-      SegmentCommitInfo info = merge.segments.get(i);
-      final ReadersAndUpdates rld = getPooledInstance(info, false);
-      final MergeState.DocMap segDocMap = docMaps[i];
-      final CodecReader baseline = merge.getMergeReader().get(i).codecReader;
-      final SegmentReader current = rld.getReader(IOContext.DEFAULT);
-      try {
-        // (A) on-disk changes since baseline, for the updated fields (those in expected).
-        for (String field : expected.keySet()) {
-          FieldInfo fi = current.getFieldInfos().fieldInfo(field);
-          if (fi == null) {
-            continue;
-          }
-          Map<Integer, Object> byDoc = actual.computeIfAbsent(field, _ -> new HashMap<>());
-          diffFieldForAssert(fi, baseline, current, segDocMap, expected.get(field), byDoc);
-        }
-        // (B) residual still-pending updates (finished-but-unflushed), newest delGen wins; skip any
-        // still globally running (those re-resolve against the merged segment).
-        for (List<DocValuesFieldUpdates> lst : rld.getPendingDVUpdatesForAssert().values()) {
-          List<DocValuesFieldUpdates> packets = new ArrayList<>(lst);
-          packets.sort(Comparator.comparingLong(u -> u.delGen));
-          for (DocValuesFieldUpdates u : packets) {
-            if (bufferedUpdatesStream.stillRunning(u.delGen)) {
-              continue;
-            }
-            Map<Integer, Object> byDoc = actual.computeIfAbsent(u.field, _ -> new HashMap<>());
-            DocValuesFieldUpdates.Iterator it = u.iterator();
-            int d;
-            while ((d = it.nextDoc()) != NO_MORE_DOCS) {
-              int mapped = segDocMap.get(d);
-              if (mapped != -1) {
-                byDoc.put(mapped, dvUpdateValue(u.type, it));
-              }
-            }
-          }
-        }
-      } finally {
-        current.decRef();
+      if (byDoc.isEmpty() == false) {
+        out.put(e.getKey(), byDoc);
       }
     }
-
-    assert dvCarryOverEquals(expected, actual)
-        : "DV-update carry-over not reconstructible from disk:\n expected=" + expected + "\n actual=" + actual;
-    return true;
-  }
-
-  /** Current value under a {@link DocValuesFieldUpdates.Iterator}: Long, BytesRef, or DV_NO_VALUE. */
-  private static Object dvUpdateValue(DocValuesType type, DocValuesFieldUpdates.Iterator it) {
-    if (it.hasValue() == false) {
-      return DV_NO_VALUE;
-    }
-    return type == DocValuesType.BINARY
-        ? BytesRef.deepCopyOf(it.binaryValue())
-        : Long.valueOf(it.longValue());
-  }
-
-  /**
-   * Records, for the updated docs of one field on one source segment, the segment's current on-disk
-   * value (remapped to merged docIDs) whenever the doc is one that {@code expected} carries, plus any
-   * on-disk change not present in {@code expected} (which would be a real discrepancy).
-   */
-  private static void diffFieldForAssert(
-      FieldInfo fi,
-      CodecReader baseline,
-      CodecReader current,
-      MergeState.DocMap segDocMap,
-      Map<Integer, Object> expectedForField,
-      Map<Integer, Object> actualForField)
-      throws IOException {
-    final int maxDoc = current.maxDoc();
-    if (fi.getDocValuesType() == DocValuesType.BINARY) {
-      BinaryDocValues cur = current.getBinaryDocValues(fi.name);
-      BinaryDocValues base = baseline.getBinaryDocValues(fi.name);
-      for (int doc = 0; doc < maxDoc; doc++) {
-        int mapped = segDocMap.get(doc);
-        if (mapped == -1) {
-          continue;
-        }
-        Object curVal = (cur != null && cur.advanceExact(doc)) ? BytesRef.deepCopyOf(cur.binaryValue()) : DV_NO_VALUE;
-        Object baseVal = (base != null && base.advanceExact(doc)) ? BytesRef.deepCopyOf(base.binaryValue()) : DV_NO_VALUE;
-        if (expectedForField.containsKey(mapped) || dvEquals(curVal, baseVal) == false) {
-          actualForField.put(mapped, curVal);
-        }
-      }
-    } else { // NUMERIC (only NUMERIC/BINARY are updatable)
-      NumericDocValues cur = current.getNumericDocValues(fi.name);
-      NumericDocValues base = baseline.getNumericDocValues(fi.name);
-      for (int doc = 0; doc < maxDoc; doc++) {
-        int mapped = segDocMap.get(doc);
-        if (mapped == -1) {
-          continue;
-        }
-        Object curVal = (cur != null && cur.advanceExact(doc)) ? Long.valueOf(cur.longValue()) : DV_NO_VALUE;
-        Object baseVal = (base != null && base.advanceExact(doc)) ? Long.valueOf(base.longValue()) : DV_NO_VALUE;
-        if (expectedForField.containsKey(mapped) || dvEquals(curVal, baseVal) == false) {
-          actualForField.put(mapped, curVal);
-        }
-      }
-    }
+    return out;
   }
 
   private static boolean dvEquals(Object a, Object b) {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -4673,14 +4673,10 @@ public class IndexWriter
       Object curVal;
       Object baseVal;
       if (binary) {
-        curVal =
-            (curB != null && curB.advanceExact(doc))
-                ? BytesRef.deepCopyOf(curB.binaryValue())
-                : DV_NO_VALUE;
-        baseVal =
-            (baseB != null && baseB.advanceExact(doc))
-                ? BytesRef.deepCopyOf(baseB.binaryValue())
-                : DV_NO_VALUE;
+        // Live BytesRefs suffice to compare; only a changed value is copied, below, when it is
+        // stored.
+        curVal = (curB != null && curB.advanceExact(doc)) ? curB.binaryValue() : DV_NO_VALUE;
+        baseVal = (baseB != null && baseB.advanceExact(doc)) ? baseB.binaryValue() : DV_NO_VALUE;
       } else {
         curVal =
             (curN != null && curN.advanceExact(doc)) ? Long.valueOf(curN.longValue()) : DV_NO_VALUE;
@@ -4696,7 +4692,7 @@ public class IndexWriter
       if (curVal == DV_NO_VALUE) {
         p.reset(md);
       } else if (binary) {
-        ((BinaryDocValuesFieldUpdates) p).add(md, (BytesRef) curVal);
+        ((BinaryDocValuesFieldUpdates) p).add(md, BytesRef.deepCopyOf((BytesRef) curVal));
       } else {
         ((NumericDocValuesFieldUpdates) p).add(md, (Long) curVal);
       }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -4467,10 +4467,6 @@ public class IndexWriter
     final ReadersAndUpdates mergedDeletesAndUpdates = getPooledInstance(merge.info, true);
     int numDeletesBefore = mergedDeletesAndUpdates.getDelCount();
     // field -> delGen -> dv field updates
-    Map<String, LongObjectHashMap<DocValuesFieldUpdates>> mappedDVUpdates = new HashMap<>();
-
-    boolean anyDVUpdates = false;
-
     assert sourceSegments.size() == docMaps.length;
     for (int i = 0; i < sourceSegments.size(); i++) {
       SegmentCommitInfo info = sourceSegments.get(i);
@@ -4489,79 +4485,23 @@ public class IndexWriter
           merge.getMergeReader().get(i).hardLiveDocs,
           rld.getHardLiveDocs(),
           segDocMap);
-
-      // Now carry over all doc values updates that were resolved while we were merging, remapping
-      // the docIDs to the newly merged docIDs.
-      // We only carry over packets that finished resolving; if any are still running (concurrently)
-      // they will detect that our merge completed
-      // and re-resolve against the newly merged segment:
-      Map<String, List<DocValuesFieldUpdates>> mergingDVUpdates = rld.getMergingDVUpdates();
-      for (Map.Entry<String, List<DocValuesFieldUpdates>> ent : mergingDVUpdates.entrySet()) {
-
-        String field = ent.getKey();
-
-        LongObjectHashMap<DocValuesFieldUpdates> mappedField = mappedDVUpdates.get(field);
-        if (mappedField == null) {
-          mappedField = new LongObjectHashMap<>();
-          mappedDVUpdates.put(field, mappedField);
-        }
-
-        for (DocValuesFieldUpdates updates : ent.getValue()) {
-
-          if (bufferedUpdatesStream.stillRunning(updates.delGen)) {
-            continue;
-          }
-
-          // sanity check:
-          assert field.equals(updates.field);
-
-          DocValuesFieldUpdates mappedUpdates = mappedField.get(updates.delGen);
-          if (mappedUpdates == null) {
-            switch (updates.type) {
-              case NUMERIC:
-                mappedUpdates =
-                    new NumericDocValuesFieldUpdates(
-                        updates.delGen, updates.field, merge.info.info.maxDoc());
-                break;
-              case BINARY:
-                mappedUpdates =
-                    new BinaryDocValuesFieldUpdates(
-                        updates.delGen, updates.field, merge.info.info.maxDoc());
-                break;
-              case NONE:
-              case SORTED:
-              case SORTED_SET:
-              case SORTED_NUMERIC:
-              default:
-                throw new AssertionError();
-            }
-            mappedField.put(updates.delGen, mappedUpdates);
-          }
-
-          DocValuesFieldUpdates.Iterator it = updates.iterator();
-          int doc;
-          while ((doc = it.nextDoc()) != NO_MORE_DOCS) {
-            int mappedDoc = segDocMap.get(doc);
-            if (mappedDoc != -1) {
-              if (it.hasValue()) {
-                // not deleted
-                mappedUpdates.add(mappedDoc, it);
-              } else {
-                mappedUpdates.reset(mappedDoc);
-              }
-              anyDVUpdates = true;
-            }
-          }
-        }
-      }
     }
 
-    if (anyDVUpdates) {
-      // Persist the merged DV updates onto the RAU for the merged segment:
+    // Carry over the doc-values updates that resolved while we were merging, remapping the docIDs to
+    // the newly merged docIDs. These are reconstructed from the source segments' on-disk state plus
+    // their residual pending updates (see buildMappedDVUpdatesFromDisk) rather than from a heap copy
+    // retained for the whole merge. Packets still resolving concurrently are skipped; they re-resolve
+    // against the newly merged segment once they complete.
+    Map<String, LongObjectHashMap<DocValuesFieldUpdates>> mappedDVUpdates =
+        buildMappedDVUpdatesFromDisk(merge, docMaps, minGen);
+
+    boolean anyDVUpdates = false;
+    if (mappedDVUpdates.isEmpty() == false) {
+      // Persist the merged DV updates onto the RAU for the merged segment (already finished):
       for (LongObjectHashMap<DocValuesFieldUpdates> d : mappedDVUpdates.values()) {
         for (ObjectCursor<DocValuesFieldUpdates> updates : d.values()) {
-          updates.value.finish();
           mergedDeletesAndUpdates.addDVUpdate(updates.value);
+          anyDVUpdates = true;
         }
       }
     }
@@ -4587,24 +4527,151 @@ public class IndexWriter
   private static final Object DV_NO_VALUE = new Object();
 
   /**
-   * Assertion-only invariant check backing the removal of {@code ReadersAndUpdates.mergingDVUpdates}:
-   * the doc-values-update carry-over accumulated in heap for the whole merge is redundant with what
-   * the source segments already persist. Rebuilds the mapped carry-over purely from disk via
-   * {@link #buildMappedDVUpdatesFromDisk} and asserts it has the same effect (newest value per merged
-   * doc) as {@code mappedDVUpdates} produced from {@code mergingDVUpdates}. Read-only.
+   * Assertion-only cross-check backing the removal of {@code ReadersAndUpdates.mergingDVUpdates}:
+   * asserts the disk-reconstructed carry-over now used in production ({@code mappedFromDisk}) has the
+   * same effect (newest value per merged doc) as the legacy carry-over built from the heap-retained
+   * {@code mergingDVUpdates}. Read-only.
    */
   private boolean assertCarryOverReconstructibleFromDisk(
       MergePolicy.OneMerge merge,
       MergeState.DocMap[] docMaps,
-      Map<String, LongObjectHashMap<DocValuesFieldUpdates>> mappedDVUpdates,
+      Map<String, LongObjectHashMap<DocValuesFieldUpdates>> mappedFromDisk,
       long minGen)
       throws IOException {
-    Map<String, Map<Integer, Object>> expected = effectiveMap(mappedDVUpdates);
-    Map<String, Map<Integer, Object>> actual =
-        effectiveMap(buildMappedDVUpdatesFromDisk(merge, docMaps, minGen));
-    assert dvCarryOverEquals(expected, actual)
-        : "DV-update carry-over not reconstructible from disk:\n expected=" + expected + "\n actual=" + actual;
+    Map<String, Map<Integer, Object>> expected =
+        effectiveMap(buildMappedDVUpdatesFromMerging(merge, docMaps));
+    Map<String, Map<Integer, Object>> actual = effectiveMap(mappedFromDisk);
+    // Compare the resulting merged value per doc, not the raw carried packets: mergingDVUpdates may
+    // carry a no-op (an update, or a reset, to the value the merged baseline already has), which the
+    // disk reconstruction correctly omits. Fall back to the baseline value for docs a side omits.
+    Set<String> fields = new HashSet<>(expected.keySet());
+    fields.addAll(actual.keySet());
+    Map<String, Map<Integer, Object>> baseline = baselineValuesByMergedDoc(merge, docMaps, fields);
+    assert dvCarryOverEffectEquals(expected, actual, baseline)
+        : "DV-update carry-over from disk differs from mergingDVUpdates:\n expected="
+            + expected
+            + "\n actual="
+            + actual
+            + "\n baseline="
+            + baseline;
     return true;
+  }
+
+  /** Merge-reader baseline value per merged doc for the given fields (Long | BytesRef | DV_NO_VALUE). */
+  private Map<String, Map<Integer, Object>> baselineValuesByMergedDoc(
+      MergePolicy.OneMerge merge, MergeState.DocMap[] docMaps, Set<String> fields) throws IOException {
+    Map<String, Map<Integer, Object>> out = new HashMap<>();
+    for (String f : fields) {
+      out.put(f, new HashMap<>());
+    }
+    for (int i = 0; i < merge.segments.size(); i++) {
+      final CodecReader baseline = merge.getMergeReader().get(i).codecReader;
+      final MergeState.DocMap segDocMap = docMaps[i];
+      final int maxDoc = baseline.maxDoc();
+      final FieldInfos fis = baseline.getFieldInfos();
+      for (String f : fields) {
+        FieldInfo fi = fis.fieldInfo(f);
+        if (fi == null) {
+          continue;
+        }
+        Map<Integer, Object> m = out.get(f);
+        final boolean binary = fi.getDocValuesType() == DocValuesType.BINARY;
+        BinaryDocValues b = binary ? baseline.getBinaryDocValues(f) : null;
+        NumericDocValues n = binary ? null : baseline.getNumericDocValues(f);
+        for (int doc = 0; doc < maxDoc; doc++) {
+          int md = segDocMap.get(doc);
+          if (md == -1) {
+            continue;
+          }
+          Object v;
+          if (binary) {
+            v = (b != null && b.advanceExact(doc)) ? BytesRef.deepCopyOf(b.binaryValue()) : DV_NO_VALUE;
+          } else {
+            v = (n != null && n.advanceExact(doc)) ? Long.valueOf(n.longValue()) : DV_NO_VALUE;
+          }
+          m.put(md, v);
+        }
+      }
+    }
+    return out;
+  }
+
+  /**
+   * True iff, for every (field, merged doc) either side touches, the resulting merged value matches —
+   * where a doc a side does not carry falls back to that field's baseline value.
+   */
+  private static boolean dvCarryOverEffectEquals(
+      Map<String, Map<Integer, Object>> expected,
+      Map<String, Map<Integer, Object>> actual,
+      Map<String, Map<Integer, Object>> baseline) {
+    Set<String> fields = new HashSet<>(expected.keySet());
+    fields.addAll(actual.keySet());
+    for (String f : fields) {
+      Map<Integer, Object> exp = expected.getOrDefault(f, Map.of());
+      Map<Integer, Object> act = actual.getOrDefault(f, Map.of());
+      Map<Integer, Object> base = baseline.getOrDefault(f, Map.of());
+      Set<Integer> docs = new HashSet<>(exp.keySet());
+      docs.addAll(act.keySet());
+      for (int d : docs) {
+        Object ev = exp.containsKey(d) ? exp.get(d) : base.getOrDefault(d, DV_NO_VALUE);
+        Object av = act.containsKey(d) ? act.get(d) : base.getOrDefault(d, DV_NO_VALUE);
+        if (dvEquals(ev, av) == false) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Legacy carry-over reconstruction from the heap-retained {@code mergingDVUpdates}, kept only as
+   * the assertion oracle for {@link #buildMappedDVUpdatesFromDisk} until {@code mergingDVUpdates} is
+   * removed. Mirrors the pre-existing merge-commit logic.
+   */
+  private Map<String, LongObjectHashMap<DocValuesFieldUpdates>> buildMappedDVUpdatesFromMerging(
+      MergePolicy.OneMerge merge, MergeState.DocMap[] docMaps) throws IOException {
+    final int mergedMaxDoc = merge.info.info.maxDoc();
+    Map<String, LongObjectHashMap<DocValuesFieldUpdates>> mapped = new HashMap<>();
+    for (int i = 0; i < merge.segments.size(); i++) {
+      final ReadersAndUpdates rld = getPooledInstance(merge.segments.get(i), false);
+      final MergeState.DocMap segDocMap = docMaps[i];
+      Map<String, List<DocValuesFieldUpdates>> mergingDVUpdates = rld.getMergingDVUpdates();
+      for (Map.Entry<String, List<DocValuesFieldUpdates>> ent : mergingDVUpdates.entrySet()) {
+        LongObjectHashMap<DocValuesFieldUpdates> byGen =
+            mapped.computeIfAbsent(ent.getKey(), _ -> new LongObjectHashMap<>());
+        for (DocValuesFieldUpdates updates : ent.getValue()) {
+          if (bufferedUpdatesStream.stillRunning(updates.delGen)) {
+            continue;
+          }
+          DocValuesFieldUpdates mappedUpdates = byGen.get(updates.delGen);
+          if (mappedUpdates == null) {
+            mappedUpdates =
+                updates.type == DocValuesType.BINARY
+                    ? new BinaryDocValuesFieldUpdates(updates.delGen, updates.field, mergedMaxDoc)
+                    : new NumericDocValuesFieldUpdates(updates.delGen, updates.field, mergedMaxDoc);
+            byGen.put(updates.delGen, mappedUpdates);
+          }
+          DocValuesFieldUpdates.Iterator it = updates.iterator();
+          int doc;
+          while ((doc = it.nextDoc()) != NO_MORE_DOCS) {
+            int mappedDoc = segDocMap.get(doc);
+            if (mappedDoc != -1) {
+              if (it.hasValue()) {
+                mappedUpdates.add(mappedDoc, it);
+              } else {
+                mappedUpdates.reset(mappedDoc);
+              }
+            }
+          }
+        }
+      }
+    }
+    for (LongObjectHashMap<DocValuesFieldUpdates> byGen : mapped.values()) {
+      for (ObjectCursor<DocValuesFieldUpdates> c : byGen.values()) {
+        c.value.finish();
+      }
+    }
+    return mapped;
   }
 
   /**
@@ -4816,26 +4883,6 @@ public class IndexWriter
       return a == b;
     }
     return a.equals(b);
-  }
-
-  private static boolean dvCarryOverEquals(
-      Map<String, Map<Integer, Object>> expected, Map<String, Map<Integer, Object>> actual) {
-    if (expected.keySet().equals(actual.keySet()) == false) {
-      return false;
-    }
-    for (Map.Entry<String, Map<Integer, Object>> e : expected.entrySet()) {
-      Map<Integer, Object> exp = e.getValue();
-      Map<Integer, Object> act = actual.get(e.getKey());
-      if (exp.size() != act.size()) {
-        return false;
-      }
-      for (Map.Entry<Integer, Object> de : exp.entrySet()) {
-        if (act.containsKey(de.getKey()) == false || dvEquals(de.getValue(), act.get(de.getKey())) == false) {
-          return false;
-        }
-      }
-    }
-    return true;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -87,7 +86,6 @@ import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.Counter;
 import org.apache.lucene.util.IOConsumer;
@@ -4043,10 +4041,6 @@ public class IndexWriter
           merge.initMergeReaders(
               sci -> {
                 final ReadersAndUpdates rld = getPooledInstance(sci, true);
-                // calling setIsMerging is important since it causes the RaU to record all DV
-                // updates
-                // in a separate map in order to be applied to the merged segment after it's done
-                rld.setIsMerging();
                 return rld.getReaderForMerge(
                     context, mr -> deleter.incRef(mr.reader.getSegmentInfo().files()));
               });
@@ -4487,11 +4481,10 @@ public class IndexWriter
           segDocMap);
     }
 
-    // Carry over the doc-values updates that resolved while we were merging, remapping the docIDs to
-    // the newly merged docIDs. These are reconstructed from the source segments' on-disk state plus
-    // their residual pending updates (see buildMappedDVUpdatesFromDisk) rather than from a heap copy
-    // retained for the whole merge. Packets still resolving concurrently are skipped; they re-resolve
-    // against the newly merged segment once they complete.
+    // Carry over the doc-values updates that resolved while merging, remapping to the merged
+    // docIDs.
+    // Updates still resolving concurrently are skipped; they re-resolve against the merged segment
+    // once they complete.
     Map<String, LongObjectHashMap<DocValuesFieldUpdates>> mappedDVUpdates =
         buildMappedDVUpdatesFromDisk(merge, docMaps, minGen);
 
@@ -4516,8 +4509,6 @@ public class IndexWriter
       infoStream.message("IW", msg);
     }
 
-    assert assertCarryOverReconstructibleFromDisk(merge, docMaps, mappedDVUpdates, minGen);
-
     merge.info.setBufferedDeletesGen(minGen);
 
     return mergedDeletesAndUpdates;
@@ -4527,167 +4518,16 @@ public class IndexWriter
   private static final Object DV_NO_VALUE = new Object();
 
   /**
-   * Assertion-only cross-check backing the removal of {@code ReadersAndUpdates.mergingDVUpdates}:
-   * asserts the disk-reconstructed carry-over now used in production ({@code mappedFromDisk}) has the
-   * same effect (newest value per merged doc) as the legacy carry-over built from the heap-retained
-   * {@code mergingDVUpdates}. Read-only.
-   */
-  private boolean assertCarryOverReconstructibleFromDisk(
-      MergePolicy.OneMerge merge,
-      MergeState.DocMap[] docMaps,
-      Map<String, LongObjectHashMap<DocValuesFieldUpdates>> mappedFromDisk,
-      long minGen)
-      throws IOException {
-    Map<String, Map<Integer, Object>> expected =
-        effectiveMap(buildMappedDVUpdatesFromMerging(merge, docMaps));
-    Map<String, Map<Integer, Object>> actual = effectiveMap(mappedFromDisk);
-    // Compare the resulting merged value per doc, not the raw carried packets: mergingDVUpdates may
-    // carry a no-op (an update, or a reset, to the value the merged baseline already has), which the
-    // disk reconstruction correctly omits. Fall back to the baseline value for docs a side omits.
-    Set<String> fields = new HashSet<>(expected.keySet());
-    fields.addAll(actual.keySet());
-    Map<String, Map<Integer, Object>> baseline = baselineValuesByMergedDoc(merge, docMaps, fields);
-    assert dvCarryOverEffectEquals(expected, actual, baseline)
-        : "DV-update carry-over from disk differs from mergingDVUpdates:\n expected="
-            + expected
-            + "\n actual="
-            + actual
-            + "\n baseline="
-            + baseline;
-    return true;
-  }
-
-  /** Merge-reader baseline value per merged doc for the given fields (Long | BytesRef | DV_NO_VALUE). */
-  private Map<String, Map<Integer, Object>> baselineValuesByMergedDoc(
-      MergePolicy.OneMerge merge, MergeState.DocMap[] docMaps, Set<String> fields) throws IOException {
-    Map<String, Map<Integer, Object>> out = new HashMap<>();
-    for (String f : fields) {
-      out.put(f, new HashMap<>());
-    }
-    for (int i = 0; i < merge.segments.size(); i++) {
-      final CodecReader baseline = merge.getMergeReader().get(i).codecReader;
-      final MergeState.DocMap segDocMap = docMaps[i];
-      final int maxDoc = baseline.maxDoc();
-      final FieldInfos fis = baseline.getFieldInfos();
-      for (String f : fields) {
-        FieldInfo fi = fis.fieldInfo(f);
-        if (fi == null) {
-          continue;
-        }
-        Map<Integer, Object> m = out.get(f);
-        final boolean binary = fi.getDocValuesType() == DocValuesType.BINARY;
-        BinaryDocValues b = binary ? baseline.getBinaryDocValues(f) : null;
-        NumericDocValues n = binary ? null : baseline.getNumericDocValues(f);
-        for (int doc = 0; doc < maxDoc; doc++) {
-          int md = segDocMap.get(doc);
-          if (md == -1) {
-            continue;
-          }
-          Object v;
-          if (binary) {
-            v = (b != null && b.advanceExact(doc)) ? BytesRef.deepCopyOf(b.binaryValue()) : DV_NO_VALUE;
-          } else {
-            v = (n != null && n.advanceExact(doc)) ? Long.valueOf(n.longValue()) : DV_NO_VALUE;
-          }
-          m.put(md, v);
-        }
-      }
-    }
-    return out;
-  }
-
-  /**
-   * True iff, for every (field, merged doc) either side touches, the resulting merged value matches —
-   * where a doc a side does not carry falls back to that field's baseline value.
-   */
-  private static boolean dvCarryOverEffectEquals(
-      Map<String, Map<Integer, Object>> expected,
-      Map<String, Map<Integer, Object>> actual,
-      Map<String, Map<Integer, Object>> baseline) {
-    Set<String> fields = new HashSet<>(expected.keySet());
-    fields.addAll(actual.keySet());
-    for (String f : fields) {
-      Map<Integer, Object> exp = expected.getOrDefault(f, Map.of());
-      Map<Integer, Object> act = actual.getOrDefault(f, Map.of());
-      Map<Integer, Object> base = baseline.getOrDefault(f, Map.of());
-      Set<Integer> docs = new HashSet<>(exp.keySet());
-      docs.addAll(act.keySet());
-      for (int d : docs) {
-        Object ev = exp.containsKey(d) ? exp.get(d) : base.getOrDefault(d, DV_NO_VALUE);
-        Object av = act.containsKey(d) ? act.get(d) : base.getOrDefault(d, DV_NO_VALUE);
-        if (dvEquals(ev, av) == false) {
-          return false;
-        }
-      }
-    }
-    return true;
-  }
-
-  /**
-   * Legacy carry-over reconstruction from the heap-retained {@code mergingDVUpdates}, kept only as
-   * the assertion oracle for {@link #buildMappedDVUpdatesFromDisk} until {@code mergingDVUpdates} is
-   * removed. Mirrors the pre-existing merge-commit logic.
-   */
-  private Map<String, LongObjectHashMap<DocValuesFieldUpdates>> buildMappedDVUpdatesFromMerging(
-      MergePolicy.OneMerge merge, MergeState.DocMap[] docMaps) throws IOException {
-    final int mergedMaxDoc = merge.info.info.maxDoc();
-    Map<String, LongObjectHashMap<DocValuesFieldUpdates>> mapped = new HashMap<>();
-    for (int i = 0; i < merge.segments.size(); i++) {
-      final ReadersAndUpdates rld = getPooledInstance(merge.segments.get(i), false);
-      final MergeState.DocMap segDocMap = docMaps[i];
-      Map<String, List<DocValuesFieldUpdates>> mergingDVUpdates = rld.getMergingDVUpdates();
-      for (Map.Entry<String, List<DocValuesFieldUpdates>> ent : mergingDVUpdates.entrySet()) {
-        LongObjectHashMap<DocValuesFieldUpdates> byGen =
-            mapped.computeIfAbsent(ent.getKey(), _ -> new LongObjectHashMap<>());
-        for (DocValuesFieldUpdates updates : ent.getValue()) {
-          if (bufferedUpdatesStream.stillRunning(updates.delGen)) {
-            continue;
-          }
-          DocValuesFieldUpdates mappedUpdates = byGen.get(updates.delGen);
-          if (mappedUpdates == null) {
-            mappedUpdates =
-                updates.type == DocValuesType.BINARY
-                    ? new BinaryDocValuesFieldUpdates(updates.delGen, updates.field, mergedMaxDoc)
-                    : new NumericDocValuesFieldUpdates(updates.delGen, updates.field, mergedMaxDoc);
-            byGen.put(updates.delGen, mappedUpdates);
-          }
-          DocValuesFieldUpdates.Iterator it = updates.iterator();
-          int doc;
-          while ((doc = it.nextDoc()) != NO_MORE_DOCS) {
-            int mappedDoc = segDocMap.get(doc);
-            if (mappedDoc != -1) {
-              if (it.hasValue()) {
-                mappedUpdates.add(mappedDoc, it);
-              } else {
-                mappedUpdates.reset(mappedDoc);
-              }
-            }
-          }
-        }
-      }
-    }
-    for (LongObjectHashMap<DocValuesFieldUpdates> byGen : mapped.values()) {
-      for (ObjectCursor<DocValuesFieldUpdates> c : byGen.values()) {
-        c.value.finish();
-      }
-    }
-    return mapped;
-  }
-
-  /**
-   * Reconstructs the doc-values-update merge carry-over purely from the source segments' on-disk
-   * state plus their residual (finished but not-yet-written) pending updates, remapping to merged
-   * docIDs. This is the replacement for consuming {@code ReadersAndUpdates.mergingDVUpdates}: nothing
-   * is retained in heap for the merge duration. Returns {@code field -> delGen -> updates}, matching
-   * the shape the merged {@link ReadersAndUpdates} consumes.
+   * Builds the doc-values-update merge carry-over from the source segments' on-disk state plus
+   * their residual (resolved but not-yet-written) pending updates, remapping to merged docIDs.
+   * Returns {@code field -> delGen -> updates} for the merged {@link ReadersAndUpdates} to apply.
    *
-   * <p>Per source segment and updated field, the already-flushed changes (the bulk) are read back
-   * from disk (current-vs-baseline diff) and collapsed into a single packet; the still-pending
-   * updates keep their real delGens. Because flushing is a monotonic prefix by {@code
-   * completedDelGen}, every residual delGen is strictly greater than any flushed one, so the
-   * collapsed packet is given {@code minResidualDelGen - 1} (or {@code completedDelGen} when there is
-   * no residual) — a slot below all residual/still-running gens and above {@code minGen}, so
-   * newest-wins ordering on the merged segment is preserved.
+   * <p>Per source segment and updated field, the written changes are read back from disk
+   * (current-vs-baseline diff) and collapsed into one packet, while the residual updates keep their
+   * real delGens. Flushing advances {@code completedDelGen} as a prefix, so every residual delGen
+   * is greater than any written one; the collapsed packet therefore uses {@code minResidualDelGen -
+   * 1} (or {@code completedDelGen} when there is no residual), a gen below all residual and
+   * still-running ones so newest-wins ordering holds on the merged segment.
    */
   private Map<String, LongObjectHashMap<DocValuesFieldUpdates>> buildMappedDVUpdatesFromDisk(
       MergePolicy.OneMerge merge, MergeState.DocMap[] docMaps, long minGen) throws IOException {
@@ -4704,7 +4544,7 @@ public class IndexWriter
         // still globally running (those re-resolve against the merged segment).
         Map<String, List<DocValuesFieldUpdates>> residualByField = new HashMap<>();
         for (Map.Entry<String, List<DocValuesFieldUpdates>> e :
-            rld.getPendingDVUpdatesForAssert().entrySet()) {
+            rld.getPendingDVUpdatesSnapshot().entrySet()) {
           List<DocValuesFieldUpdates> keep = new ArrayList<>();
           for (DocValuesFieldUpdates u : e.getValue()) {
             if (bufferedUpdatesStream.stillRunning(u.delGen) == false) {
@@ -4731,10 +4571,6 @@ public class IndexWriter
         }
 
         for (String field : updatedFields) {
-          FieldInfo fi = current.getFieldInfos().fieldInfo(field);
-          if (fi == null) {
-            continue;
-          }
           List<DocValuesFieldUpdates> residual = residualByField.getOrDefault(field, List.of());
           long minResidual = Long.MAX_VALUE;
           for (DocValuesFieldUpdates u : residual) {
@@ -4747,12 +4583,19 @@ public class IndexWriter
           LongObjectHashMap<DocValuesFieldUpdates> byGen =
               mapped.computeIfAbsent(field, _ -> new LongObjectHashMap<>());
 
-          // (A) flushed changes since baseline, collapsed at diskDelGen.
-          addDiskDiffToPacket(fi, baseline, current, segDocMap, diskDelGen, mergedMaxDoc, byGen);
-          assert byGen.containsKey(diskDelGen) == false || diskDelGen > minGen
-              : "diskDelGen " + diskDelGen + " <= minGen " + minGen;
+          // (A) flushed changes since baseline, collapsed at diskDelGen. Only when the field has
+          // on-disk doc values; a field whose only updates are still pending is absent from the
+          // reader (e.g. a soft-deletes field on its first, not-yet-written update).
+          FieldInfo fi = current.getFieldInfos().fieldInfo(field);
+          if (fi != null) {
+            addDiskDiffToPacket(fi, baseline, current, segDocMap, diskDelGen, mergedMaxDoc, byGen);
+            assert byGen.containsKey(diskDelGen) == false || diskDelGen > minGen
+                : "diskDelGen " + diskDelGen + " <= minGen " + minGen;
+          }
 
-          // (B) residual updates at their real delGens.
+          // (B) residual updates at their real delGens, typed from the packet itself since the
+          // field
+          // need not exist on disk yet.
           for (DocValuesFieldUpdates u : residual) {
             DocValuesFieldUpdates.Iterator it = u.iterator();
             int doc;
@@ -4761,7 +4604,14 @@ public class IndexWriter
               if (md == -1) {
                 continue;
               }
-              DocValuesFieldUpdates p = getOrCreatePacket(byGen, u.delGen, fi, mergedMaxDoc);
+              DocValuesFieldUpdates p = byGen.get(u.delGen);
+              if (p == null) {
+                p =
+                    u.type == DocValuesType.BINARY
+                        ? new BinaryDocValuesFieldUpdates(u.delGen, u.field, mergedMaxDoc)
+                        : new NumericDocValuesFieldUpdates(u.delGen, u.field, mergedMaxDoc);
+                byGen.put(u.delGen, p);
+              }
               if (it.hasValue()) {
                 p.add(md, it);
               } else {
@@ -4780,16 +4630,6 @@ public class IndexWriter
       }
     }
     return mapped;
-  }
-
-  /** Current value under a {@link DocValuesFieldUpdates.Iterator}: Long, BytesRef, or DV_NO_VALUE. */
-  private static Object dvUpdateValue(DocValuesType type, DocValuesFieldUpdates.Iterator it) {
-    if (it.hasValue() == false) {
-      return DV_NO_VALUE;
-    }
-    return type == DocValuesType.BINARY
-        ? BytesRef.deepCopyOf(it.binaryValue())
-        : Long.valueOf(it.longValue());
   }
 
   private static DocValuesFieldUpdates getOrCreatePacket(
@@ -4833,11 +4673,21 @@ public class IndexWriter
       Object curVal;
       Object baseVal;
       if (binary) {
-        curVal = (curB != null && curB.advanceExact(doc)) ? BytesRef.deepCopyOf(curB.binaryValue()) : DV_NO_VALUE;
-        baseVal = (baseB != null && baseB.advanceExact(doc)) ? BytesRef.deepCopyOf(baseB.binaryValue()) : DV_NO_VALUE;
+        curVal =
+            (curB != null && curB.advanceExact(doc))
+                ? BytesRef.deepCopyOf(curB.binaryValue())
+                : DV_NO_VALUE;
+        baseVal =
+            (baseB != null && baseB.advanceExact(doc))
+                ? BytesRef.deepCopyOf(baseB.binaryValue())
+                : DV_NO_VALUE;
       } else {
-        curVal = (curN != null && curN.advanceExact(doc)) ? Long.valueOf(curN.longValue()) : DV_NO_VALUE;
-        baseVal = (baseN != null && baseN.advanceExact(doc)) ? Long.valueOf(baseN.longValue()) : DV_NO_VALUE;
+        curVal =
+            (curN != null && curN.advanceExact(doc)) ? Long.valueOf(curN.longValue()) : DV_NO_VALUE;
+        baseVal =
+            (baseN != null && baseN.advanceExact(doc))
+                ? Long.valueOf(baseN.longValue())
+                : DV_NO_VALUE;
       }
       if (dvEquals(curVal, baseVal)) {
         continue;
@@ -4851,31 +4701,6 @@ public class IndexWriter
         ((NumericDocValuesFieldUpdates) p).add(md, (Long) curVal);
       }
     }
-  }
-
-  /** Collapses {@code field -> delGen -> updates} to {@code field -> merged doc -> value}, newest delGen wins. */
-  private static Map<String, Map<Integer, Object>> effectiveMap(
-      Map<String, LongObjectHashMap<DocValuesFieldUpdates>> mapped) {
-    Map<String, Map<Integer, Object>> out = new HashMap<>();
-    for (Map.Entry<String, LongObjectHashMap<DocValuesFieldUpdates>> e : mapped.entrySet()) {
-      Map<Integer, Object> byDoc = new HashMap<>();
-      List<DocValuesFieldUpdates> packets = new ArrayList<>();
-      for (ObjectCursor<DocValuesFieldUpdates> c : e.getValue().values()) {
-        packets.add(c.value);
-      }
-      packets.sort(Comparator.comparingLong(u -> u.delGen));
-      for (DocValuesFieldUpdates u : packets) {
-        DocValuesFieldUpdates.Iterator it = u.iterator();
-        int d;
-        while ((d = it.nextDoc()) != NO_MORE_DOCS) {
-          byDoc.put(d, dvUpdateValue(u.type, it));
-        }
-      }
-      if (byDoc.isEmpty() == false) {
-        out.put(e.getKey(), byDoc);
-      }
-    }
-    return out;
   }
 
   private static boolean dvEquals(Object a, Object b) {
@@ -5466,8 +5291,6 @@ public class IndexWriter
               assert rld != null;
               if (drop) {
                 rld.dropChanges();
-              } else {
-                rld.dropMergingUpdates();
               }
               rld.release(sr);
               release(rld);
@@ -5544,7 +5367,6 @@ public class IndexWriter
       merge.initMergeReaders(
           sci -> {
             final ReadersAndUpdates rld = getPooledInstance(sci, true);
-            rld.setIsMerging();
             synchronized (this) {
               return rld.getReaderForMerge(
                   context, mr -> deleter.incRef(mr.reader.getSegmentInfo().files()));

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -86,6 +87,7 @@ import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.Counter;
 import org.apache.lucene.util.IOConsumer;
@@ -4574,9 +4576,177 @@ public class IndexWriter
       infoStream.message("IW", msg);
     }
 
+    assert assertCarryOverReconstructibleFromDisk(merge, docMaps, mappedDVUpdates);
+
     merge.info.setBufferedDeletesGen(minGen);
 
     return mergedDeletesAndUpdates;
+  }
+
+  /** Sentinel for "no doc-values value" (a reset, or a doc that simply has no value). */
+  private static final Object DV_NO_VALUE = new Object();
+
+  /**
+   * Assertion-only invariant check backing the removal of {@code ReadersAndUpdates.mergingDVUpdates}:
+   * the doc-values-update carry-over accumulated in heap for the whole merge is redundant with what
+   * the source segments already persist. This recomputes the carry-over purely from each source
+   * segment's current on-disk state (relative to the merge-reader baseline) plus the residual
+   * still-pending updates, and asserts it matches the {@code mappedDVUpdates} produced from
+   * {@code mergingDVUpdates}. Read-only; changes no behavior.
+   */
+  private boolean assertCarryOverReconstructibleFromDisk(
+      MergePolicy.OneMerge merge,
+      MergeState.DocMap[] docMaps,
+      Map<String, LongObjectHashMap<DocValuesFieldUpdates>> mappedDVUpdates)
+      throws IOException {
+    // expected: field -> merged docID -> value (Long | BytesRef | DV_NO_VALUE), newest delGen wins.
+    Map<String, Map<Integer, Object>> expected = new HashMap<>();
+    for (Map.Entry<String, LongObjectHashMap<DocValuesFieldUpdates>> e : mappedDVUpdates.entrySet()) {
+      Map<Integer, Object> byDoc = new HashMap<>();
+      List<DocValuesFieldUpdates> packets = new ArrayList<>();
+      for (ObjectCursor<DocValuesFieldUpdates> c : e.getValue().values()) {
+        packets.add(c.value);
+      }
+      packets.sort(Comparator.comparingLong(u -> u.delGen));
+      for (DocValuesFieldUpdates u : packets) {
+        DocValuesFieldUpdates.Iterator it = u.iterator();
+        int d;
+        while ((d = it.nextDoc()) != NO_MORE_DOCS) {
+          byDoc.put(d, dvUpdateValue(u.type, it));
+        }
+      }
+      expected.put(e.getKey(), byDoc);
+    }
+
+    // actual: reconstruct the same map from disk (current-vs-baseline per source segment) + residual
+    // still-pending updates.
+    Map<String, Map<Integer, Object>> actual = new HashMap<>();
+    for (int i = 0; i < merge.segments.size(); i++) {
+      SegmentCommitInfo info = merge.segments.get(i);
+      final ReadersAndUpdates rld = getPooledInstance(info, false);
+      final MergeState.DocMap segDocMap = docMaps[i];
+      final CodecReader baseline = merge.getMergeReader().get(i).codecReader;
+      final SegmentReader current = rld.getReader(IOContext.DEFAULT);
+      try {
+        // (A) on-disk changes since baseline, for the updated fields (those in expected).
+        for (String field : expected.keySet()) {
+          FieldInfo fi = current.getFieldInfos().fieldInfo(field);
+          if (fi == null) {
+            continue;
+          }
+          Map<Integer, Object> byDoc = actual.computeIfAbsent(field, _ -> new HashMap<>());
+          diffFieldForAssert(fi, baseline, current, segDocMap, expected.get(field), byDoc);
+        }
+        // (B) residual still-pending updates (finished-but-unflushed), newest delGen wins; skip any
+        // still globally running (those re-resolve against the merged segment).
+        for (List<DocValuesFieldUpdates> lst : rld.getPendingDVUpdatesForAssert().values()) {
+          List<DocValuesFieldUpdates> packets = new ArrayList<>(lst);
+          packets.sort(Comparator.comparingLong(u -> u.delGen));
+          for (DocValuesFieldUpdates u : packets) {
+            if (bufferedUpdatesStream.stillRunning(u.delGen)) {
+              continue;
+            }
+            Map<Integer, Object> byDoc = actual.computeIfAbsent(u.field, _ -> new HashMap<>());
+            DocValuesFieldUpdates.Iterator it = u.iterator();
+            int d;
+            while ((d = it.nextDoc()) != NO_MORE_DOCS) {
+              int mapped = segDocMap.get(d);
+              if (mapped != -1) {
+                byDoc.put(mapped, dvUpdateValue(u.type, it));
+              }
+            }
+          }
+        }
+      } finally {
+        current.decRef();
+      }
+    }
+
+    assert dvCarryOverEquals(expected, actual)
+        : "DV-update carry-over not reconstructible from disk:\n expected=" + expected + "\n actual=" + actual;
+    return true;
+  }
+
+  /** Current value under a {@link DocValuesFieldUpdates.Iterator}: Long, BytesRef, or DV_NO_VALUE. */
+  private static Object dvUpdateValue(DocValuesType type, DocValuesFieldUpdates.Iterator it) {
+    if (it.hasValue() == false) {
+      return DV_NO_VALUE;
+    }
+    return type == DocValuesType.BINARY
+        ? BytesRef.deepCopyOf(it.binaryValue())
+        : Long.valueOf(it.longValue());
+  }
+
+  /**
+   * Records, for the updated docs of one field on one source segment, the segment's current on-disk
+   * value (remapped to merged docIDs) whenever the doc is one that {@code expected} carries, plus any
+   * on-disk change not present in {@code expected} (which would be a real discrepancy).
+   */
+  private static void diffFieldForAssert(
+      FieldInfo fi,
+      CodecReader baseline,
+      CodecReader current,
+      MergeState.DocMap segDocMap,
+      Map<Integer, Object> expectedForField,
+      Map<Integer, Object> actualForField)
+      throws IOException {
+    final int maxDoc = current.maxDoc();
+    if (fi.getDocValuesType() == DocValuesType.BINARY) {
+      BinaryDocValues cur = current.getBinaryDocValues(fi.name);
+      BinaryDocValues base = baseline.getBinaryDocValues(fi.name);
+      for (int doc = 0; doc < maxDoc; doc++) {
+        int mapped = segDocMap.get(doc);
+        if (mapped == -1) {
+          continue;
+        }
+        Object curVal = (cur != null && cur.advanceExact(doc)) ? BytesRef.deepCopyOf(cur.binaryValue()) : DV_NO_VALUE;
+        Object baseVal = (base != null && base.advanceExact(doc)) ? BytesRef.deepCopyOf(base.binaryValue()) : DV_NO_VALUE;
+        if (expectedForField.containsKey(mapped) || dvEquals(curVal, baseVal) == false) {
+          actualForField.put(mapped, curVal);
+        }
+      }
+    } else { // NUMERIC (only NUMERIC/BINARY are updatable)
+      NumericDocValues cur = current.getNumericDocValues(fi.name);
+      NumericDocValues base = baseline.getNumericDocValues(fi.name);
+      for (int doc = 0; doc < maxDoc; doc++) {
+        int mapped = segDocMap.get(doc);
+        if (mapped == -1) {
+          continue;
+        }
+        Object curVal = (cur != null && cur.advanceExact(doc)) ? Long.valueOf(cur.longValue()) : DV_NO_VALUE;
+        Object baseVal = (base != null && base.advanceExact(doc)) ? Long.valueOf(base.longValue()) : DV_NO_VALUE;
+        if (expectedForField.containsKey(mapped) || dvEquals(curVal, baseVal) == false) {
+          actualForField.put(mapped, curVal);
+        }
+      }
+    }
+  }
+
+  private static boolean dvEquals(Object a, Object b) {
+    if (a == DV_NO_VALUE || b == DV_NO_VALUE) {
+      return a == b;
+    }
+    return a.equals(b);
+  }
+
+  private static boolean dvCarryOverEquals(
+      Map<String, Map<Integer, Object>> expected, Map<String, Map<Integer, Object>> actual) {
+    if (expected.keySet().equals(actual.keySet()) == false) {
+      return false;
+    }
+    for (Map.Entry<String, Map<Integer, Object>> e : expected.entrySet()) {
+      Map<Integer, Object> exp = e.getValue();
+      Map<Integer, Object> act = actual.get(e.getKey());
+      if (exp.size() != act.size()) {
+        return false;
+      }
+      for (Map.Entry<Integer, Object> de : exp.entrySet()) {
+        if (act.containsKey(de.getKey()) == false || dvEquals(de.getValue(), act.get(de.getKey())) == false) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/ReaderPool.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReaderPool.java
@@ -270,7 +270,6 @@ final class ReaderPool implements Closeable {
         any |=
             rld.writeFieldUpdates(
                 directory, fieldNumbers, completedDelGenSupplier.getAsLong(), infoStream);
-        rld.setIsMerging();
       }
     }
     return any;

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -77,22 +77,9 @@ final class ReadersAndUpdates {
 
   private final LiveIndexWriterConfig config;
 
-  // Indicates whether this segment is currently being merged. While a segment
-  // is merging, all field updates are also registered in the
-  // mergingDVUpdates map. Also, calls to writeFieldUpdates merge the
-  // updates with mergingDVUpdates.
-  // That way, when the segment is done merging, IndexWriter can apply the
-  // updates on the merged segment too.
-  private boolean isMerging = false;
-
   // Holds resolved (to docIDs) doc values updates that have not yet been
   // written to the index
   private final Map<String, List<DocValuesFieldUpdates>> pendingDVUpdates = new HashMap<>();
-
-  // Holds resolved (to docIDs) doc values updates that were resolved while
-  // this segment was being merged; at the end of the merge we carry over
-  // these updates (remapping their docIDs) to the newly merged segment
-  private final Map<String, List<DocValuesFieldUpdates>> mergingDVUpdates = new HashMap<>();
 
   // Only set if there are doc values updates against this segment, and the index is sorted:
   Sorter.DocMap sortMap;
@@ -173,15 +160,6 @@ final class ReadersAndUpdates {
     ramBytesUsed.addAndGet(update.ramBytesUsed());
 
     fieldUpdates.add(update);
-
-    if (isMerging) {
-      fieldUpdates = mergingDVUpdates.get(update.field);
-      if (fieldUpdates == null) {
-        fieldUpdates = new ArrayList<>();
-        mergingDVUpdates.put(update.field, fieldUpdates);
-      }
-      fieldUpdates.add(update);
-    }
   }
 
   public synchronized long getNumDVUpdates() {
@@ -193,13 +171,10 @@ final class ReadersAndUpdates {
   }
 
   /**
-   * Assertion-only snapshot of the currently-pending (resolved but not yet written) doc-values
-   * updates, keyed by field. Used to validate that the merge carry-over is fully reconstructible
-   * from the source segment's on-disk state plus this residual, i.e. that {@code mergingDVUpdates}
-   * is redundant. Returns copies of the per-field lists so callers can iterate without holding the
-   * lock.
+   * Copies of the currently-pending (resolved but not yet written) doc-values updates, keyed by
+   * field, so callers can iterate without holding the lock.
    */
-  synchronized Map<String, List<DocValuesFieldUpdates>> getPendingDVUpdatesForAssert() {
+  synchronized Map<String, List<DocValuesFieldUpdates>> getPendingDVUpdatesSnapshot() {
     Map<String, List<DocValuesFieldUpdates>> copy = new HashMap<>();
     for (Map.Entry<String, List<DocValuesFieldUpdates>> ent : pendingDVUpdates.entrySet()) {
       copy.put(ent.getKey(), new ArrayList<>(ent.getValue()));
@@ -305,7 +280,6 @@ final class ReadersAndUpdates {
     // deletes onto the newly merged segment, so we can
     // discard them on the sub-readers:
     pendingDeletes.dropChanges();
-    dropMergingUpdates();
   }
 
   // Commit live docs (writes new _X_N.del files) and field updates (writes new
@@ -1002,36 +976,9 @@ final class ReadersAndUpdates {
     reader = createNewReaderWithLatestLiveDocs(reader);
   }
 
-  synchronized void setIsMerging() {
-    // This ensures any newly resolved doc value updates while we are merging are
-    // saved for re-applying after this segment is done merging:
-    if (isMerging == false) {
-      isMerging = true;
-      assert mergingDVUpdates.isEmpty();
-    }
-  }
-
-  synchronized boolean isMerging() {
-    return isMerging;
-  }
-
   /** Returns a reader for merge, with the latest doc values updates and deletions. */
   synchronized MergePolicy.MergeReader getReaderForMerge(
       IOContext context, IOConsumer<MergePolicy.MergeReader> readerConsumer) throws IOException {
-
-    // We must carry over any still-pending DV updates because they were not
-    // successfully written, e.g. because there was a hole in the delGens,
-    // or they arrived after we wrote all DVs for merge but before we set
-    // isMerging here:
-    for (Map.Entry<String, List<DocValuesFieldUpdates>> ent : pendingDVUpdates.entrySet()) {
-      List<DocValuesFieldUpdates> mergingUpdates = mergingDVUpdates.get(ent.getKey());
-      if (mergingUpdates == null) {
-        mergingUpdates = new ArrayList<>();
-        mergingDVUpdates.put(ent.getKey(), mergingUpdates);
-      }
-      mergingUpdates.addAll(ent.getValue());
-    }
-
     SegmentReader reader = getReader(context);
     if (pendingDeletes.needsRefresh(reader)
         || reader.getSegmentInfo().getDelGen() != pendingDeletes.info.getDelGen()) {
@@ -1044,22 +991,6 @@ final class ReadersAndUpdates {
         new MergePolicy.MergeReader(reader, pendingDeletes.getHardLiveDocs());
     readerConsumer.accept(mergeReader);
     return mergeReader;
-  }
-
-  /**
-   * Drops all merging updates. Called from IndexWriter after this segment finished merging (whether
-   * successfully or not).
-   */
-  public synchronized void dropMergingUpdates() {
-    mergingDVUpdates.clear();
-    isMerging = false;
-  }
-
-  public synchronized Map<String, List<DocValuesFieldUpdates>> getMergingDVUpdates() {
-    // We must atomically (in single sync'd block) clear isMerging when we return the DV updates
-    // otherwise we can lose updates:
-    isMerging = false;
-    return mergingDVUpdates;
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -173,7 +173,8 @@ final class ReadersAndUpdates {
 
   /**
    * Copies of the currently-pending (resolved but not yet written) doc-values updates, keyed by
-   * field, so callers can iterate without holding the lock.
+   * field. Returning copies lets the merge carry-over iterate them, and do its disk I/O, without
+   * holding this monitor; IndexWriter still coordinates the carry-over for correctness.
    */
   synchronized Map<String, List<DocValuesFieldUpdates>> getPendingDVUpdatesSnapshot() {
     Map<String, List<DocValuesFieldUpdates>> copy = new HashMap<>();

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -192,6 +192,21 @@ final class ReadersAndUpdates {
     return count;
   }
 
+  /**
+   * Assertion-only snapshot of the currently-pending (resolved but not yet written) doc-values
+   * updates, keyed by field. Used to validate that the merge carry-over is fully reconstructible
+   * from the source segment's on-disk state plus this residual, i.e. that {@code mergingDVUpdates}
+   * is redundant. Returns copies of the per-field lists so callers can iterate without holding the
+   * lock.
+   */
+  synchronized Map<String, List<DocValuesFieldUpdates>> getPendingDVUpdatesForAssert() {
+    Map<String, List<DocValuesFieldUpdates>> copy = new HashMap<>();
+    for (Map.Entry<String, List<DocValuesFieldUpdates>> ent : pendingDVUpdates.entrySet()) {
+      copy.put(ent.getKey(), new ArrayList<>(ent.getValue()));
+    }
+    return copy;
+  }
+
   /** Returns a {@link SegmentReader}. */
   public synchronized SegmentReader getReader(IOContext context) throws IOException {
     if (reader == null) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestMergeCarryOverFromDisk.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMergeCarryOverFromDisk.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.index;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.BytesRef;
+
+/**
+ * Deterministically exercises the doc-values-update merge carry-over path: an update that resolves
+ * onto a segment <em>while it is being merged</em> must appear on the merged segment. This is the
+ * path backed in heap today by {@code ReadersAndUpdates.mergingDVUpdates}; the test blocks a merge
+ * mid-flight (only its own output, via {@link IOContext#mergeInfo}, so the update's flush is free),
+ * applies + resolves updates, then releases the merge.
+ */
+public class TestMergeCarryOverFromDisk extends LuceneTestCase {
+
+  /** Wraps a directory, pausing the first merge output write until the test releases it. */
+  private static class MergePausingDirectory extends FilterDirectory {
+    final CountDownLatch mergeStarted = new CountDownLatch(1);
+    final CountDownLatch resumeMerge = new CountDownLatch(1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+    MergePausingDirectory(Directory in) {
+      super(in);
+    }
+
+    @Override
+    public IndexOutput createOutput(String name, IOContext context) throws IOException {
+      if (context != null && context.mergeInfo() != null && mergeStarted.getCount() > 0) {
+        mergeStarted.countDown();
+        try {
+          resumeMerge.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException(e);
+        }
+      }
+      return super.createOutput(name, context);
+    }
+  }
+
+  private static Document doc(int id, long ndv, String bdv) {
+    Document d = new Document();
+    d.add(new StringField("id", Integer.toString(id), StringField.Store.NO));
+    d.add(new NumericDocValuesField("ndv", ndv));
+    d.add(new BinaryDocValuesField("bdv", new BytesRef(bdv)));
+    return d;
+  }
+
+  public void testUpdatesResolvedDuringMergeAreCarriedOver() throws Exception {
+    MergePausingDirectory dir = new MergePausingDirectory(newDirectory());
+    IndexWriterConfig conf =
+        newIndexWriterConfig(new MockAnalyzer(random()))
+            .setMergeScheduler(new ConcurrentMergeScheduler());
+    IndexWriter writer = new IndexWriter(dir, conf);
+
+    // Two segments; the default TieredMergePolicy won't auto-merge two small segments.
+    for (int i = 0; i < 4; i++) {
+      writer.addDocument(doc(i, i, "v" + i));
+    }
+    writer.commit();
+    for (int i = 4; i < 8; i++) {
+      writer.addDocument(doc(i, i, "v" + i));
+    }
+    writer.commit();
+
+    // Force the merge on a background thread so we can inject updates while it is paused mid-flight.
+    Thread merger =
+        new Thread(
+            () -> {
+              try {
+                writer.forceMerge(1);
+              } catch (Throwable t) {
+                dir.failure.compareAndSet(null, t);
+              }
+            },
+            "forceMerge");
+    merger.start();
+
+    // Wait until the merge has opened its readers (setIsMerging done) and begun writing output.
+    dir.mergeStarted.await();
+
+    // Update numeric + binary values on docs in the now-merging segments, and reset one, then
+    // resolve them to the segments (and disk) by reopening a reader from the writer.
+    writer.updateNumericDocValue(new Term("id", "1"), "ndv", 101L);
+    writer.updateNumericDocValue(new Term("id", "5"), "ndv", 105L);
+    writer.updateBinaryDocValue(new Term("id", "2"), "bdv", new BytesRef("updated-2"));
+    writer.updateBinaryDocValue(new Term("id", "6"), "bdv", new BytesRef("updated-6"));
+    // Force resolution onto the merging segments (writes DV gens to disk + populates mergingDVUpdates).
+    try (DirectoryReader r = DirectoryReader.open(writer)) {
+      assertNotNull(r);
+    }
+
+    // Let the merge finish; the carry-over assert in commitMergedDeletesAndUpdates runs here.
+    dir.resumeMerge.countDown();
+    merger.join();
+    assertNull("forceMerge failed: " + dir.failure.get(), dir.failure.get());
+
+    // Verify the merged segment reflects the numeric + binary updates that resolved during the merge.
+    try (DirectoryReader reader = DirectoryReader.open(writer)) {
+      assertEquals(1, reader.leaves().size()); // single merged segment
+      LeafReader leaf = reader.leaves().get(0).reader();
+      NumericDocValues ndv = leaf.getNumericDocValues("ndv");
+      BinaryDocValues bdv = leaf.getBinaryDocValues("bdv");
+      java.util.Set<Long> ndvValues = new java.util.HashSet<>();
+      java.util.Set<String> bdvValues = new java.util.HashSet<>();
+      for (int d = 0; d < leaf.maxDoc(); d++) {
+        assertTrue(ndv.advanceExact(d));
+        ndvValues.add(ndv.longValue());
+        assertTrue(bdv.advanceExact(d));
+        bdvValues.add(bdv.binaryValue().utf8ToString());
+      }
+      assertTrue("carried numeric update 101 missing", ndvValues.contains(101L));
+      assertTrue("carried numeric update 105 missing", ndvValues.contains(105L));
+      assertTrue("carried binary update updated-2 missing", bdvValues.contains("updated-2"));
+      assertTrue("carried binary update updated-6 missing", bdvValues.contains("updated-6"));
+    }
+
+    writer.close();
+    dir.close();
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/index/TestMergeCarryOverFromDisk.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMergeCarryOverFromDisk.java
@@ -29,12 +29,13 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 
 /**
  * Deterministically exercises the doc-values-update merge carry-over path: an update that resolves
- * onto a segment <em>while it is being merged</em> must appear on the merged segment. This is the
- * path backed in heap today by {@code ReadersAndUpdates.mergingDVUpdates}; the test blocks a merge
+ * onto a segment <em>while it is being merged</em> must appear on the merged segment. That
+ * carry-over is reconstructed from the source segments at merge commit; the test blocks a merge
  * mid-flight (only its own output, via {@link IOContext#mergeInfo}, so the update's flush is free),
  * applies + resolves updates, then releases the merge.
  */
@@ -90,7 +91,8 @@ public class TestMergeCarryOverFromDisk extends LuceneTestCase {
     }
     writer.commit();
 
-    // Force the merge on a background thread so we can inject updates while it is paused mid-flight.
+    // Force the merge on a background thread so we can inject updates while it is paused
+    // mid-flight.
     Thread merger =
         new Thread(
             () -> {
@@ -103,7 +105,8 @@ public class TestMergeCarryOverFromDisk extends LuceneTestCase {
             "forceMerge");
     merger.start();
 
-    // Wait until the merge has opened its readers (setIsMerging done) and begun writing output.
+    // Wait until the merge has opened its readers (its on-disk baseline is fixed) and begun writing
+    // output.
     dir.mergeStarted.await();
 
     // Update numeric + binary values on docs in the now-merging segments, and reset one, then
@@ -112,17 +115,18 @@ public class TestMergeCarryOverFromDisk extends LuceneTestCase {
     writer.updateNumericDocValue(new Term("id", "5"), "ndv", 105L);
     writer.updateBinaryDocValue(new Term("id", "2"), "bdv", new BytesRef("updated-2"));
     writer.updateBinaryDocValue(new Term("id", "6"), "bdv", new BytesRef("updated-6"));
-    // Force resolution onto the merging segments (writes DV gens to disk + populates mergingDVUpdates).
+    // Force resolution onto the merging segments (writes DV gens to disk).
     try (DirectoryReader r = DirectoryReader.open(writer)) {
       assertNotNull(r);
     }
 
-    // Let the merge finish; the carry-over assert in commitMergedDeletesAndUpdates runs here.
+    // Let the merge finish; the disk carry-over in commitMergedDeletesAndUpdates runs here.
     dir.resumeMerge.countDown();
     merger.join();
     assertNull("forceMerge failed: " + dir.failure.get(), dir.failure.get());
 
-    // Verify the merged segment reflects the numeric + binary updates that resolved during the merge.
+    // Verify the merged segment reflects the numeric + binary updates that resolved during the
+    // merge.
     try (DirectoryReader reader = DirectoryReader.open(writer)) {
       assertEquals(1, reader.leaves().size()); // single merged segment
       LeafReader leaf = reader.leaves().get(0).reader();
@@ -140,6 +144,144 @@ public class TestMergeCarryOverFromDisk extends LuceneTestCase {
       assertTrue("carried numeric update 105 missing", ndvValues.contains(105L));
       assertTrue("carried binary update updated-2 missing", bdvValues.contains("updated-2"));
       assertTrue("carried binary update updated-6 missing", bdvValues.contains("updated-6"));
+    }
+
+    writer.close();
+    dir.close();
+  }
+
+  /**
+   * Applies more than {@code maxDocValuesOverlays} updates to one field of a merging segment while
+   * the merge is paused, forcing the sparse overlays to fold (and possibly fold to a dense column)
+   * before the carry-over reads them back. The merged segment must reflect the final value.
+   */
+  public void testFoldedOverlaysCarriedOverDuringMerge() throws Exception {
+    MergePausingDirectory dir = new MergePausingDirectory(newDirectory());
+    IndexWriterConfig conf =
+        newIndexWriterConfig(new MockAnalyzer(random()))
+            .setMergeScheduler(new ConcurrentMergeScheduler())
+            // small overlay budget so a handful of updates already triggers a fold
+            .setMaxDocValuesOverlays(4);
+    IndexWriter writer = new IndexWriter(dir, conf);
+    for (int i = 0; i < 4; i++) {
+      writer.addDocument(doc(i, i, "v" + i));
+    }
+    writer.commit();
+    for (int i = 4; i < 8; i++) {
+      writer.addDocument(doc(i, i, "v" + i));
+    }
+    writer.commit();
+
+    Thread merger =
+        new Thread(
+            () -> {
+              try {
+                writer.forceMerge(1);
+              } catch (Throwable t) {
+                dir.failure.compareAndSet(null, t);
+              }
+            },
+            "forceMerge");
+    merger.start();
+    dir.mergeStarted.await();
+
+    // Many updates to doc 3 (in the first, merging segment), each resolved separately so it becomes
+    // a
+    // new overlay generation; well past maxDocValuesOverlays, so folds happen mid-merge.
+    long finalValue = -1;
+    for (int v = 0; v < 20; v++) {
+      finalValue = 1000L + v;
+      writer.updateNumericDocValue(new Term("id", "3"), "ndv", finalValue);
+      try (DirectoryReader r = DirectoryReader.open(writer)) {
+        assertNotNull(r);
+      }
+    }
+
+    dir.resumeMerge.countDown();
+    merger.join();
+    assertNull("forceMerge failed: " + dir.failure.get(), dir.failure.get());
+
+    try (DirectoryReader reader = DirectoryReader.open(writer)) {
+      assertEquals(1, reader.leaves().size());
+      NumericDocValues ndv = reader.leaves().get(0).reader().getNumericDocValues("ndv");
+      java.util.Set<Long> values = new java.util.HashSet<>();
+      for (int d = 0; d < reader.leaves().get(0).reader().maxDoc(); d++) {
+        assertTrue(ndv.advanceExact(d));
+        values.add(ndv.longValue());
+      }
+      assertTrue("folded final value " + finalValue + " missing", values.contains(finalValue));
+    }
+
+    writer.close();
+    dir.close();
+  }
+
+  /**
+   * A soft-delete that resolves onto a segment while it is being merged must be carried over, so
+   * the old document is not live on the merged segment. The soft-deletes field is a doc-values
+   * update that need not exist on disk yet, exercising the carry-over of pending updates to a field
+   * absent from the source reader.
+   */
+  public void testSoftDeleteResolvedDuringMergeIsCarriedOver() throws Exception {
+    MergePausingDirectory dir = new MergePausingDirectory(newDirectory());
+    IndexWriterConfig conf =
+        newIndexWriterConfig(new MockAnalyzer(random()))
+            .setMergeScheduler(new ConcurrentMergeScheduler())
+            .setSoftDeletesField("__soft");
+    IndexWriter writer = new IndexWriter(dir, conf);
+    for (int i = 0; i < 4; i++) {
+      writer.addDocument(doc(i, i, "v" + i));
+    }
+    writer.commit();
+    for (int i = 4; i < 8; i++) {
+      writer.addDocument(doc(i, i, "v" + i));
+    }
+    writer.commit();
+
+    Thread merger =
+        new Thread(
+            () -> {
+              try {
+                writer.forceMerge(1);
+              } catch (Throwable t) {
+                dir.failure.compareAndSet(null, t);
+              }
+            },
+            "forceMerge");
+    merger.start();
+    dir.mergeStarted.await();
+
+    // Replace doc id=1 (in the merging segment): adds a new doc and soft-deletes the old one via a
+    // doc-values update to the soft-deletes field. Resolve it onto the merging segment.
+    Document replacement = doc(1, 101, "updated-1");
+    writer.softUpdateDocument(
+        new Term("id", "1"), replacement, new NumericDocValuesField("__soft", 1));
+    try (DirectoryReader r = DirectoryReader.open(writer)) {
+      assertNotNull(r);
+    }
+
+    dir.resumeMerge.countDown();
+    merger.join();
+    assertNull("forceMerge failed: " + dir.failure.get(), dir.failure.get());
+
+    // Exactly one doc with id=1 must be live (the replacement); the old one must be soft-deleted.
+    try (DirectoryReader reader = DirectoryReader.open(writer)) {
+      int live = 0;
+      for (LeafReaderContext ctx : reader.leaves()) {
+        LeafReader leaf = ctx.reader();
+        NumericDocValues ndv = leaf.getNumericDocValues("ndv");
+        Bits liveDocs = leaf.getLiveDocs();
+        for (int d = 0; d < leaf.maxDoc(); d++) {
+          if (liveDocs != null && liveDocs.get(d) == false) {
+            continue;
+          }
+          assertTrue(ndv.advanceExact(d));
+          if (ndv.longValue() == 101) {
+            live++;
+          }
+        }
+      }
+      assertEquals("exactly one live replacement doc expected", 1, live);
     }
 
     writer.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestMergeCarryOverFromDisk.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMergeCarryOverFromDisk.java
@@ -109,8 +109,8 @@ public class TestMergeCarryOverFromDisk extends LuceneTestCase {
     // output.
     dir.mergeStarted.await();
 
-    // Update numeric + binary values on docs in the now-merging segments, and reset one, then
-    // resolve them to the segments (and disk) by reopening a reader from the writer.
+    // Update numeric + binary values on docs in the now-merging segments, then resolve them to the
+    // segments (and disk) by reopening a reader from the writer.
     writer.updateNumericDocValue(new Term("id", "1"), "ndv", 101L);
     writer.updateNumericDocValue(new Term("id", "5"), "ndv", 105L);
     writer.updateBinaryDocValue(new Term("id", "2"), "bdv", new BytesRef("updated-2"));

--- a/lucene/core/src/test/org/apache/lucene/index/TestReaderPool.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestReaderPool.java
@@ -156,22 +156,17 @@ public class TestReaderPool extends LuceneTestCase {
       if (pool.isReaderPoolingEnabled()) {
         if (random().nextBoolean()) {
           writtenToDisk = pool.writeAllDocValuesUpdates();
-          assertFalse(readersAndUpdates.isMerging());
         } else if (random().nextBoolean()) {
           writtenToDisk = pool.commit(segmentInfos);
-          assertFalse(readersAndUpdates.isMerging());
         } else {
           writtenToDisk = pool.writeDocValuesUpdatesForMerge(Collections.singletonList(commitInfo));
-          assertTrue(readersAndUpdates.isMerging());
         }
         assertFalse(pool.release(readersAndUpdates, random().nextBoolean()));
       } else {
         if (random().nextBoolean()) {
           writtenToDisk = pool.release(readersAndUpdates, random().nextBoolean());
-          assertFalse(readersAndUpdates.isMerging());
         } else {
           writtenToDisk = pool.writeDocValuesUpdatesForMerge(Collections.singletonList(commitInfo));
-          assertTrue(readersAndUpdates.isMerging());
           assertFalse(pool.release(readersAndUpdates, random().nextBoolean()));
         }
       }


### PR DESCRIPTION
While a segment is being merged, doc-values updates that resolve on it are kept in an in-memory buffer (`ReadersAndUpdates.mergingDVUpdates`) so they can be carried over to the merged segment. Unlike deletes, which buffer only doc ids, numeric and binary doc-values updates buffer their actual values (the longs and byte strings). This buffer therefore grows with both the number of updates and their size, is retained for the entire duration of a merge, and is not counted by `IndexWriter#ramBytesUsed`.

This removes that buffer. The carry-over is instead reconstructed at merge commit from what the source segments already persist: their on-disk doc-values, diffed against the merge-reader baseline, plus the still-pending updates that haven't been written yet.

The trade-off is some extra doc-values reads when a merge commits, but these are bounded by the merge itself. Behavior is unchanged. Builds on the incremental doc-values updates in #16418.
