### PR TITLE
docs: add AI policy and link from CONTRIBUTING.md

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,52 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<!-- Sourced verbatim from https://github.com/astral-sh/.github/ -->
+
+# AI POLICY
+
+We support using AI (i.e., LLMs) as tools for coding. However, you remain
+responsible for any code you publish and we are responsible for any code we
+merge and release. We hold a high bar for all contributions to our projects.
+
+**AI should not be used to generate comments when communicating with
+maintainers**. We expect comments on our projects to be written by humans. We
+may hide any comments that we believe are AI generated.
+
+If you are opening an issue, we expect you to describe the problem in your own
+words.
+
+If you are opening a pull request, we expect you to be able to explain the
+proposed changes in your own words. This includes the pull request body and
+responses to questions. **Do not copy responses from the AI when replying to
+questions from maintainers.**
+
+Due to the foundational nature of our projects, we require a human in the loop
+who understands the work produced by AI. **We do not allow autonomous agents to
+be used for contributing to our projects**. We will close any pull requests that
+we believe were created autonomously.
+
+If you wish to include context from an interaction with AI in your comments, it
+must be in a quote block (e.g., using `>`) and disclosed as such. It must be
+accompanied by human commentary explaining the relevance and implications of the
+context. Do not share long snippets.
+
+We understand that AI is useful when communicating as a non-native English
+speaker. If you are using AI to edit your comments for this purpose, please take
+the time to ensure it reflects your own voice and ideas. If using AI for
+translation, we recommend writing in your native language and including the AI
+translation in a quote block.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,10 @@ Before creating your patch, you may want to get 'main' up to date with the lates
 
 You may want to add a CHANGES entry to [CHANGES.txt](./lucene/CHANGES.txt). A CHANGES entry should start with the issue or pull request number `GITHUB#XXX` that is followed by the description of the change and contributors' name. Please see the existing entries for reference.
 
+### Use of AI
+
+We require all use of AI in contributions to follow our [AI Policy](AI_POLICY.md).
+
 ## Stay involved
 
 Contributors should join the [Lucene mailing lists](https://lucene.apache.org/core/discussion.html). In particular, the commit list (to see changes as they are made), the dev list (to join discussions of changes) and the user list (to help others).


### PR DESCRIPTION
Per discussion on dev, add simple AI policy and link it from CONTRIBUTING.md.
Policy is sourced from [astral's policy](https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)

PR template today already links to CONTRIBUTING.md:

```markdown
<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
```

Issue templates already link to CONTRIBUTING.md (via github's default widgets):

<img width="666" height="135" alt="Screen_Shot_2026-08-29_at_08 19 04" src="https://github.com/user-attachments/assets/e4a6abfa-aa63-43ce-afe3-c97bccc2c937" />

So the content is reachable from the key places where it counts. If there is trouble, we could always do more aggressive stuff as a followup (e.g. direct links to AI policy from these templates, required checkboxes on those templates that you've read it, etc etc). But it seems best to avoid that kind of thing unless it becomes strictly necessary.