### PR TITLE
Make HNSW merges abortable during graph initialization and repair

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -214,6 +214,10 @@ Optimizations
 
 Bug Fixes
 ---------------------
+* GITHUB#16620: Make HNSW merges abortable during graph initialization and repair, so that the
+  copy, repair and rebalance phases of an initialized graph build can be promptly aborted when the
+  surrounding merge is cancelled. (Tanguy Leroux)
+
 * GITHUB#16553: Fix stored-fields corruption when PerField#finish throws: the stored-fields frame
   was left open, causing "Wrote N docs, finish called with numDocs=M" at flush. (Michael Marshall)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -217,10 +217,6 @@ Optimizations
 
 Bug Fixes
 ---------------------
-* GITHUB#16620: Make HNSW merges abortable during graph initialization and repair, so that the
-  copy, repair and rebalance phases of an initialized graph build can be promptly aborted when the
-  surrounding merge is cancelled. (Tanguy Leroux)
-
 * GITHUB#16553: Fix stored-fields corruption when PerField#finish throws: the stored-fields frame
   was left open, causing "Wrote N docs, finish called with numDocs=M" at flush. (Michael Marshall)
 
@@ -493,6 +489,10 @@ Optimizations
 
 Bug Fixes
 ---------------------
+
+* GITHUB#16620: Make HNSW merges abortable during graph initialization and repair, so that the
+  copy, repair and rebalance phases of an initialized graph build can be promptly aborted when the
+  surrounding merge is cancelled. (Tanguy Leroux)
 
 * GITHUB#16565: IndexWriter#updateBinaryDocValue now rejects updating a field that is part of the
   index sort, matching IndexWriter#updateNumericDocValue. (Jim Ferenczi)

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsWriter.java
@@ -419,6 +419,8 @@ public final class Lucene99HnswVectorsWriter extends KnnVectorsWriter {
   public IORunnable mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
     flatVectorWriter.mergeOneFlatVectorField(fieldInfo, mergeState);
     return () -> {
+      // Bail out before the potentially heavy graph build if the merge was already aborted
+      mergeState.checkAborted();
       // Lazily finish flat writer and open a reader for the written segment
       ensureFlatReaderOpen();
       // Get the vector values and scorer supplier from the written segment

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswMerger.java
@@ -97,7 +97,12 @@ public class ConcurrentHnswMerger extends IncrementalHnswGraphMerger {
                 initializedNodes);
         graph =
             InitializedHnswGraphBuilder.initGraph(
-                initializerGraph, oldToNewOrdinalMap, maxOrd, beamWidth, scorerSupplier);
+                initializerGraph,
+                oldToNewOrdinalMap,
+                maxOrd,
+                beamWidth,
+                scorerSupplier,
+                abortCheck);
       }
     }
     return new HnswConcurrentMergeBuilder(

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -220,6 +220,16 @@ public class HnswGraphBuilder implements HnswBuilder {
     this.abortCheck = abortCheck;
   }
 
+  /**
+   * Runs the abort check if one has been set, otherwise does nothing. Subclasses should call this
+   * from any long-running merge operation so that a cancelled merge can be aborted promptly.
+   */
+  protected final void maybeAbort() throws IOException {
+    if (abortCheck != null) {
+      abortCheck.run();
+    }
+  }
+
   @Override
   public OnHeapHnswGraph getCompletedGraph() throws IOException {
     if (!frozen) {

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/IncrementalHnswGraphMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/IncrementalHnswGraphMerger.java
@@ -177,7 +177,8 @@ public class IncrementalHnswGraphMerger implements HnswGraphMerger {
         graphs,
         ordMaps,
         maxOrd,
-        initializedNodes);
+        initializedNodes,
+        abortCheck);
   }
 
   protected final int[][] getNewOrdMapping(

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
@@ -109,9 +109,10 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
    *     tracking)
    * @param totalNumberOfVectors the total number of vectors in the merged graph (used for
    *     pre-allocation)
-   * @param abortCheck optional check invoked before every node insertion during graph construction;
-   *     may throw {@link org.apache.lucene.index.MergePolicy.MergeAbortedException} to abort the
-   *     build when the surrounding merge has been aborted, or null
+   * @param abortCheck optional check polled during graph construction, i.e. while copying,
+   *     repairing and rebalancing the initializer graph and before each node insertion; may throw
+   *     {@link org.apache.lucene.index.MergePolicy.MergeAbortedException} to abort the build when
+   *     the surrounding merge has been aborted, or null
    * @return a new builder initialized with the provided graph structure
    * @throws IOException if an I/O error occurs during graph initialization
    */
@@ -175,9 +176,10 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
    * @param totalNumberOfVectors the total number of vectors in the merged graph
    * @param beamWidth the search beam width for graph construction
    * @param scorerSupplier provides vector similarity scoring
-   * @param abortCheck optional check invoked before every node insertion during graph construction;
-   *     may throw {@link org.apache.lucene.index.MergePolicy.MergeAbortedException} to abort the
-   *     build when the surrounding merge has been aborted, or null
+   * @param abortCheck optional check polled during graph construction, i.e. while copying,
+   *     repairing and rebalancing the initializer graph and before each node insertion; may throw
+   *     {@link org.apache.lucene.index.MergePolicy.MergeAbortedException} to abort the build when
+   *     the surrounding merge has been aborted, or null
    * @return a fully initialized on-heap HNSW graph
    * @throws IOException if an I/O error occurs during graph initialization
    */
@@ -452,11 +454,11 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
       Iterator<IntCursor> it = levelToNodes[level - 1].iterator();
 
       while (it.hasNext() && currentNodesAtLevel < maxNodesAtLevel) {
-        maybeAbort();
         int node = it.next().value;
 
         // Promote with probability 1/M, matching HNSW's level assignment distribution
         if (random.nextDouble() < invMaxConn && !hnsw.nodeExistAtLevel(level, node)) {
+          maybeAbort();
           scorer.setScoringOrdinal(node);
           hnsw.addNode(level, node);
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
@@ -30,6 +30,7 @@ import org.apache.lucene.internal.hppc.IntArrayList;
 import org.apache.lucene.internal.hppc.IntCursor;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.IORunnable;
 
 /**
  * This creates a graph builder that is initialized with the provided HnswGraph. This is useful for
@@ -108,6 +109,9 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
    *     tracking)
    * @param totalNumberOfVectors the total number of vectors in the merged graph (used for
    *     pre-allocation)
+   * @param abortCheck optional check invoked before every node insertion during graph construction;
+   *     may throw {@link org.apache.lucene.index.MergePolicy.MergeAbortedException} to abort the
+   *     build when the surrounding merge has been aborted, or null
    * @return a new builder initialized with the provided graph structure
    * @throws IOException if an I/O error occurs during graph initialization
    */
@@ -118,7 +122,8 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
       HnswGraph initializerGraph,
       int[] newOrdMap,
       BitSet initializedNodes,
-      int totalNumberOfVectors)
+      int totalNumberOfVectors,
+      IORunnable abortCheck)
       throws IOException {
 
     InitializedHnswGraphBuilder builder =
@@ -129,8 +134,35 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
             new OnHeapHnswGraph(initializerGraph.maxConn(), totalNumberOfVectors),
             initializedNodes);
 
+    if (abortCheck != null) {
+      builder.setAbortCheck(abortCheck);
+    }
     builder.initializeFromGraph(initializerGraph, newOrdMap);
     return builder;
+  }
+
+  /**
+   * Same as {@link #fromGraph(RandomVectorScorerSupplier, int, long, HnswGraph, int[], BitSet, int,
+   * IORunnable)} but without an abort check.
+   */
+  public static InitializedHnswGraphBuilder fromGraph(
+      RandomVectorScorerSupplier scorerSupplier,
+      int beamWidth,
+      long seed,
+      HnswGraph initializerGraph,
+      int[] newOrdMap,
+      BitSet initializedNodes,
+      int totalNumberOfVectors)
+      throws IOException {
+    return fromGraph(
+        scorerSupplier,
+        beamWidth,
+        seed,
+        initializerGraph,
+        newOrdMap,
+        initializedNodes,
+        totalNumberOfVectors,
+        null);
   }
 
   /**
@@ -143,6 +175,9 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
    * @param totalNumberOfVectors the total number of vectors in the merged graph
    * @param beamWidth the search beam width for graph construction
    * @param scorerSupplier provides vector similarity scoring
+   * @param abortCheck optional check invoked before every node insertion during graph construction;
+   *     may throw {@link org.apache.lucene.index.MergePolicy.MergeAbortedException} to abort the
+   *     build when the surrounding merge has been aborted, or null
    * @return a fully initialized on-heap HNSW graph
    * @throws IOException if an I/O error occurs during graph initialization
    */
