### PR TITLE
Parallelize the repair process for disconnected nodes during HNSW merge-re-use

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -178,6 +178,10 @@ Improvements
 
 Optimizations
 ---------------------
+* GITHUB#16618: Repair disconnected nodes during HNSW merge-reuse across the merge worker
+  pool instead of serially on the merge thread, so reusing a graph with deletes is no longer
+  slower than a full rebuild. (Ethan Baker)
+
 * GITHUB#16431: Add support for Block-Max WAND dynamic score skipping in FunctionScoreQuery
   and DoubleValuesSource using DocValuesSkipper. (Rajat Jain)
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswMerger.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/ConcurrentHnswMerger.java
@@ -74,6 +74,7 @@ public class ConcurrentHnswMerger extends IncrementalHnswGraphMerger {
       throws IOException {
     OnHeapHnswGraph graph;
     BitSet initializedNodes = null;
+    InitializedHnswGraphBuilder.PrunedGraph prunedGraph = null;
 
     if (largestGraphReader == null) {
       graph = new OnHeapHnswGraph(M, maxOrd);
@@ -95,18 +96,20 @@ public class ConcurrentHnswMerger extends IncrementalHnswGraphMerger {
                 initGraphSize,
                 mergedVectorValues,
                 initializedNodes);
-        graph =
-            InitializedHnswGraphBuilder.initGraph(
+        InitializedHnswGraphBuilder.PrunedGraph result =
+            InitializedHnswGraphBuilder.pruneGraph(
+                scorerSupplier,
+                beamWidth,
                 initializerGraph,
                 oldToNewOrdinalMap,
                 maxOrd,
-                beamWidth,
-                scorerSupplier,
                 abortCheck);
+        graph = result.graph();
+        prunedGraph = result.hasDeletes() ? result : null;
       }
     }
     return new HnswConcurrentMergeBuilder(
-        taskExecutor, numWorker, scorerSupplier, beamWidth, graph, initializedNodes);
+        taskExecutor, numWorker, scorerSupplier, beamWidth, graph, initializedNodes, prunedGraph);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswConcurrentMergeBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswConcurrentMergeBuilder.java
@@ -33,6 +33,7 @@ import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IORunnable;
 import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.IntsRef;
 
 /**
  * A graph builder that manages multiple workers, it only supports adding the whole graph all at
@@ -42,10 +43,13 @@ public class HnswConcurrentMergeBuilder implements HnswBuilder {
 
   private static final int DEFAULT_BATCH_SIZE =
       2048; // number of vectors the worker handles sequentially at one batch
+  // Number of disconnected nodes a repair worker claims atomically at a time.
+  private static final int REPAIR_BATCH_SIZE = 64;
 
   private final TaskExecutor taskExecutor;
   private final ConcurrentMergeWorker[] workers;
   private final HnswLock hnswLock;
+  private final InitializedHnswGraphBuilder.PrunedGraph prunedGraph;
   private InfoStream infoStream = InfoStream.getDefault();
   private boolean frozen;
 
@@ -56,6 +60,24 @@ public class HnswConcurrentMergeBuilder implements HnswBuilder {
       int beamWidth,
       OnHeapHnswGraph hnsw,
       BitSet initializedNodes)
+      throws IOException {
+    this(taskExecutor, numWorker, scorerSupplier, beamWidth, hnsw, initializedNodes, null);
+  }
+
+  /**
+   * Creates a builder that, when the pruned source graph had deletes, repairs its disconnected
+   * nodes across the worker pool and rebalances it before inserting the remaining vectors.
+   *
+   * @param prunedGraph the deferred repair state, or null when the reused graph had no deletes
+   */
+  HnswConcurrentMergeBuilder(
+      TaskExecutor taskExecutor,
+      int numWorker,
+      RandomVectorScorerSupplier scorerSupplier,
+      int beamWidth,
+      OnHeapHnswGraph hnsw,
+      BitSet initializedNodes,
+      InitializedHnswGraphBuilder.PrunedGraph prunedGraph)
       throws IOException {
     this.taskExecutor = taskExecutor;
     AtomicInteger workProgress = new AtomicInteger(0);
@@ -72,6 +94,7 @@ public class HnswConcurrentMergeBuilder implements HnswBuilder {
               initializedNodes,
               workProgress);
     }
+    this.prunedGraph = prunedGraph;
   }
 
   @Override
@@ -89,6 +112,23 @@ public class HnswConcurrentMergeBuilder implements HnswBuilder {
     for (ConcurrentMergeWorker worker : workers) {
       worker.setMergeStartTimeNs(mergeStartTimeNs);
       worker.setCumulativeWorkTimeNs(cumulativeWorkTimeNs);
+    }
+    if (prunedGraph != null) {
+      long repairStartNs = System.nanoTime();
+      repairDisconnectedNodes();
+      long rebalanceStartNs = System.nanoTime();
+      prunedGraph.builder().rebalanceGraph();
+      long rebalanceEndNs = System.nanoTime();
+      if (infoStream.isEnabled(HNSW_COMPONENT)) {
+        infoStream.message(
+            HNSW_COMPONENT,
+            String.format(
+                Locale.ROOT,
+                "repaired reused graph: %.2f ms repair with %d workers, %.2f ms rebalance",
+                (rebalanceStartNs - repairStartNs) / 1_000_000.0,
+                workers.length,
+                (rebalanceEndNs - rebalanceStartNs) / 1_000_000.0));
+      }
     }
     List<Callable<Void>> futures = new ArrayList<>();
     for (int i = 0; i < workers.length; i++) {
@@ -115,6 +155,44 @@ public class HnswConcurrentMergeBuilder implements HnswBuilder {
               effectiveConcurrency));
     }
     return getCompletedGraph();
