### PR TITLE
Dedicated merge policy for vectors - sandbox

### DIFF
--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/KnnHnswPairingBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/KnnHnswPairingBenchmark.java
@@ -1,0 +1,374 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.ConcurrentMergeScheduler;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.MergePolicy.OneMerge;
+import org.apache.lucene.index.MergeScheduler;
+import org.apache.lucene.index.MergeTrigger;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.SerialMergeScheduler;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TieredMergePolicy;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.sandbox.index.ProactiveCleanMergePolicy;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.util.IOUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Frozen-index HNSW merge cost. Dirty segments delete {@link #DIRTY_DELETE_PCT}% of docs, which is
+ * above {@code IncrementalHnswGraphMerger}'s 40% base-graph cutoff: a dirty graph cannot be the
+ * merge base. A sibling 0-delete graph still can; if every graph is over that cutoff the merge
+ * rebuilds from scratch.
+ *
+ * <p>Pairing uses {@code forceMerge(1)} of exactly two segments. Policy comparison runs {@code
+ * maybeMerge()} then {@code forceMerge(1)} so both land on one segment: natural selection still
+ * goes through the policy, the finish step uses {@code findForcedMerges} (not intercepted). A lone
+ * {@code forceMerge(1)} would ignore {@link ProactiveCleanMergePolicy}. Indexing is {@code @Setup};
+ * the timed region is copy + merge + close.
+ *
+ * <p>Run with:
+ *
+ * <pre>
+ *   ./gradlew :lucene:benchmark-jmh:assemble
+ *   java -jar lucene/benchmark-jmh/build/benchmarks/lucene-benchmark-jmh-*.jar KnnHnswPairingBenchmark -f 1 -wi 0 -i 3 -foe false
+ * </pre>
+ */
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 0)
+@Measurement(iterations = 3)
+@Fork(
+    value = 1,
+    jvmArgsAppend = {"-Xmx8g", "-Xms8g", "-XX:+AlwaysPreTouch"})
+public class KnnHnswPairingBenchmark {
+
+  private static final int MAX_CONN = 16;
+  private static final int BEAM_WIDTH = 100;
+  private static final int DIM = 128;
+  private static final int DOCS_PER_SEG = 20_000;
+
+  /** Must be {@code > 40} so the dirty HNSW graph cannot be selected as merge base. */
+  private static final int DIRTY_DELETE_PCT = 50;
+
+  @Param({"1"})
+  public int numMergeWorkers;
+
+  private float[][] vectors;
+  private Path root;
+  private Path twoClean;
+  private Path cleanPlusHeavy;
+  private Path twoHeavy;
+  private Path mixedSix;
+
+  @Setup(Level.Trial)
+  public void setup() throws IOException {
+    Random random = new Random(42);
+    int maxDocs = 6 * DOCS_PER_SEG;
+    vectors = new float[maxDocs][];
+    for (int i = 0; i < maxDocs; i++) {
+      vectors[i] = randomUnitVector(random);
+    }
+    root = Files.createTempDirectory("knnHnswPairingBenchmark");
+    twoClean = root.resolve("twoClean");
+    cleanPlusHeavy = root.resolve("cleanPlusHeavy");
+    twoHeavy = root.resolve("twoHeavy");
+    mixedSix = root.resolve("mixed6");
+    buildIndex(twoClean, 2, 0);
+    buildIndex(cleanPlusHeavy, 2, 1);
+    buildIndex(twoHeavy, 2, 2);
+    buildIndex(mixedSix, 6, 1);
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws IOException {
+    IOUtils.rm(root);
+  }
+
+  /** forceMerge(1) of 2 zero-delete HNSW segments (join-set / largest-graph base). */
+  @Benchmark
+  public int mergeTwoClean() throws IOException {
+    return mergeCopied(twoClean, true, null);
+  }
+
+  /**
+   * forceMerge(1) of 1 clean + 1 50%-deleted segment. Dirty graph cannot be base; live dirty
+   * vectors are inserted into the clean graph.
+   */
+  @Benchmark
+  public int mergeCleanPlusHeavyDirty() throws IOException {
+    return mergeCopied(cleanPlusHeavy, true, null);
+  }
+
+  /**
+   * forceMerge(1) of 2 segments that are both 50% deleted. Neither graph can be base, so the merger
+   * rebuilds from scratch.
+   */
+  @Benchmark
+  public int mergeTwoHeavyDirty() throws IOException {
+    return mergeCopied(twoHeavy, true, null);
+  }
+
+  /** maybeMerge then forceMerge(1) of 5 clean + 1 50%-deleted under over-budget TMP. */
+  @Benchmark
+  public int mergeToOneTmp() throws IOException {
+    return mergeCopied(mixedSix, false, "tmp");
+  }
+
+  /** Same finish line under proactive-then-TMP. */
+  @Benchmark
+  public int mergeToOneProactive() throws IOException {
+    return mergeCopied(mixedSix, false, "proactive");
+  }
+
+  private int mergeCopied(Path src, boolean pairingForceMerge, String policy) throws IOException {
+    Path runPath = Files.createTempDirectory(root, "run");
+    CountingMergeScheduler scheduler = new CountingMergeScheduler();
+    try {
+      copyIndex(src, runPath);
+      IndexWriterConfig iwc = new IndexWriterConfig();
+      iwc.setCodec(codec());
+      iwc.setOpenMode(IndexWriterConfig.OpenMode.APPEND);
+      iwc.setMergeScheduler(scheduler);
+      iwc.setUseCompoundFile(false);
+      if (pairingForceMerge) {
+        iwc.setMergePolicy(overBudgetTmp());
+      } else {
+        iwc.setMergePolicy(naturalPolicy(policy));
+      }
+      int checksum;
+      try (Directory dir = new MMapDirectory(runPath);
+          IndexWriter w = new IndexWriter(dir, iwc)) {
+        if (pairingForceMerge) {
+          w.forceMerge(1);
+        } else {
+          // Natural phase uses findMerges (policy). Finish uses findForcedMerges (inner TMP).
+          w.maybeMerge();
+          w.forceMerge(1);
+        }
+        checksum = w.getDocStats().maxDoc;
+      }
+      int segments;
+      try (Directory dir = new MMapDirectory(runPath);
+          DirectoryReader reader = DirectoryReader.open(dir)) {
+        segments = reader.leaves().size();
+      }
+      System.out.println(
+          "pairing="
+              + src.getFileName()
+              + " pairingForceMerge="
+              + pairingForceMerge
+              + " policy="
+              + policy
+              + " workers="
+              + numMergeWorkers
+              + " merges="
+              + scheduler.mergeCount.get()
+              + " fanIn="
+              + scheduler.fanIn
+              + " segments="
+              + segments);
+      return checksum;
+    } finally {
+      IOUtils.rm(runPath);
+    }
+  }
+
+  private void buildIndex(Path dest, int numSegs, int dirtySegCount) throws IOException {
+    Files.createDirectories(dest);
+    IndexWriterConfig iwc = new IndexWriterConfig();
+    iwc.setCodec(codec());
+    iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+    iwc.setMergeScheduler(new SerialMergeScheduler());
+    iwc.setMaxBufferedDocs(DOCS_PER_SEG);
+    iwc.setRAMBufferSizeMB(IndexWriterConfig.DISABLE_AUTO_FLUSH);
+    iwc.setUseCompoundFile(false);
+    try (Directory dir = new MMapDirectory(dest);
+        IndexWriter w = new IndexWriter(dir, iwc)) {
+      Document doc = new Document();
+      StringField idField = new StringField("id", "", Field.Store.NO);
+      KnnFloatVectorField vecField =
+          new KnnFloatVectorField("vec", new float[DIM], VectorSimilarityFunction.DOT_PRODUCT);
+      doc.add(idField);
+      doc.add(vecField);
+      int total = numSegs * DOCS_PER_SEG;
+      for (int i = 0; i < total; i++) {
+        idField.setStringValue(Integer.toString(i));
+        vecField.setVectorValue(vectors[i]);
+        w.addDocument(doc);
+      }
+      if (dirtySegCount > 0) {
+        int nDelete = DOCS_PER_SEG * DIRTY_DELETE_PCT / 100;
+        for (int s = 0; s < dirtySegCount; s++) {
+          int start = s * DOCS_PER_SEG;
+          Term[] terms = new Term[nDelete];
+          for (int i = 0; i < nDelete; i++) {
+            terms[i] = new Term("id", Integer.toString(start + i));
+          }
+          w.deleteDocuments(terms);
+        }
+      }
+      w.commit();
+    }
+  }
+
+  private MergePolicy naturalPolicy(String policy) {
+    TieredMergePolicy tmp = overBudgetTmp();
+    switch (policy) {
+      case "tmp":
+        return tmp;
+      case "proactive":
+        ProactiveCleanMergePolicy proactive = new ProactiveCleanMergePolicy(tmp);
+        proactive.setMinProactiveSegmentSize(0);
+        return proactive;
+      default:
+        throw new IllegalArgumentException("unknown policy: " + policy);
+    }
+  }
+
+  private static TieredMergePolicy overBudgetTmp() {
+    TieredMergePolicy tmp = new TieredMergePolicy();
+    tmp.setSegmentsPerTier(2);
+    tmp.setTargetSearchConcurrency(1);
+    return tmp;
+  }
+
+  private Lucene104Codec codec() {
+    final int workers = numMergeWorkers;
+    return new Lucene104Codec() {
+      private final KnnVectorsFormat knn =
+          new Lucene99HnswVectorsFormat(MAX_CONN, BEAM_WIDTH, workers, null);
+
+      @Override
+      public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+        return knn;
+      }
+    };
+  }
+
+  private static void copyIndex(Path src, Path dest) throws IOException {
+    Files.createDirectories(dest);
+    try (Directory from = FSDirectory.open(src);
+        Directory to = FSDirectory.open(dest)) {
+      for (String file : from.listAll()) {
+        if ("write.lock".equals(file)) {
+          continue;
+        }
+        to.copyFrom(from, file, file, IOContext.DEFAULT);
+      }
+    }
+  }
+
+  private static float[] randomUnitVector(Random random) {
+    float[] v = new float[DIM];
+    float sumSquares = 0f;
+    for (int i = 0; i < DIM; i++) {
+      float x = random.nextFloat() * 2 - 1;
+      v[i] = x;
+      sumSquares += x * x;
+    }
+    float norm = (float) Math.sqrt(sumSquares);
+    for (int i = 0; i < DIM; i++) {
+      v[i] /= norm;
+    }
+    return v;
+  }
+
+  private static final class CountingMergeScheduler extends ConcurrentMergeScheduler {
+    final AtomicInteger mergeCount = new AtomicInteger();
+    final List<Integer> fanIn = new ArrayList<>();
+
+    @Override
+    public void merge(MergeSource mergeSource, MergeTrigger trigger) throws IOException {
+      super.merge(new CountingMergeSource(mergeSource, mergeCount, fanIn), trigger);
+    }
+  }
+
+  private static final class CountingMergeSource implements MergeScheduler.MergeSource {
+    private final MergeScheduler.MergeSource in;
+    private final AtomicInteger mergeCount;
+    private final List<Integer> fanIn;
+
+    CountingMergeSource(
+        MergeScheduler.MergeSource in, AtomicInteger mergeCount, List<Integer> fanIn) {
+      this.in = in;
+      this.mergeCount = mergeCount;
+      this.fanIn = fanIn;
+    }
+
+    @Override
+    public OneMerge getNextMerge() {
+      OneMerge merge = in.getNextMerge();
+      if (merge != null) {
+        mergeCount.incrementAndGet();
+        fanIn.add(merge.segments.size());
+      }
+      return merge;
+    }
+
+    @Override
+    public void onMergeFinished(OneMerge merge) {
+      in.onMergeFinished(merge);
+    }
+
+    @Override
+    public boolean hasPendingMerges() {
+      return in.hasPendingMerges();
+    }
+
+    @Override
+    public void merge(OneMerge merge) throws IOException {
+      in.merge(merge);
+    }
+  }
+}

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/KnnMergePolicyBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/KnnMergePolicyBenchmark.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.benchmark.jmh;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.ConcurrentMergeScheduler;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.MergePolicy.OneMerge;
+import org.apache.lucene.index.MergeScheduler;
+import org.apache.lucene.index.MergeTrigger;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TieredMergePolicy;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.sandbox.index.ProactiveCleanMergePolicy;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.util.IOUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Natural flush+merge cost of HNSW indexing under {@link TieredMergePolicy} vs {@link
+ * ProactiveCleanMergePolicy}. {@code deletePct=0} must match {@code tmp} (append-only bypass). The
+ * expected win is at {@code 20} / {@code 35}. {@link #indexThenForceMerge} must match across
+ * policies (forced merges are not intercepted).
+ *
+ * <p>Indexing is two-phase: the first half of the documents are flushed, deletes are applied to
+ * those older docs and flushed, then the second half is appended. That leaves a mix of dirty and
+ * clean segments so {@code proactive} can fire. {@code deletePct=0} skips deletes (append-only
+ * bypass).
+ *
+ * <p>Run with:
+ *
+ * <pre>
+ *   ./gradlew clean :lucene:benchmark-jmh:assemble
+ *   java -jar lucene/benchmark-jmh/build/benchmarks/lucene-benchmark-jmh-*.jar KnnMergePolicyBenchmark -f 1 -wi 1 -i 3 -foe false
+ * </pre>
+ */
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 1)
+@Measurement(iterations = 3)
+@Fork(
+    value = 1,
+    jvmArgsAppend = {"-Xmx8g", "-Xms8g", "-XX:+AlwaysPreTouch"})
+public class KnnMergePolicyBenchmark {
+
+  private static final int MAX_CONN = 16;
+  private static final int BEAM_WIDTH = 100;
+
+  /** Batches large enough that vectors alone exceed TMP's 16MB floor (40k × 128 × 4 = 20MB). */
+  private static final int DOCS_PER_FLUSH = 40_000;
+
+  @Param({"tmp", "proactive"})
+  public String policy;
+
+  @Param({"0", "20", "35"})
+  public int deletePct;
+
+  @Param({"1", "8"})
+  public int numMergeWorkers;
+
+  @Param({"240000"})
+  public int docCount;
+
+  @Param({"128"})
+  public int dim;
+
+  private float[][] vectors;
+  private Path path;
+
+  @Setup(Level.Trial)
+  public void setup() throws IOException {
+    Random random = new Random(42);
+    vectors = new float[docCount][];
+    for (int i = 0; i < docCount; i++) {
+      vectors[i] = randomUnitVector(dim, random);
+    }
+    path = Files.createTempDirectory("knnMergePolicyBenchmark");
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws IOException {
+    IOUtils.rm(path);
+  }
+
+  @Benchmark
+  public int indexWithNaturalMerges() throws IOException {
+    return index(false);
+  }
+
+  @Benchmark
+  public int indexThenForceMerge() throws IOException {
+    return index(true);
+  }
+
+  private int index(boolean forceMerge) throws IOException {
+    Path runPath = Files.createTempDirectory(path, policy);
+    CountingMergeScheduler scheduler = new CountingMergeScheduler();
+    try (Directory dir = new MMapDirectory(runPath)) {
+      IndexWriterConfig iwc = new IndexWriterConfig();
+      iwc.setCodec(codec());
+      iwc.setMergePolicy(mergePolicy());
+      iwc.setMergeScheduler(scheduler);
+      iwc.setMaxBufferedDocs(DOCS_PER_FLUSH);
+      iwc.setRAMBufferSizeMB(IndexWriterConfig.DISABLE_AUTO_FLUSH);
+      iwc.setUseCompoundFile(false);
+      int checksum;
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        Document doc = new Document();
+        StringField idField = new StringField("id", "", Field.Store.NO);
+        KnnFloatVectorField vecField =
+            new KnnFloatVectorField("vec", new float[dim], VectorSimilarityFunction.DOT_PRODUCT);
+        doc.add(idField);
+        doc.add(vecField);
+        int mid = docCount / 2;
+        addDocs(w, doc, idField, vecField, 0, mid);
+        applyDeletes(w, mid);
+        w.flush();
+        addDocs(w, doc, idField, vecField, mid, docCount);
+        if (forceMerge) {
+          w.forceMerge(1);
+        }
+        checksum = w.getDocStats().maxDoc;
+      }
+      int segments;
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        segments = reader.leaves().size();
+      }
+      System.out.println(
+          "policy="
+              + policy
+              + " deletePct="
+              + deletePct
+              + " workers="
+              + numMergeWorkers
+              + " forceMerge="
+              + forceMerge
+              + " merges="
+              + scheduler.mergeCount.get()
+              + " segments="
+              + segments);
+      return checksum;
+    } finally {
+      IOUtils.rm(runPath);
+    }
+  }
+
+  private void addDocs(
+      IndexWriter w,
+      Document doc,
+      StringField idField,
+      KnnFloatVectorField vecField,
+      int from,
+      int to)
+      throws IOException {
+    for (int i = from; i < to; i++) {
+      idField.setStringValue(Integer.toString(i));
+      vecField.setVectorValue(vectors[i]);
+      w.addDocument(doc);
+    }
+  }
+
+  private void applyDeletes(IndexWriter w, int cutoff) throws IOException {
+    if (deletePct == 0) {
+      return;
+    }
+    int threshold = deletePct * 2;
+    int n = 0;
+    for (int i = 0; i < cutoff; i++) {
+      if ((i % 100) < threshold) {
+        n++;
+      }
+    }
+    Term[] terms = new Term[n];
+    int upto = 0;
+    for (int i = 0; i < cutoff; i++) {
+      if ((i % 100) < threshold) {
+        terms[upto] = new Term("id", Integer.toString(i));
+        upto++;
+      }
+    }
+    w.deleteDocuments(terms);
+  }
+
+  private MergePolicy mergePolicy() {
+    TieredMergePolicy tmp = new TieredMergePolicy();
+    switch (policy) {
+      case "tmp":
+        return tmp;
+      case "proactive":
+        return new ProactiveCleanMergePolicy(tmp);
+      default:
+        throw new IllegalArgumentException("unknown policy: " + policy);
+    }
+  }
+
+  private Lucene104Codec codec() {
+    final int workers = numMergeWorkers;
+    return new Lucene104Codec() {
+      private final KnnVectorsFormat knn =
+          new Lucene99HnswVectorsFormat(MAX_CONN, BEAM_WIDTH, workers, null);
+
+      @Override
+      public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+        return knn;
+      }
+    };
+  }
+
+  private static float[] randomUnitVector(int dim, Random random) {
+    float[] v = new float[dim];
+    float sumSquares = 0f;
+    for (int i = 0; i < dim; i++) {
+      float x = random.nextFloat() * 2 - 1;
+      v[i] = x;
+      sumSquares += x * x;
+    }
+    float norm = (float) Math.sqrt(sumSquares);
+    for (int i = 0; i < dim; i++) {
+      v[i] /= norm;
+    }
+    return v;
+  }
+
+  private static final class CountingMergeScheduler extends ConcurrentMergeScheduler {
+    final AtomicInteger mergeCount = new AtomicInteger();
+
+    @Override
+    public void merge(MergeSource mergeSource, MergeTrigger trigger) throws IOException {
+      super.merge(new CountingMergeSource(mergeSource, mergeCount), trigger);
+    }
+  }
+
+  private static final class CountingMergeSource implements MergeScheduler.MergeSource {
+    private final MergeScheduler.MergeSource in;
+    private final AtomicInteger mergeCount;
+
+    CountingMergeSource(MergeScheduler.MergeSource in, AtomicInteger mergeCount) {
+      this.in = in;
+      this.mergeCount = mergeCount;
+    }
+
+    @Override
+    public OneMerge getNextMerge() {
+      OneMerge merge = in.getNextMerge();
+      if (merge != null) {
+        mergeCount.incrementAndGet();
+      }
+      return merge;
+    }
+
+    @Override
+    public void onMergeFinished(OneMerge merge) {
+      in.onMergeFinished(merge);
+    }
+
+    @Override
+    public boolean hasPendingMerges() {
+      return in.hasPendingMerges();
+    }
+
+    @Override
+    public void merge(OneMerge merge) throws IOException {
+      in.merge(merge);
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
@@ -673,7 +673,7 @@ public class TieredMergePolicy extends MergePolicy {
   }
 
   /** Expert: scores one merge */
-  MergeScore score(
+  protected MergeScore score(
       List<SegmentCommitInfo> candidate,
       boolean hitTooLarge,
       Map<SegmentCommitInfo, SegmentSizeAndDocs> segmentsSizes)

--- a/lucene/sandbox/src/java/org/apache/lucene/sandbox/index/ProactiveCleanMergePolicy.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/sandbox/index/ProactiveCleanMergePolicy.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.sandbox.index;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.lucene.index.FilterMergePolicy;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.MergeTrigger;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.TieredMergePolicy;
+import org.apache.lucene.util.Unwrappable;
+
+/**
+ * A {@link FilterMergePolicy} that force-picks same-size-tier merges of zero-delete segments before
+ * the wrapped policy scores candidates. That keeps cheap HNSW join-set merges available and avoids
+ * pairing clean segments with deleted ones.
+ *
+ * <p>When every segment has zero deletes (append-only), this policy delegates to the wrapped policy
+ * unchanged: {@link TieredMergePolicy}'s size-tier budget is a better fit than packing every clean
+ * flush. Segments below {@code minProactiveSegmentSize} (the wrapped TMP floor by default) are left
+ * for the inner cascade. Forced merges are not intercepted.
+ *
+ * <p>On commit, {@link #findFullFlushMerges} also requires each source segment to be smaller than
+ * {@link #maxFullFlushMergeSize}. With a wrapped TMP those two bounds are the same by default (the
+ * floor), so full-flush proactive merges are a no-op until {@code minProactiveSegmentSize} is set
+ * below that cap.
+ *
+ * @lucene.experimental
+ */
+public class ProactiveCleanMergePolicy extends FilterMergePolicy {
+  private static final long DEFAULT_MAX_PROACTIVE_MERGE_BYTES = 5L * 1024 * 1024 * 1024;
+  private static final long DEFAULT_MIN_PROACTIVE_SEGMENT_SIZE = 16L * 1024 * 1024;
+
+  private int minSegmentsForProactive = 3;
+  private int maxProactiveMergeSegments = 10;
+  private long maxProactiveMergeBytes;
+  private long minProactiveSegmentSize;
+
+  public ProactiveCleanMergePolicy(MergePolicy in) {
+    super(in);
+    MergePolicy unwrapped = Unwrappable.unwrapAll(in);
+    if (unwrapped instanceof TieredMergePolicy) {
+      TieredMergePolicy tmp = (TieredMergePolicy) unwrapped;
+      maxProactiveMergeBytes = mbToBytes(tmp.getMaxMergedSegmentMB());
+      minProactiveSegmentSize = mbToBytes(tmp.getFloorSegmentMB());
+    } else {
+      maxProactiveMergeBytes = DEFAULT_MAX_PROACTIVE_MERGE_BYTES;
+      minProactiveSegmentSize = DEFAULT_MIN_PROACTIVE_SEGMENT_SIZE;
+    }
+  }
+
+  public int getMinSegmentsForProactive() {
+    return minSegmentsForProactive;
+  }
+
+  public void setMinSegmentsForProactive(int minSegmentsForProactive) {
+    if (minSegmentsForProactive < 2) {
+      throw new IllegalArgumentException(
+          "minSegmentsForProactive must be >= 2 (got " + minSegmentsForProactive + ")");
+    }
+    this.minSegmentsForProactive = minSegmentsForProactive;
+  }
+
+  public int getMaxProactiveMergeSegments() {
+    return maxProactiveMergeSegments;
+  }
+
+  public void setMaxProactiveMergeSegments(int maxProactiveMergeSegments) {
+    if (maxProactiveMergeSegments < 2) {
+      throw new IllegalArgumentException(
+          "maxProactiveMergeSegments must be >= 2 (got " + maxProactiveMergeSegments + ")");
+    }
+    this.maxProactiveMergeSegments = maxProactiveMergeSegments;
+  }
+
+  public long getMaxProactiveMergeBytes() {
+    return maxProactiveMergeBytes;
+  }
+
+  public void setMaxProactiveMergeBytes(long maxProactiveMergeBytes) {
+    if (maxProactiveMergeBytes <= 0) {
+      throw new IllegalArgumentException(
+          "maxProactiveMergeBytes must be > 0 (got " + maxProactiveMergeBytes + ")");
+    }
+    this.maxProactiveMergeBytes = maxProactiveMergeBytes;
+  }
+
+  public long getMinProactiveSegmentSize() {
+    return minProactiveSegmentSize;
+  }
+
+  public void setMinProactiveSegmentSize(long minProactiveSegmentSize) {
+    if (minProactiveSegmentSize < 0) {
+      throw new IllegalArgumentException(
+          "minProactiveSegmentSize must be >= 0 (got " + minProactiveSegmentSize + ")");
+    }
+    this.minProactiveSegmentSize = minProactiveSegmentSize;
+  }
+
+  @Override
+  public MergeSpecification findMerges(
+      MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext)
+      throws IOException {
+    return selectMerges(mergeTrigger, segmentInfos, mergeContext, false);
+  }
+
+  @Override
+  public MergeSpecification findFullFlushMerges(
+      MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext)
+      throws IOException {
+    return selectMerges(mergeTrigger, segmentInfos, mergeContext, true);
+  }
+
+  private MergeSpecification selectMerges(
+      MergeTrigger mergeTrigger,
+      SegmentInfos segmentInfos,
+      MergeContext mergeContext,
+      boolean fullFlush)
+      throws IOException {
+    if (hasDeletes(segmentInfos, mergeContext) == false) {
+      return delegateFind(mergeTrigger, segmentInfos, mergeContext, fullFlush);
+    }
+    long maxSizeBytes = fullFlush ? maxFullFlushMergeSize() : maxProactiveMergeBytes;
+    List<SegAndSize> candidates = collectCleanCandidates(segmentInfos, mergeContext, maxSizeBytes);
+    if (candidates.size() < minSegmentsForProactive) {
+      return delegateFind(mergeTrigger, segmentInfos, mergeContext, fullFlush);
+    }
+    Collections.sort(candidates, (a, b) -> Long.compare(a.size, b.size));
+    List<OneMerge> proactive = packTiers(candidates);
+    if (proactive.isEmpty()) {
+      return delegateFind(mergeTrigger, segmentInfos, mergeContext, fullFlush);
+    }
+    Set<SegmentCommitInfo> taken = new HashSet<>();
+    for (int i = 0; i < proactive.size(); i++) {
+      taken.addAll(proactive.get(i).segments);
+    }
+    SegmentInfos remaining = leftovers(segmentInfos, taken);
+    MergeSpecification tmp = delegateFind(mergeTrigger, remaining, mergeContext, fullFlush);
+    return combine(proactive, tmp);
+  }
+
+  private MergeSpecification delegateFind(
+      MergeTrigger mergeTrigger,
+      SegmentInfos segmentInfos,
+      MergeContext mergeContext,
+      boolean fullFlush)
+      throws IOException {
+    if (fullFlush) {
+      return in.findFullFlushMerges(mergeTrigger, segmentInfos, mergeContext);
+    }
+    return in.findMerges(mergeTrigger, segmentInfos, mergeContext);
+  }
+
+  private static boolean hasDeletes(SegmentInfos segmentInfos, MergeContext mergeContext)
+      throws IOException {
+    for (SegmentCommitInfo sci : segmentInfos) {
+      if (mergeContext.numDeletesToMerge(sci) != 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private List<SegAndSize> collectCleanCandidates(
+      SegmentInfos segmentInfos, MergeContext mergeContext, long maxSizeBytes) throws IOException {
+    Set<SegmentCommitInfo> merging = mergeContext.getMergingSegments();
+    List<SegAndSize> candidates = new ArrayList<>();
+    for (SegmentCommitInfo sci : segmentInfos) {
+      if (merging.contains(sci)) {
+        continue;
+      }
+      if (mergeContext.numDeletesToMerge(sci) != 0) {
+        continue;
+      }
+      long segSize = size(sci, mergeContext);
+      if (segSize < minProactiveSegmentSize) {
+        continue;
+      }
+      if (segSize >= maxSizeBytes) {
+        continue;
+      }
+      candidates.add(new SegAndSize(sci, segSize));
+    }
+    return candidates;
+  }
+
+  private List<OneMerge> packTiers(List<SegAndSize> candidates) {
+    List<OneMerge> merges = new ArrayList<>();
+    int i = 0;
+    while (i < candidates.size()) {
+      List<SegmentCommitInfo> group = new ArrayList<>();
+      long firstSize = candidates.get(i).size;
+      long sum = 0;
+      int j = i;
+      while (j < candidates.size() && group.size() < maxProactiveMergeSegments) {
+        long nextSize = candidates.get(j).size;
+        if (nextSize > 2 * firstSize) {
+          break;
+        }
+        if (sum + nextSize > maxProactiveMergeBytes) {
+          break;
+        }
+        group.add(candidates.get(j).info);
+        sum += nextSize;
+        j++;
+      }
+      if (group.size() >= minSegmentsForProactive) {
+        merges.add(new OneMerge(group));
+        i = j;
+      } else {
+        i++;
+      }
+    }
+    return merges;
+  }
+
+  private static SegmentInfos leftovers(SegmentInfos segmentInfos, Set<SegmentCommitInfo> taken) {
+    SegmentInfos remaining = new SegmentInfos(segmentInfos.getIndexCreatedVersionMajor());
+    for (SegmentCommitInfo sci : segmentInfos) {
+      if (taken.contains(sci) == false) {
+        remaining.add(sci);
+      }
+    }
+    return remaining;
+  }
+
+  private static MergeSpecification combine(List<OneMerge> proactive, MergeSpecification tmp) {
+    if (proactive.isEmpty()) {
+      return tmp;
+    }
+    MergeSpecification spec = new MergeSpecification();
+    for (int i = 0; i < proactive.size(); i++) {
+      spec.add(proactive.get(i));
+    }
+    if (tmp != null) {
+      List<OneMerge> tmpMerges = tmp.merges;
+      for (int i = 0; i < tmpMerges.size(); i++) {
+        spec.add(tmpMerges.get(i));
+      }
+    }
+    return spec;
+  }
+
+  private static long mbToBytes(double mb) {
+    return (long) (mb * 1024 * 1024);
+  }
+
+  private static final class SegAndSize {
+    final SegmentCommitInfo info;
+    final long size;
+
+    SegAndSize(SegmentCommitInfo info, long size) {
+      this.info = info;
+      this.size = size;
+    }
+  }
+}

--- a/lucene/sandbox/src/test/org/apache/lucene/sandbox/index/TestProactiveCleanMergePolicy.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/sandbox/index/TestProactiveCleanMergePolicy.java
@@ -1,0 +1,587 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.sandbox.index;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FilterMergePolicy;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.MergePolicy.MergeSpecification;
+import org.apache.lucene.index.MergePolicy.OneMerge;
+import org.apache.lucene.index.MergeTrigger;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.SerialMergeScheduler;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.TieredMergePolicy;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.apache.lucene.tests.index.BaseMergePolicyTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.Version;
+
+/** Test for {@link ProactiveCleanMergePolicy}. */
+public class TestProactiveCleanMergePolicy extends BaseMergePolicyTestCase {
+
+  private static final double ABOVE_FLOOR_MB = 20.0;
+  private static final double BELOW_FLOOR_MB = 1.0;
+  private static final long ONE_MB = 1024L * 1024;
+
+  @Override
+  protected MergePolicy mergePolicy() {
+    MergePolicy inner = newMergePolicy();
+    if (inner instanceof TieredMergePolicy) {
+      ((TieredMergePolicy) inner)
+          .setMaxMergedSegmentMB(TestUtil.nextInt(random(), 1024, 10 * 1024));
+    }
+    return new ProactiveCleanMergePolicy(inner);
+  }
+
+  @Override
+  protected void assertSegmentInfos(MergePolicy policy, SegmentInfos infos) {}
+
+  @Override
+  protected void assertMerge(MergePolicy policy, MergeSpecification merge) {}
+
+  public void testThreeCleanAndOneDirtyFires() throws IOException {
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(noNaturalMerges());
+    MergeSpecification spec =
+        find(policy, infos(clean("_0"), clean("_1"), clean("_2"), dirty("_3")));
+    assertNotNull(spec);
+    assertEquals(1, spec.merges.size());
+    assertEquals(List.of("_0", "_1", "_2"), names(spec.merges.get(0)));
+  }
+
+  public void testThreeCleanAndTwoDirtyLeavesDirtyToInner() throws IOException {
+    RecordingMergePolicy inner = new RecordingMergePolicy(noNaturalMerges());
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(inner);
+    SegmentCommitInfo d3 = dirty("_3");
+    SegmentCommitInfo d4 = dirty("_4");
+    MergeSpecification spec = find(policy, infos(clean("_0"), clean("_1"), clean("_2"), d3, d4));
+    assertNotNull(spec);
+    assertEquals(List.of("_0", "_1", "_2"), names(spec.merges.get(0)));
+    assertNotNull(inner.lastInfos);
+    assertEquals(Set.of("_3", "_4"), names(inner.lastInfos));
+    assertSame(d3, inner.lastInfos.info(0));
+    assertSame(d4, inner.lastInfos.info(1));
+  }
+
+  public void testThreeCleanAndTwoDirtyTmpMayMergeDirty() throws IOException {
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(new TieredMergePolicy());
+    MergeSpecification spec =
+        find(policy, infos(clean("_0"), clean("_1"), clean("_2"), dirty("_3"), dirty("_4")));
+    assertNotNull(spec);
+    assertEquals(List.of("_0", "_1", "_2"), names(spec.merges.get(0)));
+  }
+
+  public void testAllDirtyEqualsInner() throws IOException {
+    TieredMergePolicy tmp = new TieredMergePolicy();
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(tmp);
+    SegmentInfos segmentInfos = infos(dirty("_0"), dirty("_1"), dirty("_2"), dirty("_3"));
+    MockMergeContext ctx = context();
+    assertSameSpecification(
+        tmp.findMerges(MergeTrigger.EXPLICIT, segmentInfos, ctx),
+        policy.findMerges(MergeTrigger.EXPLICIT, segmentInfos, ctx));
+  }
+
+  public void testAppendOnlyEqualsInner() throws IOException {
+    TieredMergePolicy tmp = new TieredMergePolicy();
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(tmp);
+    SegmentInfos segmentInfos = infos(clean("_0"), clean("_1"), clean("_2"), clean("_3"));
+    MockMergeContext ctx = context();
+    assertSameSpecification(
+        tmp.findMerges(MergeTrigger.EXPLICIT, segmentInfos, ctx),
+        policy.findMerges(MergeTrigger.EXPLICIT, segmentInfos, ctx));
+  }
+
+  public void testAppendOnlyDoesNotFilterInfos() throws IOException {
+    RecordingMergePolicy inner = new RecordingMergePolicy(new TieredMergePolicy());
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(inner);
+    SegmentInfos segmentInfos = infos(clean("_0"), clean("_1"), clean("_2"));
+    find(policy, segmentInfos);
+    assertSame(segmentInfos, inner.lastInfos);
+  }
+
+  public void testBelowFloorSkipped() throws IOException {
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(noNaturalMerges());
+    MergeSpecification spec =
+        find(
+            policy,
+            infos(
+                cleanBelowFloor("_0"), cleanBelowFloor("_1"), cleanBelowFloor("_2"), dirty("_3")));
+    assertNull(spec);
+  }
+
+  public void testSizeTierTooSkewedWithDefaultMin() throws IOException {
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(noNaturalMerges());
+    MergeSpecification spec =
+        find(
+            policy,
+            infos(
+                clean("_0", ABOVE_FLOOR_MB),
+                clean("_1", ABOVE_FLOOR_MB * 1.2),
+                clean("_2", ABOVE_FLOOR_MB * 5),
+                dirty("_3")));
+    assertNull(spec);
+  }
+
+  public void testCombinedSizeOverMaxBytes() throws IOException {
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(noNaturalMerges());
+    policy.setMaxProactiveMergeBytes(30 * ONE_MB);
+    assertNull(find(policy, infos(clean("_0"), clean("_1"), clean("_2"), dirty("_3"))));
+  }
+
+  public void testOneCleanAndDirtyDoesNotFire() throws IOException {
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(noNaturalMerges());
+    assertNull(find(policy, infos(clean("_0"), dirty("_1"))));
+  }
+
+  public void testAlreadyMergingCleanExcluded() throws IOException {
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(noNaturalMerges());
+    SegmentCommitInfo c0 = clean("_0");
+    MockMergeContext ctx = context();
+    ctx.setMergingSegments(Set.of(c0));
+    assertNull(
+        policy.findMerges(
+            MergeTrigger.EXPLICIT, infos(c0, clean("_1"), clean("_2"), dirty("_3")), ctx));
+  }
+
+  public void testFindFullFlushMergesSkipsLargeClean() throws IOException {
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(noNaturalMerges());
+    policy.setMinProactiveSegmentSize(ONE_MB);
+    assertNull(
+        policy.findFullFlushMerges(
+            MergeTrigger.COMMIT,
+            infos(clean("_0"), clean("_1"), clean("_2"), dirty("_3")),
+            context()));
+  }
+
+  public void testFindFullFlushMergesTakesSmallAboveFloor() throws IOException {
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(noNaturalMerges());
+    policy.setMinProactiveSegmentSize(ONE_MB);
+    double smallMb = 5.0;
+    MergeSpecification spec =
+        policy.findFullFlushMerges(
+            MergeTrigger.COMMIT,
+            infos(
+                clean("_0", smallMb),
+                clean("_1", smallMb),
+                clean("_2", smallMb),
+                dirty("_3", smallMb)),
+            context());
+    assertNotNull(spec);
+    assertEquals(1, spec.merges.size());
+    assertEquals(List.of("_0", "_1", "_2"), names(spec.merges.get(0)));
+  }
+
+  public void testLeftoverSciIdentity() throws IOException {
+    RecordingMergePolicy inner = new RecordingMergePolicy(noNaturalMerges());
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(inner);
+    SegmentCommitInfo dirty = dirty("_3");
+    find(policy, infos(clean("_0"), clean("_1"), clean("_2"), dirty));
+    assertNotNull(inner.lastInfos);
+    assertEquals(1, inner.lastInfos.size());
+    assertSame(dirty, inner.lastInfos.info(0));
+  }
+
+  public void testTmpMixesCleanWithDirtyWhenOverBudget() throws IOException {
+    TieredMergePolicy tmp = overBudgetTmp();
+    MergeSpecification spec =
+        tmp.findMerges(
+            MergeTrigger.EXPLICIT,
+            infos(clean("_0"), clean("_1"), clean("_2"), clean("_3"), clean("_4"), dirty40("_5")),
+            context());
+    assertNotNull("TMP should merge when segsPerTier=2 and 6 same-tier segs exist", spec);
+    assertTrue(
+        "TMP should pair a 0-delete seg with a dirty one when over budget", hasMixedMerge(spec));
+  }
+
+  public void testProactiveDoesNotMixPackableCleansWhenTmpWould() throws IOException {
+    TieredMergePolicy tmp = overBudgetTmp();
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(tmp);
+    MergeSpecification spec =
+        find(
+            policy,
+            infos(clean("_0"), clean("_1"), clean("_2"), clean("_3"), clean("_4"), dirty40("_5")));
+    assertNotNull(spec);
+    assertEquals(List.of("_0", "_1", "_2", "_3", "_4"), names(spec.merges.get(0)));
+    assertFalse(
+        "proactive must not put packable 0-delete segs in a mixed merge", hasMixedMerge(spec));
+  }
+
+  public void testTmpMixesCleanWithOverFortyDirtyWhenOverBudget() throws IOException {
+    TieredMergePolicy tmp = overBudgetTmp();
+    MergeSpecification spec =
+        tmp.findMerges(
+            MergeTrigger.EXPLICIT,
+            infos(
+                clean("_0"),
+                clean("_1"),
+                clean("_2"),
+                clean("_3"),
+                clean("_4"),
+                dirtyOverForty("_5")),
+            context());
+    assertNotNull("TMP should merge when segsPerTier=2 and 6 same-tier segs exist", spec);
+    assertTrue(
+        "TMP should pair a 0-delete seg with a >40%-deleted one when over budget",
+        hasMixedMerge(spec));
+  }
+
+  public void testProactiveDoesNotMixWhenTmpWouldMixOverForty() throws IOException {
+    TieredMergePolicy tmp = overBudgetTmp();
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(tmp);
+    MergeSpecification spec =
+        find(
+            policy,
+            infos(
+                clean("_0"),
+                clean("_1"),
+                clean("_2"),
+                clean("_3"),
+                clean("_4"),
+                dirtyOverForty("_5")));
+    assertNotNull(spec);
+    assertEquals(List.of("_0", "_1", "_2", "_3", "_4"), names(spec.merges.get(0)));
+    assertFalse(
+        "proactive must not put packable 0-delete segs in a mixed merge", hasMixedMerge(spec));
+  }
+
+  public void testForcedMergesEqualInner() throws IOException {
+    TieredMergePolicy tmp = new TieredMergePolicy();
+    ProactiveCleanMergePolicy policy = new ProactiveCleanMergePolicy(tmp);
+    SegmentInfos segmentInfos = infos(clean("_0"), clean("_1"), dirty("_2"), dirty("_3"));
+    Map<SegmentCommitInfo, Boolean> segmentsToMerge = new HashMap<>();
+    for (SegmentCommitInfo sci : segmentInfos) {
+      segmentsToMerge.put(sci, Boolean.TRUE);
+    }
+    MockMergeContext ctx = context();
+    assertSameSpecification(
+        tmp.findForcedMerges(segmentInfos, 1, segmentsToMerge, ctx),
+        policy.findForcedMerges(segmentInfos, 1, segmentsToMerge, ctx));
+  }
+
+  public void testLiveAppendOnlyMatchesTmp() throws IOException {
+    int maxBufferedDocs = 20;
+    int numDocs = 200;
+    List<Integer> tmpLayout = indexAndSnapshot(new TieredMergePolicy(), maxBufferedDocs, numDocs);
+    List<Integer> proactiveLayout =
+        indexAndSnapshot(
+            new ProactiveCleanMergePolicy(new TieredMergePolicy()), maxBufferedDocs, numDocs);
+    assertEquals(tmpLayout, proactiveLayout);
+  }
+
+  public void testLiveMixedProactiveTakesCleanGroup() throws IOException {
+    int maxBufferedDocs = 10;
+    ProactiveCleanMergePolicy proactive = new ProactiveCleanMergePolicy(new TieredMergePolicy());
+    proactive.setMinProactiveSegmentSize(0);
+    MixingRecorder recorder = new MixingRecorder(proactive);
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = liveWriterConfig(recorder, maxBufferedDocs);
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        for (int i = 0; i < 40; i++) {
+          w.addDocument(idDoc(i));
+        }
+        // Partial deletes so the dirty flush stays live (100% deleted segs are dropped).
+        for (int i = 0; i < 5; i++) {
+          w.deleteDocuments(new Term("id", Integer.toString(i)));
+        }
+        for (int i = 40; i < 70; i++) {
+          w.addDocument(idDoc(i));
+        }
+        w.flush();
+        w.maybeMerge();
+      }
+    }
+    assertFalse(
+        "proactive merge must not mix 0-delete segs into dirty ones when a legal group exists",
+        recorder.sawMixedMergeWhileCleanGroupExisted);
+    assertTrue(
+        "expected a clean proactive group once deletes mixed the index",
+        recorder.sawCleanProactiveGroup);
+  }
+
+  private List<Integer> indexAndSnapshot(MergePolicy mergePolicy, int maxBufferedDocs, int numDocs)
+      throws IOException {
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwc = liveWriterConfig(mergePolicy, maxBufferedDocs);
+      try (IndexWriter w = new IndexWriter(dir, iwc)) {
+        for (int i = 0; i < numDocs; i++) {
+          w.addDocument(new Document());
+        }
+      }
+      return segmentMaxDocs(dir);
+    }
+  }
+
+  private IndexWriterConfig liveWriterConfig(MergePolicy mergePolicy, int maxBufferedDocs) {
+    IndexWriterConfig iwc = new IndexWriterConfig(new MockAnalyzer(random()));
+    iwc.setMergePolicy(mergePolicy);
+    iwc.setMergeScheduler(new SerialMergeScheduler());
+    iwc.setMaxBufferedDocs(maxBufferedDocs);
+    iwc.setRAMBufferSizeMB(IndexWriterConfig.DISABLE_AUTO_FLUSH);
+    iwc.setCodec(TestUtil.getDefaultCodec());
+    iwc.setUseCompoundFile(false);
+    return iwc;
+  }
+
+  private static Document idDoc(int id) {
+    Document doc = new Document();
+    doc.add(new StringField("id", Integer.toString(id), Field.Store.NO));
+    return doc;
+  }
+
+  private static List<Integer> segmentMaxDocs(Directory dir) throws IOException {
+    try (DirectoryReader reader = DirectoryReader.open(dir)) {
+      List<Integer> maxDocs = new ArrayList<>();
+      for (LeafReaderContext leaf : reader.leaves()) {
+        maxDocs.add(leaf.reader().maxDoc());
+      }
+      Collections.sort(maxDocs);
+      return maxDocs;
+    }
+  }
+
+  private MergeSpecification find(ProactiveCleanMergePolicy policy, SegmentInfos infos)
+      throws IOException {
+    return policy.findMerges(MergeTrigger.EXPLICIT, infos, context());
+  }
+
+  private static MockMergeContext context() {
+    return new MockMergeContext(SegmentCommitInfo::getDelCount);
+  }
+
+  private SegmentCommitInfo clean(String name) {
+    return clean(name, ABOVE_FLOOR_MB);
+  }
+
+  private SegmentCommitInfo clean(String name, double sizeMB) {
+    return makeSegmentCommitInfo(name, 1000, 0, sizeMB, IndexWriter.SOURCE_FLUSH);
+  }
+
+  private SegmentCommitInfo cleanBelowFloor(String name) {
+    return makeSegmentCommitInfo(name, 1000, 0, BELOW_FLOOR_MB, IndexWriter.SOURCE_FLUSH);
+  }
+
+  private SegmentCommitInfo dirty(String name) {
+    return dirty(name, ABOVE_FLOOR_MB);
+  }
+
+  private SegmentCommitInfo dirty(String name, double sizeMB) {
+    return makeSegmentCommitInfo(name, 1000, 100, sizeMB, IndexWriter.SOURCE_FLUSH);
+  }
+
+  private SegmentCommitInfo dirty40(String name) {
+    return makeSegmentCommitInfo(name, 1000, 400, ABOVE_FLOOR_MB, IndexWriter.SOURCE_FLUSH);
+  }
+
+  /** 50% deleted: above HNSW's 40% base-graph cutoff, still large enough for TMP's 1.5x rule. */
+  private SegmentCommitInfo dirtyOverForty(String name) {
+    return makeSegmentCommitInfo(name, 1000, 500, ABOVE_FLOOR_MB, IndexWriter.SOURCE_FLUSH);
+  }
+
+  private static TieredMergePolicy overBudgetTmp() {
+    TieredMergePolicy tmp = new TieredMergePolicy();
+    tmp.setSegmentsPerTier(2);
+    tmp.setTargetSearchConcurrency(1);
+    return tmp;
+  }
+
+  private static boolean hasMixedMerge(MergeSpecification spec) {
+    for (OneMerge merge : spec.merges) {
+      boolean clean = false;
+      boolean dirty = false;
+      for (SegmentCommitInfo sci : merge.segments) {
+        if (sci.getDelCount() == 0) {
+          clean = true;
+        } else {
+          dirty = true;
+        }
+      }
+      if (clean && dirty) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static SegmentInfos infos(SegmentCommitInfo... scis) {
+    SegmentInfos segmentInfos = new SegmentInfos(Version.LATEST.major);
+    for (SegmentCommitInfo sci : scis) {
+      segmentInfos.add(sci);
+    }
+    return segmentInfos;
+  }
+
+  private static List<String> names(OneMerge merge) {
+    List<String> names = new ArrayList<>();
+    for (SegmentCommitInfo sci : merge.segments) {
+      names.add(sci.info.name);
+    }
+    return names;
+  }
+
+  private static Set<String> names(SegmentInfos infos) {
+    Set<String> names = new HashSet<>();
+    for (SegmentCommitInfo sci : infos) {
+      names.add(sci.info.name);
+    }
+    return names;
+  }
+
+  private static void assertSameSpecification(
+      MergeSpecification expected, MergeSpecification actual) {
+    if (expected == null) {
+      assertNull(actual);
+      return;
+    }
+    assertNotNull(actual);
+    assertEquals(expected.merges.size(), actual.merges.size());
+    for (int i = 0; i < expected.merges.size(); i++) {
+      assertEquals(names(expected.merges.get(i)), names(actual.merges.get(i)));
+    }
+  }
+
+  /**
+   * Wrapped TMP that never proposes natural merges, so tests can observe only proactive {@link
+   * OneMerge}s. {@link #size} still delegates to TMP.
+   */
+  private static MergePolicy noNaturalMerges() {
+    return new FilterMergePolicy(new TieredMergePolicy()) {
+      @Override
+      public MergeSpecification findMerges(
+          MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext) {
+        return null;
+      }
+
+      @Override
+      public MergeSpecification findFullFlushMerges(
+          MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext) {
+        return null;
+      }
+    };
+  }
+
+  private static final class RecordingMergePolicy extends FilterMergePolicy {
+    SegmentInfos lastInfos;
+
+    RecordingMergePolicy(MergePolicy in) {
+      super(in);
+    }
+
+    @Override
+    public MergeSpecification findMerges(
+        MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext)
+        throws IOException {
+      lastInfos = segmentInfos;
+      return in.findMerges(mergeTrigger, segmentInfos, mergeContext);
+    }
+
+    @Override
+    public MergeSpecification findFullFlushMerges(
+        MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext)
+        throws IOException {
+      lastInfos = segmentInfos;
+      return in.findFullFlushMerges(mergeTrigger, segmentInfos, mergeContext);
+    }
+  }
+
+  /**
+   * Notes whether a legal 0-delete group existed at merge-selection time and whether the returned
+   * spec mixed those clean segments with dirty ones.
+   */
+  private static final class MixingRecorder extends FilterMergePolicy {
+    boolean sawMixedMergeWhileCleanGroupExisted;
+    boolean sawCleanProactiveGroup;
+
+    MixingRecorder(MergePolicy in) {
+      super(in);
+    }
+
+    @Override
+    public MergeSpecification findMerges(
+        MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext)
+        throws IOException {
+      MergeSpecification spec = in.findMerges(mergeTrigger, segmentInfos, mergeContext);
+      inspect(spec, segmentInfos, mergeContext);
+      return spec;
+    }
+
+    @Override
+    public MergeSpecification findFullFlushMerges(
+        MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext)
+        throws IOException {
+      MergeSpecification spec = in.findFullFlushMerges(mergeTrigger, segmentInfos, mergeContext);
+      inspect(spec, segmentInfos, mergeContext);
+      return spec;
+    }
+
+    private void inspect(
+        MergeSpecification spec, SegmentInfos segmentInfos, MergeContext mergeContext)
+        throws IOException {
+      int clean = 0;
+      int dirty = 0;
+      for (SegmentCommitInfo sci : segmentInfos) {
+        if (mergeContext.getMergingSegments().contains(sci)) {
+          continue;
+        }
+        if (mergeContext.numDeletesToMerge(sci) == 0) {
+          clean++;
+        } else {
+          dirty++;
+        }
+      }
+      boolean groupPossible = clean >= 3 && dirty > 0;
+      if (spec == null || groupPossible == false) {
+        return;
+      }
+      for (OneMerge merge : spec.merges) {
+        int mergeClean = 0;
+        int mergeDirty = 0;
+        for (SegmentCommitInfo sci : merge.segments) {
+          if (mergeContext.numDeletesToMerge(sci) == 0) {
+            mergeClean++;
+          } else {
+            mergeDirty++;
+          }
+        }
+        // Mixing 3+ packable cleans with dirty segs is the failure mode; 1 leftover clean
+        // handed to TMP is allowed.
+        if (mergeClean >= 3 && mergeDirty > 0) {
+          sawMixedMergeWhileCleanGroupExisted = true;
+        }
+        if (mergeClean >= 3 && mergeDirty == 0) {
+          sawCleanProactiveGroup = true;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The current merge policy was designed for documents, preferring merging of segments with deletes. For vectors, combining segments with no deletes is preferable since it preserves the eligibility for join-set merge path instead of doing a full rebuild.

Hence this PR which extends the merge policy to allow different strategies to be used based when picking up the segments to merge.