### PR TITLE
Reduce IndexOrDocValuesQuery DV penalty from 8x to 6x

### DIFF
--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/IndexOrDocValuesQueryBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/IndexOrDocValuesQueryBenchmark.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KeywordField;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MMapDirectory;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmarks the points-vs-DV decision in IndexOrDocValuesQuery (LUCENE-7897 penalty). The 8x
+ * penalty predates DocValuesSkipper (2017). With block-level skipping, DV is competitive.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 5, time = 5)
+@Fork(value = 2, warmups = 1)
+public class IndexOrDocValuesQueryBenchmark {
+
+  private Directory dir;
+  private IndexReader reader;
+  private IndexSearcher searcher;
+  private Path path;
+
+  private BooleanQuery crossover10Query;
+  private BooleanQuery crossover20Query;
+  private BooleanQuery crossover30Query;
+  private BooleanQuery dvFavorableQuery;
+  private BooleanQuery pointsFavorableQuery;
+
+  @Param({"1000000", "10000000"})
+  public int docCount;
+
+  @Setup(Level.Trial)
+  public void setup() throws Exception {
+    path = Files.createTempDirectory("idvqBench");
+    dir = MMapDirectory.open(path);
+
+    IndexWriterConfig iwc = new IndexWriterConfig();
+    IndexWriter w = new IndexWriter(dir, iwc);
+
+    int numBuckets = 100;
+    for (int i = 0; i < docCount; i++) {
+      Document doc = new Document();
+      doc.add(new LongField("timestamp", i, Field.Store.NO));
+      doc.add(new KeywordField("bucket", "b" + (i % numBuckets), Field.Store.NO));
+      w.addDocument(doc);
+    }
+    w.forceMerge(1);
+    reader = DirectoryReader.open(w);
+    w.close();
+    searcher = new IndexSearcher(reader);
+    searcher.setQueryCache(null);
+
+    Query range80 = LongField.newRangeQuery("timestamp", 0, docCount * 4L / 5);
+
+    // 10% lead + 80% range. 8x→points, 4x/2x→DV.
+    crossover10Query = buildConjunction(range80, 10, numBuckets);
+
+    // 20% lead + 80% range. 8x/4x→points, 2x→DV.
+    // indexCost=800K, leadCost=200K. 8x: 100K<=200K→pts. 4x: 200K<=200K→pts. 2x: 400K>200K→DV.
+    crossover20Query = buildConjunction(range80, 20, numBuckets);
+
+    // 30% lead + 80% range. 8x/4x/2x→points.
+    // indexCost=800K, leadCost=300K. 2x: 400K>300K→DV. So 2x still DV here.
+    // Actually 2x threshold = 400K > 300K → DV. Need 1x for points: 800K > 300K → DV.
+    // So 30% lead is still DV at 2x. This tests DV with more docs to check.
+    crossover30Query = buildConjunction(range80, 30, numBuckets);
+
+    // DV favorable: 1% lead + 80% range. Both 8x and 4x choose DV.
+    dvFavorableQuery =
+        new BooleanQuery.Builder()
+            .add(new TermQuery(new Term("bucket", "b0")), Occur.FILTER)
+            .add(range80, Occur.FILTER)
+            .build();
+
+    // Points favorable: 50% lead + 5% range. Both choose points.
+    Query range5 = LongField.newRangeQuery("timestamp", 0, docCount / 20);
+    BooleanQuery.Builder lead50 = new BooleanQuery.Builder();
+    for (int i = 0; i < 50; i++) {
+      lead50.add(new TermQuery(new Term("bucket", "b" + i)), Occur.SHOULD);
+    }
+    pointsFavorableQuery =
+        new BooleanQuery.Builder()
+            .add(lead50.build(), Occur.FILTER)
+            .add(range5, Occur.FILTER)
+            .build();
+  }
+
+  private static BooleanQuery buildConjunction(Query range, int leadBuckets, int totalBuckets) {
+    BooleanQuery.Builder lead = new BooleanQuery.Builder();
+    for (int i = 0; i < leadBuckets; i++) {
+      lead.add(new TermQuery(new Term("bucket", "b" + i)), Occur.SHOULD);
+    }
+    return new BooleanQuery.Builder()
+        .add(lead.build(), Occur.FILTER)
+        .add(range, Occur.FILTER)
+        .build();
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws Exception {
+    reader.close();
+    dir.close();
+    try (Stream<Path> walk = Files.walk(path)) {
+      walk.sorted(Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+    }
+  }
+
+  @Benchmark
+  public TopDocs crossover10() throws IOException {
+    return searcher.search(crossover10Query, 10);
+  }
+
+  @Benchmark
+  public TopDocs crossover20() throws IOException {
+    return searcher.search(crossover20Query, 10);
+  }
+
+  @Benchmark
+  public TopDocs crossover30() throws IOException {
+    return searcher.search(crossover30Query, 10);
+  }
+
+  @Benchmark
+  public TopDocs dvFavorable() throws IOException {
+    return searcher.search(dvFavorableQuery, 10);
+  }
+
+  @Benchmark
+  public TopDocs pointsFavorable() throws IOException {
+    return searcher.search(pointsFavorableQuery, 10);
+  }
+}

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/IndexOrDocValuesQueryBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/IndexOrDocValuesQueryBenchmark.java
@@ -19,9 +19,7 @@ package org.apache.lucene.benchmark.jmh;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KeywordField;
@@ -39,6 +37,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.util.IOUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -54,8 +53,8 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 /**
- * Benchmarks the points-vs-DV decision in IndexOrDocValuesQuery (LUCENE-7897 penalty). The 8x
- * penalty predates DocValuesSkipper (2017). With block-level skipping, DV is competitive.
+ * Benchmarks the points-vs-DV decision in IndexOrDocValuesQuery. Monotonic timestamps are close to
+ * a best case for BKD, so these results are conservative for DV relative to real workloads.
  */
 @State(Scope.Thread)
 @BenchmarkMode(Mode.Throughput)
@@ -102,17 +101,8 @@ public class IndexOrDocValuesQueryBenchmark {
 
     Query range80 = LongField.newRangeQuery("timestamp", 0, docCount * 4L / 5);
 
-    // 10% lead + 80% range. 8x→points, 4x/2x→DV.
     crossover10Query = buildConjunction(range80, 10, numBuckets);
-
-    // 20% lead + 80% range. 8x/4x→points, 2x→DV.
-    // indexCost=800K, leadCost=200K. 8x: 100K<=200K→pts. 4x: 200K<=200K→pts. 2x: 400K>200K→DV.
     crossover20Query = buildConjunction(range80, 20, numBuckets);
-
-    // 30% lead + 80% range. 8x/4x/2x→points.
-    // indexCost=800K, leadCost=300K. 2x: 400K>300K→DV. So 2x still DV here.
-    // Actually 2x threshold = 400K > 300K → DV. Need 1x for points: 800K > 300K → DV.
-    // So 30% lead is still DV at 2x. This tests DV with more docs to check.
     crossover30Query = buildConjunction(range80, 30, numBuckets);
 
     // DV favorable: 1% lead + 80% range. Both 8x and 4x choose DV.
@@ -150,9 +140,7 @@ public class IndexOrDocValuesQueryBenchmark {
   public void tearDown() throws Exception {
     reader.close();
     dir.close();
-    try (Stream<Path> walk = Files.walk(path)) {
-      walk.sorted(Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
-    }
+    IOUtils.rm(path);
   }
 
   @Benchmark

--- a/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
@@ -174,8 +174,10 @@ public final class IndexOrDocValuesQuery extends Query {
             // At equal costs, doc values tend to be worse than points since they
             // still need to perform one comparison per document while points can
             // do much better than that given how values are organized. So we give
-            // an arbitrary 8x penalty to doc values.
-            final long threshold = cost() >>> 3;
+            // a 6x penalty to doc values. (Reduced from 8x: DocValuesSkipper
+            // enables block-level skipping that makes DV competitive with points
+            // for selective leads in conjunctions.)
+            final long threshold = cost() / 6;
             if (threshold <= leadCost) {
               return indexScorerSupplier.get(leadCost);
             } else {


### PR DESCRIPTION
Revisit the threshold in IndexOrDocValuesQuery for picking points vs DV (especially now with DocVlauesSkipper).
With block-level skipping, DV is competitive with points for selective leads in conjunctions. Reducing to 6x lets the DV path be chosen in the crossover regime, yielding 1.78x throughput on selective-lead queries without regressing any other case.

 /4 was also tested but caused a 43% regression at 20% lead + 10M docs due to BKD cost estimation noise at
the threshold boundary

### Benchmark

AMD EPYC 7R32 (c5a.2xlarge), JDK 25, 2 forks, 5 iters × 3s.
Index: monotonic timestamps + 100-bucket keyword field, forceMerge(1).
Queries: TermQuery lead (FILTER) + LongField.newRangeQuery (FILTER).

| method          | lead | range | docs | /8 (ops/s)  | /6 (ops/s)  | ratio |
|-----------------|------|-------|------|-------------|-------------|-------|
| crossover10     | 10%  | 80%   | 1M   | 8,634 ± 66  | 15,362 ± 51 | 1.78x |
| crossover10     | 10%  | 80%   | 10M  | 285 ± 10    | 290 ± 1     | 1.02x |
| crossover20     | 20%  | 80%   | 1M   | 6,948 ± 141 | 6,835 ± 72  | 0.98x |
| crossover20     | 20%  | 80%   | 10M  | 183 ± 2     | 186 ± 0.4   | 1.02x |
| crossover30     | 30%  | 80%   | 1M   | 5,764 ± 47  | 5,832 ± 37  | 1.01x |
| crossover30     | 30%  | 80%   | 10M  | 72 ± 1      | 72 ± 1      | 1.01x |
| dvFavorable     | 1%   | 80%   | 1M   | 39,487 ± 161| 39,658 ± 371| 1.00x |
| dvFavorable     | 1%   | 80%   | 10M  | 4,508 ± 17  | 4,501 ± 18  | 1.00x |
| pointsFavorable | 50%  | 5%    | 1M   | 4,693 ± 31  | 4,746 ± 18  | 1.01x |
| pointsFavorable | 50%  | 5%    | 10M  | 2,350 ± 16  | 2,390 ± 13  | 1.02x |

The crossover10 case (10% lead + 80% range, 1M docs) shows 1.78x: the reduced
divisor switches from points to DV, and DV with skip blocks is faster for this
selective-lead, broad-range pattern. All other cases show no regression.

Fix #16425