### PR TITLE
Improve org.apache.lucene.store package-level documentation

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/store/package-info.java
@@ -15,5 +15,50 @@
  * limitations under the License.
  */
 
-/** Binary i/o API, used for all index data. */
+/**
+ * Binary I/O API used for all of Lucene's index data.
+ *
+ * <p>This package provides the storage layer on top of which every Lucene index is built. All index
+ * artifacts (postings, stored fields, term vectors, doc values, points and kNN vectors) are
+ * persisted and read back through a {@link org.apache.lucene.store.Directory} using the binary
+ * stream abstractions defined here.
+ *
+ * <h2>Directory</h2>
+ *
+ * <p>The central entry point of this package is {@link org.apache.lucene.store.Directory}, an
+ * abstract directory of named files. {@link org.apache.lucene.store.Directory#openInput(String,
+ * org.apache.lucene.store.IOContext)} opens an existing file for reading, while {@link
+ * org.apache.lucene.store.Directory#createOutput(String,
+ * org.apache.lucene.store.IOContext)} creates a new file for writing. The concrete implementation of
+ * {@link org.apache.lucene.store.Directory} describes where the files physically live:
+ *
+ * <ul>
+ *   <li>{@link org.apache.lucene.store.FSDirectory} (and its optimized subclass {@link
+ *       org.apache.lucene.store.MMapDirectory}) stores files on the local file system.
+ *   <li>{@link org.apache.lucene.store.ByteBuffersDirectory} keeps files in off-heap memory and is
+ *       primarily used internally.
+ *   <li>Base classes such as {@link org.apache.lucene.store.FilterDirectory} and {@link
+ *       org.apache.lucene.store.TrackingDirectoryWrapper} make it easy to add behaviour around an
+ *       existing directory.
+ * </ul>
+ *
+ * <h2>Reading and writing</h2>
+ *
+ * <p>Reading and writing are performed via {@link org.apache.lucene.store.IndexInput} and {@link
+ * org.apache.lucene.store.IndexOutput}, whose low-level primitives are provided by the abstract
+ * {@link org.apache.lucene.store.DataInput} and {@link org.apache.lucene.store.DataOutput} classes.
+ * These streams support the primitive integer and long encodings that Lucene's codecs rely on, and
+ * {@link org.apache.lucene.store.ChecksumIndexInput} reports a checksum over the bytes read so a
+ * caller can verify that a file was not corrupted.
+ *
+ * <h2>Locking and consistency</h2>
+ *
+ * <p>To make sure only one process writes a given directory at a time, the package exposes {@link
+ * org.apache.lucene.store.Lock} and its factories (for example {@link
+ * org.apache.lucene.store.SimpleFSLockFactory} or {@link org.apache.lucene.store.NativeFSLockFactory})
+ * through {@link org.apache.lucene.store.Directory#obtainLock(String)}.
+ *
+ * <p>See {@link org.apache.lucene.index.IndexWriter} in the {@code org.apache.lucene.index}
+ * package for the canonical example of using this package to build and maintain an index.
+ */
 package org.apache.lucene.store;


### PR DESCRIPTION
Related to #15225

This PR expands the sparse, one-line package description of `org.apache.lucene.store` into concise documentation that explains the package's purpose and key abstractions (Directory, IndexInput/IndexOutput, DataInput/DataOutput, ChecksumIndexInput, Lock/LockFactory, and common Directory implementations).

What was changed:
- Rewrote `lucene/core/src/java/org/apache/lucene/store/package-info.java` with pointed, human-first documentation covering:
  - The role of the store package as the binary I/O layer for all index data
  - The `Directory` abstraction and common implementations (`FSDirectory`, `MMapDirectory`, `ByteBuffersDirectory`, `FilterDirectory`, `TrackingDirectoryWrapper`)
  - Reading/writing via `IndexInput`/`IndexOutput` and their `DataInput`/`DataOutput` primitives
  - Checksum verification via `ChecksumIndexInput`
  - Locking and consistency through `Lock`/`LockFactory`

I deliberately kept it concise rather than verbose. If any wording needs adjustment to match Lucene's documentation style, I'm happy to revise.

cc @jainankitk for review