### PR TITLE
Don't use PointValues stats for doc-values range rewrite

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -217,6 +217,10 @@ Bug Fixes
 * GITHUB#16553: Fix stored-fields corruption when PerField#finish throws: the stored-fields frame
   was left open, causing "Wrote N docs, finish called with numDocs=M" at flush. (Michael Marshall)
 
+* GITHUB#16573: SortedNumericDocValuesRangeQuery.rewrite no longer consults PointValues
+  stats, which can disagree with doc-values encoding for float/double fields.
+  (Burak KALAYCI)
+
 * GITHUB#16552: Reconnect HNSW nodes whose out-degree decays across successive
   merge-reuse generations, preventing progressive recall loss under low delete
   rates. (Ethan Baker)

--- a/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/SortedNumericDocValuesRangeQuery.java
@@ -96,7 +96,9 @@ final class SortedNumericDocValuesRangeQuery extends NumericDocValuesRangeQuery 
     if (lowerValue > upperValue) {
       return MatchNoDocsQuery.INSTANCE;
     }
-    final Stats stats = NumericFieldStats.getStats(indexSearcher.getIndexReader(), field);
+    // PointValues for the same field name may use a different encoding than doc values
+    // (GITHUB#16573), so only skipper stats are safe for this rewrite.
+    final Stats stats = NumericFieldStats.getDocValuesStats(indexSearcher.getIndexReader(), field);
     if (stats != null) {
       if (lowerValue > stats.max() || upperValue < stats.min()) {
         return MatchNoDocsQuery.INSTANCE;

--- a/lucene/core/src/java/org/apache/lucene/search/NumericFieldStats.java
+++ b/lucene/core/src/java/org/apache/lucene/search/NumericFieldStats.java
@@ -46,6 +46,10 @@ public final class NumericFieldStats {
    * Returns the global statistics for the given numeric field across all segments. Probes {@link
    * PointValues} first; if unavailable, falls back to {@link DocValuesSkipper}.
    *
+   * <p>Do not use this for doc-values range queries: point values for the same field name may use a
+   * different numeric encoding than the doc-values (for example {@code DoublePoint} vs {@code
+   * Double.doubleToLongBits}). Use {@link #getDocValuesStats} instead.
+   *
    * @param reader the {@link IndexReader} to query
    * @param field the name of the numeric field
    * @return a {@link Stats} containing the global min, max, and doc count, or {@code null} if
@@ -56,6 +60,18 @@ public final class NumericFieldStats {
     if (result != null) {
       return result;
     }
+    return getStatsFromSkipper(reader, field);
+  }
+
+  /**
+   * Returns global statistics from {@link DocValuesSkipper} only, ignoring {@link PointValues}.
+   *
+   * @param reader the {@link IndexReader} to query
+   * @param field the name of the numeric field
+   * @return a {@link Stats} containing the global min, max, and doc count, or {@code null} if no
+   *     skipper is available for the field
+   */
+  public static Stats getDocValuesStats(IndexReader reader, String field) {
     return getStatsFromSkipper(reader, field);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/document/TestSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestSortedNumericDocValuesRangeQuery.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.document;
+
+import java.io.IOException;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.IndexOrDocValuesQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.NumericUtils;
+
+public class TestSortedNumericDocValuesRangeQuery extends LuceneTestCase {
+
+  public void testRangeQueryDoesNotUseMismatchedDoublePointStats() throws IOException {
+    assertNotEquals(
+        "test requires encodings that actually differ",
+        Double.doubleToLongBits(-1.5),
+        NumericUtils.doubleToSortableLong(-1.5));
+    assertHitsForIeeeBitsAndPoints(-1.5, false);
+    assertHitsForIeeeBitsAndPoints(-1.5, true);
+  }
+
+  public void testRangeQueryDoesNotUseMismatchedFloatPointStats() throws IOException {
+    assertNotEquals(
+        "test requires encodings that actually differ",
+        Float.floatToIntBits(-1.5f),
+        NumericUtils.floatToSortableInt(-1.5f));
+    assertHitsForIeeeFloatBitsAndPoints(-1.5f, false);
+    assertHitsForIeeeFloatBitsAndPoints(-1.5f, true);
+  }
+
+  public void testIndexOrDocValuesQueryDoesNotDropHitsOnMismatchedDoubleEncodings()
+      throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      // An empty document keeps the points query from rewriting to MatchAllDocsQuery,
+      // which would hide a MatchNoDocs rewrite of the doc-values side.
+      final double value = -2.25;
+      final Document doc = new Document();
+      doc.add(new DoublePoint("field", value));
+      doc.add(new NumericDocValuesField("field", Double.doubleToLongBits(value)));
+      w.addDocument(doc);
+      w.addDocument(new Document());
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        final long bits = Double.doubleToLongBits(value);
+        final Query query =
+            new IndexOrDocValuesQuery(
+                DoublePoint.newRangeQuery("field", value, value),
+                NumericDocValuesField.newSlowRangeQuery("field", bits, bits));
+        assertEquals(1, searcher.count(query));
+        assertFalse(searcher.rewrite(query) instanceof MatchNoDocsQuery);
+      }
+    }
+  }
+
+  private void assertHitsForIeeeBitsAndPoints(double value, boolean skipIndex) throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc = new Document();
+      doc.add(new DoublePoint("field", value));
+      final long bits = Double.doubleToLongBits(value);
+      if (skipIndex) {
+        doc.add(NumericDocValuesField.indexedField("field", bits));
+      } else {
+        doc.add(new NumericDocValuesField("field", bits));
+      }
+      w.addDocument(doc);
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        final Query query = NumericDocValuesField.newSlowRangeQuery("field", bits, bits);
+        assertEquals("skipIndex=" + skipIndex, 1, searcher.count(query));
+        assertFalse("skipIndex=" + skipIndex, searcher.rewrite(query) instanceof MatchNoDocsQuery);
+      }
+    }
+  }
+
+  private void assertHitsForIeeeFloatBitsAndPoints(float value, boolean skipIndex)
+      throws IOException {
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      final Document doc = new Document();
+      doc.add(new FloatPoint("field", value));
+      final int bits = Float.floatToIntBits(value);
+      if (skipIndex) {
+        doc.add(NumericDocValuesField.indexedField("field", bits));
+      } else {
+        doc.add(new NumericDocValuesField("field", bits));
+      }
+      w.addDocument(doc);
+      w.commit();
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        final IndexSearcher searcher = newSearcher(reader);
+        final Query query = NumericDocValuesField.newSlowRangeQuery("field", bits, bits);
+        assertEquals("skipIndex=" + skipIndex, 1, searcher.count(query));
+        assertFalse("skipIndex=" + skipIndex, searcher.rewrite(query) instanceof MatchNoDocsQuery);
+      }
+    }
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDocValuesQueries.java
@@ -1015,7 +1015,7 @@ public class TestDocValuesQueries extends LuceneTestCaseJupiter {
   }
 
   @Test
