### PR TITLE
Propagate getMergeInstance() through the quantized vector readers

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -215,6 +215,10 @@ Optimizations
 * GITHUB#16619: DirectIODirectory's slice() no longer performs a blocking direct read when
   creating a slice; the first read resolves the deferred start position instead. (John Maurice)
 
+* GITHUB#16622: Lucene104ScalarQuantizedVectorsReader, and the backward-codecs Lucene99 and
+  Lucene102 quantized vector readers, now propagate getMergeInstance() and finishMerge() to their
+  raw vectors reader, so merges read raw vectors with sequential read advice. (John Maurice)
+
 Bug Fixes
 ---------------------
 * GITHUB#16553: Fix stored-fields corruption when PerField#finish throws: the stored-fields frame

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene102/Lucene102BinaryQuantizedVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene102/Lucene102BinaryQuantizedVectorsReader.java
@@ -79,7 +79,7 @@ public class Lucene102BinaryQuantizedVectorsReader extends FlatVectorsReader
   private static final long SHALLOW_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(Lucene102BinaryQuantizedVectorsReader.class);
 
-  private final Map<String, FieldEntry> fields = new HashMap<>();
+  private final Map<String, FieldEntry> fields;
   private final IndexInput quantizedVectorData;
   private final FlatVectorsReader rawVectorsReader;
   private final Lucene102BinaryFlatVectorsScorer vectorScorer;
@@ -97,6 +97,7 @@ public class Lucene102BinaryQuantizedVectorsReader extends FlatVectorsReader
       FlatVectorsReader rawVectorsReader,
       Lucene102BinaryFlatVectorsScorer vectorsScorer)
       throws IOException {
+    this.fields = new HashMap<>();
     this.vectorScorer = vectorsScorer;
     this.rawVectorsReader = rawVectorsReader;
     int versionMeta = -1;
@@ -136,6 +137,36 @@ public class Lucene102BinaryQuantizedVectorsReader extends FlatVectorsReader
       IOUtils.closeWhileSuppressingExceptions(t, this);
       throw t;
     }
+  }
+
+  /**
+   * Copy constructor for {@link #getMergeInstance()}: the copy shares {@code reader}'s open state
+   * and reads raw vectors through {@code rawVectorsReader}, normally the merge instance of the
+   * original's. It is used only by the merging thread and is never closed.
+   */
+  protected Lucene102BinaryQuantizedVectorsReader(
+      Lucene102BinaryQuantizedVectorsReader reader, FlatVectorsReader rawVectorsReader) {
+    this.fields = reader.fields;
+    this.quantizedVectorData = reader.quantizedVectorData;
+    this.rawVectorsReader = rawVectorsReader;
+    this.vectorScorer = reader.vectorScorer;
+  }
+
+  /**
+   * Returns a copy of this reader that reads raw vectors through the raw reader's merge instance. A
+   * subclass that adds state must override this method and build its own copy through the {@link
+   * #Lucene102BinaryQuantizedVectorsReader(Lucene102BinaryQuantizedVectorsReader,
+   * FlatVectorsReader) copy constructor}, or its merge instance will be a plain {@code
+   * Lucene102BinaryQuantizedVectorsReader}.
+   */
+  @Override
+  public FlatVectorsReader getMergeInstance() throws IOException {
+    return new Lucene102BinaryQuantizedVectorsReader(this, rawVectorsReader.getMergeInstance());
+  }
+
+  @Override
+  public void finishMerge() throws IOException {
+    rawVectorsReader.finishMerge();
   }
 
   private void readFields(ChecksumIndexInput meta, FieldInfos infos) throws IOException {

--- a/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
+++ b/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene99/Lucene99ScalarQuantizedVectorsReader.java
@@ -67,16 +67,17 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
   private static final long SHALLOW_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(Lucene99ScalarQuantizedVectorsReader.class);
 
-  private final IntObjectHashMap<FieldEntry> fields = new IntObjectHashMap<>();
+  private final IntObjectHashMap<FieldEntry> fields;
   private final FlatVectorsScorer vectorScorer;
   private final IndexInput quantizedVectorData;
   private final FlatVectorsReader rawVectorsReader;
   private final FieldInfos fieldInfos;
 
-  /** Sole constructor */
+  /** Creates a reader from segment state. */
   public Lucene99ScalarQuantizedVectorsReader(
       SegmentReadState state, FlatVectorsReader rawVectorsReader, FlatVectorsScorer scorer)
       throws IOException {
+    this.fields = new IntObjectHashMap<>();
     this.vectorScorer = scorer;
     this.rawVectorsReader = rawVectorsReader;
     this.fieldInfos = state.fieldInfos;
@@ -117,6 +118,30 @@ public final class Lucene99ScalarQuantizedVectorsReader extends FlatVectorsReade
       IOUtils.closeWhileSuppressingExceptions(t, this);
       throw t;
     }
+  }
+
+  /**
+   * Copy constructor for {@link #getMergeInstance()}: the copy shares {@code reader}'s open state
+   * and reads raw vectors through {@code rawVectorsReader}, normally the merge instance of the
+   * original's. It is used only by the merging thread and is never closed.
+   */
+  private Lucene99ScalarQuantizedVectorsReader(
+      Lucene99ScalarQuantizedVectorsReader reader, FlatVectorsReader rawVectorsReader) {
+    this.fields = reader.fields;
+    this.vectorScorer = reader.vectorScorer;
+    this.quantizedVectorData = reader.quantizedVectorData;
+    this.rawVectorsReader = rawVectorsReader;
+    this.fieldInfos = reader.fieldInfos;
+  }
+
+  @Override
+  public FlatVectorsReader getMergeInstance() throws IOException {
+    return new Lucene99ScalarQuantizedVectorsReader(this, rawVectorsReader.getMergeInstance());
+  }
+
+  @Override
+  public void finishMerge() throws IOException {
+    rawVectorsReader.finishMerge();
   }
 
   private void readFields(ChecksumIndexInput meta, int versionMeta, FieldInfos infos)

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene102/TestLucene102HnswBinaryQuantizedVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene102/TestLucene102HnswBinaryQuantizedVectorsFormat.java
@@ -24,9 +24,16 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.CompoundFormat;
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
@@ -38,13 +45,21 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LogDocMergePolicy;
+import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.DataAccessHint;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.SameThreadExecutorService;
@@ -176,6 +191,152 @@ public class TestLucene102HnswBinaryQuantizedVectorsFormat extends BaseKnnVector
           assertEquals(3, offHeap.size());
         }
       }