+  }
+
+  /**
+   * Repairs the pruned graph's disconnected nodes across the worker pool, one level at a time from
+   * the top down.
+   */
+  private void repairDisconnectedNodes() throws IOException {
+    for (int level = prunedGraph.numLevels() - 1; level >= 0; level--) {
+      IntsRef disconnectedNodes = prunedGraph.disconnectedNodesByLevel()[level];
+      if (disconnectedNodes == null) {
+        continue;
+      }
+      int total = disconnectedNodes.length;
+      // Use at most one task per worker and no more tasks than repair batches; each task
+      // dynamically claims batches below.
+      int taskCount = Math.min(workers.length, Math.ceilDiv(total, REPAIR_BATCH_SIZE));
+      AtomicInteger repairProgress = new AtomicInteger(0);
+      int repairLevel = level;
+      List<Callable<Void>> tasks = new ArrayList<>(taskCount);
+      for (int t = 0; t < taskCount; t++) {
+        ConcurrentMergeWorker worker = workers[t];
+        tasks.add(
+            () -> {
+              int from;
+              while ((from = repairProgress.getAndAdd(REPAIR_BATCH_SIZE)) < total) {
+                int length = Math.min(REPAIR_BATCH_SIZE, total - from);
+                worker.fixDisconnectedNodes(
+                    new IntsRef(disconnectedNodes.ints, disconnectedNodes.offset + from, length),
+                    repairLevel,
+                    worker.scorer);
+              }
+              return null;
+            });
+      }
+      // Finish every repair task at this level before repairing the next lower level, because
+      // addConnections descends through the already-repaired upper levels.
+      taskExecutor.invokeAll(tasks);
+    }
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -666,6 +666,103 @@ public class HnswGraphBuilder implements HnswBuilder {
   }
 
   /**
+   * Fixes disconnected nodes at a specific level by performing graph searches from their existing
+   * neighbors to find additional connections.
+   *
+   * <p>For each disconnected node:
+   *
+   * <ol>
+   *   <li>Use existing neighbors as entry points for graph search
+   *   <li>Search the level to find candidate neighbors
+   *   <li>Add diverse neighbors using the HNSW heuristic selection algorithm
+   * </ol>
+   *
+   * <p>If a node has no neighbors at all, it cannot be repaired at this level and will rely on the
+   * rebalancing phase.
+   *
+   * @param disconnectedNodes list of node ordinals that need additional neighbors
+   * @param level the level at which to repair connections
+   * @param scorer vector similarity scorer for distance calculations
+   * @throws IOException if an I/O error occurs during search operations
+   */
+  void fixDisconnectedNodes(
+      List<Integer> disconnectedNodes, int level, UpdateableRandomVectorScorer scorer)
+      throws IOException {
+    if (disconnectedNodes.isEmpty()) return;
+
+    int beamWidth = beamCandidates.k();
+    GraphBuilderKnnCollector candidates = new GraphBuilderKnnCollector(beamWidth);
+    NeighborArray scratchArray = new NeighborArray(beamWidth, false);
+
+    for (int node : disconnectedNodes) {
+      maybeAbort();
+      scorer.setScoringOrdinal(node);
+      NeighborArray existingNeighbors = hnsw.getNeighbors(level, node);
+
+      // Only repair if node has at least one neighbor to use as entry point
+      if (existingNeighbors.size() > 0) {
+        // Use all existing neighbors as entry points for search
+        int[] entryPoints = new int[existingNeighbors.size()];
+        System.arraycopy(existingNeighbors.nodes(), 0, entryPoints, 0, existingNeighbors.size());
+
+        // Search from entry points to find candidate neighbors
+        graphSearcher.searchLevel(candidates, scorer, level, entryPoints, hnsw, null);
+        popToScratch(candidates, scratchArray);
+
+        // Add diverse neighbors using HNSW heuristic (prunes similar neighbors)
+        addDiverseNeighbors(level, node, scratchArray, scorer, true);
+      } else {
+        // Node has no nighbors, add connections from scratch
+        addConnections(node, level, scorer);
+      }
+
+      // Clear for next iteration
+      scratchArray.clear();
+      candidates.clear();
+    }
+  }
+
+  /**
+   * Adds connections for an existing node at a specific level in the graph hierarchy.
+   *
+   * <p>The process involves:
+   *
+   * <ol>
+   *   <li>Navigate down from the top level to find the closest node at the target level
+   *   <li>Perform a full search at the target level to find neighbors
+   *   <li>Add diverse neighbors using the HNSW heuristic selection
+   * </ol>
+   *
+   * @param node the node ordinal to add connections for
+   * @param targetLevel the level to add connections at
+   * @param scorer vector similarity scorer for distance calculations
+   * @throws IOException if an I/O error occurs during search or neighbor addition
+   */
+  void addConnections(int node, int targetLevel, UpdateableRandomVectorScorer scorer)
+      throws IOException {
+
+    int beamWidth = beamCandidates.k();
+    GraphBuilderKnnCollector candidates = new GraphBuilderKnnCollector(beamWidth);
+    int[] eps = {hnsw.entryNode()};
+
+    // Navigate down from top to target level, greedily moving toward the new node
+    for (int level = hnsw.numLevels() - 1; level > targetLevel; level--) {
+      graphSearcher.searchLevel(candidates, scorer, level, eps, hnsw, null);
+      eps[0] = candidates.popNode();
+      candidates.clear();
+    }
+
+    // Perform full search at target level to find neighbors
+    graphSearcher.searchLevel(candidates, scorer, targetLevel, eps, hnsw, null);
+
+    NeighborArray scratchArray = new NeighborArray(beamWidth, false);
+    popToScratch(candidates, scratchArray);
+
+    // Add diverse neighbors and establish bidirectional connections
+    addDiverseNeighbors(targetLevel, node, scratchArray, scorer, true);
+  }
+
+  /**
    * A restricted, specialized knnCollector that can be used when building a graph.
    *
    * <p>Does not support TopDocs

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphBuilder.java
@@ -35,6 +35,7 @@ import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IORunnable;
 import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.IntsRef;
 import org.apache.lucene.util.hnsw.HnswUtil.Component;
 
 /**
@@ -419,8 +420,21 @@ public class HnswGraphBuilder implements HnswBuilder {
      */
     NeighborArray neighbors = hnsw.getNeighbors(level, node);
     int maxConnOnLevel = level == 0 ? M * 2 : M;
-    boolean[] mask =
-        selectAndLinkDiverse(node, neighbors, candidates, maxConnOnLevel, scorer, isLinkRepair);
+    boolean[] mask;
+    if (isLinkRepair && hnswLock != null) {
+      // A repaired node is already discoverable, so lock its own array against a concurrent
+      // reciprocal write.
+      Lock selfLock = hnswLock.write(level, node);
+      try {
+        mask =
+            selectAndLinkDiverse(node, neighbors, candidates, maxConnOnLevel, scorer, isLinkRepair);
+      } finally {
+        selfLock.unlock();
+      }
+    } else {
+      mask =
+          selectAndLinkDiverse(node, neighbors, candidates, maxConnOnLevel, scorer, isLinkRepair);
+    }
 
     // Link the selected nodes to the new node, and the new node to the selected nodes (again
     // applying diversity heuristic)
@@ -677,42 +691,58 @@ public class HnswGraphBuilder implements HnswBuilder {
    *   <li>Add diverse neighbors using the HNSW heuristic selection algorithm
    * </ol>
    *
-   * <p>If a node has no neighbors at all, it cannot be repaired at this level and will rely on the
-   * rebalancing phase.
+   * <p>A node with no neighbors is instead connected from scratch via {@link #addConnections}.
    *
-   * @param disconnectedNodes list of node ordinals that need additional neighbors
+   * <p>When {@link #hnswLock} is set (concurrent repair) each node's existing neighbors are
+   * snapshot under its read lock, since another worker may be adding a reciprocal link into the
+   * same array.
+   *
+   * @param disconnectedNodes node ordinals that need additional neighbors
    * @param level the level at which to repair connections
    * @param scorer vector similarity scorer for distance calculations
    * @throws IOException if an I/O error occurs during search operations
    */
   void fixDisconnectedNodes(
-      List<Integer> disconnectedNodes, int level, UpdateableRandomVectorScorer scorer)
+      IntsRef disconnectedNodes, int level, UpdateableRandomVectorScorer scorer)
       throws IOException {
-    if (disconnectedNodes.isEmpty()) return;
-
     int beamWidth = beamCandidates.k();
     GraphBuilderKnnCollector candidates = new GraphBuilderKnnCollector(beamWidth);
     NeighborArray scratchArray = new NeighborArray(beamWidth, false);
 
-    for (int node : disconnectedNodes) {
+    for (int i = disconnectedNodes.offset;
+        i < disconnectedNodes.offset + disconnectedNodes.length;
+        i++) {
+      int node = disconnectedNodes.ints[i];
       maybeAbort();
       scorer.setScoringOrdinal(node);
-      NeighborArray existingNeighbors = hnsw.getNeighbors(level, node);
 
-      // Only repair if node has at least one neighbor to use as entry point
-      if (existingNeighbors.size() > 0) {
-        // Use all existing neighbors as entry points for search
-        int[] entryPoints = new int[existingNeighbors.size()];
-        System.arraycopy(existingNeighbors.nodes(), 0, entryPoints, 0, existingNeighbors.size());
+      int[] entryPoints;
+      if (hnswLock != null) {
+        Lock readLock = hnswLock.read(level, node);
+        try {
+          NeighborArray existingNeighbors = hnsw.getNeighbors(level, node);
+          int size = existingNeighbors.size();
+          entryPoints = new int[size];
+          System.arraycopy(existingNeighbors.nodes(), 0, entryPoints, 0, size);
+        } finally {
+          readLock.unlock();
+        }
+      } else {
+        NeighborArray existingNeighbors = hnsw.getNeighbors(level, node);
+        int size = existingNeighbors.size();
+        entryPoints = new int[size];
+        System.arraycopy(existingNeighbors.nodes(), 0, entryPoints, 0, size);
+      }
 
+      // Use all existing neighbors as entry points for search
+      if (entryPoints.length > 0) {
         // Search from entry points to find candidate neighbors
         graphSearcher.searchLevel(candidates, scorer, level, entryPoints, hnsw, null);
         popToScratch(candidates, scratchArray);
-
         // Add diverse neighbors using HNSW heuristic (prunes similar neighbors)
         addDiverseNeighbors(level, node, scratchArray, scorer, true);
       } else {
-        // Node has no nighbors, add connections from scratch
+        // Node has no neighbors, add connections from scratch
         addConnections(node, level, scorer);
       }
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
@@ -353,63 +353,6 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
   }
 
   /**
-   * Fixes disconnected nodes at a specific level by performing graph searches from their existing
-   * neighbors to find additional connections.
-   *
-   * <p>For each disconnected node:
-   *
-   * <ol>
-   *   <li>Use existing neighbors as entry points for graph search
-   *   <li>Search the level to find candidate neighbors
-   *   <li>Add diverse neighbors using the HNSW heuristic selection algorithm
-   * </ol>
-   *
-   * <p>If a node has no neighbors at all, it cannot be repaired at this level and will rely on the
-   * rebalancing phase.
-   *
-   * @param disconnectedNodes list of node ordinals that need additional neighbors
-   * @param level the level at which to repair connections
-   * @param scorer vector similarity scorer for distance calculations
-   * @throws IOException if an I/O error occurs during search operations
-   */
-  private void fixDisconnectedNodes(
-      List<Integer> disconnectedNodes, int level, UpdateableRandomVectorScorer scorer)
-      throws IOException {
-    if (disconnectedNodes.isEmpty()) return;
-
-    int beamWidth = beamCandidates.k();
-    GraphBuilderKnnCollector candidates = new GraphBuilderKnnCollector(beamWidth);
-    NeighborArray scratchArray = new NeighborArray(beamWidth, false);
-
-    for (int node : disconnectedNodes) {
-      maybeAbort();
-      scorer.setScoringOrdinal(node);
-      NeighborArray existingNeighbors = hnsw.getNeighbors(level, node);
-
-      // Only repair if node has at least one neighbor to use as entry point
-      if (existingNeighbors.size() > 0) {
-        // Use all existing neighbors as entry points for search
-        int[] entryPoints = new int[existingNeighbors.size()];
-        System.arraycopy(existingNeighbors.nodes(), 0, entryPoints, 0, existingNeighbors.size());
-
-        // Search from entry points to find candidate neighbors
-        graphSearcher.searchLevel(candidates, scorer, level, entryPoints, hnsw, null);
-        popToScratch(candidates, scratchArray);
-
-        // Add diverse neighbors using HNSW heuristic (prunes similar neighbors)
-        addDiverseNeighbors(level, node, scratchArray, scorer, true);
-      } else {
-        // Node has no nighbors, add connections from scratch
-        addConnections(node, level, scorer);
-      }
-
-      // Clear for next iteration
-      scratchArray.clear();
-      candidates.clear();
-    }
-  }
-
-  /**
    * Rebalances the graph hierarchy by promoting nodes from lower levels to higher levels to
    * maintain the expected exponential decay in level sizes according to the HNSW probabilistic
    * model.
@@ -475,46 +418,6 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
         }
       }
     }
-  }
-
-  /**
-   * Adds connections for an existing node at a specific level in the graph hierarchy.
-   *
-   * <p>The process involves:
-   *
-   * <ol>
-   *   <li>Navigate down from the top level to find the closest node at the target level
-   *   <li>Perform a full search at the target level to find neighbors
-   *   <li>Add diverse neighbors using the HNSW heuristic selection
-   * </ol>
-   *
-   * @param node the node ordinal to add connections for
-   * @param targetLevel the level to add connections at
-   * @param scorer vector similarity scorer for distance calculations
-   * @throws IOException if an I/O error occurs during search or neighbor addition
-   */
-  private void addConnections(int node, int targetLevel, UpdateableRandomVectorScorer scorer)
-      throws IOException {
-
-    int beamWidth = beamCandidates.k();
-    GraphBuilderKnnCollector candidates = new GraphBuilderKnnCollector(beamWidth);
-    int[] eps = {hnsw.entryNode()};
-
-    // Navigate down from top to target level, greedily moving toward the new node
-    for (int level = hnsw.numLevels() - 1; level > targetLevel; level--) {
-      graphSearcher.searchLevel(candidates, scorer, level, eps, hnsw, null);
-      eps[0] = candidates.popNode();
-      candidates.clear();
-    }
-
-    // Perform full search at target level to find neighbors
-    graphSearcher.searchLevel(candidates, scorer, targetLevel, eps, hnsw, null);
-
-    NeighborArray scratchArray = new NeighborArray(beamWidth, false);
-    popToScratch(candidates, scratchArray);
-
-    // Add diverse neighbors and establish bidirectional connections
-    addDiverseNeighbors(targetLevel, node, scratchArray, scorer, true);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/InitializedHnswGraphBuilder.java
@@ -20,17 +20,15 @@ package org.apache.lucene.util.hnsw;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import java.util.SplittableRandom;
 import org.apache.lucene.internal.hppc.IntArrayList;
 import org.apache.lucene.internal.hppc.IntCursor;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.IORunnable;
+import org.apache.lucene.util.IntsRef;
+import org.apache.lucene.util.IntsRefBuilder;
 
 /**
  * This creates a graph builder that is initialized with the provided HnswGraph. This is useful for
@@ -91,6 +89,9 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
 
   // Tracks if the graph has deletes
   private boolean hasDeletes = false;
+
+  /** Seeds the rebalance promotions, kept separate from the level-assignment stream. */
+  private final long seed;
 
   /**
    * Creates an initialized HNSW graph builder from an existing graph.
@@ -229,6 +230,60 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
       throws IOException {
     super(scorerSupplier, beamWidth, seed, initializedGraph);
     this.initializedNodes = initializedNodes;
+    this.seed = seed;
+  }
+
+  /**
+   * Prunes deleted nodes and edges from the initializer graph without repairing or rebalancing it,
+   * returning the pruned graph plus the state a caller needs to run those phases itself.
+   *
+   * @param scorerSupplier provides vector similarity scoring for graph operations
+   * @param beamWidth the search beam width for graph construction
+   * @param initializerGraph the source graph to prune
+   * @param newOrdMap maps old ordinals to new ordinals; -1 indicates deleted documents
+   * @param totalNumberOfVectors the total number of vectors in the merged graph
+   * @param abortCheck optional check invoked during pruning; may be null
+   * @return the pruned graph and its deferred repair/rebalance state
+   * @throws IOException if an I/O error occurs while pruning
+   */
+  static PrunedGraph pruneGraph(
+      RandomVectorScorerSupplier scorerSupplier,
+      int beamWidth,
+      HnswGraph initializerGraph,
+      int[] newOrdMap,
+      int totalNumberOfVectors,
+      IORunnable abortCheck)
+      throws IOException {
+    InitializedHnswGraphBuilder builder =
+        new InitializedHnswGraphBuilder(
+            scorerSupplier,
+            beamWidth,
+            randSeed,
+            new OnHeapHnswGraph(initializerGraph.maxConn(), totalNumberOfVectors),
+            null);
+    if (abortCheck != null) {
+      builder.setAbortCheck(abortCheck);
+    }
+    IntsRef[] disconnectedNodesByLevel =
+        builder.copyAndPruneGraphStructure(initializerGraph, newOrdMap);
+    return new PrunedGraph(builder, disconnectedNodesByLevel, builder.hasDeletes);
+  }
+
+  /**
+   * A pruned graph and the state needed to repair and rebalance it, as produced by {@link
+   * #pruneGraph}. Repair and rebalance are deferred so a caller can parallelize the repair phase;
+   * the builder is retained because the serial rebalance runs on it.
+   */
+  record PrunedGraph(
+      InitializedHnswGraphBuilder builder, IntsRef[] disconnectedNodesByLevel, boolean hasDeletes) {
+
+    OnHeapHnswGraph graph() {
+      return builder.getGraph();
+    }
+
+    int numLevels() {
+      return disconnectedNodesByLevel.length;
+    }
   }
 
   /**
@@ -248,8 +303,7 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
   private void initializeFromGraph(HnswGraph initializerGraph, int[] newOrdMap) throws IOException {
     hasDeletes = false;
     // Phase 1: Copy structure and identify nodes that lost too many neighbors
-    Map<Integer, List<Integer>> disconnectedNodesByLevel =
-        copyGraphStructure(initializerGraph, newOrdMap);
+    IntsRef[] disconnectedNodesByLevel = copyAndPruneGraphStructure(initializerGraph, newOrdMap);
 
     // Repair graph if it has deletes
     if (hasDeletes) {
@@ -262,8 +316,8 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
   }
 
   /**
-   * Copies the graph structure from the initializer graph, applying ordinal remapping and
-   * identifying nodes that have lost neighbors.
+   * Copies the surviving graph structure while pruning deleted nodes and edges and applying ordinal
+   * remapping.
    *
    * <p>Deleted neighbors show up as -1 in newOrdMap and are dropped. A node that loses any this way
    * is flagged for repair when it crosses one of the two thresholds ({@link
@@ -278,18 +332,19 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
    *
    * @param initializerGraph the source graph to copy from
    * @param newOrdMap maps old ordinals to new ordinals; -1 indicates deleted documents
-   * @return map of level to list of disconnected node ordinals at that level
+   * @return disconnected node ordinals by level; a null entry means no nodes need repair at that
+   *     level
    * @throws IOException if an I/O error occurs during graph traversal
    */
-  private Map<Integer, List<Integer>> copyGraphStructure(
-      HnswGraph initializerGraph, int[] newOrdMap) throws IOException {
+  private IntsRef[] copyAndPruneGraphStructure(HnswGraph initializerGraph, int[] newOrdMap)
+      throws IOException {
     int numLevels = initializerGraph.numLevels();
     levelToNodes = new IntArrayList[numLevels];
-    Map<Integer, List<Integer>> disconnectedNodesByLevel = new HashMap<>(numLevels);
+    IntsRef[] disconnectedNodesByLevel = new IntsRef[numLevels];
 
     for (int level = numLevels - 1; level >= 0; level--) {
       levelToNodes[level] = new IntArrayList();
-      List<Integer> disconnectedNodes = new ArrayList<>();
+      IntsRefBuilder disconnectedNodes = null;
       HnswGraph.NodesIterator it = initializerGraph.getNodesOnLevel(level);
 
       while (it.hasNext()) {
@@ -329,10 +384,15 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
         if (newNeighbors.size() < oldNeighbourCount * DISCONNECTED_NODE_FACTOR
             || (newNeighbors.size() < oldNeighbourCount
                 && newNeighbors.size() < maxConnOnLevel * CUMULATIVE_DEGREE_FLOOR_FACTOR)) {
-          disconnectedNodes.add(newOrd);
+          if (disconnectedNodes == null) {
+            disconnectedNodes = new IntsRefBuilder();
+          }
+          disconnectedNodes.append(newOrd);
         }
       }
-      disconnectedNodesByLevel.put(level, disconnectedNodes);
+      if (disconnectedNodes != null) {
+        disconnectedNodesByLevel[level] = disconnectedNodes.get();
+      }
     }
     return disconnectedNodesByLevel;
   }
@@ -341,14 +401,18 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
    * Repairs disconnected nodes at all levels by finding additional neighbors to restore
    * connectivity.
    *
-   * @param disconnectedNodesByLevel map of level to disconnected nodes at that level
+   * @param disconnectedNodesByLevel disconnected node ordinals by level; a null entry means no
+   *     nodes need repair at that level
    * @param numLevels total number of levels in the graph hierarchy
    * @throws IOException if an I/O error occurs during repair operations
    */
-  private void repairDisconnectedNodes(
-      Map<Integer, List<Integer>> disconnectedNodesByLevel, int numLevels) throws IOException {
+  private void repairDisconnectedNodes(IntsRef[] disconnectedNodesByLevel, int numLevels)
+      throws IOException {
     for (int level = numLevels - 1; level >= 0; level--) {
-      fixDisconnectedNodes(disconnectedNodesByLevel.get(level), level, scorer);
+      IntsRef disconnectedNodes = disconnectedNodesByLevel[level];
+      if (disconnectedNodes != null) {
+        fixDisconnectedNodes(disconnectedNodes, level, scorer);
+      }
     }
   }
 
@@ -368,8 +432,8 @@ public final class InitializedHnswGraphBuilder extends HnswGraphBuilder {
    *
    * @throws IOException if an I/O error occurs during node promotion
    */
-  private void rebalanceGraph() throws IOException {
-    SplittableRandom random = new SplittableRandom();
+  void rebalanceGraph() throws IOException {
+    SplittableRandom random = new SplittableRandom(seed);
     int size = hnsw.size();
     double invMaxConn = 1.0 / M;
 

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/TestHnswFloatVectorGraph.java
@@ -17,26 +17,56 @@
 
 package org.apache.lucene.util.hnsw;
 
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+
 import com.carrotsearch.randomizedtesting.RandomizedTest;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader;
+import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.CodecReader;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TaskExecutor;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IORunnable;
+import org.apache.lucene.util.IntsRef;
+import org.apache.lucene.util.NamedThreadFactory;
+import org.apache.lucene.util.PrintStreamInfoStream;
 import org.junit.Before;
 
 /** Tests HNSW KNN graphs */
@@ -148,7 +178,8 @@ public class TestHnswFloatVectorGraph extends HnswGraphTestCase<float[]> {
         newOrdMap[i] = (i == entry || (i & 1) == 0) ? i : -1;
       }
 
-      // copyGraphStructure polls the abort check exactly once per source node across every level.
+      // copyAndPruneGraphStructure polls the abort check exactly once per source node across every
+      // level.
       int copyLoopChecks = 0;
       for (int level = 0; level < graph.numLevels(); level++) {
         copyLoopChecks += graph.getNodesOnLevel(level).size();
@@ -186,6 +217,300 @@ public class TestHnswFloatVectorGraph extends HnswGraphTestCase<float[]> {
     } finally {
       HnswGraphBuilder.randSeed = savedRandSeed;
     }
+  }
+
+  /**
+   * With a single worker, {@link HnswConcurrentMergeBuilder}'s locked repair branch (non-null
+   * {@code hnswLock}) must produce the same graph as the serial {@link
+   * InitializedHnswGraphBuilder#initGraph} path (null {@code hnswLock}). Copy, repair and the
+   * seeded rebalance are all deterministic, and one worker repairs in the same order as the serial
+   * loop, so every level must match.
+   */
+  public void testSingleWorkerRepairMatchesSerial() throws IOException {
+    long savedRandSeed = HnswGraphBuilder.randSeed;
+    ExecutorService exec = Executors.newFixedThreadPool(1, new NamedThreadFactory("hnswRepair1"));
+    try {
+      HnswGraphBuilder.randSeed = 42;
+      similarityFunction = VectorSimilarityFunction.EUCLIDEAN;
+      int M = 16;
+      int beamWidth = 100;
+      int size = 512;
+      int dim = 16;
+      MockVectorValues vectors =
+          MockVectorValues.fromValues(createRandomFloatVectors(size, dim, new Random(42)));
+      RandomVectorScorerSupplier supplier = buildScorerSupplier(vectors);
+      OnHeapHnswGraph base = HnswGraphBuilder.create(supplier, M, beamWidth, 42).build(size);
+
+      // Delete ~33% (<= 40% so the base graph is reused), compacting survivors into a dense
+      // ordinal space so the merged graph has no holes.
+      int[] newOrdMap = new int[size];
+      int liveCount = 0;
+      for (int old = 0; old < size; old++) {
+        newOrdMap[old] = (old % 3 == 1) ? -1 : liveCount++;
+      }
+
+      OnHeapHnswGraph serial =
+          InitializedHnswGraphBuilder.initGraph(base, newOrdMap, liveCount, beamWidth, supplier);
+
+      InitializedHnswGraphBuilder.PrunedGraph prunedGraph =
+          InitializedHnswGraphBuilder.pruneGraph(
+              supplier, beamWidth, base, newOrdMap, liveCount, null);
+      assertTrue(
+          "deletes must trigger repair for this test to be meaningful", prunedGraph.hasDeletes());
+      IntsRef flaggedAtLevel0 = prunedGraph.disconnectedNodesByLevel()[0];
+      assertNotNull("level 0 must have flagged nodes", flaggedAtLevel0);
+      assertTrue(
+          "level 0 must have flagged nodes, else the equality is vacuous",
+          flaggedAtLevel0.length > 0);
+      FixedBitSet initialized = new FixedBitSet(liveCount);
+      initialized.set(0, liveCount); // all live nodes pre-populated; no extra inserts in build()
+      HnswConcurrentMergeBuilder builder =
+          new HnswConcurrentMergeBuilder(
+              new TaskExecutor(exec),
+              1,
+              supplier,
+              beamWidth,
+              prunedGraph.graph(),
+              initialized,
+              prunedGraph);
+      builder.build(liveCount);
+      OnHeapHnswGraph concurrent = builder.getCompletedGraph();
+
+      assertEquals(serial.size(), concurrent.size());
+      assertEquals(serial.numLevels(), concurrent.numLevels());
+      assertEquals(serial.entryNode(), concurrent.entryNode());
+      for (int level = 0; level < serial.numLevels(); level++) {
+        for (int node = 0; node < liveCount; node++) {
+          assertEquals(
+              "node existence differs at level " + level + " for node " + node,
+              serial.nodeExistAtLevel(level, node),
+              concurrent.nodeExistAtLevel(level, node));
+          if (serial.nodeExistAtLevel(level, node)) {
+            assertEquals(
+                "neighbors differ at level " + level + " for node " + node,
+                sortedNeighbors(serial, level, node),
+                sortedNeighbors(concurrent, level, node));
+          }
+        }
+      }
+    } finally {
+      exec.shutdownNow();
+      HnswGraphBuilder.randSeed = savedRandSeed;
+    }
+  }
+
+  /**
+   * Multi-worker repair must be thread-safe and correct: no exception or deadlock, the merged graph
+   * has the right size and a single rooted level-0 component, and every flagged node is repaired
+   * (gains at least one neighbor and never drops below its pre-repair degree). The graph data is
+   * pinned so the flagged set is deterministic; the real thread pool supplies the interleaving that
+   * {@code -Ptests.dups} stresses. Assertions are floors/invariants only, never full-graph
+   * equality.
+   */
+  public void testConcurrentRepairIsThreadSafeAndRepairsFlaggedNodes() throws IOException {
+    long savedRandSeed = HnswGraphBuilder.randSeed;
+    ExecutorService exec = Executors.newFixedThreadPool(2, new NamedThreadFactory("hnswRepair2"));
+    try {
+      HnswGraphBuilder.randSeed = 17;
+      similarityFunction = VectorSimilarityFunction.EUCLIDEAN;
+      int M = 16;
+      int beamWidth = 100;
+      int size = 512;
+      int dim = 16;
+      MockVectorValues vectors =
+          MockVectorValues.fromValues(createRandomFloatVectors(size, dim, new Random(17)));
+      RandomVectorScorerSupplier supplier = buildScorerSupplier(vectors);
+      OnHeapHnswGraph base = HnswGraphBuilder.create(supplier, M, beamWidth, 17).build(size);
+
+      int[] newOrdMap = new int[size];
+      int liveCount = 0;
+      for (int old = 0; old < size; old++) {
+        newOrdMap[old] = (old % 3 == 1) ? -1 : liveCount++; // ~33% deleted, <= 40%
+      }
+
+      InitializedHnswGraphBuilder.PrunedGraph prunedGraph =
+          InitializedHnswGraphBuilder.pruneGraph(
+              supplier, beamWidth, base, newOrdMap, liveCount, null);
+      assertTrue("deletes must trigger repair", prunedGraph.hasDeletes());
+
+      // Snapshot the flagged nodes and their pre-repair degrees, and confirm repair partitions
+      // across >= 2 levels so the top-down per-level barrier is actually exercised.
+      IntsRef[] flaggedByLevel = prunedGraph.disconnectedNodesByLevel();
+      List<int[]> flaggedBefore = new ArrayList<>(); // {level, node, degreeBeforeRepair}
+      int levelsWithFlags = 0;
+      for (int level = 0; level < flaggedByLevel.length; level++) {
+        IntsRef nodesAtLevel = flaggedByLevel[level];
+        if (nodesAtLevel == null) {
+          continue;
+        }
+        levelsWithFlags++;
+        for (int i = nodesAtLevel.offset; i < nodesAtLevel.offset + nodesAtLevel.length; i++) {
+          int node = nodesAtLevel.ints[i];
+          flaggedBefore.add(
+              new int[] {level, node, prunedGraph.graph().getNeighbors(level, node).size()});
+        }
+      }
+      assertTrue(
+          "expected flagged nodes on >= 2 levels, got " + levelsWithFlags, levelsWithFlags >= 2);
+      assertFalse("expected some flagged nodes", flaggedBefore.isEmpty());
+      int maxFlaggedOnAnyLevel = 0;
+      for (IntsRef nodesAtLevel : flaggedByLevel) {
+        if (nodesAtLevel != null) {
+          maxFlaggedOnAnyLevel = Math.max(maxFlaggedOnAnyLevel, nodesAtLevel.length);
+        }
+      }
+      assertTrue(
+          "need > 64 flagged nodes on some level to submit multiple same-level repair tasks, got "
+              + maxFlaggedOnAnyLevel,
+          maxFlaggedOnAnyLevel > 64);
+
+      FixedBitSet initialized = new FixedBitSet(liveCount);
+      initialized.set(0, liveCount);
+      HnswConcurrentMergeBuilder builder =
+          new HnswConcurrentMergeBuilder(
+              new TaskExecutor(exec),
+              2,
+              supplier,
+              beamWidth,
+              prunedGraph.graph(),
+              initialized,
+              prunedGraph);
+      builder.build(liveCount);
+      OnHeapHnswGraph merged = builder.getCompletedGraph();
+
+      assertEquals("merged graph should contain every live node", liveCount, merged.size());
+      // No isolated nodes: level 0 is a single rooted component after concurrent repair.
+      assertEquals(
+          "graph should be a single rooted component after repair",
+          1,
+          HnswUtil.componentSizes(merged).size());
+
+      // Every flagged node gained >= 1 neighbor and never lost neighbors during repair.
+      for (int[] fb : flaggedBefore) {
+        int level = fb[0];
+        int node = fb[1];
+        int before = fb[2];
+        int after = merged.getNeighbors(level, node).size();
+        assertTrue(
+            "flagged node "
+                + node
+                + " lost neighbors on level "
+                + level
+                + ": "
+                + before
+                + " -> "
+                + after,
+            after >= before);
+        assertTrue(
+            "flagged node " + node + " has no neighbors after repair on level " + level, after > 0);
+      }
+    } finally {
+      exec.shutdownNow();
+      HnswGraphBuilder.randSeed = savedRandSeed;
+    }
+  }
+
+  /**
+   * End-to-end: a real force-merge with 2 merge workers over an index whose largest segment carries
+   * deletes (&lt;= 40%, so its graph is reused as the merge base) drives {@link
+   * org.apache.lucene.util.hnsw.ConcurrentHnswMerger} through {@code pruneGraph} and the concurrent
+   * repair path. The merged graph must be sized correctly, rooted, and searchable.
+   */
+  public void testConcurrentMergeReuseWithDeletesEndToEnd() throws IOException {
+    similarityFunction = RandomizedTest.randomFrom(VectorSimilarityFunction.values());
+    int M = 16;
+    int beamWidth = 100;
+    int dim = 16;
+    String field = "vec";
+    int baseSize = atLeast(1200);
+    int addSize = 300;
+    int total = baseSize + addSize;
+    MockVectorValues vectors =
+        MockVectorValues.fromValues(createRandomFloatVectors(total, dim, random()));
+    ExecutorService mergeExec =
+        Executors.newFixedThreadPool(2, new NamedThreadFactory("hnsw-merge-worker"));
+    try (Directory dir = newDirectory()) {
+      ByteArrayOutputStream infoBytes = new ByteArrayOutputStream();
+      Codec codec =
+          TestUtil.alwaysKnnVectorsFormat(
+              // 2 merge workers + always build a graph (tinySegmentsThreshold = 0)
+              new Lucene99HnswVectorsFormat(M, beamWidth, 2, mergeExec, 0));
+      // ingest with merging off, so the force-merge below sees exactly these two segments
+      try (IndexWriter w =
+          new IndexWriter(
+              dir,
+              new IndexWriterConfig().setCodec(codec).setMergePolicy(NoMergePolicy.INSTANCE))) {
+        for (int i = 0; i < baseSize; i++) {
+          Document doc = new Document();
+          doc.add(knnVectorField(field, vectors.vectorValue(i), similarityFunction));
+          doc.add(new StringField("id", Integer.toString(i), Field.Store.NO));
+          w.addDocument(doc);
+        }
+        w.flush(); // segment 1 = the base graph
+        for (int i = baseSize; i < total; i++) {
+          Document doc = new Document();
+          doc.add(knnVectorField(field, vectors.vectorValue(i), similarityFunction));
+          doc.add(new StringField("id", Integer.toString(i), Field.Store.NO));
+          w.addDocument(doc);
+        }
+        w.flush(); // segment 2, deletion-free
+        // Delete ~30% of the base segment: leaves it eligible as the reuse base AND with deletes.
+        for (int d = 0; d < baseSize; d += 10) {
+          for (int off = 0; off < 3 && d + off < baseSize; off++) {
+            w.deleteDocuments(new Term("id", Integer.toString(d + off)));
+          }
+        }
+        w.commit();
+      }
+      try (IndexWriter w =
+          new IndexWriter(
+              dir,
+              new IndexWriterConfig()
+                  .setCodec(codec)
+                  .setInfoStream(
+                      new PrintStreamInfoStream(
+                          new PrintStream(infoBytes, true, StandardCharsets.UTF_8))))) {
+        w.forceMerge(1);
+      }
+      assertTrue(
+          "expected the concurrent reuse+repair path to run",
+          infoBytes.toString(StandardCharsets.UTF_8).contains("repaired reused graph"));
+      try (IndexReader reader = DirectoryReader.open(dir)) {
+        int liveCount = reader.numDocs();
+        assertTrue("expected some docs to be deleted", liveCount < total);
+        for (LeafReaderContext ctx : reader.leaves()) {
+          HnswGraph graph =
+              ((Lucene99HnswVectorsReader)
+                      ((CodecReader) ctx.reader()).getVectorReader().unwrapReaderForField(field))
+                  .getGraph(field);
+          assertEquals(liveCount, graph.size());
+          for (int node = 0; node < graph.size(); node++) {
+            graph.seek(0, node);
+            assertNotEquals(
+                "node " + node + " has no level-0 neighbors after repair",
+                NO_MORE_DOCS,
+                graph.nextNeighbor());
+          }
+        }
+
+        IndexSearcher searcher = newSearcher(reader);
+        TopDocs td = searcher.search(knnQuery(field, randomVector(dim), 10), 10);
+        assertEquals("KNN search should return k results", 10, td.scoreDocs.length);
+      }
+    } finally {
+      mergeExec.shutdownNow();
+    }
+  }
+
+  private static List<Integer> sortedNeighbors(OnHeapHnswGraph graph, int level, int node) {
+    NeighborArray arr = graph.getNeighbors(level, node);
+    List<Integer> neighbors = new ArrayList<>(arr.size());
+    int[] nodes = arr.nodes();
+    for (int i = 0; i < arr.size(); i++) {
+      neighbors.add(nodes[i]);
+    }
+    Collections.sort(neighbors);
+    return neighbors;
   }
 
   @Override


### PR DESCRIPTION
### Overview

Currently, when `IncrementalHnswGraphMerger` reuses an existing graph, `InitializedHnswGraphBuilder` copies it, repairs the nodes that lost too many neighbors, and rebalances the levels. This logic runs inside `ConcurrentHnswMerger.createBuilder`. Which is called before `HnswConcurrentMergeBuilder` even exists, so the copy/repair/rebalance process runs on the single merge thread without utilizing the worker pool.

This is expensive especially for repair as it does a search per flagged node. Benchmarking with a 500k cohere index at 35% deletes shows repair takes 97.7s of a 174.7s merge. This is slower than the full rebuild process which does use the paralellized worker pool, even though it reduces CPU utilization. (Full rebuild of the same index took 97.7s for ALL steps, while the repair step itself took the same amount of time)

### Changes 

The three phases used to be one unit where `initGraph` would copy, repair, and rebalance the graph. With this change, the copy now fires alone (keep this part serial, its difficult/not worth to parallelize) and the other work is deferred to the concurrent merge builder which finishes the process. In practice: `InitializedHnswGraphBuilder.copyGraph` executes the copy and returns the half-built graph and the list of nodes needing repair per level, then `ConcurrentHnswMerger` hands both to `HnswConcurrentMergeBuilder`, which repairs and rebalances inside `build()`, which utilizes the worker pool.

Repair is now structured to be per node per level work items to allow this parallelization. On each level, the workers take batches of flagged nodes off a shared `AtomicInteger` until that level's list is drained, one task per worker, and each worker repairs its nodes through its own scorer and searcher.

Levels are repaired top-down with `invokeAll` serializing the levels (workers dont move on to next level until the current one is complete). This is necessary because nodes with no surviving neighbors have no entry point to search from, so it walks from the entry node to reach the current level, which looks at above levels (that must be completed before this happens). For this pr the rebalance work stays serial on the copy builder afterwards, as its time is negligible to the overall re-use process. 

Repairing concurrently needed one lock that a normal insert doesn't. With copied nodes that already inherit connections, its possible one node can be adding a reciprocal link into the same array that another is selecting. During repair, I hold `hnswLock.write(level, node)` around the selection and snapshot the entry points under `hnswLock.read(level, node)` before searching. I then release the lock before the per-neighbor loop that takes `hnswLock.write(level, nbr)`. This ensures that a worker holds at most one stripe at a time.

### Notes for reviewers

- The first commit is pure restructuring as I needed to moves `fixDisconnectedNodes` and `addConnections` onto `HnswGraphBuilder`, so it may be useful to look at inter-commit diff while reviewing. 
- I suspect this will conflict with #16620 which at the time of writing is approved but not merged, so I will rebase afterwards.

### Benchmarking / Testing

In addition to the unit tests added in the PR, I ran before/after benchmarks on cohere to show the difference with/without parallelization.

cohere-1024, M=32, beamWidth=200, 500k vectors indexed as 5x100k segments, 35% delete, forceMerge(1), numMergeWorkers=8, m7g.4xlarge pinned to 8 cores

| Arm | copy+repair | parallel insert | total | vs rebuild |
|---|---|---|---|---|
| reuse: before (#16618) | 97.7s | 77.0s | 174.7s | 1.79× |
| reuse: this fix | 18.1s | 79.2s | 97.4s | 1.00× |
| rebuild | 3.0s | 94.7s | 97.7s | 1.00× |

We see a dramatic speedup in copy+repair time from this fix compared to re-use with no parallelism. Note that in this run specifically, re-use and rebuild are nearly the same, but this is at 35% deletes (near upper limit of the amount of repair work the merge algo needs to do) This shows that we, at worst, restore the wall-time that was lost with the previous unparallel implementation and that with lower delete percents, the speedup will be more visible (at 10% deletes, I see a ~13% speedup with re-use vs rebuild). 

Closes #16618
