### PR TITLE
Draft: Add single-query many-doc bulk scoring API to VectorUtilSupport (#16556)

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/DefaultVectorUtilSupport.java
@@ -76,6 +76,13 @@ final class DefaultVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public void dotProductBulk(float[] query, float[][] docs, float[] results) {
+    for (int i = 0; i < docs.length; i++) {
+      results[i] = dotProduct(query, docs[i]);
+    }
+  }
+
+  @Override
   public float cosine(float[] a, float[] b) {
     float sum = 0.0f;
     float norm1 = 0.0f;

--- a/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
+++ b/lucene/core/src/java/org/apache/lucene/internal/vectorization/VectorUtilSupport.java
@@ -32,6 +32,15 @@ public interface VectorUtilSupport {
    */
   float dotProduct(short[] a, short[] b);
 
+  /**
+   * Calculate the dot product of a query vector against a batch of document vectors
+   *
+   * @param query The query vector
+   * @param docs Array of document vectors to score against
+   * @param results Result vector which will be overwritten
+   */
+  void dotProductBulk(float[] query, float[][] docs, float[] results);
+
   /** Returns the cosine similarity between the two vectors. */
   float cosine(float[] v1, float[] v2);
 

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -93,6 +93,34 @@ public final class VectorUtil {
   }
 
   /**
+   * Calculates the dot product of a query vector against a batch of document vectors.
+   *
+   * @param query The query vector
+   * @param docs Array of document vectors to score against
+   * @param results Pre-allocated array where the resulting scores will be written
+   * @throws IllegalArgumentException if the query dimensions do not match the document dimensions,
+   *     or if the results array is incorrectly sized.
+   */
+  public static void dotProductBulk(float[] query, float[][] docs, float[] results) {
+    if (docs.length != results.length) {
+      throw new IllegalArgumentException(
+          "results array length ("
+              + results.length
+              + ") must match docs array length ("
+              + docs.length
+              + ")");
+    }
+    if (docs.length == 0) {
+      return;
+    }
+    if (query.length != docs[0].length) {
+      throw new IllegalArgumentException(
+          "vector dimensions differ: " + query.length + "!=" + docs[0].length);
+    }
+    IMPL.dotProductBulk(query, docs, results);
+  }
+
+  /**
    * Returns the cosine similarity between the two vectors.
    *
    * @throws IllegalArgumentException if the vectors' dimensions differ.

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/NativeVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/NativeVectorUtilSupport.java
@@ -405,6 +405,11 @@ final class NativeVectorUtilSupport implements VectorUtilSupport {
   }
 
   @Override
+  public void dotProductBulk(float[] query, float[][] docs, float[] results) {
+    delegateVectorUtilSupport.dotProductBulk(query, docs, results);
+  }
+
+  @Override
   public int dotProduct(byte[] a, byte[] b) {
     return (dotProduct$MH != null)
         ? dotProduct(MemorySegment.ofArray(a), MemorySegment.ofArray(b))

--- a/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
+++ b/lucene/core/src/java25/org/apache/lucene/internal/vectorization/PanamaVectorUtilSupport.java
@@ -169,6 +169,57 @@ final class PanamaVectorUtilSupport implements VectorUtilSupport {
     return res1.add(res2).reduceLanes(ADD);
   }
 
+  /** */
+  @Override
+  public void dotProductBulk(float[] query, float[][] docs, float[] results) {
+    int docIdx = 0;
+
+    // Process in batches of 4 documents at a time
+    for (; docIdx + 3 < docs.length; docIdx += 4) {
+      float[] d0 = docs[docIdx];
+      float[] d1 = docs[docIdx + 1];
+      float[] d2 = docs[docIdx + 2];
+      float[] d3 = docs[docIdx + 3];
+
+      FloatVector acc0 = FloatVector.zero(FLOAT_SPECIES);
+      FloatVector acc1 = FloatVector.zero(FLOAT_SPECIES);
+      FloatVector acc2 = FloatVector.zero(FLOAT_SPECIES);
+      FloatVector acc3 = FloatVector.zero(FLOAT_SPECIES);
+
+      int i = 0;
+      int limit = FLOAT_SPECIES.loopBound(query.length);
+
+      for (; i < limit; i += FLOAT_SPECIES.length()) {
+        // LOAD QUERY ONCE
+        FloatVector vq = FloatVector.fromArray(FLOAT_SPECIES, query, i);
+
+        // SCORE AGAINST 4 DOCUMENTS
+        acc0 = fma(vq, FloatVector.fromArray(FLOAT_SPECIES, d0, i), acc0);
+        acc1 = fma(vq, FloatVector.fromArray(FLOAT_SPECIES, d1, i), acc1);
+        acc2 = fma(vq, FloatVector.fromArray(FLOAT_SPECIES, d2, i), acc2);
+        acc3 = fma(vq, FloatVector.fromArray(FLOAT_SPECIES, d3, i), acc3);
+      }
+
+      results[docIdx] = acc0.reduceLanes(ADD) + scalarDotProductBulk(query, d0, i);
+      results[docIdx + 1] = acc1.reduceLanes(ADD) + scalarDotProductBulk(query, d1, i);
+      results[docIdx + 2] = acc2.reduceLanes(ADD) + scalarDotProductBulk(query, d2, i);
+      results[docIdx + 3] = acc3.reduceLanes(ADD) + scalarDotProductBulk(query, d3, i);
+    }
+
+    for (; docIdx < docs.length; docIdx++) {
+      results[docIdx] = dotProduct(query, docs[docIdx]);
+    }
+  }
+
+  /** Helper method to process the remaining un-vectorized tail of the arrays */
+  private float scalarDotProductBulk(float[] a, float[] b, int startIndex) {
+    float res = 0;
+    for (int i = startIndex; i < a.length; i++) {
+      res = fma(a[i], b[i], res);
+    }
+    return res;
+  }
+
   @Override
   public float cosine(float[] a, float[] b) {
     int i = 0;


### PR DESCRIPTION
### Description
This is Draft PR addressing #16556 and subsequently progressing #15155 

This PR is trying to move bulk scoring API down to `VectorUtilSupport` layer, allowing the `PanamaVectorUtilSupport` to see bulk operations.

**Current progress (float32 dot product):**
1. Added zero-allocation `void dotProductBulk(float[] query, float[][] docs, float[] results)` to `VectorUtilSupport`.
2. Added scalar fallback loop to `DefaultVectorUtilSupport` and pass-through to `NativeVectorUtilSupport`.
3.  Added 4 vector unrolling in `PanamaVectorUtilSupport` 

**Next steps:**
* Update `RandomVectorScorer` to consume the new `VectorUtil.dotProductBulk()` method to prove the end-to-end integration.
* Add similar methods to in bulk format.