+    }
+  }
+
+  public void testMergeInstancePropagatesToRawVectorsReader() throws IOException {
+    RecordingDirectory dir = new RecordingDirectory(newDirectory());
+    // a deterministic merge policy (MockRandomMergePolicy may wrap the merge in a reordering or
+    // slow reader, which does not propagate merge instances at all) and deterministic flushing, so
+    // that exactly the two committed segments reach forceMerge below
+    IndexWriterConfig config =
+        newIndexWriterConfig()
+            .setMergePolicy(new LogDocMergePolicy())
+            .setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+            .setRAMBufferSizeMB(IndexWriterConfig.DEFAULT_RAM_BUFFER_SIZE_MB);
+    // compound files would hide the raw vector file opens: disable them for flushed segments
+    // (IndexWriterConfig) and for merged segments (the codec's CompoundFormat, restored below)
+    config.setUseCompoundFile(false);
+    CompoundFormat compoundFormat = config.getCodec().compoundFormat();
+    boolean restoreCompoundFile = compoundFormat.getShouldUseCompoundFile();
+    compoundFormat.setShouldUseCompoundFile(false);
+    try (dir;
+        IndexWriter w = new IndexWriter(dir, config)) {
+      int dims = random().nextInt(12, 100);
+      int numDocs = random().nextInt(200, 400);
+      for (int i = 0; i < numDocs; i++) {
+        Document doc = new Document();
+        doc.add(
+            new KnnFloatVectorField("f", randomVector(dims), VectorSimilarityFunction.EUCLIDEAN));
+        w.addDocument(doc);
+        if (i == numDocs / 2) {
+          w.commit(); // ensure at least two segments exist, so forceMerge does real work
+        }
+      }
+      w.commit();
+      // keep a reader open across the merge so the merge reuses the pooled search readers, as on
+      // an index that is serving searches. Readers the merge opens itself use a merge context that
+      // ignores advice hints, so the sequential flip would not be visible through them.
+      try (IndexReader beforeMerge = DirectoryReader.open(w)) {
+        assertEquals(numDocs, beforeMerge.numDocs());
+        assertEquals(2, beforeMerge.leaves().size());
+        w.forceMerge(1);
+      }
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        SegmentReader leaf = (SegmentReader) getOnlyLeafReader(reader);
+        String mergedSegmentPrefix = leaf.getSegmentName() + "_";
+        // the merge itself propagated to the source segments: their raw vector inputs received
+        // the sequential hint while they were merged away
+        assertTrue(
+            dir.contextUpdates.entrySet().stream()
+                .anyMatch(
+                    e ->
+                        e.getKey().startsWith(mergedSegmentPrefix) == false
+                            && hasSequentialUpdate(e.getValue())));
+
+        List<String> mergedVecs =
+            dir.vecFiles.stream().filter(n -> n.startsWith(mergedSegmentPrefix)).toList();
+        assertEquals(mergedVecs.toString(), 1, mergedVecs.size());
+        String mergedVec = mergedVecs.get(0);
+        assertTrue(dir.updatesFor(mergedVec).isEmpty());
+
+        KnnVectorsReader knnReader = leaf.getVectorReader().unwrapReaderForField("f");
+        KnnVectorsReader mergeInstance = knnReader.getMergeInstance();
+        // asking for a merge instance must flip the merged segment's raw vector input to
+        // sequential advice; without propagation through Lucene102BinaryQuantizedVectorsReader
+        // nothing is recorded
+        assertTrue(hasSequentialUpdate(dir.updatesFor(mergedVec)));
+
+        FloatVectorValues expected = knnReader.getFloatVectorValues("f");
+        FloatVectorValues actual = mergeInstance.getFloatVectorValues("f");
+        assertEquals(expected.size(), actual.size());
+        for (int ord = 0; ord < expected.size(); ord++) {
+          assertArrayEquals(expected.vectorValue(ord), actual.vectorValue(ord), 0f);
+        }
+
+        // finishMerge reaches the raw reader, which reverts the advice
+        mergeInstance.finishMerge();
+        List<IOContext> updates = dir.updatesFor(mergedVec);
+        assertFalse(updates.get(updates.size() - 1).hints().contains(DataAccessHint.SEQUENTIAL));
+
+        // merge instances are views over the live reader's resources and are never closed
+        assertNotNull(knnReader.getFloatVectorValues("f"));
+      }
+    } finally {
+      compoundFormat.setShouldUseCompoundFile(restoreCompoundFile);
+    }
+  }
+
+  private static boolean hasSequentialUpdate(List<IOContext> updates) {
+    return updates.stream().anyMatch(ctx -> ctx.hints().contains(DataAccessHint.SEQUENTIAL));
+  }
+
+  /** Records {@link IndexInput#updateIOContext} calls on raw vector files, per full file name. */
+  private static final class RecordingDirectory extends FilterDirectory {
+    final Map<String, List<IOContext>> contextUpdates = new ConcurrentHashMap<>();
+    final Set<String> vecFiles = ConcurrentHashMap.newKeySet();
+
+    RecordingDirectory(Directory in) {
+      super(in);
+    }
+
+    @Override
+    public IndexInput openInput(String name, IOContext context) throws IOException {
+      IndexInput input = super.openInput(name, context);
+      if (name.endsWith(".vec") == false) {
+        return input;
+      }
+      vecFiles.add(name);
+      return new RecordingIndexInput(input, name, contextUpdates);
+    }
+
+    List<IOContext> updatesFor(String name) {
+      return contextUpdates.getOrDefault(name, List.of());
+    }
+  }
+
+  /**
+   * Records {@link IndexInput#updateIOContext} calls and forwards them, which {@link
+   * FilterIndexInput} does not do on its own (the {@link IndexInput} default is a no-op). Clones
+   * and slices come straight from the wrapped input: readers only update the context on their
+   * top-level input.
+   */
+  private static final class RecordingIndexInput extends FilterIndexInput {
+    private final String name;
+    private final Map<String, List<IOContext>> contextUpdates;
+
+    RecordingIndexInput(IndexInput in, String name, Map<String, List<IOContext>> contextUpdates) {
+      super("RecordingIndexInput(" + name + ")", in);
+      this.name = name;
+      this.contextUpdates = contextUpdates;
+    }
+
+    @Override
+    public void updateIOContext(IOContext context) throws IOException {
+      contextUpdates
+          .computeIfAbsent(name, _ -> Collections.synchronizedList(new ArrayList<>()))
+          .add(context);
+      in.updateIOContext(context);
+    }
+
+    @Override
+    public IndexInput clone() {
+      return in.clone();
+    }
+
+    @Override
+    public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+      return in.slice(sliceDescription, offset, length);
     }
   }
 

