### PR TITLE
Add Query#isKnownToMatchAllDocs() to replace == checks

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -183,6 +183,11 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#NNNNN: Add Query#isKnownToMatchAllDocs() to replace concrete MatchAllDocsQuery type
+  checks. ConstantScoreQuery and BoostQuery delegate the check to their wrapped queries, allowing
+  KnnVectorQuery, IndexOrDocValuesQuery, BooleanQuery, and IndexWriter to recognize wrapped
+  match-all queries. (Michael Marshall)
+
 * GITHUB#16431: Add support for Block-Max WAND dynamic score skipping in FunctionScoreQuery
   and DoubleValuesSource using DocValuesSkipper. (Rajat Jain)
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -69,7 +69,6 @@ import org.apache.lucene.internal.tests.IndexWriterAccess;
 import org.apache.lucene.internal.tests.TestSecrets;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FieldExistsQuery;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
@@ -1885,7 +1884,7 @@ public class IndexWriter
 
     // LUCENE-6379: Specialize MatchAllDocsQuery
     for (Query query : queries) {
-      if (query.getClass() == MatchAllDocsQuery.class) {
+      if (query.isKnownToMatchAllDocs()) {
         return deleteAll();
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/AbstractKnnVectorQuery.java
@@ -84,7 +84,7 @@ abstract class AbstractKnnVectorQuery extends Query {
         // If the filter is a match no docs query, we can also skip it
         return rewrittenFilter;
       }
-      if (rewrittenFilter.getClass() != MatchAllDocsQuery.class) {
+      if (!rewrittenFilter.isKnownToMatchAllDocs()) {
         BooleanQuery booleanQuery =
             new BooleanQuery.Builder()
                 .add(filter, BooleanClause.Occur.FILTER)

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
@@ -456,7 +456,7 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
           must = boostQuery.getQuery();
           boost = boostQuery.getBoost();
         }
-        if (must.getClass() == MatchAllDocsQuery.class) {
+        if (must.isKnownToMatchAllDocs()) {
           // our single scoring clause matches everything: rewrite to a CSQ on the filter
           // ignore SHOULD clause for now
           BooleanQuery.Builder builder = new BooleanQuery.Builder();

--- a/lucene/core/src/java/org/apache/lucene/search/BoostQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BoostQuery.java
@@ -54,6 +54,11 @@ public final class BoostQuery extends Query {
   }
 
   @Override
+  public boolean isKnownToMatchAllDocs() {
+    return query.isKnownToMatchAllDocs();
+  }
+
+  @Override
   public boolean equals(Object other) {
     return sameClassAs(other) && equalsTo(getClass().cast(other));
   }

--- a/lucene/core/src/java/org/apache/lucene/search/ConstantScoreQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ConstantScoreQuery.java
@@ -39,6 +39,11 @@ public final class ConstantScoreQuery extends Query {
   }
 
   @Override
+  public boolean isKnownToMatchAllDocs() {
+    return query.isKnownToMatchAllDocs();
+  }
+
+  @Override
   public Query rewrite(IndexSearcher indexSearcher) throws IOException {
 
     Query rewritten = query.rewrite(indexSearcher);

--- a/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexOrDocValuesQuery.java
@@ -113,8 +113,7 @@ public final class IndexOrDocValuesQuery extends Query {
   public Query rewrite(IndexSearcher indexSearcher) throws IOException {
     Query indexRewrite = indexQuery.rewrite(indexSearcher);
     Query dvRewrite = dvQuery.rewrite(indexSearcher);
-    if (indexRewrite.getClass() == MatchAllDocsQuery.class
-        || dvRewrite.getClass() == MatchAllDocsQuery.class) {
+    if (indexRewrite.isKnownToMatchAllDocs() || dvRewrite.isKnownToMatchAllDocs()) {
       return MatchAllDocsQuery.INSTANCE;
     }
     if (indexRewrite.getClass() == MatchNoDocsQuery.class

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -133,7 +133,7 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends NumericDocValuesR
     }
 
     Query rewrittenFallback = fallbackQuery.rewrite(indexSearcher);
-    if (rewrittenFallback.getClass() == MatchAllDocsQuery.class) {
+    if (rewrittenFallback.isKnownToMatchAllDocs()) {
       return MatchAllDocsQuery.INSTANCE;
     }
     if (rewrittenFallback == fallbackQuery) {

--- a/lucene/core/src/java/org/apache/lucene/search/MatchAllDocsQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MatchAllDocsQuery.java
@@ -36,6 +36,11 @@ public final class MatchAllDocsQuery extends Query {
   }
 
   @Override
+  public boolean isKnownToMatchAllDocs() {
+    return true;
+  }
+
+  @Override
   public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) {
     return new ConstantScoreWeight(this, boost) {
       @Override

--- a/lucene/core/src/java/org/apache/lucene/search/Query.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Query.java
@@ -86,6 +86,17 @@ public abstract class Query {
   }
 
   /**
+   * Returns whether this query is known to match all documents. This method may return {@code
+   * false} for a query that matches all documents, but never {@code true} for one that does not.
+   *
+   * <p>This is an inexpensive structural check and says nothing about scores. Wrappers may delegate
+   * when they do not restrict the set of matching documents.
+   */
+  public boolean isKnownToMatchAllDocs() {
+    return false;
+  }
+
+  /**
    * Recurse through the query tree, visiting any child queries.
    *
    * @param visitor a QueryVisitor to be called by each query in the tree

--- a/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/search/BaseKnnVectorQueryTestCase.java
@@ -51,6 +51,7 @@ import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.knn.KnnCollectorManager;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.search.knn.TopKnnCollectorManager;
@@ -264,6 +265,23 @@ abstract class BaseKnnVectorQueryTestCase extends LuceneTestCase {
       // make sure we don't drop to exact search, even though the filter matches fewer than k docs
       Query kvq =
           getThrowingKnnVectorQuery("field", new float[] {0, 0}, 10, MatchAllDocsQuery.INSTANCE);
+      TopDocs topDocs = searcher.search(kvq, 3);
+      assertEquals(3, topDocs.totalHits.value());
+    }
+  }
+
+  public void testMatchAllFilterWrappedInBooleanQuery() throws IOException {
+    try (Directory indexStore =
+            getIndexStore("field", new float[] {0, 1}, new float[] {1, 2}, new float[] {0, 0});
+        IndexReader reader = DirectoryReader.open(indexStore)) {
+      IndexSearcher searcher = newSearcher(reader);
+
+      // A BooleanQuery with a single FILTER=MatchAllDocs clause rewrites to
+      // BoostQuery(ConstantScoreQuery(MatchAllDocs), 0). isKnownToMatchAllDocs() should propagate
+      // through the wrappers so KNN takes the no-filter (HNSW) path rather than building a BitSet.
+      Query filter =
+          new BooleanQuery.Builder().add(MatchAllDocsQuery.INSTANCE, Occur.FILTER).build();
+      Query kvq = getThrowingKnnVectorQuery("field", new float[] {0, 0}, 10, filter);
       TopDocs topDocs = searcher.search(kvq, 3);
       assertEquals(3, topDocs.totalHits.value());
     }

--- a/lucene/core/src/test/org/apache/lucene/search/TestConstantScoreQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestConstantScoreQuery.java
@@ -265,4 +265,18 @@ public class TestConstantScoreQuery extends LuceneTestCase {
     Query query = new ConstantScoreQuery(MatchNoDocsQuery.INSTANCE);
     assertEquals(MatchNoDocsQuery.INSTANCE, searcher.rewrite(query));
   }
+
+  public void testIsKnownToMatchAllDocs() {
+    // MatchAllDocsQuery is match-all
+    assertTrue(new MatchAllDocsQuery().isKnownToMatchAllDocs());
+
+    // Wrappers delegate
+    assertTrue(new ConstantScoreQuery(new MatchAllDocsQuery()).isKnownToMatchAllDocs());
+    assertTrue(new BoostQuery(new MatchAllDocsQuery(), 2f).isKnownToMatchAllDocs());
+
+    // Non-match-all queries return false
+    assertFalse(new ConstantScoreQuery(new MatchNoDocsQuery()).isKnownToMatchAllDocs());
+    assertFalse(new MatchNoDocsQuery().isKnownToMatchAllDocs());
+    assertFalse(new TermQuery(new Term("f", "v")).isKnownToMatchAllDocs());
+  }
 }


### PR DESCRIPTION
### Description

I put this together as a draft to see what it'd look like to replace the `== MatchAllDocsQuery.class` checks. It seems valuable for `AbstractKnnVectorQuery` in the case where a `MatchAllDocsQuery` is wrapped in a `ConstantScoreQuery` or a `BoostQuery`, which can happen when a boolean query wraps a single `MatchAllDocsQuery` as a filter clause, because that is a case where we wouldn't want to add the filter. However, what is not clear is if the other  `== MatchAllDocsQuery.class` checks can correctly use this new method or if we need something more careful.

The primary benefit of this change is for `AbstractKnnVectorQuery` to skip building a filter. Adding a match all filter has two costs. First, we intersect with `new FieldExistsQuery(field)`, and second, we call `cost()` which eagerly materializes a fixed bitset, costing memory proportional to the number of docs.

Leaving this as a draft for now, as I'm not sure the API design is quite right. I'll continue to think about it.