### PR TITLE
Add ReturnFieldsRetriever: concurrent scatter/gather utility for per-hit return fields

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -123,7 +123,7 @@ API Changes
 
 New Features
 ---------------------
-* GITHUB#xxx: Add ReturnFieldsRetriever, a concurrent scatter/gather engine that computes one value per hit for an
+* GITHUB#16572: Add ReturnFieldsRetriever, a concurrent scatter/gather engine that computes one value per hit for an
   int[] of global doc IDs and returns them in input order, built on ReaderUtil.partitionByLeaf. Callers supply a
   per-leaf visitor for the value type. Includes DoubleValuesRetriever, a DoubleValuesSource specialization. (Zihan Xu)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -123,6 +123,10 @@ API Changes
 
 New Features
 ---------------------
+* GITHUB#xxx: Add ReturnFieldsRetriever, a concurrent scatter/gather engine that computes one value per hit for an
+  int[] of global doc IDs and returns them in input order, built on ReaderUtil.partitionByLeaf. Callers supply a
+  per-leaf visitor for the value type. Includes DoubleValuesRetriever, a DoubleValuesSource specialization. (Zihan Xu)
+
 * GITHUB#16418: Incremental doc-values updates. A set-only doc-values update (NUMERIC or BINARY) is written as a sparse
   "delta" overlay holding just the updated documents and layered over the base column at read time, instead of
   rewriting the whole column, turning per-update write amplification from O(column) into O(updated docs). Enabled by

--- a/lucene/core/src/java/org/apache/lucene/search/DoubleValuesRetriever.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DoubleValuesRetriever.java
@@ -18,36 +18,17 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.ReaderUtil;
 
 /**
- * Utility for retrieving {@link DoubleValuesSource} values for a set of global doc IDs (the "return
- * fields" of a set of hits), concurrently across leaves.
+ * Retrieves {@link DoubleValuesSource} values for an {@code int[]} of global doc IDs, returning a
+ * {@code double[hit][source]} grid in input order: {@code result[i][s]} is {@code sources[s]}'s
+ * value for {@code globalDocIds[i]}. The input array is not mutated.
  *
- * <p>Given an {@link IndexReader}, an {@code int[]} of global doc IDs (typically the doc IDs of a
- * page of hits, in ranking order), and one or more {@link DoubleValuesSource}s, this returns a
- * {@code double[hit][source]} grid. The result preserves input order: row {@code i} holds the
- * values for {@code globalDocIds[i]}, and column {@code s} holds the value produced by {@code
- * sources[s]}.
- *
- * <p>Internally the doc IDs are scattered to their leaves and sorted ascending within each leaf
- * (via {@link ReaderUtil#partitionByLeaf}), each leaf is processed as an independent task on the
- * supplied {@link Executor}, and the per-leaf results are gathered back into input order using the
- * ordinals tracked by {@code partitionByLeaf}. The input array is not mutated.
- *
- * <p>Documents that have no value for a given source (i.e. {@link DoubleValues#advanceExact} returns
- * {@code false}) are reported as {@link Double#NaN}.
- *
- * <p>This concrete retriever does not supply document scores, so every source must return {@code
- * false} from {@link DoubleValuesSource#needsScores()}; otherwise an {@link
- * IllegalArgumentException} is thrown.
+ * <p>A {@code DoubleValuesSource}-specific specialization of {@link ReturnFieldsRetriever}. A doc
+ * with no value for a source yields {@link Double#NaN}.
  *
  * @lucene.experimental
  */