--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene99/TestLucene99HnswScalarQuantizedVectorsFormat.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene99/TestLucene99HnswScalarQuantizedVectorsFormat.java
@@ -20,17 +20,34 @@ package org.apache.lucene.backward_codecs.lucene99;
 import static org.apache.lucene.index.VectorSimilarityFunction.DOT_PRODUCT;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.CompoundFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.CodecReader;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LogDocMergePolicy;
+import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.DataAccessHint;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 
@@ -63,6 +80,152 @@ public class TestLucene99HnswScalarQuantizedVectorsFormat extends BaseKnnVectors
           assertEquals(3, offHeap.size());
         }
       }
+    }
+  }
+
+  public void testMergeInstancePropagatesToRawVectorsReader() throws IOException {
+    RecordingDirectory dir = new RecordingDirectory(newDirectory());
+    // a deterministic merge policy (MockRandomMergePolicy may wrap the merge in a reordering or
+    // slow reader, which does not propagate merge instances at all) and deterministic flushing, so
+    // that exactly the two committed segments reach forceMerge below
+    IndexWriterConfig config =
+        newIndexWriterConfig()
+            .setMergePolicy(new LogDocMergePolicy())
+            .setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+            .setRAMBufferSizeMB(IndexWriterConfig.DEFAULT_RAM_BUFFER_SIZE_MB);
+    // compound files would hide the raw vector file opens: disable them for flushed segments
+    // (IndexWriterConfig) and for merged segments (the codec's CompoundFormat, restored below)
+    config.setUseCompoundFile(false);
+    CompoundFormat compoundFormat = config.getCodec().compoundFormat();
+    boolean restoreCompoundFile = compoundFormat.getShouldUseCompoundFile();
+    compoundFormat.setShouldUseCompoundFile(false);
+    try (dir;
+        IndexWriter w = new IndexWriter(dir, config)) {
+      int dims = random().nextInt(12, 100);
+      int numDocs = random().nextInt(200, 400);
+      for (int i = 0; i < numDocs; i++) {
+        Document doc = new Document();
+        doc.add(
+            new KnnFloatVectorField("f", randomVector(dims), VectorSimilarityFunction.EUCLIDEAN));
+        w.addDocument(doc);
+        if (i == numDocs / 2) {
+          w.commit(); // ensure at least two segments exist, so forceMerge does real work
+        }
+      }
+      w.commit();
+      // keep a reader open across the merge so the merge reuses the pooled search readers, as on
+      // an index that is serving searches. Readers the merge opens itself use a merge context that
+      // ignores advice hints, so the sequential flip would not be visible through them.
+      try (IndexReader beforeMerge = DirectoryReader.open(w)) {
+        assertEquals(numDocs, beforeMerge.numDocs());
+        assertEquals(2, beforeMerge.leaves().size());
+        w.forceMerge(1);
+      }
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        SegmentReader leaf = (SegmentReader) getOnlyLeafReader(reader);
+        String mergedSegmentPrefix = leaf.getSegmentName() + "_";
+        // the merge itself propagated to the source segments: their raw vector inputs received
+        // the sequential hint while they were merged away
+        assertTrue(
+            dir.contextUpdates.entrySet().stream()
+                .anyMatch(
+                    e ->
+                        e.getKey().startsWith(mergedSegmentPrefix) == false
+                            && hasSequentialUpdate(e.getValue())));
+
+        List<String> mergedVecs =
+            dir.vecFiles.stream().filter(n -> n.startsWith(mergedSegmentPrefix)).toList();
+        assertEquals(mergedVecs.toString(), 1, mergedVecs.size());
+        String mergedVec = mergedVecs.get(0);
+        assertTrue(dir.updatesFor(mergedVec).isEmpty());
+
+        KnnVectorsReader knnReader = leaf.getVectorReader().unwrapReaderForField("f");
+        KnnVectorsReader mergeInstance = knnReader.getMergeInstance();
+        // asking for a merge instance must flip the merged segment's raw vector input to
+        // sequential advice; without propagation through Lucene99ScalarQuantizedVectorsReader
+        // nothing is recorded
+        assertTrue(hasSequentialUpdate(dir.updatesFor(mergedVec)));
+
+        FloatVectorValues expected = knnReader.getFloatVectorValues("f");
+        FloatVectorValues actual = mergeInstance.getFloatVectorValues("f");
+        assertEquals(expected.size(), actual.size());
+        for (int ord = 0; ord < expected.size(); ord++) {
+          assertArrayEquals(expected.vectorValue(ord), actual.vectorValue(ord), 0f);
+        }
+
+        // finishMerge reaches the raw reader, which reverts the advice
+        mergeInstance.finishMerge();
+        List<IOContext> updates = dir.updatesFor(mergedVec);
+        assertFalse(updates.get(updates.size() - 1).hints().contains(DataAccessHint.SEQUENTIAL));
+
+        // merge instances are views over the live reader's resources and are never closed
+        assertNotNull(knnReader.getFloatVectorValues("f"));
+      }
+    } finally {
+      compoundFormat.setShouldUseCompoundFile(restoreCompoundFile);
+    }
+  }
+
+  private static boolean hasSequentialUpdate(List<IOContext> updates) {
+    return updates.stream().anyMatch(ctx -> ctx.hints().contains(DataAccessHint.SEQUENTIAL));
+  }
+
+  /** Records {@link IndexInput#updateIOContext} calls on raw vector files, per full file name. */
+  private static final class RecordingDirectory extends FilterDirectory {
+    final Map<String, List<IOContext>> contextUpdates = new ConcurrentHashMap<>();
+    final Set<String> vecFiles = ConcurrentHashMap.newKeySet();
+
+    RecordingDirectory(Directory in) {
+      super(in);
+    }
+
+    @Override
+    public IndexInput openInput(String name, IOContext context) throws IOException {
+      IndexInput input = super.openInput(name, context);
+      if (name.endsWith(".vec") == false) {
+        return input;
+      }
+      vecFiles.add(name);
+      return new RecordingIndexInput(input, name, contextUpdates);
+    }
+
+    List<IOContext> updatesFor(String name) {
+      return contextUpdates.getOrDefault(name, List.of());
+    }
+  }
+
+  /**
+   * Records {@link IndexInput#updateIOContext} calls and forwards them, which {@link
+   * FilterIndexInput} does not do on its own (the {@link IndexInput} default is a no-op). Clones
+   * and slices come straight from the wrapped input: readers only update the context on their
+   * top-level input.
+   */
+  private static final class RecordingIndexInput extends FilterIndexInput {
+    private final String name;
+    private final Map<String, List<IOContext>> contextUpdates;
+
+    RecordingIndexInput(IndexInput in, String name, Map<String, List<IOContext>> contextUpdates) {
+      super("RecordingIndexInput(" + name + ")", in);
+      this.name = name;
+      this.contextUpdates = contextUpdates;
+    }
+
+    @Override
+    public void updateIOContext(IOContext context) throws IOException {
+      contextUpdates
+          .computeIfAbsent(name, _ -> Collections.synchronizedList(new ArrayList<>()))
+          .add(context);
+      in.updateIOContext(context);
+    }
+
+    @Override
+    public IndexInput clone() {
+      return in.clone();
+    }
+
+    @Override
+    public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+      return in.slice(sliceDescription, offset, length);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene104/Lucene104ScalarQuantizedVectorsReader.java
@@ -79,7 +79,7 @@ public class Lucene104ScalarQuantizedVectorsReader extends FlatVectorsReader
   private static final long SHALLOW_SIZE =
       RamUsageEstimator.shallowSizeOfInstance(Lucene104ScalarQuantizedVectorsReader.class);
 
-  private final Map<String, FieldEntry> fields = new HashMap<>();
+  private final Map<String, FieldEntry> fields;
   private final IndexInput quantizedVectorData;
   private final FlatVectorsReader rawVectorsReader;
   private final Lucene104ScalarQuantizedVectorScorer vectorScorer;
@@ -101,6 +101,7 @@ public class Lucene104ScalarQuantizedVectorsReader extends FlatVectorsReader
       Lucene104ScalarQuantizedVectorScorer vectorsScorer,
       DataAccessHint accessHint)
       throws IOException {
+    this.fields = new HashMap<>();
     this.vectorScorer = vectorsScorer;
     this.rawVectorsReader = rawVectorsReader;
     int versionMeta = -1;
@@ -142,6 +143,36 @@ public class Lucene104ScalarQuantizedVectorsReader extends FlatVectorsReader
       IOUtils.closeWhileSuppressingExceptions(t, this);
       throw t;
     }
