### PR TITLE
Lower default maxDocValuesOverlays from 16 to 8

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
@@ -109,10 +109,10 @@ public final class IndexWriterConfig extends LiveIndexWriterConfig {
 
   /**
    * Default maximum number of sparse doc-values overlays a field keeps before they are folded into
-   * one: {@code 16}. {@code 0} disables the feature (classic full-column rewrite); higher values
+   * one: {@code 8}. {@code 0} disables the feature (classic full-column rewrite); higher values
    * lower write amplification but keep more overlays (hence more files) live to merge at read time.
    */
-  public static final int DEFAULT_MAX_DOC_VALUES_OVERLAYS = 16;
+  public static final int DEFAULT_MAX_DOC_VALUES_OVERLAYS = 8;
 
   // indicates whether this config instance is already attached to a writer.
   // not final so that it can be cloned properly.


### PR DESCRIPTION
A field keeps one open producer per live overlay generation, so open file handles scale with segments times updated fields times the overlay budget (#16644). Lowering the default from 16 to 8 halves that envelope. Write amplification is essentially unchanged for batched updates, where the fold cost is a small fraction of the total, so 8 is a better default. The feature is not released yet, so no CHANGES entry.

Relates to #16644.