@@ -64,14 +45,13 @@ public final class DoubleValuesRetriever {
    * @param executor executor used to process leaves concurrently
    * @return a {@code double[globalDocIds.length][sources.length]} grid, in input order; missing
    *     values are {@link Double#NaN}
+   * @throws IllegalArgumentException if any source needs scores (this retriever supplies none)
    */
   public static double[][] retrieve(
       IndexReader reader, int[] globalDocIds, DoubleValuesSource[] sources, Executor executor)
       throws IOException {
     Objects.requireNonNull(reader, "reader");
-    Objects.requireNonNull(globalDocIds, "globalDocIds");
     Objects.requireNonNull(sources, "sources");
-    Objects.requireNonNull(executor, "executor");
 
     // Rewrite the sources once against the top-level reader, as required by DoubleValuesSource.
     final IndexSearcher searcher = new IndexSearcher(reader);
@@ -87,64 +67,23 @@ public final class DoubleValuesRetriever {
       }
     }
 
-    final double[][] values = new double[globalDocIds.length][];
-    if (globalDocIds.length == 0) {
-      return values;
-    }
-
-    final List<LeafReaderContext> leaves = reader.leaves();
-    final ReaderUtil.PartitionedHits partitioned =
-        ReaderUtil.partitionByLeaf(globalDocIds, leaves);
-    final int[][] docIdsByLeaf = partitioned.docIdsByLeaf();
-    final int[][] ordinalsByLeaf = partitioned.ordinalsByLeaf();
-
-    // One task per non-empty leaf. Each task writes disjoint rows of `values` (each ordinal is
-    // unique across leaves), so no synchronization is needed.
-    final List<Callable<Void>> tasks = new ArrayList<>();
-    for (int leafIdx = 0; leafIdx < leaves.size(); leafIdx++) {
-      final int[] leafDocs = docIdsByLeaf[leafIdx];
-      if (leafDocs.length == 0) {
-        continue;
-      }
-      final int[] leafOrds = ordinalsByLeaf[leafIdx];
-      final LeafReaderContext leaf = leaves.get(leafIdx);
-      tasks.add(
-          () -> {
-            retrieveLeaf(leaf, leafDocs, leafOrds, rewritten, values);
-            return null;
-          });
-    }
-
-    new TaskExecutor(executor).invokeAll(tasks);
-    return values;
-  }
-
-  /**
-   * Retrieves values for a single leaf: builds one {@link DoubleValues} cursor per source, then
-   * walks the leaf's (ascending) doc IDs, writing each hit's row into {@code values} at its
-   * original input ordinal.
-   */
-  private static void retrieveLeaf(
-      LeafReaderContext leaf,
-      int[] leafDocs,
-      int[] leafOrds,
-      DoubleValuesSource[] sources,
-      double[][] values)
-      throws IOException {
-    final int docBase = leaf.docBase;
-    final DoubleValues[] cursors = new DoubleValues[sources.length];
-    for (int s = 0; s < sources.length; s++) {
-      cursors[s] = sources[s].getValues(leaf, null);
-    }
-    for (int i = 0; i < leafDocs.length; i++) {
-      final int localDoc = leafDocs[i] - docBase;
-      final double[] row = new double[sources.length];
-      for (int s = 0; s < sources.length; s++) {
-        // TODO(discuss): missing-value policy. We report NaN when a doc has no value for a source.
-        // Revisit for the abstract/visitor version.
-        row[s] = cursors[s].advanceExact(localDoc) ? cursors[s].doubleValue() : Double.NaN;
-      }
-      values[leafOrds[i]] = row;
-    }
+    return ReturnFieldsRetriever.retrieve(
+        reader,
+        globalDocIds,
+        leaf -> {
+          final DoubleValues[] cursors = new DoubleValues[rewritten.length];
+          for (int s = 0; s < rewritten.length; s++) {
+            cursors[s] = rewritten[s].getValues(leaf, null);
+          }
+          return localDoc -> {
+            final double[] row = new double[cursors.length];
+            for (int s = 0; s < cursors.length; s++) {
+              row[s] = cursors[s].advanceExact(localDoc) ? cursors[s].doubleValue() : Double.NaN;
+            }
+            return row;
+          };
+        },
+        double[][]::new,
+        executor);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/DoubleValuesRetriever.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DoubleValuesRetriever.java
@@ -19,16 +19,16 @@ package org.apache.lucene.search;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.concurrent.Executor;
-import org.apache.lucene.index.IndexReader;
 
 /**
  * Retrieves {@link DoubleValuesSource} values for an {@code int[]} of global doc IDs, returning a
  * {@code double[hit][source]} grid in input order: {@code result[i][s]} is {@code sources[s]}'s
  * value for {@code globalDocIds[i]}. The input array is not mutated.
  *
- * <p>A {@code DoubleValuesSource}-specific specialization of {@link ReturnFieldsRetriever}. A doc
- * with no value for a source yields {@link Double#NaN}.
+ * <p>A {@code DoubleValuesSource}-specific specialization of {@link ReturnFieldsRetriever}.
+ *
+ * <p>A doc with no value for a source yields {@link Double#NaN}. This cannot be distinguished from
+ * a doc that legitimately stores {@code NaN} (e.g. via {@link DoubleValuesSource#fromDoubleField}).
  *
  * @lucene.experimental
  */
@@ -39,22 +39,23 @@ public final class DoubleValuesRetriever {
   /**
    * Retrieves the values of each source for each global doc ID.
    *
-   * @param reader an open index reader (the caller is responsible for its reference count)
+   * @param searcher the searcher whose reader holds the docs; its {@link
+   *     IndexSearcher#getSimilarity() similarity}, query cache, and {@link
+   *     IndexSearcher#getTaskExecutor() task executor} are used, so sources are rewritten against
+   *     the caller's actual search context
    * @param globalDocIds global doc IDs in any order (e.g. ranking order); not mutated
    * @param sources the value sources to evaluate for each doc; none may need scores
-   * @param executor executor used to process leaves concurrently
    * @return a {@code double[globalDocIds.length][sources.length]} grid, in input order; missing
    *     values are {@link Double#NaN}
    * @throws IllegalArgumentException if any source needs scores (this retriever supplies none)
    */
   public static double[][] retrieve(
-      IndexReader reader, int[] globalDocIds, DoubleValuesSource[] sources, Executor executor)
-      throws IOException {
-    Objects.requireNonNull(reader, "reader");
+      IndexSearcher searcher, int[] globalDocIds, DoubleValuesSource[] sources) throws IOException {
+    Objects.requireNonNull(searcher, "searcher");
+    Objects.requireNonNull(globalDocIds, "globalDocIds");
     Objects.requireNonNull(sources, "sources");
 
-    // Rewrite the sources once against the top-level reader, as required by DoubleValuesSource.
-    final IndexSearcher searcher = new IndexSearcher(reader);
+    // Rewrite the sources against the caller's searcher, as required by DoubleValuesSource.
     final DoubleValuesSource[] rewritten = new DoubleValuesSource[sources.length];
     for (int s = 0; s < sources.length; s++) {
       rewritten[s] = sources[s].rewrite(searcher);
@@ -68,7 +69,7 @@ public final class DoubleValuesRetriever {
     }
 
     return ReturnFieldsRetriever.retrieve(
-        reader,
+        searcher.getIndexReader(),
         globalDocIds,
         leaf -> {
           final DoubleValues[] cursors = new DoubleValues[rewritten.length];
@@ -84,6 +85,6 @@ public final class DoubleValuesRetriever {
           };
         },
         double[][]::new,
-        executor);
+        searcher.getTaskExecutor());
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/DoubleValuesRetriever.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DoubleValuesRetriever.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.ReaderUtil;
+
+/**
+ * Utility for retrieving {@link DoubleValuesSource} values for a set of global doc IDs (the "return
+ * fields" of a set of hits), concurrently across leaves.
+ *
+ * <p>Given an {@link IndexReader}, an {@code int[]} of global doc IDs (typically the doc IDs of a
+ * page of hits, in ranking order), and one or more {@link DoubleValuesSource}s, this returns a
+ * {@code double[hit][source]} grid. The result preserves input order: row {@code i} holds the
+ * values for {@code globalDocIds[i]}, and column {@code s} holds the value produced by {@code
+ * sources[s]}.
+ *
+ * <p>Internally the doc IDs are scattered to their leaves and sorted ascending within each leaf
+ * (via {@link ReaderUtil#partitionByLeaf}), each leaf is processed as an independent task on the
+ * supplied {@link Executor}, and the per-leaf results are gathered back into input order using the
+ * ordinals tracked by {@code partitionByLeaf}. The input array is not mutated.
+ *
+ * <p>Documents that have no value for a given source (i.e. {@link DoubleValues#advanceExact} returns
+ * {@code false}) are reported as {@link Double#NaN}.
+ *
+ * <p>This concrete retriever does not supply document scores, so every source must return {@code
+ * false} from {@link DoubleValuesSource#needsScores()}; otherwise an {@link
+ * IllegalArgumentException} is thrown.
+ *
+ * @lucene.experimental
+ */
+public final class DoubleValuesRetriever {
+
+  private DoubleValuesRetriever() {}
+
+  /**
+   * Retrieves the values of each source for each global doc ID.
+   *
+   * @param reader an open index reader (the caller is responsible for its reference count)
+   * @param globalDocIds global doc IDs in any order (e.g. ranking order); not mutated
+   * @param sources the value sources to evaluate for each doc; none may need scores
+   * @param executor executor used to process leaves concurrently
+   * @return a {@code double[globalDocIds.length][sources.length]} grid, in input order; missing
+   *     values are {@link Double#NaN}
+   */
+  public static double[][] retrieve(
+      IndexReader reader, int[] globalDocIds, DoubleValuesSource[] sources, Executor executor)
+      throws IOException {
+    Objects.requireNonNull(reader, "reader");
+    Objects.requireNonNull(globalDocIds, "globalDocIds");
+    Objects.requireNonNull(sources, "sources");
+    Objects.requireNonNull(executor, "executor");
+
+    // Rewrite the sources once against the top-level reader, as required by DoubleValuesSource.
+    final IndexSearcher searcher = new IndexSearcher(reader);
+    final DoubleValuesSource[] rewritten = new DoubleValuesSource[sources.length];
+    for (int s = 0; s < sources.length; s++) {
+      rewritten[s] = sources[s].rewrite(searcher);
+      if (rewritten[s].needsScores()) {
+        throw new IllegalArgumentException(
+            "DoubleValuesRetriever does not supply scores, but sources["
+                + s
+                + "] requires them: "
+                + sources[s]);
+      }
+    }
+
+    final double[][] values = new double[globalDocIds.length][];
+    if (globalDocIds.length == 0) {
+      return values;
+    }
+
+    final List<LeafReaderContext> leaves = reader.leaves();
+    final ReaderUtil.PartitionedHits partitioned =
+        ReaderUtil.partitionByLeaf(globalDocIds, leaves);
+    final int[][] docIdsByLeaf = partitioned.docIdsByLeaf();
+    final int[][] ordinalsByLeaf = partitioned.ordinalsByLeaf();
+
+    // One task per non-empty leaf. Each task writes disjoint rows of `values` (each ordinal is
+    // unique across leaves), so no synchronization is needed.
+    final List<Callable<Void>> tasks = new ArrayList<>();
+    for (int leafIdx = 0; leafIdx < leaves.size(); leafIdx++) {
+      final int[] leafDocs = docIdsByLeaf[leafIdx];
+      if (leafDocs.length == 0) {
+        continue;
+      }
+      final int[] leafOrds = ordinalsByLeaf[leafIdx];
+      final LeafReaderContext leaf = leaves.get(leafIdx);
+      tasks.add(
+          () -> {
+            retrieveLeaf(leaf, leafDocs, leafOrds, rewritten, values);
+            return null;
+          });
+    }
+
+    new TaskExecutor(executor).invokeAll(tasks);
+    return values;
+  }
+
+  /**
+   * Retrieves values for a single leaf: builds one {@link DoubleValues} cursor per source, then
+   * walks the leaf's (ascending) doc IDs, writing each hit's row into {@code values} at its
+   * original input ordinal.
+   */
+  private static void retrieveLeaf(
+      LeafReaderContext leaf,
+      int[] leafDocs,
+      int[] leafOrds,
+      DoubleValuesSource[] sources,
+      double[][] values)
+      throws IOException {
+    final int docBase = leaf.docBase;
+    final DoubleValues[] cursors = new DoubleValues[sources.length];
+    for (int s = 0; s < sources.length; s++) {
+      cursors[s] = sources[s].getValues(leaf, null);
+    }
+    for (int i = 0; i < leafDocs.length; i++) {
+      final int localDoc = leafDocs[i] - docBase;
+      final double[] row = new double[sources.length];
+      for (int s = 0; s < sources.length; s++) {
+        // TODO(discuss): missing-value policy. We report NaN when a doc has no value for a source.
+        // Revisit for the abstract/visitor version.
+        row[s] = cursors[s].advanceExact(localDoc) ? cursors[s].doubleValue() : Double.NaN;
+      }
+      values[leafOrds[i]] = row;
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/ReturnFieldsRetriever.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ReturnFieldsRetriever.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.function.IntFunction;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.ReaderUtil;
+
+/**
+ * Generic engine for computing per-hit "return fields": given an {@link IndexReader} and an {@code
+ * int[]} of global doc IDs (in any order), it produces one result per hit and returns them in input
+ * order ({@code result[i]} is the value for {@code globalDocIds[i]}). The input array is not mutated.
+ *
+ * <p>It owns the scatter/gather machinery (partition via {@link ReaderUtil#partitionByLeaf}, run
+ * leaves on the {@link Executor}, gather back to input order) but is agnostic about <em>what</em> is
+ * produced per hit: the caller supplies a {@link LeafVisitorFactory} that turns a document into a
+ * value of type {@code T}.
+ *
+ * <p><b>Concurrency contract.</b> Leaves run concurrently, so {@link
+ * LeafVisitorFactory#newLeafVisitor} must return a <em>fresh</em>, single-threaded {@link
+ * LeafVisitor} per leaf (like {@link CollectorManager#newCollector()}).
+ *
+ * @lucene.experimental
+ */
+public final class ReturnFieldsRetriever {
+
+  private ReturnFieldsRetriever() {}
+
+  /**
+   * Creates a {@link LeafVisitor} bound to a single leaf. Called once per leaf, on the thread that
+   * will process that leaf.
+   *
+   * @param <T> the per-hit result type
+   */
+  @FunctionalInterface
+  public interface LeafVisitorFactory<T> {
+    /**
+     * Returns a fresh visitor for the given leaf. Must not return a shared/reused instance: leaves
+     * are processed concurrently.
+     */
+    LeafVisitor<T> newLeafVisitor(LeafReaderContext leaf) throws IOException;
+  }
+
+  /**
+   * Produces the result for a single hit within a leaf. Instances are single-threaded and bound to
+   * one leaf.
+   *
+   * @param <T> the per-hit result type
+   */
+  @FunctionalInterface
+  public interface LeafVisitor<T> {
+    /**
+     * Produces the result for one document. The engine calls this with leaf-local doc IDs in
+     * ascending order.
+     *
+     * @param localDoc the doc ID relative to the leaf (i.e. {@code globalDocId - leaf.docBase})
+     */
+    T visit(int localDoc) throws IOException;
+  }
+
+  /**
+   * Retrieves one result per global doc ID, in input order.
+   *
+   * @param reader an open index reader (the caller is responsible for its reference count)
+   * @param globalDocIds global doc IDs in any order (e.g. ranking order); not mutated
+   * @param factory creates a fresh per-leaf {@link LeafVisitor}; see the concurrency contract
+   * @param arrayFactory allocates the result array of the required length (e.g. {@code
+   *     String[]::new})
+   * @param executor executor used to process leaves concurrently
+   * @param <T> the per-hit result type
+   * @return an array of length {@code globalDocIds.length}, where element {@code i} is the result
+   *     for {@code globalDocIds[i]}
+   */
+  public static <T> T[] retrieve(
+      IndexReader reader,
+      int[] globalDocIds,
+      LeafVisitorFactory<T> factory,
+      IntFunction<T[]> arrayFactory,
+      Executor executor)
+      throws IOException {
+    Objects.requireNonNull(reader, "reader");
+    Objects.requireNonNull(globalDocIds, "globalDocIds");
+    Objects.requireNonNull(factory, "factory");
+    Objects.requireNonNull(arrayFactory, "arrayFactory");
+    Objects.requireNonNull(executor, "executor");
+
+    final T[] results = arrayFactory.apply(globalDocIds.length);
+    if (globalDocIds.length == 0) {
+      return results;
+    }
+
+    final List<LeafReaderContext> leaves = reader.leaves();
+    final ReaderUtil.PartitionedHits partitioned =
+        ReaderUtil.partitionByLeaf(globalDocIds, leaves);
+    final int[][] docIdsByLeaf = partitioned.docIdsByLeaf();
+    final int[][] ordinalsByLeaf = partitioned.ordinalsByLeaf();
+
+    // One task per non-empty leaf. Each task writes disjoint slots of `results` (each ordinal is
+    // unique across leaves), so no synchronization is needed.
+    final List<Callable<Void>> tasks = new ArrayList<>();
+    for (int leafIdx = 0; leafIdx < leaves.size(); leafIdx++) {
+      final int[] leafDocs = docIdsByLeaf[leafIdx];
+      if (leafDocs.length == 0) {
+        continue;
+      }
+      final int[] leafOrds = ordinalsByLeaf[leafIdx];
+      final LeafReaderContext leaf = leaves.get(leafIdx);
+      tasks.add(
+          () -> {
+            final LeafVisitor<T> visitor = factory.newLeafVisitor(leaf);
+            final int docBase = leaf.docBase;
+            for (int i = 0; i < leafDocs.length; i++) {
+              results[leafOrds[i]] = visitor.visit(leafDocs[i] - docBase);
+            }
+            return null;
+          });
+    }
+
+    new TaskExecutor(executor).invokeAll(tasks);
+    return results;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/ReturnFieldsRetriever.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ReturnFieldsRetriever.java
@@ -31,12 +31,13 @@ import org.apache.lucene.index.ReaderUtil;
 /**
  * Generic engine for computing per-hit "return fields": given an {@link IndexReader} and an {@code
  * int[]} of global doc IDs (in any order), it produces one result per hit and returns them in input
- * order ({@code result[i]} is the value for {@code globalDocIds[i]}). The input array is not mutated.
+ * order ({@code result[i]} is the value for {@code globalDocIds[i]}). The input array is not
+ * mutated.
  *
  * <p>It owns the scatter/gather machinery (partition via {@link ReaderUtil#partitionByLeaf}, run
- * leaves on the {@link Executor}, gather back to input order) but is agnostic about <em>what</em> is
- * produced per hit: the caller supplies a {@link LeafVisitorFactory} that turns a document into a
- * value of type {@code T}.
+ * leaves on the {@link Executor}, gather back to input order) but is agnostic about <em>what</em>
+ * is produced per hit: the caller supplies a {@link LeafVisitorFactory} that turns a document into
+ * a value of type {@code T}.
  *
  * <p><b>Concurrency contract.</b> Leaves run concurrently, so {@link
  * LeafVisitorFactory#newLeafVisitor} must return a <em>fresh</em>, single-threaded {@link
@@ -112,8 +113,7 @@ public final class ReturnFieldsRetriever {
     }
 
     final List<LeafReaderContext> leaves = reader.leaves();
-    final ReaderUtil.PartitionedHits partitioned =
-        ReaderUtil.partitionByLeaf(globalDocIds, leaves);
+    final ReaderUtil.PartitionedHits partitioned = ReaderUtil.partitionByLeaf(globalDocIds, leaves);
     final int[][] docIdsByLeaf = partitioned.docIdsByLeaf();
     final int[][] ordinalsByLeaf = partitioned.ordinalsByLeaf();
 

--- a/lucene/core/src/java/org/apache/lucene/search/ReturnFieldsRetriever.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ReturnFieldsRetriever.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
-import java.util.concurrent.Executor;
 import java.util.function.IntFunction;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
@@ -35,9 +34,9 @@ import org.apache.lucene.index.ReaderUtil;
  * mutated.
  *
  * <p>It owns the scatter/gather machinery (partition via {@link ReaderUtil#partitionByLeaf}, run
- * leaves on the {@link Executor}, gather back to input order) but is agnostic about <em>what</em>
- * is produced per hit: the caller supplies a {@link LeafVisitorFactory} that turns a document into
- * a value of type {@code T}.
+ * leaves on the {@link TaskExecutor}, gather back to input order) but is agnostic about
+ * <em>what</em> is produced per hit: the caller supplies a {@link LeafVisitorFactory} that turns a
+ * document into a value of type {@code T}.
  *
  * <p><b>Concurrency contract.</b> Leaves run concurrently, so {@link
  * LeafVisitorFactory#newLeafVisitor} must return a <em>fresh</em>, single-threaded {@link
@@ -89,7 +88,8 @@ public final class ReturnFieldsRetriever {
    * @param factory creates a fresh per-leaf {@link LeafVisitor}; see the concurrency contract
    * @param arrayFactory allocates the result array of the required length (e.g. {@code
    *     String[]::new})
-   * @param executor executor used to process leaves concurrently
+   * @param taskExecutor task executor used to process leaves concurrently (e.g. {@link
+   *     IndexSearcher#getTaskExecutor()})
    * @param <T> the per-hit result type
    * @return an array of length {@code globalDocIds.length}, where element {@code i} is the result
    *     for {@code globalDocIds[i]}
@@ -99,13 +99,13 @@ public final class ReturnFieldsRetriever {
       int[] globalDocIds,
       LeafVisitorFactory<T> factory,
       IntFunction<T[]> arrayFactory,
-      Executor executor)
+      TaskExecutor taskExecutor)
       throws IOException {
     Objects.requireNonNull(reader, "reader");
     Objects.requireNonNull(globalDocIds, "globalDocIds");
     Objects.requireNonNull(factory, "factory");
     Objects.requireNonNull(arrayFactory, "arrayFactory");
-    Objects.requireNonNull(executor, "executor");
+    Objects.requireNonNull(taskExecutor, "taskExecutor");
 
     final T[] results = arrayFactory.apply(globalDocIds.length);
     if (globalDocIds.length == 0) {
@@ -138,7 +138,7 @@ public final class ReturnFieldsRetriever {
           });
     }
 
-    new TaskExecutor(executor).invokeAll(tasks);
+    taskExecutor.invokeAll(tasks);
     return results;
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesRetriever.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesRetriever.java
@@ -20,7 +20,6 @@ package org.apache.lucene.search;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.lucene.document.Document;
@@ -35,9 +34,6 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.NamedThreadFactory;
 
 public class TestDoubleValuesRetriever extends LuceneTestCase {
-
-  /** Same-thread executor, so the concurrency wrapper is exercised without real threads. */
-  private static final Executor DIRECT_EXECUTOR = Runnable::run;
 
   /**
    * Value stored in field "a" for the doc whose global id is {@code globalId}. Chosen to be a
@@ -61,10 +57,9 @@ public class TestDoubleValuesRetriever extends LuceneTestCase {
       try (DirectoryReader reader = DirectoryReader.open(writer)) {
         double[][] values =
             DoubleValuesRetriever.retrieve(
-                reader,
+                new IndexSearcher(reader),
                 new int[0],
-                new DoubleValuesSource[] {DoubleValuesSource.fromLongField("a")},
-                DIRECT_EXECUTOR);
+                new DoubleValuesSource[] {DoubleValuesSource.fromLongField("a")});
         assertEquals(0, values.length);
       }
     }
@@ -85,7 +80,7 @@ public class TestDoubleValuesRetriever extends LuceneTestCase {
           DoubleValuesSource.fromLongField("a"), DoubleValuesSource.fromLongField("b")
         };
         double[][] values =
-            DoubleValuesRetriever.retrieve(reader, docIds, sources, DIRECT_EXECUTOR);
+            DoubleValuesRetriever.retrieve(new IndexSearcher(reader), docIds, sources);
 
         assertEquals(docIds.length, values.length);
         for (int i = 0; i < docIds.length; i++) {
@@ -116,7 +111,7 @@ public class TestDoubleValuesRetriever extends LuceneTestCase {
           DoubleValuesSource.fromLongField("a"), DoubleValuesSource.fromLongField("b")
         };
         double[][] values =
-            DoubleValuesRetriever.retrieve(reader, new int[] {0, 1}, sources, DIRECT_EXECUTOR);
+            DoubleValuesRetriever.retrieve(new IndexSearcher(reader), new int[] {0, 1}, sources);
 
         assertEquals((double) valueA(0), values[0][0], 0.0);
         assertEquals((double) valueB(0), values[0][1], 0.0);
@@ -135,15 +130,13 @@ public class TestDoubleValuesRetriever extends LuceneTestCase {
         DoubleValuesSource[] sources = {DoubleValuesSource.SCORES};
         expectThrows(
             IllegalArgumentException.class,
-            () -> DoubleValuesRetriever.retrieve(reader, new int[] {0}, sources, DIRECT_EXECUTOR));
+            () ->
+                DoubleValuesRetriever.retrieve(new IndexSearcher(reader), new int[] {0}, sources));
       }
     }
   }
 
-  /**
-   * The adapter's own guards; {@code globalDocIds}/{@code executor} nulls are the engine's
-   * contract.
-   */
+  /** The adapter's own guards; {@code globalDocIds} nulls are the engine's contract. */
   public void testNullArgumentsRejected() throws IOException {
     try (Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
@@ -153,10 +146,10 @@ public class TestDoubleValuesRetriever extends LuceneTestCase {
         int[] docIds = {0};
         expectThrows(
             NullPointerException.class,
-            () -> DoubleValuesRetriever.retrieve(null, docIds, sources, DIRECT_EXECUTOR));
+            () -> DoubleValuesRetriever.retrieve(null, docIds, sources));
         expectThrows(
             NullPointerException.class,
-            () -> DoubleValuesRetriever.retrieve(reader, docIds, null, DIRECT_EXECUTOR));
+            () -> DoubleValuesRetriever.retrieve(new IndexSearcher(reader), docIds, null));
       }
     }
   }
@@ -207,7 +200,9 @@ public class TestDoubleValuesRetriever extends LuceneTestCase {
             DoubleValuesSource[] sources = {
               DoubleValuesSource.fromLongField("a"), DoubleValuesSource.fromLongField("b")
             };
-            double[][] values = DoubleValuesRetriever.retrieve(reader, docIds, sources, executor);
+            double[][] values =
+                DoubleValuesRetriever.retrieve(
+                    new IndexSearcher(reader, executor), docIds, sources);
 
             assertArrayEquals("input array must not be mutated", inputCopy, docIds);
             assertEquals(docIds.length, values.length);

--- a/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesRetriever.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesRetriever.java
@@ -70,7 +70,9 @@ public class TestDoubleValuesRetriever extends LuceneTestCase {
     }
   }
 
-  /** Single segment, multiple sources, deliberately unsorted input: output must be in input order. */
+  /**
+   * Single segment, multiple sources, deliberately unsorted input: output must be in input order.
+   */
   public void testPreservesInputOrder() throws IOException {
     try (Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
@@ -133,14 +135,15 @@ public class TestDoubleValuesRetriever extends LuceneTestCase {
         DoubleValuesSource[] sources = {DoubleValuesSource.SCORES};
         expectThrows(
             IllegalArgumentException.class,
-            () ->
-                DoubleValuesRetriever.retrieve(
-                    reader, new int[] {0}, sources, DIRECT_EXECUTOR));
+            () -> DoubleValuesRetriever.retrieve(reader, new int[] {0}, sources, DIRECT_EXECUTOR));
       }
     }
   }
 
-  /** The adapter's own guards; {@code globalDocIds}/{@code executor} nulls are the engine's contract. */
+  /**
+   * The adapter's own guards; {@code globalDocIds}/{@code executor} nulls are the engine's
+   * contract.
+   */
   public void testNullArgumentsRejected() throws IOException {
     try (Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
@@ -204,8 +207,7 @@ public class TestDoubleValuesRetriever extends LuceneTestCase {
             DoubleValuesSource[] sources = {
               DoubleValuesSource.fromLongField("a"), DoubleValuesSource.fromLongField("b")
             };
-            double[][] values =
-                DoubleValuesRetriever.retrieve(reader, docIds, sources, executor);
+            double[][] values = DoubleValuesRetriever.retrieve(reader, docIds, sources, executor);
 
             assertArrayEquals("input array must not be mutated", inputCopy, docIds);
             assertEquals(docIds.length, values.length);

--- a/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesRetriever.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesRetriever.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.NamedThreadFactory;
+
+public class TestDoubleValuesRetriever extends LuceneTestCase {
+
+  /** Same-thread executor, so the concurrency wrapper is exercised without real threads. */
+  private static final Executor DIRECT_EXECUTOR = Runnable::run;
+
+  /**
+   * Value stored in field "a" for the doc whose global id is {@code globalId}. Chosen to be a
+   * distinctive, invertible function of the global id so the test can predict every value.
+   */
+  private static long valueA(int globalId) {
+    return globalId * 10L + 1;
+  }
+
+  /** Value stored in field "b"; a different function so columns can't be confused. */
+  private static long valueB(int globalId) {
+    return globalId * 100L + 7;
+  }
+
+  public void testEmptyDocIds() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+      for (int i = 0; i < 5; i++) {
+        writer.addDocument(docWith(i));
+      }
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        double[][] values =
+            DoubleValuesRetriever.retrieve(
+                reader,
+                new int[0],
+                new DoubleValuesSource[] {DoubleValuesSource.fromLongField("a")},
+                DIRECT_EXECUTOR);
+        assertEquals(0, values.length);
+      }
+    }
+  }
+
+  /** Single segment, multiple sources, deliberately unsorted input: output must be in input order. */
+  public void testPreservesInputOrder() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+      for (int i = 0; i < 10; i++) {
+        writer.addDocument(docWith(i));
+      }
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        int[] docIds = {5, 4, 3, 2, 1};
+        DoubleValuesSource[] sources = {
+          DoubleValuesSource.fromLongField("a"), DoubleValuesSource.fromLongField("b")
+        };
+        double[][] values =
+            DoubleValuesRetriever.retrieve(reader, docIds, sources, DIRECT_EXECUTOR);
+
+        assertEquals(docIds.length, values.length);
+        for (int i = 0; i < docIds.length; i++) {
+          int globalId = docIds[i];
+          assertEquals(2, values[i].length);
+          assertEquals((double) valueA(globalId), values[i][0], 0.0);
+          assertEquals((double) valueB(globalId), values[i][1], 0.0);
+        }
+      }
+    }
+  }
+
+  /** Hits spread across several segments, including an empty middle and trailing segment. */
+  public void testAcrossSegments() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer =
+            new IndexWriter(
+                dir, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
+      // 4 segments: docs 0-9, 10-19, 20-29, 30-39.
+      for (int seg = 0; seg < 4; seg++) {
+        for (int i = 0; i < 10; i++) {
+          writer.addDocument(docWith(seg * 10 + i));
+        }
+        writer.commit();
+      }
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        assertEquals(4, reader.leaves().size());
+
+        // Hits only in segments 0 and 2; unsorted, so we also exercise the gather.
+        int[] docIds = {25, 3, 8};
+        DoubleValuesSource[] sources = {DoubleValuesSource.fromLongField("a")};
+        double[][] values =
+            DoubleValuesRetriever.retrieve(reader, docIds, sources, DIRECT_EXECUTOR);
+
+        assertEquals(3, values.length);
+        assertEquals((double) valueA(25), values[0][0], 0.0);
+        assertEquals((double) valueA(3), values[1][0], 0.0);
+        assertEquals((double) valueA(8), values[2][0], 0.0);
+      }
+    }
+  }
+
+  /** A doc missing the requested field yields Double.NaN for that source. */
+  public void testMissingValueIsNaN() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+      // Doc 0 has both fields; doc 1 has only "a" (missing "b").
+      Document d0 = new Document();
+      d0.add(new NumericDocValuesField("a", valueA(0)));
+      d0.add(new NumericDocValuesField("b", valueB(0)));
+      writer.addDocument(d0);
+      Document d1 = new Document();
+      d1.add(new NumericDocValuesField("a", valueA(1)));
+      writer.addDocument(d1);
+
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        DoubleValuesSource[] sources = {
+          DoubleValuesSource.fromLongField("a"), DoubleValuesSource.fromLongField("b")
+        };
+        double[][] values =
+            DoubleValuesRetriever.retrieve(reader, new int[] {0, 1}, sources, DIRECT_EXECUTOR);
+
+        assertEquals((double) valueA(0), values[0][0], 0.0);
+        assertEquals((double) valueB(0), values[0][1], 0.0);
+        assertEquals((double) valueA(1), values[1][0], 0.0);
+        assertTrue("missing value should be NaN", Double.isNaN(values[1][1]));
+      }
+    }
+  }
+
+  /** Sources that need scores are rejected up front, since this retriever supplies none. */
+  public void testRejectsScoreNeedingSource() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+      writer.addDocument(docWith(0));
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        DoubleValuesSource[] sources = {DoubleValuesSource.SCORES};
+        expectThrows(
+            IllegalArgumentException.class,
+            () ->
+                DoubleValuesRetriever.retrieve(
+                    reader, new int[] {0}, sources, DIRECT_EXECUTOR));
+      }
+    }
+  }
+
+  public void testNullArgumentsRejected() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+      writer.addDocument(docWith(0));
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        DoubleValuesSource[] sources = {DoubleValuesSource.fromLongField("a")};
+        int[] docIds = {0};
+        expectThrows(
+            NullPointerException.class,
+            () -> DoubleValuesRetriever.retrieve(null, docIds, sources, DIRECT_EXECUTOR));
+        expectThrows(
+            NullPointerException.class,
+            () -> DoubleValuesRetriever.retrieve(reader, null, sources, DIRECT_EXECUTOR));
+        expectThrows(
+            NullPointerException.class,
+            () -> DoubleValuesRetriever.retrieve(reader, docIds, null, DIRECT_EXECUTOR));
+        expectThrows(
+            NullPointerException.class,
+            () -> DoubleValuesRetriever.retrieve(reader, docIds, sources, null));
+      }
+    }
+  }
+
+  /**
+   * Randomized round-trip against a real thread pool: build random segments, request a random
+   * subset of doc IDs in random order, and verify every returned value matches the known function
+   * of its global doc id, in input order.
+   */
+  public void testRandomized() throws IOException {
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            TestUtil.nextInt(random(), 1, 4),
+            new NamedThreadFactory(TestDoubleValuesRetriever.class.getSimpleName()));
+    try {
+      for (int iter = 0; iter < 50; iter++) {
+        int numSegments = random().nextInt(6) + 1;
+        int totalDocs = 0;
+        try (Directory dir = newDirectory();
+            IndexWriter writer =
+                new IndexWriter(
+                    dir, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
+          for (int seg = 0; seg < numSegments; seg++) {
+            int docsInSeg = random().nextInt(10) + 1;
+            for (int i = 0; i < docsInSeg; i++) {
+              writer.addDocument(docWith(totalDocs++));
+            }
+            writer.commit();
+          }
+
+          try (DirectoryReader reader = DirectoryReader.open(writer)) {
+            // Random subset of global doc ids, in random order.
+            int numHits = random().nextInt(totalDocs + 1);
+            Set<Integer> hitSet = new HashSet<>();
+            while (hitSet.size() < numHits) {
+              hitSet.add(random().nextInt(totalDocs));
+            }
+            int[] docIds = hitSet.stream().mapToInt(Integer::intValue).toArray();
+            // Shuffle so input is not docId-sorted.
+            for (int i = docIds.length - 1; i > 0; i--) {
+              int j = random().nextInt(i + 1);
+              int tmp = docIds[i];
+              docIds[i] = docIds[j];
+              docIds[j] = tmp;
+            }
+            int[] inputCopy = docIds.clone();
+
+            DoubleValuesSource[] sources = {
+              DoubleValuesSource.fromLongField("a"), DoubleValuesSource.fromLongField("b")
+            };
+            double[][] values =
+                DoubleValuesRetriever.retrieve(reader, docIds, sources, executor);
+
+            assertArrayEquals("input array must not be mutated", inputCopy, docIds);
+            assertEquals(docIds.length, values.length);
+            for (int i = 0; i < docIds.length; i++) {
+              int globalId = docIds[i];
+              assertEquals(2, values[i].length);
+              assertEquals((double) valueA(globalId), values[i][0], 0.0);
+              assertEquals((double) valueB(globalId), values[i][1], 0.0);
+            }
+          }
+        }
+      }
+    } finally {
+      executor.shutdown();
+    }
+  }
+
+  private static Document docWith(int globalId) {
+    Document doc = new Document();
+    doc.add(new NumericDocValuesField("a", valueA(globalId)));
+    doc.add(new NumericDocValuesField("b", valueB(globalId)));
+    return doc;
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesRetriever.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesRetriever.java
@@ -96,36 +96,6 @@ public class TestDoubleValuesRetriever extends LuceneTestCase {
     }
   }
 