+  }
+
+  /**
+   * Copy constructor for {@link #getMergeInstance()}: the copy shares {@code reader}'s open state
+   * and reads raw vectors through {@code rawVectorsReader}, normally the merge instance of the
+   * original's. It is used only by the merging thread and is never closed.
+   */
+  protected Lucene104ScalarQuantizedVectorsReader(
+      Lucene104ScalarQuantizedVectorsReader reader, FlatVectorsReader rawVectorsReader) {
+    this.fields = reader.fields;
+    this.quantizedVectorData = reader.quantizedVectorData;
+    this.rawVectorsReader = rawVectorsReader;
+    this.vectorScorer = reader.vectorScorer;
+  }
+
+  /**
+   * Returns a copy of this reader that reads raw vectors through the raw reader's merge instance. A
+   * subclass that adds state must override this method and build its own copy through the {@link
+   * #Lucene104ScalarQuantizedVectorsReader(Lucene104ScalarQuantizedVectorsReader,
+   * FlatVectorsReader) copy constructor}, or its merge instance will be a plain {@code
+   * Lucene104ScalarQuantizedVectorsReader}.
+   */
+  @Override
+  public FlatVectorsReader getMergeInstance() throws IOException {
+    return new Lucene104ScalarQuantizedVectorsReader(this, rawVectorsReader.getMergeInstance());
+  }
+
+  @Override
+  public void finishMerge() throws IOException {
+    rawVectorsReader.finishMerge();
   }
 
   private void readFields(ChecksumIndexInput meta, FieldInfos infos) throws IOException {

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene104/TestLucene104HnswScalarQuantizedVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene104/TestLucene104HnswScalarQuantizedVectorsFormat.java
@@ -23,9 +23,16 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.CompoundFormat;
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
@@ -38,12 +45,20 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LogDocMergePolicy;
+import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.DataAccessHint;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.ArrayUtil;
@@ -204,6 +219,166 @@ public class TestLucene104HnswScalarQuantizedVectorsFormat extends BaseKnnVector
           assertEquals(3, offHeap.size());
         }
       }