-  public void testRewriteWorksWithPointsButNoSkipIndex(Random random) throws IOException {
+  public void testRewriteDoesNotUsePointStatsWithoutSkipIndex(Random random) throws IOException {
     try (Directory dir = newDirectory()) {
       try (RandomIndexWriter iw = new RandomIndexWriter(random, dir)) {
         for (int i = 0; i < 100; i++) {
@@ -1026,16 +1026,20 @@ public class TestDocValuesQueries extends LuceneTestCaseJupiter {
         iw.commit();
         try (IndexReader reader = iw.getReader()) {
           final IndexSearcher searcher = new IndexSearcher(reader);
-          // Query range [0, 50] is entirely below field range [100, 199]
+          // LongField also indexes points, but point encodings can differ from
+          // doc-values (GITHUB#16573). Without a skipper, rewrite must not use
+          // point min/max. Hits are still correct via the doc-values query.
           Query query = SortedNumericDocValuesField.newSlowRangeQuery("field", 0, 50);
           Query rewritten = searcher.rewrite(query);
-          assertThat(rewritten, instanceOf(MatchNoDocsQuery.class));
+          assertThat(
+              rewritten.getClass().toString(), containsString("SortedNumericDocValuesRangeQuery"));
+          assertEquals(0, searcher.count(query));
 
-          // Query range [0, 250] covers entire field range [100, 199]
-          // and all docs have a value
           query = SortedNumericDocValuesField.newSlowRangeQuery("field", 0, 250);
           rewritten = searcher.rewrite(query);
-          assertThat(rewritten, instanceOf(MatchAllDocsQuery.class));
+          assertThat(
+              rewritten.getClass().toString(), containsString("SortedNumericDocValuesRangeQuery"));
+          assertEquals(100, searcher.count(query));
         }
       }
     }


### PR DESCRIPTION
### Description

`SortedNumericDocValuesRangeQuery.rewrite` used `NumericFieldStats.getStats`, which prefers `PointValues`. Point encodings can differ from doc-values (for example `DoublePoint` vs `Double.doubleToLongBits` on `NumericDocValuesField`), so a valid doc-values range was rewritten to `MatchNoDocsQuery`. `IndexOrDocValuesQuery` then dropped the hits as well.

This rewrite now uses skipper-only stats. When no skipper is present, the min/max optimization is skipped and the query runs against the actual doc-values.

Fixes #16573

### Tests

- `./gradlew :lucene:core:test --tests org.apache.lucene.document.TestSortedNumericDocValuesRangeQuery --tests org.apache.lucene.search.TestNumericFieldStats --tests org.apache.lucene.search.TestIndexSortSortedNumericDocValuesRangeQuery --tests org.apache.lucene.document.TestDoubleRange --tests org.apache.lucene.document.TestFloatRange` (44 tests)
- `./gradlew :lucene:sandbox:test --tests org.apache.lucene.sandbox.document.TestHalfFloatPoint.testNumericFieldStats` (1 test)