### PR TITLE
Close the reader pool before deleting files on rollback

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -217,6 +217,10 @@ Optimizations
 
 Bug Fixes
 ---------------------
+* GITHUB#16625: Close the reader pool before the deleter removes files on rollback, so that
+  uncommitted segment files are not deleted while pooled readers still hold them open.
+  (Jean Pierre Mandujano)
+
 * GITHUB#16553: Fix stored-fields corruption when PerField#finish throws: the stored-fields frame
   was left open, causing "Wrote N docs, finish called with numDocs=M" at flush. (Michael Marshall)
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -2621,6 +2621,11 @@ public class IndexWriter
 
         testPoint("rollback before checkpoint");
 
+        // Drop the pooled readers before the deleter removes files: they hold open
+        // the files of segments that are about to be deleted. Nothing is lost by
+        // dropping them, since a rollback saves no changes anyway.
+        readerPool.close();
+
         // Ask deleter to locate unreferenced files & remove
         // them ... only when we are not experiencing a tragedy, else
         // these methods throw ACE:
@@ -2631,8 +2636,6 @@ public class IndexWriter
         }
 
         lastCommitChangeCount = changeCount.get();
-        // Don't bother saving any changes in our segmentInfos
-        readerPool.close();
         // Must set closed while inside the same sync block where we call deleter.refresh, else
         // concurrent threads may try to sneak a flush in,
         // after we leave this sync block and before we enter the sync block in the finally clause

--- a/lucene/core/src/java/org/apache/lucene/index/ReaderPool.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReaderPool.java
@@ -397,6 +397,11 @@ final class ReaderPool implements Closeable {
         : "info.dir=" + info.info.dir + " vs " + originalDirectory;
     if (closed.get()) {
       assert readerMap.isEmpty() : "Reader map is not empty: " + readerMap;
+      if (create == false) {
+        // A closed pool holds no readers, which is the answer a lookup is asking
+        // for. Callers passing create=false already handle a null result.
+        return null;
+      }
       throw new AlreadyClosedException("ReaderPool is already closed");
     }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterRollbackReaderPool.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterRollbackReaderPool.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.index;
+
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.tests.store.MockDirectoryWrapper;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+public class TestIndexWriterRollbackReaderPool extends LuceneTestCase {
+
+  public void testRollbackUncommittedMergedSegment() throws Exception {
+    try (MockDirectoryWrapper dir =
+        new MockDirectoryWrapper(random(), new ByteBuffersDirectory())) {
+      dir.setAssertNoDeleteOpenFile(true);
+      dir.setThrottling(MockDirectoryWrapper.Throttling.NEVER);
+
+      LogDocMergePolicy mergePolicy = new LogDocMergePolicy();
+      mergePolicy.setMergeFactor(100);
+
+      IndexWriterConfig config =
+          new IndexWriterConfig()
+              .setCodec(new Lucene104Codec())
+              .setMergeScheduler(new SerialMergeScheduler())
+              .setMergePolicy(mergePolicy)
+              .setUseCompoundFile(true)
+              .setMaxBufferedDocs(2)
+              .setCommitOnClose(false);
+      config.getCodec().compoundFormat().setCfsThresholdDocSize(Integer.MAX_VALUE);
+
+      try (IndexWriter writer = new IndexWriter(dir, config)) {
+        for (int i = 0; i < 4; i++) {
+          Document doc = new Document();
+          doc.add(new StringField("id", Integer.toString(i), Field.Store.NO));
+          writer.addDocument(doc);
+        }
+        writer.commit();
+
+        // Commit two segments, then replace them with an uncommitted compound segment.
+        try (DirectoryReader committed = DirectoryReader.open(dir)) {
+          assertEquals(4, committed.numDocs());
+          assertEquals(2, committed.leaves().size());
+        }
+        writer.forceMerge(1);
+
+        try (DirectoryReader reader = DirectoryReader.open(writer)) {
+          assertEquals(4, reader.numDocs());
+          assertEquals(1, reader.leaves().size());
+          SegmentReader segmentReader = (SegmentReader) reader.leaves().getFirst().reader();
+          assertTrue(segmentReader.getSegmentInfo().info.getUseCompoundFile());
+        }
+      }
+
+      try (DirectoryReader committed = DirectoryReader.open(dir)) {
+        assertEquals(4, committed.numDocs());
+        assertEquals(2, committed.leaves().size());
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description

`rollbackInternalNoCommit` asks the deleter to remove unreferenced files while the pooled readers are still open, so an uncommitted segment gets deleted from under them. On a directory that checks for this the rollback fails outright:

```
java.io.IOException: MockDirectoryWrapper: file "_2.cfs" is still open: cannot delete
    at org.apache.lucene.util.FileDeleter.delete(FileDeleter.java:234)
    at org.apache.lucene.index.IndexFileDeleter.decRef(IndexFileDeleter.java:620)
    at org.apache.lucene.index.IndexFileDeleter.checkpoint(IndexFileDeleter.java:578)
    at org.apache.lucene.index.IndexWriter.rollbackInternalNoCommit(IndexWriter.java:2628)
```

Moving `readerPool.close()` ahead of `deleter.checkpoint(...)` is the fix, and as @LuXugang notes in the issue it isn't enough on its own: the checkpoint's own diagnostic logging goes back to the pool through `segString` → `numDeletedDocs` → `getPooledInstance(info, false)`, which throws `AlreadyClosedException` once the pool is closed.

That second part turns out to be a lookup answering with an exception where it could answer with the truth. `ReaderPool.get(info, create)` throws for a closed pool even when `create == false`, but a closed pool holds no readers (its own assert says the map is empty), so `null` is the accurate answer for a lookup. So `get` now returns `null` in that case and keeps throwing when asked to create.

On the callers: there are eight `create == false` lookups in `IndexWriter`. Five null-check the result (`numDeletedDocs` falls back to `info.getDelCount(...)`; the others skip the segment). The remaining three sit on the merge path (`commitMergedDeletesAndUpdates`, `buildMappedDVUpdatesFromDisk`, `closeMergeReaders`), hold their own ref on the reader, and two of them already `assert rld != null` on that basis. Reaching them with a closed pool was an invalid state before this change too — `abortMerges()` runs before the pool is closed on rollback — so the difference there is only which exception reports it.

### Tests

`TestIndexWriterRollbackReaderPool` is the reproducer from the issue. It fails on `main` with the stack trace above and passes with this change.

The full `lucene/core` suite is green with the change: 8689 tests, 319 skipped, 0 failures — which is where the `AlreadyClosedException` mentioned in the issue would show up.

Closes #16625