+    }
+  }
+
+  public void testMergeInstancePropagatesToRawVectorsReader() throws IOException {
+    RecordingDirectory dir = new RecordingDirectory(newDirectory());
+    // a deterministic merge policy (MockRandomMergePolicy may wrap the merge in a reordering or
+    // slow reader, which does not propagate merge instances at all) and deterministic flushing, so
+    // that exactly the two committed segments reach forceMerge below
+    IndexWriterConfig config =
+        newIndexWriterConfig()
+            .setCodec(TestUtil.alwaysKnnVectorsFormat(format))
+            .setMergePolicy(new LogDocMergePolicy())
+            .setMaxBufferedDocs(IndexWriterConfig.DISABLE_AUTO_FLUSH)
+            .setRAMBufferSizeMB(IndexWriterConfig.DEFAULT_RAM_BUFFER_SIZE_MB);
+    // compound files would hide the raw vector file opens: disable them for flushed segments
+    // (IndexWriterConfig) and for merged segments (the codec's CompoundFormat, restored below)
+    config.setUseCompoundFile(false);
+    CompoundFormat compoundFormat = config.getCodec().compoundFormat();
+    boolean restoreCompoundFile = compoundFormat.getShouldUseCompoundFile();
+    compoundFormat.setShouldUseCompoundFile(false);
+    try (dir;
+        IndexWriter w = new IndexWriter(dir, config)) {
+      int dims = random().nextInt(12, 100);
+      int numDocs = random().nextInt(200, 400);
+      for (int i = 0; i < numDocs; i++) {
+        Document doc = new Document();
+        doc.add(
+            new KnnFloatVectorField("f", randomVector(dims), VectorSimilarityFunction.EUCLIDEAN));
+        w.addDocument(doc);
+        if (i == numDocs / 2) {
+          w.commit(); // ensure at least two segments exist, so forceMerge does real work
+        }
+      }
+      w.commit();
+      // keep a reader open across the merge so the merge reuses the pooled search readers, as on
+      // an index that is serving searches. Readers the merge opens itself use a merge context that
+      // ignores advice hints, so the sequential flip would not be visible through them.
+      try (IndexReader beforeMerge = DirectoryReader.open(w)) {
+        assertEquals(numDocs, beforeMerge.numDocs());
+        assertEquals(2, beforeMerge.leaves().size());
+        w.forceMerge(1);
+      }
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        SegmentReader leaf = (SegmentReader) getOnlyLeafReader(reader);
+        String mergedSegmentPrefix = leaf.getSegmentName() + "_";
+        // the merge itself propagated to the source segments: their raw vector inputs received
+        // the sequential hint while they were merged away (matched by full file name, so the
+        // merged segment's own file cannot satisfy this), and finishMerge reverted it before
+        // those inputs were closed
+        assertTrue(
+            dir.contextUpdates.entrySet().stream()
+                .anyMatch(
+                    e ->
+                        e.getKey().startsWith(mergedSegmentPrefix) == false
+                            && hasSequentialUpdate(e.getValue())));
+        for (Map.Entry<String, List<IOContext>> e : dir.contextUpdates.entrySet()) {
+          List<IOContext> updates = e.getValue();
+          if (hasSequentialUpdate(updates)) {
+            assertFalse(
+                "read advice on [" + e.getKey() + "] was not reverted after the merge",
+                updates.get(updates.size() - 1).hints().contains(DataAccessHint.SEQUENTIAL));
+          }
+        }
+
+        // the merged segment's own raw vector file; nothing has touched its advice yet
+        List<String> mergedVecs =
+            dir.vecFiles.stream().filter(n -> n.startsWith(mergedSegmentPrefix)).toList();
+        assertEquals(mergedVecs.toString(), 1, mergedVecs.size());
+        String mergedVec = mergedVecs.get(0);
+        assertTrue(dir.updatesFor(mergedVec).isEmpty());
+
+        KnnVectorsReader knnReader = leaf.getVectorReader().unwrapReaderForField("f");
+        KnnVectorsReader mergeInstance = knnReader.getMergeInstance();
+        // asking for a merge instance must flip the merged segment's raw vector input to
+        // sequential advice; without propagation through Lucene104ScalarQuantizedVectorsReader
+        // nothing is recorded
+        assertTrue(hasSequentialUpdate(dir.updatesFor(mergedVec)));
+
+        // the merge view reads the same vectors in the same order as the live reader
+        FloatVectorValues expected = knnReader.getFloatVectorValues("f");
+        FloatVectorValues actual = mergeInstance.getFloatVectorValues("f");
+        assertEquals(expected.size(), actual.size());
+        for (int ord = 0; ord < expected.size(); ord++) {
+          assertArrayEquals(expected.vectorValue(ord), actual.vectorValue(ord), 0f);
+        }
+
+        // finishMerge reaches the raw reader, which reverts the advice
+        mergeInstance.finishMerge();
+        List<IOContext> updates = dir.updatesFor(mergedVec);
+        assertFalse(updates.get(updates.size() - 1).hints().contains(DataAccessHint.SEQUENTIAL));
+
+        // merge instances are views over the live reader's resources and are never closed; the
+        // live reader must keep working after the view is abandoned
+        assertNotNull(knnReader.getFloatVectorValues("f"));
+      }
+    } finally {
+      compoundFormat.setShouldUseCompoundFile(restoreCompoundFile);
+    }
+  }
+
+  private static boolean hasSequentialUpdate(List<IOContext> updates) {
+    return updates.stream().anyMatch(ctx -> ctx.hints().contains(DataAccessHint.SEQUENTIAL));
+  }
+
+  /** Records {@link IndexInput#updateIOContext} calls on raw vector files, per full file name. */
+  private static final class RecordingDirectory extends FilterDirectory {
+    final Map<String, List<IOContext>> contextUpdates = new ConcurrentHashMap<>();
+    final Set<String> vecFiles = ConcurrentHashMap.newKeySet();
+
+    RecordingDirectory(Directory in) {
+      super(in);
+    }
+
+    @Override
+    public IndexInput openInput(String name, IOContext context) throws IOException {
+      IndexInput input = super.openInput(name, context);
+      if (name.endsWith(".vec") == false) {
+        return input;
+      }
+      vecFiles.add(name);
+      return new RecordingIndexInput(input, name, contextUpdates);
+    }
+
+    List<IOContext> updatesFor(String name) {
+      return contextUpdates.getOrDefault(name, List.of());
+    }
+  }
+
+  /**
+   * Records {@link IndexInput#updateIOContext} calls and forwards them, which {@link
+   * FilterIndexInput} does not do on its own (the {@link IndexInput} default is a no-op). Clones
+   * and slices come straight from the wrapped input: readers only update the context on their
+   * top-level input.
+   */
+  private static final class RecordingIndexInput extends FilterIndexInput {
+    private final String name;
+    private final Map<String, List<IOContext>> contextUpdates;
+
+    RecordingIndexInput(IndexInput in, String name, Map<String, List<IOContext>> contextUpdates) {
+      super("RecordingIndexInput(" + name + ")", in);
+      this.name = name;
+      this.contextUpdates = contextUpdates;
+    }
+
+    @Override
+    public void updateIOContext(IOContext context) throws IOException {
+      contextUpdates
+          .computeIfAbsent(name, _ -> Collections.synchronizedList(new ArrayList<>()))
+          .add(context);
+      in.updateIOContext(context);
+    }
+
+    @Override
+    public IndexInput clone() {
+      return in.clone();
+    }
+
+    @Override
+    public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+      return in.slice(sliceDescription, offset, length);
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene104/TestLucene104ScalarQuantizedVectorsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene104/TestLucene104ScalarQuantizedVectorsFormat.java
@@ -584,4 +584,44 @@ public class TestLucene104ScalarQuantizedVectorsFormat extends BaseKnnVectorsFor
       CodecUtil.writeFooter(out);
     }
   }