-  /** Hits spread across several segments, including an empty middle and trailing segment. */
-  public void testAcrossSegments() throws IOException {
-    try (Directory dir = newDirectory();
-        IndexWriter writer =
-            new IndexWriter(
-                dir, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
-      // 4 segments: docs 0-9, 10-19, 20-29, 30-39.
-      for (int seg = 0; seg < 4; seg++) {
-        for (int i = 0; i < 10; i++) {
-          writer.addDocument(docWith(seg * 10 + i));
-        }
-        writer.commit();
-      }
-      try (DirectoryReader reader = DirectoryReader.open(writer)) {
-        assertEquals(4, reader.leaves().size());
-
-        // Hits only in segments 0 and 2; unsorted, so we also exercise the gather.
-        int[] docIds = {25, 3, 8};
-        DoubleValuesSource[] sources = {DoubleValuesSource.fromLongField("a")};
-        double[][] values =
-            DoubleValuesRetriever.retrieve(reader, docIds, sources, DIRECT_EXECUTOR);
-
-        assertEquals(3, values.length);
-        assertEquals((double) valueA(25), values[0][0], 0.0);
-        assertEquals((double) valueA(3), values[1][0], 0.0);
-        assertEquals((double) valueA(8), values[2][0], 0.0);
-      }
-    }
-  }
-
   /** A doc missing the requested field yields Double.NaN for that source. */
   public void testMissingValueIsNaN() throws IOException {
     try (Directory dir = newDirectory();
@@ -170,6 +140,7 @@ public class TestDoubleValuesRetriever extends LuceneTestCase {
     }
   }
 
+  /** The adapter's own guards; {@code globalDocIds}/{@code executor} nulls are the engine's contract. */
   public void testNullArgumentsRejected() throws IOException {
     try (Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
@@ -182,13 +153,7 @@ public class TestDoubleValuesRetriever extends LuceneTestCase {
             () -> DoubleValuesRetriever.retrieve(null, docIds, sources, DIRECT_EXECUTOR));
         expectThrows(
             NullPointerException.class,
-            () -> DoubleValuesRetriever.retrieve(reader, null, sources, DIRECT_EXECUTOR));
-        expectThrows(
-            NullPointerException.class,
             () -> DoubleValuesRetriever.retrieve(reader, docIds, null, DIRECT_EXECUTOR));
-        expectThrows(
-            NullPointerException.class,
-            () -> DoubleValuesRetriever.retrieve(reader, docIds, sources, null));
       }
     }
   }
@@ -198,10 +163,10 @@ public class TestDoubleValuesRetriever extends LuceneTestCase {
    * subset of doc IDs in random order, and verify every returned value matches the known function
    * of its global doc id, in input order.
    */
-  public void testRandomized() throws IOException {
+  public void testRandomizedConcurrent() throws IOException {
     ExecutorService executor =
         Executors.newFixedThreadPool(
-            TestUtil.nextInt(random(), 1, 4),
+            TestUtil.nextInt(random(), 2, 5),
             new NamedThreadFactory(TestDoubleValuesRetriever.class.getSimpleName()));
     try {
       for (int iter = 0; iter < 50; iter++) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestReturnFieldsRetriever.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestReturnFieldsRetriever.java
@@ -20,7 +20,6 @@ package org.apache.lucene.search;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.lucene.document.Document;
@@ -39,7 +38,7 @@ import org.apache.lucene.util.NamedThreadFactory;
 
 public class TestReturnFieldsRetriever extends LuceneTestCase {
 
-  private static final Executor DIRECT_EXECUTOR = Runnable::run;
+  private static final TaskExecutor DIRECT_EXECUTOR = new TaskExecutor(Runnable::run);
 
   /** Stored "title" for the doc whose global id is {@code globalId}. */
   private static String title(int globalId) {
@@ -168,6 +167,7 @@ public class TestReturnFieldsRetriever extends LuceneTestCase {
         Executors.newFixedThreadPool(
             TestUtil.nextInt(random(), 2, 5),
             new NamedThreadFactory(TestReturnFieldsRetriever.class.getSimpleName()));
+    TaskExecutor taskExecutor = new TaskExecutor(executor);
     try {
       for (int iter = 0; iter < 50; iter++) {
         int numSegments = random().nextInt(6) + 1;
@@ -201,7 +201,7 @@ public class TestReturnFieldsRetriever extends LuceneTestCase {
 
             String[] result =
                 ReturnFieldsRetriever.retrieve(
-                    reader, docIds, titleFactory(), String[]::new, executor);
+                    reader, docIds, titleFactory(), String[]::new, taskExecutor);
 
             assertArrayEquals("input must not be mutated", inputCopy, docIds);
             assertEquals(docIds.length, result.length);

--- a/lucene/core/src/test/org/apache/lucene/search/TestReturnFieldsRetriever.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestReturnFieldsRetriever.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.NamedThreadFactory;
+
+public class TestReturnFieldsRetriever extends LuceneTestCase {
+
+  private static final Executor DIRECT_EXECUTOR = Runnable::run;
+
+  /** Stored "title" for the doc whose global id is {@code globalId}. */
+  private static String title(int globalId) {
+    return "doc-" + globalId;
+  }
+
+  /** A String-payload factory: reads the stored "title" field of each doc. */
+  private static ReturnFieldsRetriever.LeafVisitorFactory<String> titleFactory() {
+    return leaf -> {
+      StoredFields storedFields = leaf.reader().storedFields();
+      return localDoc -> storedFields.document(localDoc).get("title");
+    };
+  }
+
+  public void testEmptyDocIds() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+      for (int i = 0; i < 5; i++) {
+        writer.addDocument(docWith(i));
+      }
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        String[] result =
+            ReturnFieldsRetriever.retrieve(
+                reader, new int[0], titleFactory(), String[]::new, DIRECT_EXECUTOR);
+        assertEquals(0, result.length);
+      }
+    }
+  }
+
+  /** A generic (String) payload, unsorted input across segments, verifying input-order output. */
+  public void testStringPayloadPreservesInputOrder() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer =
+            new IndexWriter(
+                dir, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
+      // 3 segments: docs 0-9, 10-19, 20-29.
+      for (int seg = 0; seg < 3; seg++) {
+        for (int i = 0; i < 10; i++) {
+          writer.addDocument(docWith(seg * 10 + i));
+        }
+        writer.commit();
+      }
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        assertEquals(3, reader.leaves().size());
+
+        int[] docIds = {25, 3, 17, 9};
+        String[] result =
+            ReturnFieldsRetriever.retrieve(
+                reader, docIds, titleFactory(), String[]::new, DIRECT_EXECUTOR);
+
+        assertEquals(docIds.length, result.length);
+        for (int i = 0; i < docIds.length; i++) {
+          assertEquals(title(docIds[i]), result[i]);
+        }
+      }
+    }
+  }
+
+  /**
+   * The engine is payload-agnostic: an Integer payload computed from a doc-value goes through the
+   * same machinery with no double-specific coupling.
+   */
+  public void testIntegerPayload() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+      for (int i = 0; i < 20; i++) {
+        writer.addDocument(docWith(i));
+      }
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        int[] docIds = {7, 2, 15};
+        ReturnFieldsRetriever.LeafVisitorFactory<Integer> factory =
+            leaf -> {
+              NumericDocValues dv = leaf.reader().getNumericDocValues("id");
+              return localDoc -> {
+                boolean present = dv.advanceExact(localDoc);
+                assertTrue(present);
+                return (int) dv.longValue();
+              };
+            };
+        Integer[] result =
+            ReturnFieldsRetriever.retrieve(
+                reader, docIds, factory, Integer[]::new, DIRECT_EXECUTOR);
+
+        assertEquals(docIds.length, result.length);
+        for (int i = 0; i < docIds.length; i++) {
+          assertEquals(Integer.valueOf(docIds[i]), result[i]);
+        }
+      }
+    }
+  }
+
+  public void testNullArgumentsRejected() throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+      writer.addDocument(docWith(0));
+      try (DirectoryReader reader = DirectoryReader.open(writer)) {
+        ReturnFieldsRetriever.LeafVisitorFactory<String> factory = titleFactory();
+        int[] docIds = {0};
+        expectThrows(
+            NullPointerException.class,
+            () ->
+                ReturnFieldsRetriever.retrieve(
+                    null, docIds, factory, String[]::new, DIRECT_EXECUTOR));
+        expectThrows(
+            NullPointerException.class,
+            () ->
+                ReturnFieldsRetriever.retrieve(
+                    reader, null, factory, String[]::new, DIRECT_EXECUTOR));
+        expectThrows(
+            NullPointerException.class,
+            () ->
+                ReturnFieldsRetriever.retrieve(
+                    reader, docIds, null, String[]::new, DIRECT_EXECUTOR));
+        expectThrows(
+            NullPointerException.class,
+            () ->
+                ReturnFieldsRetriever.retrieve(reader, docIds, factory, null, DIRECT_EXECUTOR));
+        expectThrows(
+            NullPointerException.class,
+            () ->
+                ReturnFieldsRetriever.retrieve(reader, docIds, factory, String[]::new, null));
+      }
+    }
+  }
+
+  /** Randomized round-trip on a real thread pool, verifying input order and non-mutation. */
+  public void testRandomizedConcurrent() throws IOException {
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            TestUtil.nextInt(random(), 2, 5),
+            new NamedThreadFactory(TestReturnFieldsRetriever.class.getSimpleName()));
+    try {
+      for (int iter = 0; iter < 50; iter++) {
+        int numSegments = random().nextInt(6) + 1;
+        int totalDocs = 0;
+        try (Directory dir = newDirectory();
+            IndexWriter writer =
+                new IndexWriter(
+                    dir, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
+          for (int seg = 0; seg < numSegments; seg++) {
+            int docsInSeg = random().nextInt(10) + 1;
+            for (int i = 0; i < docsInSeg; i++) {
+              writer.addDocument(docWith(totalDocs++));
+            }
+            writer.commit();
+          }
+
+          try (DirectoryReader reader = DirectoryReader.open(writer)) {
+            int numHits = random().nextInt(totalDocs + 1);
+            Set<Integer> hitSet = new HashSet<>();
+            while (hitSet.size() < numHits) {
+              hitSet.add(random().nextInt(totalDocs));
+            }
+            int[] docIds = hitSet.stream().mapToInt(Integer::intValue).toArray();
+            for (int i = docIds.length - 1; i > 0; i--) {
+              int j = random().nextInt(i + 1);
+              int tmp = docIds[i];
+              docIds[i] = docIds[j];
+              docIds[j] = tmp;
+            }
+            int[] inputCopy = docIds.clone();
+
+            String[] result =
+                ReturnFieldsRetriever.retrieve(
+                    reader, docIds, titleFactory(), String[]::new, executor);
+
+            assertArrayEquals("input must not be mutated", inputCopy, docIds);
+            assertEquals(docIds.length, result.length);
+            for (int i = 0; i < docIds.length; i++) {
+              assertEquals(title(docIds[i]), result[i]);
+            }
+          }
+        }
+      }
+    } finally {
+      executor.shutdown();
+    }
+  }
+
+  private static Document docWith(int globalId) {
+    Document doc = new Document();
+    doc.add(new StoredField("title", title(globalId)));
+    doc.add(new NumericDocValuesField("id", globalId));
+    return doc;
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/search/TestReturnFieldsRetriever.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestReturnFieldsRetriever.java
@@ -73,8 +73,7 @@ public class TestReturnFieldsRetriever extends LuceneTestCase {
   public void testStringPayloadPreservesInputOrder() throws IOException {
     try (Directory dir = newDirectory();
         IndexWriter writer =
-            new IndexWriter(
-                dir, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
+            new IndexWriter(dir, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE))) {
       // 3 segments: docs 0-9, 10-19, 20-29.
       for (int seg = 0; seg < 3; seg++) {
         for (int i = 0; i < 10; i++) {
@@ -155,12 +154,10 @@ public class TestReturnFieldsRetriever extends LuceneTestCase {
                     reader, docIds, null, String[]::new, DIRECT_EXECUTOR));
         expectThrows(
             NullPointerException.class,
-            () ->
-                ReturnFieldsRetriever.retrieve(reader, docIds, factory, null, DIRECT_EXECUTOR));
+            () -> ReturnFieldsRetriever.retrieve(reader, docIds, factory, null, DIRECT_EXECUTOR));
         expectThrows(
             NullPointerException.class,
-            () ->
-                ReturnFieldsRetriever.retrieve(reader, docIds, factory, String[]::new, null));
+            () -> ReturnFieldsRetriever.retrieve(reader, docIds, factory, String[]::new, null));
       }
     }
   }


### PR DESCRIPTION
### Description

Adds a reusable utility for fetching "return fields" — one value per hit for a set of
global doc IDs — concurrently across leaves, returning results 1:1 in the caller's input
order. This is the follow-up to the `ReaderUtil.partitionByLeaf` scatter/gather API
#16496; it builds the retriever the ordinal tracking was designed for.

### Motivation

Fetching field values for a page of hits (in ranking order) is a common need, and getting
the leaf partitioning + concurrency + input-order reassembly right is tricky and easy to
get subtly wrong. Today callers hand-roll this. This packages it once.

### What's included

Two classes:

- **`ReturnFieldsRetriever`** — the generic engine. Owns only the reusable machinery:
  scatter doc IDs to leaves via `ReaderUtil.partitionByLeaf`, run each leaf as an
  independent task on a supplied `Executor` (via `TaskExecutor`), and gather per-leaf
  results back into input order. It is agnostic about *what* is produced per hit: the
  caller supplies a `LeafVisitorFactory<T>` that turns a document into a value of type `T`.

    ```java
    public static <T> T[] retrieve(
        IndexReader reader, int[] globalDocIds,
        LeafVisitorFactory<T> factory, IntFunction<T[]> arrayFactory, Executor executor)
    ```

- **`DoubleValuesRetriever`** — a thin `DoubleValuesSource`-specific specialization built
  on the engine. Adapts each source to a `LeafVisitor<double[]>`:

    ```java
    public static double[][] retrieve(
        IndexReader reader, int[] globalDocIds, DoubleValuesSource[] sources, Executor executor)
    ```

### Design notes

- **Concurrency contract:** leaves run concurrently, so `newLeafVisitor` is called once per
  leaf and must return a fresh, single-threaded visitor. Each leaf writes disjoint slots of the result array,
  so no synchronization is needed.
- **Input order preserved:** `result[i]` is the value for `globalDocIds[i]`. The input
  array is not mutated.
