### PR TITLE
Enable VectorizationProvider on JDK 27

### DIFF
--- a/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
+++ b/build-tools/build-infra/src/main/java/org/apache/lucene/gradle/plugins/java/TestsAndRandomizationPlugin.java
@@ -356,7 +356,7 @@ public class TestsAndRandomizationPlugin extends LuceneGradlePlugin {
 
     // JDK versions where the vector module is still incubating.
     boolean incubatorJavaVersion =
-        Set.of("21", "22", "23", "24", "25", "26").contains(runtimeJava.getMajorVersion());
+        Set.of("21", "22", "23", "24", "25", "26", "27").contains(runtimeJava.getMajorVersion());
 
     TaskContainer tasks = project.getTasks();
 

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorizationProvider.java
@@ -65,7 +65,7 @@ public abstract class VectorizationProvider {
 
   private static final String UPPER_JAVA_FEATURE_VERSION_SYSPROP =
       "org.apache.lucene.vectorization.upperJavaFeatureVersion";
-  private static final int DEFAULT_UPPER_JAVA_FEATURE_VERSION = 26;
+  private static final int DEFAULT_UPPER_JAVA_FEATURE_VERSION = 27;
 
   private static int getUpperJavaFeatureVersion() {
     int runtimeVersion = DEFAULT_UPPER_JAVA_FEATURE_VERSION;


### PR DESCRIPTION
Hi!

incubating vector api had no changes between JDK 26 and 27 (see [JEP 537](https://openjdk.org/jeps/537)).

smoke test: running NetBeans on 27 with `-J--add-modules=jdk.incubator.vector -J-Dorg.apache.lucene.vectorization.upperJavaFeatureVersion=27` and everything works fine (code and maven-indexer uses lucene, although I don't know how much of it hits the vectorized code paths).