+
+  public void testMergeInstanceSharesStateAndScoresIdentically() throws IOException {
+    int dims = random().nextInt(4, 65);
+    int numDocs = random().nextInt(100, 300);
+    try (Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+      for (int i = 0; i < numDocs; i++) {
+        Document doc = new Document();
+        doc.add(
+            new KnnFloatVectorField("f", randomVector(dims), VectorSimilarityFunction.EUCLIDEAN));
+        w.addDocument(doc);
+      }
+      w.commit();
+      w.forceMerge(1);
+      try (IndexReader reader = DirectoryReader.open(w)) {
+        LeafReader r = getOnlyLeafReader(reader);
+        KnnVectorsReader knnReader = ((CodecReader) r).getVectorReader().unwrapReaderForField("f");
+
+        KnnVectorsReader mergeInstance = knnReader.getMergeInstance();
+
+        // the merge view shares the quantized state: quantized scoring is bit-identical
+        float[] query = randomVector(dims);
+        VectorScorer expectedScorer = knnReader.getFloatVectorValues("f").scorer(query);
+        VectorScorer actualScorer = mergeInstance.getFloatVectorValues("f").scorer(query);
+        DocIdSetIterator expectedDocs = expectedScorer.iterator();
+        DocIdSetIterator actualDocs = actualScorer.iterator();
+        int compared = 0;
+        while (expectedDocs.nextDoc() != NO_MORE_DOCS) {
+          assertEquals(expectedDocs.docID(), actualDocs.nextDoc());
+          assertEquals(expectedScorer.score(), actualScorer.score(), 0f);
+          compared++;
+        }
+        assertEquals(NO_MORE_DOCS, actualDocs.nextDoc());
+        assertEquals(numDocs, compared);
+
+        // the merge view is never closed; abandoning it must not affect the original
+        assertNotNull(knnReader.getFloatVectorValues("f"));
+      }
+    }
+  }
 }


