### PR TITLE
Backport changes to action revisions and some minor differences in wo…

### DIFF
--- a/.github/actions/eclint/action.yml
+++ b/.github/actions/eclint/action.yml
@@ -1,0 +1,33 @@
+name: Install eclint
+description: Installs eclint from cache, or builds it
+
+inputs:
+  eclint-version:
+    required: false
+    description: "eclint version to use"
+    default: "v0.5.1"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache eclint binary
+      id: cache-eclint
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.local/bin/eclint
+        key: eclint-${{ inputs.eclint-version }}-${{ runner.os }}-${{ runner.arch }}
+    - name: Setup go
+      if: steps.cache-eclint.outputs.cache-hit != 'true'
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        go-version: '1.24'
+        cache: false
+    - name: Install eclint
+      if: steps.cache-eclint.outputs.cache-hit != 'true'
+      run: GOBIN=${HOME}/.local/bin go install gitlab.com/greut/eclint/cmd/eclint@${ECLINT_VERSION}
+      shell: bash
+      env:
+        ECLINT_VERSION: ${{ inputs.eclint-version }}
+    - name: Configure gradle
+      run: echo "lucene.tool.eclint=eclint" >> build-options.local.properties
+      shell: bash

--- a/.github/actions/prepare-for-build/action.yml
+++ b/.github/actions/prepare-for-build/action.yml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Java (${{ inputs.java-distribution }}, ${{ inputs.java-version }})"
-      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
       with:
         distribution: ${{ inputs.java-distribution }}
         java-version: ${{ inputs.java-version }}
@@ -40,7 +40,7 @@ runs:
     # This includes "smart" caching of gradle dependencies.
     - name: Set up Gradle
       if: ${{ fromJSON(inputs.use-cache) }}
-      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+      uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
       with:
         # increase expiry time for the temp. develocity token.
         # https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#increasing-the-expiry-time-for-develocity-access-tokens

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,16 @@ updates:
     commit-message:
       prefix: ci
     labels: [dependencies, skip-changelog]
+    groups:
+      # codeql init/analyze must match exactly: validate each others versions
+      codeql:
+        patterns:
+          - github/codeql-action/*
+      # group patch/minor updates, typically no breaking changes
+      actions:
+        update-types:
+          - patch
+          - minor
     cooldown:
       default-days: 7
 
@@ -23,6 +33,12 @@ updates:
     commit-message:
       prefix: build(deps)
     labels: [dependencies, skip-changelog]
+    groups:
+      # group patch/minor updates, typically no breaking changes
+      python:
+        update-types:
+          - patch
+          - minor
     cooldown:
       default-days: 7
 
@@ -35,5 +51,11 @@ updates:
     commit-message:
       prefix: deps(java)
     labels: [dependencies, skip-changelog]
+    groups:
+      # group patch/minor updates, typically no breaking changes
+      java:
+        update-types:
+          - patch
+          - minor
     cooldown:
       default-days: 7

--- a/.github/workflows/mark-stale-PRs.yml
+++ b/.github/workflows/mark-stale-PRs.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Run stale PR action
-        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/run-checks-all.yml
+++ b/.github/workflows/run-checks-all.yml
@@ -40,12 +40,16 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Configure tools
         uses: ./.github/actions/prepare-for-build
+
+      - name: Install eclint
+        if: ${{ ! startsWith(matrix.os, 'windows') }}
+        uses: ./.github/actions/eclint
 
       - name: Run gradle check (without tests)
         run: ./gradlew check -x test "-Ptask.times=true"
@@ -77,7 +81,7 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -90,9 +94,10 @@ jobs:
           mkdir /tmp/tmpfs
           sudo mount_tmpfs -o noowners -s 1g /tmp/tmpfs
           sudo sysctl debug.lowpri_throttle_enabled=0
+          echo "tests.workDir=/tmp/tmpfs/lucene" >> build-options.local.properties
 
       - name: Run gradle tests
-        run: ./gradlew test "-Ptask.times=true" "-Pvalidation.errorprone=false" "-Ptests.workDir=/tmp/tmpfs/lucene"
+        run: ./gradlew displayGradleDiagnostics allOptions test "-Ptask.times=true" "-Pvalidation.errorprone=false"
         env:
           # Set to the defaults to override the "CI"-based logic that would enable C2
           # we can't afford C2 on github runners.

--- a/.github/workflows/run-checks-gradle-upgrade.yml
+++ b/.github/workflows/run-checks-gradle-upgrade.yml
@@ -26,18 +26,18 @@ env:
 
 jobs:
   gradleScriptBootstrapCheck:
-    name: "Check gradle boostrap script sanity on old JVMs."
+    name: "Check gradle bootstrap script sanity on old JVMs."
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: 'temurin'
           java-version: 11
           java-package: jdk
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -53,10 +53,30 @@ jobs:
             exit 1
           fi
 
+  gradleWindowsSanityCheck:
+    name: "Check gradlew help works on Windows."
+    timeout-minutes: 30
+    runs-on: windows-latest
+    steps:
+      - name: Correct git autocrlf on Windows
+        run: git config --global core.autocrlf false
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/prepare-for-build
+        with:
+          java-version: '21'
+          use-cache: false
+
+      - run: ./gradlew help
+
   gradleSanityCheck:
     name: "Run tasks (java: ${{ matrix.java-version }}, alt-java: ${{ matrix.uses-alt-java }})"
     timeout-minutes: 30
-    needs: gradleScriptBootstrapCheck
+    needs: [gradleScriptBootstrapCheck, gradleWindowsSanityCheck]
 
     strategy:
       matrix:
@@ -71,7 +91,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -128,6 +148,7 @@ jobs:
       - run: ./gradlew licenses writeChecksums
       - run: ./gradlew check -x test
       - run: ./gradlew assembleRelease mavenToLocal
+      - run: ./gradlew eclipse
 
       # Conserve resources: only run these in non-alt-java mode.
       - run: ./gradlew getGeoNames

--- a/.github/workflows/run-checks-mod-analysis-common-hunspell.yml
+++ b/.github/workflows/run-checks-mod-analysis-common-hunspell.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/run-checks-mod-distribution.tests.yml
+++ b/.github/workflows/run-checks-mod-distribution.tests.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/run-checks-python.yml
+++ b/.github/workflows/run-checks-python.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12.6"
 

--- a/.github/workflows/run-nightly-smoketester.yml
+++ b/.github/workflows/run-nightly-smoketester.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        java-version: [ '21', '24' ]
+        java-version: [ '21', '25' ]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -33,12 +33,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: 'temurin'
           java-package: jdk

--- a/.github/workflows/run-scheduled-hunspell.yml
+++ b/.github/workflows/run-scheduled-hunspell.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Backport of github action hashes to 10x. 

I also wanted to backport prek and linters but this would require us to apply a fairly extensive follow-up cleanups (like it was done on main - glob imports, typos, all sorts of other oddities). May be too much to digest.