@@ -151,7 +186,8 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
       int[] newOrdMap,
       int totalNumberOfVectors,
       int beamWidth,
-      RandomVectorScorerSupplier scorerSupplier)
+      RandomVectorScorerSupplier scorerSupplier,
+      IORunnable abortCheck)
       throws IOException {
 
     InitializedHnswGraphBuilder builder =
@@ -162,8 +198,24 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
             initializerGraph,
             newOrdMap,
             null,
-            totalNumberOfVectors);
+            totalNumberOfVectors,
+            abortCheck);
     return builder.getGraph();
+  }
+
+  /**
+   * Same as {@link #initGraph(HnswGraph, int[], int, int, RandomVectorScorerSupplier, IORunnable)}
+   * but without an abort check.
+   */
+  public static OnHeapHnswGraph initGraph(
+      HnswGraph initializerGraph,
+      int[] newOrdMap,
+      int totalNumberOfVectors,
+      int beamWidth,
+      RandomVectorScorerSupplier scorerSupplier)
+      throws IOException {
+    return initGraph(
+        initializerGraph, newOrdMap, totalNumberOfVectors, beamWidth, scorerSupplier, null);
   }
 
   private InitializedHnswGraphBuilder(
@@ -239,6 +291,7 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
       HnswGraph.NodesIterator it = initializerGraph.getNodesOnLevel(level);
 
       while (it.hasNext()) {
+        maybeAbort();
         int oldOrd = it.nextInt();
         int newOrd = newOrdMap[oldOrd];
 
@@ -327,6 +380,7 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
     NeighborArray scratchArray = new NeighborArray(beamWidth, false);
 
     for (int node : disconnectedNodes) {
+      maybeAbort();
       scorer.setScoringOrdinal(node);
       NeighborArray existingNeighbors = hnsw.getNeighbors(level, node);
 
@@ -398,6 +452,7 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
       Iterator<IntCursor> it = levelToNodes[level - 1].iterator();
 
       while (it.hasNext() && currentNodesAtLevel < maxNodesAtLevel) {
+        maybeAbort();
         int node = it.next().value;
 
         // Promote with probability 1/M, matching HNSW's level assignment distribution

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/MergingHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/MergingHnswGraphBuilder.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Locale;
 import org.apache.lucene.internal.hppc.IntHashSet;
 import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.IORunnable;
 
 /**
  * A graph builder that is used during segments' merging.
@@ -87,6 +88,9 @@ public final class MergingHnswGraphBuilder extends HnswGraphBuilder {
    *     all vectors expected to be added to the graph in the future
    * @param initializedNodes the nodes will be initialized through the merging, if null, all nodes
    *     should be already initialized after {@link #updateGraph(HnswGraph, int[])} being called
+   * @param abortCheck optional check invoked during the graph-join initialization/repair of the
+   *     base graph; may throw {@link org.apache.lucene.index.MergePolicy.MergeAbortedException} to
+   *     abort a cancelled merge promptly rather than only during subsequent node insertion, or null
    * @return a new HnswGraphBuilder that is initialized with the provided HnswGraph
    * @throws IOException when reading the graph fails
    */
@@ -97,13 +101,43 @@ public final class MergingHnswGraphBuilder extends HnswGraphBuilder {
       HnswGraph[] graphs,
       int[][] ordMaps,
       int totalNumberOfVectors,
-      BitSet initializedNodes)
+      BitSet initializedNodes,
+      IORunnable abortCheck)
       throws IOException {
     OnHeapHnswGraph graph =
         InitializedHnswGraphBuilder.initGraph(
-            graphs[0], ordMaps[0], totalNumberOfVectors, beamWidth, scorerSupplier);
+            graphs[0], ordMaps[0], totalNumberOfVectors, beamWidth, scorerSupplier, abortCheck);
     return new MergingHnswGraphBuilder(
         scorerSupplier, beamWidth, seed, graph, graphs, ordMaps, initializedNodes);
+  }
+
+  /**
+   * Same as {@link #fromGraphs(RandomVectorScorerSupplier, int, long, HnswGraph[], int[][], int,
+   * BitSet, IORunnable)} but without an abort check.
+   *
+   * <p>This parameter-less overload is kept deliberately so the abort-check change stays purely
+   * additive: existing call sites keep compiling unchanged, which keeps the backport to 10.5
+   * minimal. New callers should prefer the {@code abortCheck} overload so a cancelled merge can be
+   * aborted during the graph-join initialization/repair phase.
+   */
+  public static MergingHnswGraphBuilder fromGraphs(
+      RandomVectorScorerSupplier scorerSupplier,
+      int beamWidth,
+      long seed,
+      HnswGraph[] graphs,
+      int[][] ordMaps,
+      int totalNumberOfVectors,
+      BitSet initializedNodes)
+      throws IOException {
+    return fromGraphs(
+        scorerSupplier,
+        beamWidth,
+        seed,
+        graphs,
+        ordMaps,
+        totalNumberOfVectors,
+        initializedNodes,
+        null);
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
@@ -20,11 +20,13 @@ package org.apache.lucene.util.hnsw;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.KnnCollector;
@@ -34,6 +36,7 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.IORunnable;
 import org.junit.Before;
 
 /** Tests HNSW KNN graphs */
@@ -112,6 +115,74 @@ public class TestHnswFloatVectorGraph extends HnswGraphTestCase<float[]> {
       assertTrue(
           "target below the cumulative floor should be reconnected during merge",
           merged.getNeighbors(0, target).size() >= degreeBefore);
+    } finally {
+      HnswGraphBuilder.randSeed = savedRandSeed;
+    }
+  }
+
+  /**
+   * A cancelled merge must be able to abort HNSW graph construction during the graph-join
+   * initialization and disconnected-node repair phases, not only during the subsequent incremental
+   * node insertion.
+   */
+  public void testAbortCheckInterruptsGraphInitAndRepair() throws IOException {
+    // Pin vectors, both graph seeds, and similarity so the merged graph is identical every run.
+    long savedRandSeed = HnswGraphBuilder.randSeed;
+    try {
+      HnswGraphBuilder.randSeed = 42;
+      similarityFunction = VectorSimilarityFunction.EUCLIDEAN;
+      int M = 16;
+      int beamWidth = 100;
+      int size = 256;
+      int dim = 16;
+      MockVectorValues vectors =
+          MockVectorValues.fromValues(createRandomFloatVectors(size, dim, new Random(42)));
+      RandomVectorScorerSupplier supplier = buildScorerSupplier(vectors);
+      OnHeapHnswGraph graph = HnswGraphBuilder.create(supplier, M, beamWidth, 42).build(size);
+
+      // Delete every other document (never the entry node) so the merge takes the graph-join path
+      // with deletes: many survivors lose neighbors and get repaired by fixDisconnectedNodes.
+      int entry = graph.entryNode();
+      int[] newOrdMap = new int[size];
+      for (int i = 0; i < size; i++) {
+        newOrdMap[i] = (i == entry || (i & 1) == 0) ? i : -1;
+      }
+
+      // copyGraphStructure polls the abort check exactly once per source node across every level.
+      int copyLoopChecks = 0;
+      for (int level = 0; level < graph.numLevels(); level++) {
+        copyLoopChecks += graph.getNodesOnLevel(level).size();
+      }
+
+      // Test that aborting on the very first check stops the graph initialization immediately
+      IORunnable abortImmediately =
+          () -> {
+            throw new MergePolicy.MergeAbortedException("aborted before init");
+          };
+      expectThrows(
+          MergePolicy.MergeAbortedException.class,
+          () ->
+              InitializedHnswGraphBuilder.initGraph(
+                  graph, newOrdMap, size, beamWidth, supplier, abortImmediately));
+
+      // Test that aborting during repair stops the graph initialization immediately
+      AtomicInteger checksUntilAbort = new AtomicInteger(copyLoopChecks + 1);
+      IORunnable abortDuringRepair =
+          () -> {
+            if (checksUntilAbort.decrementAndGet() == 0) {
+              throw new MergePolicy.MergeAbortedException("aborted mid-repair");
+            }
+          };
+      expectThrows(
+          MergePolicy.MergeAbortedException.class,
+          () ->
+              InitializedHnswGraphBuilder.initGraph(
+                  graph, newOrdMap, size, beamWidth, supplier, abortDuringRepair));
+
+      // Test that the graph can be correctly initialized
+      OnHeapHnswGraph merged =
+          InitializedHnswGraphBuilder.initGraph(graph, newOrdMap, size, beamWidth, supplier, null);
+      assertNotNull(merged);
     } finally {
       HnswGraphBuilder.randSeed = savedRandSeed;
     }


### PR DESCRIPTION
We observed some merge threads pinned at 100% CPU building a HNSW graph while the Lucene index writer rollback was blocked waiting for the merges to abort:

```java
...
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.util.hnsw.HnswGraphSearcher.searchLevel(HnswGraphSearcher.java:342)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.util.hnsw.InitializedHnswGraphBuilder.fixDisconnectedNodes(InitializedHnswGraphBuilder.java:323)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.util.hnsw.InitializedHnswGraphBuilder.repairDisconnectedNodes(InitializedHnswGraphBuilder.java:279)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.util.hnsw.InitializedHnswGraphBuilder.initializeFromGraph(InitializedHnswGraphBuilder.java:192)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.util.hnsw.InitializedHnswGraphBuilder.fromGraph(InitializedHnswGraphBuilder.java:121)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.util.hnsw.InitializedHnswGraphBuilder.initGraph(InitializedHnswGraphBuilder.java:147)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.util.hnsw.MergingHnswGraphBuilder.fromGraphs(MergingHnswGraphBuilder.java:104)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.util.hnsw.IncrementalHnswGraphMerger.createBuilder(IncrementalHnswGraphMerger.java:175)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.util.hnsw.IncrementalHnswGraphMerger.merge(IncrementalHnswGraphMerger.java:234)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsWriter.buildAndWriteGraph(Lucene99HnswVectorsWriter.java:488)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsWriter.lambda$mergeOneField$0(Lucene99HnswVectorsWriter.java:442)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsWriter$$Lambda/0x00000000093a6818.run(Unknown Source)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.codecs.KnnVectorsWriter.merge(KnnVectorsWriter.java:146)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.index.SegmentMerger.mergeVectorValues(SegmentMerger.java:273)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.index.SegmentMerger$$Lambda/0x00000000093a55d0.merge(Unknown Source)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.index.SegmentMerger.mergeWithLogging(SegmentMerger.java:316)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.index.SegmentMerger.merge(SegmentMerger.java:160)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.index.IndexWriter.mergeMiddle(IndexWriter.java:5400)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.index.IndexWriter.merge(IndexWriter.java:4859)
       app/org.apache.lucene.core@10.5.1/org.apache.lucene.index.IndexWriter$IndexWriterMergeSource.merge(IndexWriter.java:6684)
...
```

The abort check added in #16368 is only consulted during the incremental node insertion path (ie, `addGraphNode` method) but not during the graph initialization and repair phases (methods `copyGraphStructure`, `repairDisconnectedNodes`/`fixDisconnectedNodes`, `rebalanceGraph`) which happen before. 

This change threads the abort check down to the graph initialization and repair methods so that those phases can also be promptly aborted if a merge is cancelled. 

The `abortCheck` was introduced as non-final so I had to workaround this a bit. I also kept the public static methods without the `abortCheck` parameter around in the hope that it could help backporting this to 10.6 / 10.5.2.