### PR DESCRIPTION
`MergeState` asks every reader for a merge instance when a merge starts, and
`Lucene99HnswVectorsReader` passes that on to its flat reader. For quantized fields the flat reader
is `Lucene104ScalarQuantizedVectorsReader` (or, for older segments, the `Lucene99` and `Lucene102`
quantized readers in backward-codecs), and that's where the request dies: these readers wrap a
`rawVectorsReader` but don't override `getMergeInstance()`, so they return `this` and the raw reader
never hears about the merge. Same for `finishMerge()`.

What that costs depends on the raw reader. In Lucene it is `Lucene99FlatVectorsReader`, whose merge
instance is the same reader with its `.vec` input switched to sequential read advice, so quantized
fields miss an optimization that plain float fields already get on every merge. A raw reader that
keeps a separate input for merging would hand that back instead, and it never gets the chance
either.

I ran into this in Elasticsearch, where the direct-I/O vector stack has one reader for searches and
one for merges and chooses between them in `getMergeInstance()`. On `int8_hnsw` fields the choice
never happened, so every merge read the whole source `.vec` through the search reader. With direct
I/O that is one 8 KiB device round-trip at a time, and twice over the file, once for the integrity
check and once for the copy. Jim Ferenczi fixed the links Elasticsearch owns in
elastic/elasticsearch#153423 and left this one in the commit message: "`Lucene104ScalarQuantizedVectorsReader`
(`int8_hnsw` / `int4_hnsw`) overrides neither method, so nothing below it is reached for those field
types. It keeps its `rawVectorsReader` private with no copy constructor, so the equivalent fix cannot
be made from the Elasticsearch subclass and belongs upstream." So here it is.

