### PR TITLE
ci: dial down dependabot PR volume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
       codeql:
         patterns:
           - github/codeql-action/*
+      # group patch/minor updates, typically no breaking changes
+      actions:
+        update-types:
+          - patch
+          - minor
     cooldown:
       default-days: 7
 
@@ -28,6 +33,12 @@ updates:
     commit-message:
       prefix: build(deps)
     labels: [dependencies, skip-changelog]
+    groups:
+      # group patch/minor updates, typically no breaking changes
+      python:
+        update-types:
+          - patch
+          - minor
     cooldown:
       default-days: 7
 
@@ -40,5 +51,11 @@ updates:
     commit-message:
       prefix: deps(java)
     labels: [dependencies, skip-changelog]
+    groups:
+      # group patch/minor updates, typically no breaking changes
+      java:
+        update-types:
+          - patch
+          - minor
     cooldown:
       default-days: 7


### PR DESCRIPTION
Group patch and minor updates into a single PR for each ecosystem. Major updates still get their own PR.

I know it seems aggressive to include the minor too, but I think it is the best fit for this repo. Lucene core has no dependencies and uses mature java tooling (not a bunch of zero-ver stuff). The python and actions dependencies are just tooling on the side.