The change is small. Each reader gets a copy constructor that shares the original's open state and
takes a different `rawVectorsReader`. `getMergeInstance()` returns a copy built around
`rawVectorsReader.getMergeInstance()`, and `finishMerge()` forwards to the raw reader. That is how
`Lucene99HnswVectorsReader` already handles its own flat reader. The `fields` map moves out of its
field initializer into the main constructor, because a final field with an initializer can't be
assigned by the copy constructor. On the two non-final readers the copy constructor is
`protected`, and the `getMergeInstance()` javadoc explains that a subclass with state of its own has
to override it and build its own copy, or it gets a plain base-class merge instance.
`Lucene99ScalarQuantizedVectorsReader` is final, so its constructor stays private.

A merge instance is a view over the live reader's resources: the merging thread uses it and nobody
closes it, the same as the HNSW readers' merge instances. If the raw reader's `getMergeInstance()`
returns `this`, the copy reads through the same objects and the only effect is whatever the raw
reader did along the way. No file format changes.

I included the two backward-codecs readers because they still serve every merge whose sources are
pre-10.4 scalar-quantized or 10.2 binary-quantized segments, which is what an upgrade merge reads
for anyone who had quantized vectors before 10.4. I can split them into a follow-up if you'd rather
keep this to core.

A few limits. This only matters when the merge reads through a pooled reader, so on an index that is
serving searches, or NRT. Without a pooled reader, `IndexWriter` opens the sources with a merge
context that `MMapDirectory` already maps to sequential advice. Merges that go through
`MergePolicy#reorder` or `addIndexes(CodecReader...)` are wrapped in readers that don't propagate
merge instances at all, before or after this. And while a merge runs, a quantized field's `.vec` is
on sequential advice for concurrent searches that read full-precision vectors, which is already the
case for plain float fields.