### PR TITLE
Fix LRUQueryCache hashCode/equals contract and account query RAM once per distinct query

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -214,6 +214,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
+* GITHUB#16657: Fix hashCode/equals contract violation in LRUQueryCache's QueryCacheKey. (Sagar Upadhyaya)
+
 * GITHUB#16553: Fix stored-fields corruption when PerField#finish throws: the stored-fields frame
   was left open, causing "Wrote N docs, finish called with numDocs=M" at flush. (Michael Marshall)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -214,7 +214,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
-* GITHUB#16657: Fix hashCode/equals contract violation in LRUQueryCache's QueryCacheKey. (Sagar Upadhyaya)
+* GITHUB#16657: Fix hashCode/equals contract violation in LRUQueryCache's QueryCacheKey and account a
+  cached query's RAM once per distinct query. (Sagar Upadhyaya)
 
 * GITHUB#16553: Fix stored-fields corruption when PerField#finish throws: the stored-fields frame
   was left open, causing "Wrote N docs, finish called with numDocs=M" at flush. (Michael Marshall)

--- a/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/LRUQueryCacheBenchmark.java
+++ b/lucene/benchmark-jmh/src/java/org/apache/lucene/benchmark/jmh/LRUQueryCacheBenchmark.java
@@ -38,6 +38,7 @@ import org.openjdk.jmh.annotations.Group;
 import org.openjdk.jmh.annotations.GroupThreads;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -56,18 +57,26 @@ public class LRUQueryCacheBenchmark {
 
   private static final int SEGMENTS = 50;
 
+  // 16 = partitioned; 1 = single global lock (proxy for the pre-partition 10.x cache).
+  @Param({"16", "1"})
+  public int numberOfPartitions;
+
   private Query[] queries;
   private IndexReader.CacheHelper[] cacheHelpers;
 
   private LRUQueryCache.CacheAndCount sampleCacheAndCount;
   private LRUQueryCache queryCache;
+  // Small cap so the working set overflows and eviction fires continuously.
+  private static final long EVICTING_MAX_RAM_BYTES = 8L * 1024 * 1024; // 8MB
+  private LRUQueryCache evictingCache;
   private int[] zipfKeys;
   private int[] zipfKeysForInvalidation;
   private AtomicBoolean[] invalidated;
   private final AtomicLong lastInvalidateNs = new AtomicLong(0);
   private static final long INVALIDATE_INTERVAL_NS = TimeUnit.MILLISECONDS.toNanos(2000);
-  private static final long CACHE_BACKGROUND_CLEANUP_INTERVAL_NS =
-      TimeUnit.MILLISECONDS.toNanos(1000);
+  // CacheCleanUpParameters expects milliseconds; keep this small so background cleanup actually
+  // runs during a benchmark iteration.
+  private static final long CACHE_BACKGROUND_CLEANUP_INTERVAL_MS = 100;
 
   @Setup
   public void setup() {
@@ -87,7 +96,7 @@ public class LRUQueryCacheBenchmark {
     }
     LRUQueryCache.CacheCleanUpParameters cacheCleanUpParameters =
         new LRUQueryCache.CacheCleanUpParameters(
-            CACHE_BACKGROUND_CLEANUP_INTERVAL_NS,
+            CACHE_BACKGROUND_CLEANUP_INTERVAL_MS,
             new ScheduledThreadPoolExecutor(1, new DefaultCleanUpThreadFactory()));
     queryCache =
         new LRUQueryCache(
@@ -95,8 +104,12 @@ public class LRUQueryCacheBenchmark {
             MAX_SIZE_IN_BYTES * 16,
             _ -> true,
             100000,
-            16,
+            numberOfPartitions,
             cacheCleanUpParameters);
+
+    evictingCache =
+        new LRUQueryCache(
+            MAX_SIZE, EVICTING_MAX_RAM_BYTES, _ -> true, 100000, numberOfPartitions, null);
 
     this.queries = new Query[MAX_SIZE];
     for (int i = 0; i < MAX_SIZE; i++) {
@@ -136,6 +149,7 @@ public class LRUQueryCacheBenchmark {
     assert queryCache.getCacheSize() >= 0;
     assert queryCache.getCacheCount() > 0;
     assert queryCache.ramBytesUsed() >= 0;
+    evictingCache.clear();
     queryCache.clear();
     assert queryCache.getCacheSize() == 0;
     assert queryCache.ramBytesUsed() == 0;
@@ -148,6 +162,43 @@ public class LRUQueryCacheBenchmark {
     int random = ThreadLocalRandom.current().nextInt(MAX_SIZE);
     queryCache.putIfAbsent(
         queries[random], this.sampleCacheAndCount, cacheHelpers[random & (SEGMENTS - 1)]);
+  }
+
+  // Eviction under contention: random (query, segment) over the full space against a small cache,
+  // so the working set overflows and evictIfNecessary fires on almost every insert. Put-heavy.
+  @Benchmark
+  @Group("evictionHeavy")
+  @GroupThreads(8)
+  public void evictionHeavy_putIfAbsent() {
+    int q = ThreadLocalRandom.current().nextInt(MAX_SIZE);
+    int seg = ThreadLocalRandom.current().nextInt(SEGMENTS);
+    evictingCache.putIfAbsent(queries[q], this.sampleCacheAndCount, cacheHelpers[seg]);
+  }
+
+  @Benchmark
+  @Group("evictionHeavy")
+  @GroupThreads(2)
+  public LRUQueryCache.CacheAndCount evictionHeavy_get() {
+    int q = ThreadLocalRandom.current().nextInt(MAX_SIZE);
+    int seg = ThreadLocalRandom.current().nextInt(SEGMENTS);
+    return evictingCache.get(queries[q], cacheHelpers[seg]);
+  }
+
+  // Worst case for query-only routing: one hot query, so all its entries share a single partition.
+  @Benchmark
+  @Group("hotSingleQuery")
+  @GroupThreads(6)
+  public LRUQueryCache.CacheAndCount hotSingleQuery_get() {
+    int seg = ThreadLocalRandom.current().nextInt(SEGMENTS);
+    return queryCache.get(queries[0], cacheHelpers[seg]);
+  }
+
+  @Benchmark
+  @Group("hotSingleQuery")
+  @GroupThreads(4)
+  public void hotSingleQuery_putIfAbsent() {
+    int seg = ThreadLocalRandom.current().nextInt(SEGMENTS);
+    queryCache.putIfAbsent(queries[0], this.sampleCacheAndCount, cacheHelpers[seg]);
   }
 
   @Benchmark

--- a/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
@@ -1210,17 +1210,18 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
 
     IndexReader.CacheKey cacheKey;
     Query query;
+    private final int hash;
 
     QueryCacheKey(IndexReader.CacheKey cacheKey, Query query) {
       this.cacheKey = cacheKey;
       this.query = query;
+      int res = System.identityHashCode(cacheKey);
+      this.hash = 31 * res + query.hashCode();
     }
 
     @Override
     public int hashCode() {
-      int res = System.identityHashCode(cacheKey);
-      res = 31 * res + System.identityHashCode(query);
-      return res;
+      return hash;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
@@ -421,8 +421,9 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
     assert key instanceof BoostQuery == false;
     assert key instanceof ConstantScoreQuery == false;
     final IndexReader.CacheKey readerKey = cacheHelper.getKey();
-    QueryCacheKey queryCacheKey = new QueryCacheKey(readerKey, key);
-    int partitionNumber = getPartitionNumber(queryCacheKey);
+    final int queryHash = key.hashCode();
+    QueryCacheKey queryCacheKey = new QueryCacheKey(readerKey, key, queryHash);
+    int partitionNumber = queryHash & (this.numberOfPartitions - 1);
     return this.lruQueryCachePartition[partitionNumber].get(queryCacheKey, key, cacheHelper);
   }
 
@@ -430,10 +431,12 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
     assert query instanceof BoostQuery == false;
     assert query instanceof ConstantScoreQuery == false;
     final IndexReader.CacheKey key = cacheHelper.getKey();
-    QueryCacheKey queryCacheKey = new QueryCacheKey(key, query);
-    int partitionNumber = getPartitionNumber(queryCacheKey);
+    // This saves computing the hash twice for the cache lookup and the routing.
+    final int queryHash = query.hashCode();
+    QueryCacheKey queryCacheKey = new QueryCacheKey(key, query, queryHash);
+    int partitionNumber = queryHash & (this.numberOfPartitions - 1);
     this.lruQueryCachePartition[partitionNumber].putIfAbsent(
-        queryCacheKey, query, cacheHelper, cached);
+        queryCacheKey, query, queryHash, cacheHelper, cached);
   }
 
   /** Remove all cache entries for the given core cache key. */
@@ -459,10 +462,12 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
     onClear();
   }
 
-  private static long getRamBytesUsed(Query query) {
+  // Deep RAM cost of the query object itself. This is accounted once per distinct query in a
+  // partition (see LRUQueryCachePartition#uniqueQueries), not once per (segment, query) cache
+  // entry, because a query cached across N segments is a single shared Query instance on the heap.
+  private static long queryRamBytesUsed(Query query) {
     // Here 32 represents a rough shallow size for a query object
-    long queryRamBytesUsed = RamUsageEstimator.sizeOf(query, 32);
-    return LINKED_HASHTABLE_RAM_BYTES_PER_ENTRY + queryRamBytesUsed;
+    return RamUsageEstimator.sizeOf(query, 32);
   }
 
   // pkg-private for testing
@@ -501,6 +506,11 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
         }
         for (CacheAndCount cached : this.lruQueryCachePartition[i].cache.values()) {
           recomputedRamBytesUsed += cached.ramBytesUsed();
+        }
+        // Query objects are accounted once per distinct query, not per entry.
+        for (LRUQueryCachePartition.QueryRef ref :
+            this.lruQueryCachePartition[i].uniqueQueries.values()) {
+          recomputedRamBytesUsed += ref.queryBytes;
         }
         if (recomputedRamBytesUsed != this.lruQueryCachePartition[i].ramBytesUsed) {
           throw new AssertionError(
@@ -936,6 +946,14 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
     private volatile long cacheSize;
     private final Map<QueryCacheKey, LRUQueryCache.CacheAndCount> cache;
 
+    // Distinct queries held by this partition, keyed by value. Because routing is by query alone,
+    // every (segment, query) entry for a given query lands in this partition, so this map sees all
+    // of them. It canonicalizes queries to a single shared instance and reference-counts how many
+    // cache entries use each one, so the query object is accounted exactly once. Any mutation
+    // operations
+    // happen under the write lock.
+    private final Map<Query, QueryRef> uniqueQueries;
+
     LRUQueryCachePartition(int maxSize, long maxRamBytesUsed) {
       ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
       writeLock = lock.writeLock();
@@ -945,7 +963,58 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
       this.maxSize = maxSize;
       this.maxRamBytesUsed = maxRamBytesUsed;
       cache = new HashMap<>();
+      uniqueQueries = new HashMap<>();
       this.ramBytesUsed = 0;
+    }
+
+    /**
+     * Canonical instance of a query held by this partition, plus a reference count of the cache
+     * entries (one per segment) that use it and the RAM cost of the query object.
+     */
+    private static final class QueryRef {
+      final Query canonical;
+      final long queryBytes;
+      int refCount;
+
+      QueryRef(Query canonical, long queryBytes) {
+        this.canonical = canonical;
+        this.queryBytes = queryBytes;
+      }
+    }
+
+    /**
+     * Resolve {@code query} to this partition's canonical instance for that value, incrementing its
+     * reference count (creating the entry on the first reference). Does not touch {@link
+     * #ramBytesUsed}; callers add the query bytes to it on the first reference (when the returned
+     * ref's count is 1). Must be called under the write lock. Returns the {@link QueryRef}.
+     */
+    private QueryRef acquireQuery(Query query) {
+      assert writeLock.isHeldByCurrentThread();
+      QueryRef ref = uniqueQueries.get(query);
+      if (ref == null) {
+        ref = new QueryRef(query, queryRamBytesUsed(query));
+        uniqueQueries.put(query, ref);
+      }
+      ref.refCount++;
+      return ref;
+    }
+
+    /**
+     * Drop one reference to {@code query}'s canonical instance. On the last reference (1 -&gt; 0)
+     * the query is removed and its query bytes are returned so the caller can subtract them from
+     * {@link #ramBytesUsed}; otherwise returns 0. Must be called under the write lock.
+     */
+    private long releaseQuery(Query query) {
+      assert writeLock.isHeldByCurrentThread();
+      QueryRef ref = uniqueQueries.get(query);
+      if (ref == null) {
+        return 0;
+      }
+      if (--ref.refCount == 0) {
+        uniqueQueries.remove(query);
+        return ref.queryBytes;
+      }
+      return 0;
     }
 
     void setMaxSize(int maxSize) {
@@ -1012,32 +1081,46 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
     void putIfAbsent(
         QueryCacheKey queryCacheKey,
         Query query,
+        int queryHash,
         IndexReader.CacheHelper cacheHelper,
         LRUQueryCache.CacheAndCount cached) {
       assert query instanceof BoostQuery == false;
       assert query instanceof ConstantScoreQuery == false;
 
-      // Pre-calculate values outside lock
-      long ramBytes = queryCacheKey.ramBytesUsed();
+      // Pre-calculate values outside lock. perEntryBytes is the query-independent per-entry
+      // overhead; the query object is accounted separately, once per distinct query.
+      long perEntryBytes = queryCacheKey.ramBytesUsed();
       IndexReader.CacheKey cacheKey = cacheHelper.getKey();
       long cachedValueBytesUsed = HASHTABLE_RAM_BYTES_PER_ENTRY + cached.ramBytesUsed();
 
       writeLock.lock();
       try {
-        // Use putIfAbsent return value to determine if insertion actually happened
-        LRUQueryCache.CacheAndCount existing = cache.putIfAbsent(queryCacheKey, cached);
-        if (existing != null) {
-          // Entry already exists, no work needed
+        // Entry already cached: skip canonicalization and the reference count.
+        if (cache.containsKey(queryCacheKey)) {
           return;
         }
 
-        // Only execute side effects when insertion actually occurred
-        QueryMetadata metadata = new QueryMetadata(queryCacheKey.query, ramBytes);
-        uniqueCacheKeys.putIfAbsent(queryCacheKey, metadata);
-        onQueryCache(queryCacheKey, ramBytes);
+        // Absent: canonicalize the query to this partition's shared instance and store the entry
+        // under it, so every segment's entry for this query references a single Query object. We
+        // only acquire a reference on this path, so there is nothing to undo.
+        QueryRef ref = acquireQuery(query);
+        boolean firstReference = ref.refCount == 1;
+        Query canonical = ref.canonical;
+        QueryCacheKey key =
+            canonical == queryCacheKey.query
+                ? queryCacheKey
+                : new QueryCacheKey(cacheKey, canonical, queryHash);
+
+        cache.put(key, cached);
+
+        // Account the query object only on the first entry that references it in this partition.
+        long queryBytes = perEntryBytes + (firstReference ? ref.queryBytes : 0);
+        QueryMetadata metadata = new QueryMetadata(canonical, perEntryBytes);
+        uniqueCacheKeys.putIfAbsent(key, metadata);
+        onQueryCache(key, queryBytes);
         onDocIdSetCache(cacheKey, cachedValueBytesUsed);
         LRUQueryCache.this.onCacheEntryInserted(
-            cacheKey, queryCacheKey.query, ramBytes + cachedValueBytesUsed);
+            cacheKey, canonical, queryBytes + cachedValueBytesUsed);
         evictIfNecessary();
       } finally {
         writeLock.unlock();
@@ -1060,11 +1143,12 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
     }
 
     /**
-     * Remove a cache entry. If {@code knownQueryBytes} is non-negative, it is used as the query RAM
-     * cost (for cases where the uniqueCacheKeys entry was already removed externally, e.g. during
-     * eviction). Otherwise the query bytes are looked up from uniqueCacheKeys.
+     * Remove a cache entry. {@code knownPerEntryBytes} &gt;= 0 means the caller already removed the
+     * {@code uniqueCacheKeys} entry (e.g. eviction) and passes its per-entry overhead; otherwise it
+     * is removed here. The query's reference count is dropped, and the query bytes are subtracted
+     * from {@link #ramBytesUsed} when its last entry goes.
      */
-    private void remove(QueryCacheKey queryCacheKey, long knownQueryBytes) {
+    private void remove(QueryCacheKey queryCacheKey, long knownPerEntryBytes) {
       writeLock.lock();
       try {
         CacheAndCount cacheAndCount = cache.remove(queryCacheKey);
@@ -1073,16 +1157,23 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
           docIdSetBytes = HASHTABLE_RAM_BYTES_PER_ENTRY + cacheAndCount.ramBytesUsed();
           onDocIdSetEviction(queryCacheKey.cacheKey, 1, docIdSetBytes);
         }
-        long queryBytes = 0;
-        if (knownQueryBytes >= 0) {
-          // Query bytes already accounted for by caller (e.g. evictIfNecessary)
-          queryBytes = knownQueryBytes;
+        long perEntryBytes;
+        boolean tracked;
+        if (knownPerEntryBytes >= 0) {
+          perEntryBytes = knownPerEntryBytes;
+          tracked = true;
         } else {
           QueryMetadata queryMetadata = uniqueCacheKeys.remove(queryCacheKey);
-          if (queryMetadata != null && queryMetadata.query != null) {
-            queryBytes = queryMetadata.queryRamBytesUsed;
-            onQueryEviction(queryCacheKey, queryBytes);
-          }
+          tracked = queryMetadata != null && queryMetadata.query != null;
+          perEntryBytes = tracked ? queryMetadata.queryRamBytesUsed : 0;
+        }
+        long queryBytes = 0;
+        if (tracked) {
+          // Drop this entry's reference to the query; reclaim the query bytes on the last
+          // reference.
+          long releasedQueryBytes = releaseQuery(queryCacheKey.query);
+          queryBytes = perEntryBytes + releasedQueryBytes;
+          onQueryEviction(queryCacheKey, queryBytes);
         }
         if (cacheAndCount != null || queryBytes > 0) {
           LRUQueryCache.this.onCacheEntryEvicted(
@@ -1100,6 +1191,7 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
         // Note that this also clears the uniqueCacheKeys map since mostRecentlyUsedCacheKeys is the
         // uniqueCacheKeys.keySet view:
         mostRecentlyUsedCacheKeys.clear();
+        uniqueQueries.clear();
         onClear();
       } finally {
         writeLock.unlock();
@@ -1146,7 +1238,6 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
                     + entry.getKey()
                     + "]");
           }
-          onQueryEviction(entry.getKey(), entry.getValue().queryRamBytesUsed);
           remove(entry.getKey(), entry.getValue().queryRamBytesUsed);
         } while (iterator.hasNext() && requiresEviction());
       }
@@ -1172,7 +1263,15 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
   }
 
   public int getPartitionNumber(QueryCacheKey queryCacheKey) {
-    return queryCacheKey.hashCode() & (this.numberOfPartitions - 1);
+    return getPartitionNumber(queryCacheKey.query);
+  }
+
+  // Route to a partition by the query alone (not the segment), so that every (segment, query) entry
+  // for a given query lands in the same partition. This lets each partition maintain a complete,
+  // cache-wide view of the queries it holds (see uniqueQueries), which is what makes per-partition
+  // query canonicalization and count-once RAM accounting correct.
+  private int getPartitionNumber(Query query) {
+    return query.hashCode() & (this.numberOfPartitions - 1);
   }
 
   /** Cache of doc ids with a count. */
@@ -1213,10 +1312,15 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
     private final int hash;
 
     QueryCacheKey(IndexReader.CacheKey cacheKey, Query query) {
+      this(cacheKey, query, query.hashCode());
+    }
+
+    // Variant that reuses an already-computed query.hashCode() to avoid recomputing it (query
+    // hashing, e.g. murmur over term bytes, is a hot cost on get/putIfAbsent).
+    QueryCacheKey(IndexReader.CacheKey cacheKey, Query query, int queryHash) {
       this.cacheKey = cacheKey;
       this.query = query;
-      int res = System.identityHashCode(cacheKey);
-      this.hash = 31 * res + query.hashCode();
+      this.hash = 31 * System.identityHashCode(cacheKey) + queryHash;
     }
 
     @Override
@@ -1236,7 +1340,9 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
 
     @Override
     public long ramBytesUsed() {
-      return BASE_RAM_BYTES_USED + getRamBytesUsed(query);
+      // Per-entry overhead only: the QueryCacheKey object plus its slot in the uniqueCacheKeys
+      // LinkedHashMap. The query object is accounted separately, once per distinct query.
+      return BASE_RAM_BYTES_USED + LINKED_HASHTABLE_RAM_BYTES_PER_ENTRY;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LRUQueryCache.java
@@ -950,8 +950,7 @@ public class LRUQueryCache implements QueryCache, Accountable, Closeable {
     // every (segment, query) entry for a given query lands in this partition, so this map sees all
     // of them. It canonicalizes queries to a single shared instance and reference-counts how many
     // cache entries use each one, so the query object is accounted exactly once. Any mutation
-    // operations
-    // happen under the write lock.
+    // operations happen under the write lock.
     private final Map<Query, QueryRef> uniqueQueries;
 
     LRUQueryCachePartition(int maxSize, long maxRamBytesUsed) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -2748,6 +2748,55 @@ public class TestLRUQueryCache extends LuceneTestCase {
     queryCache.close();
   }
 
+  // A re-query with a fresh-but-value-equal Query instance must hit the cache: QueryCacheKey's
+  // hashCode must be derived from query.hashCode() to stay consistent with its value-based
+  // equals().
+  public void testReQueryWithEqualButDistinctQueryInstanceHits() throws IOException {
+    try (Directory dir = newDirectory();
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+      Document doc = new Document();
+      doc.add(new StringField("color", "red", Store.NO));
+      w.addDocument(doc);
+      w.forceMerge(1);
+      try (IndexReader reader = w.getReader()) {
+        // single segment, so the reader core cache key is stable across the two queries
+        assertEquals(1, reader.leaves().size());
+        final IndexSearcher searcher = newSearcher(reader);
+
+        final AtomicLong hitCount = new AtomicLong();
+        final AtomicLong missCount = new AtomicLong();
+        final LRUQueryCache queryCache =
+            new LRUQueryCache(1000000, 10000000, _ -> true, Float.POSITIVE_INFINITY) {
+              @Override
+              protected void onHit(Object readerCoreKey, Query query) {
+                super.onHit(readerCoreKey, query);
+                hitCount.incrementAndGet();
+              }
+
+              @Override
+              protected void onMiss(Object readerCoreKey, Query query) {
+                super.onMiss(readerCoreKey, query);
+                missCount.incrementAndGet();
+              }
+            };
+        searcher.setQueryCache(queryCache);
+        searcher.setQueryCachingPolicy(ALWAYS_CACHE);
+
+        // First request caches the doc-id set for this (segment, query).
+        searcher.search(new ConstantScoreQuery(new TermQuery(new Term("color", "red"))), 1);
+        assertEquals(0, hitCount.longValue());
+        assertEquals(1, missCount.longValue());
+
+        // Second request uses a distinct-but-value-equal Query instance. It must hit.
+        searcher.search(new ConstantScoreQuery(new TermQuery(new Term("color", "red"))), 1);
+        assertEquals(1, hitCount.longValue());
+        assertEquals(1, missCount.longValue());
+
+        queryCache.close();
+      }
+    }
+  }
+
   public static class DefaultCleanUpThreadFactory implements ThreadFactory {
     private final String namePrefix;
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestLRUQueryCache.java
@@ -653,6 +653,9 @@ public class TestLRUQueryCache extends LuceneTestCase {
     var expectedRamBytesUsed =
         HASHTABLE_RAM_BYTES_PER_ENTRY
             + queryCacheKey.ramBytesUsed()
+            // The query object is accounted once per distinct query, separately from the per-entry
+            // key overhead (here there is a single segment, so a single entry).
+            + RamUsageEstimator.sizeOf(accountableQuery, 32)
             + queryCache.getChildResources().iterator().next().ramBytesUsed();
     assertEquals(expectedRamBytesUsed, queryCache.ramBytesUsed());
     queryCache.assertConsistent();
@@ -2748,9 +2751,6 @@ public class TestLRUQueryCache extends LuceneTestCase {
     queryCache.close();
   }
 
-  // A re-query with a fresh-but-value-equal Query instance must hit the cache: QueryCacheKey's
-  // hashCode must be derived from query.hashCode() to stay consistent with its value-based
-  // equals().
   public void testReQueryWithEqualButDistinctQueryInstanceHits() throws IOException {
     try (Directory dir = newDirectory();
         RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
@@ -2759,7 +2759,6 @@ public class TestLRUQueryCache extends LuceneTestCase {
       w.addDocument(doc);
       w.forceMerge(1);
       try (IndexReader reader = w.getReader()) {
-        // single segment, so the reader core cache key is stable across the two queries
         assertEquals(1, reader.leaves().size());
         final IndexSearcher searcher = newSearcher(reader);
 
@@ -2782,16 +2781,90 @@ public class TestLRUQueryCache extends LuceneTestCase {
         searcher.setQueryCache(queryCache);
         searcher.setQueryCachingPolicy(ALWAYS_CACHE);
 
-        // First request caches the doc-id set for this (segment, query).
         searcher.search(new ConstantScoreQuery(new TermQuery(new Term("color", "red"))), 1);
         assertEquals(0, hitCount.longValue());
         assertEquals(1, missCount.longValue());
 
-        // Second request uses a distinct-but-value-equal Query instance. It must hit.
+        // second request uses a distinct-but-value-equal Query instance
         searcher.search(new ConstantScoreQuery(new TermQuery(new Term("color", "red"))), 1);
         assertEquals(1, hitCount.longValue());
         assertEquals(1, missCount.longValue());
 
+        queryCache.close();
+      }
+    }
+  }
+
+  private static IndexReader twoSegmentIndex(Directory dir, String term) throws IOException {
+    IndexWriterConfig iwc = new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE);
+    try (IndexWriter w = new IndexWriter(dir, iwc)) {
+      for (int i = 0; i < 2; i++) {
+        Document doc = new Document();
+        doc.add(new StringField("f", term, Store.NO));
+        w.addDocument(doc);
+        w.commit(); // separate segment per doc
+      }
+      IndexReader reader = DirectoryReader.open(w);
+      assertEquals(2, reader.leaves().size());
+      return reader;
+    }
+  }
+
+  public void testQueryRamAccountedOncePerDistinctQuery() throws IOException {
+    try (Directory dir = newDirectory()) {
+      // large term so the query bytes dominate per-entry and doc-id-set overhead
+      String bigTerm = "x".repeat(4000);
+      try (IndexReader reader = twoSegmentIndex(dir, bigTerm)) {
+        IndexSearcher searcher = new IndexSearcher(reader);
+        LRUQueryCache queryCache =
+            new LRUQueryCache(100, 100_000_000, _ -> true, Float.POSITIVE_INFINITY);
+        searcher.setQueryCache(queryCache);
+        searcher.setQueryCachingPolicy(ALWAYS_CACHE);
+
+        TermQuery query = new TermQuery(new Term("f", bigTerm));
+        long queryBytes = RamUsageEstimator.sizeOf(query, 32);
+
+        searcher.search(new ConstantScoreQuery(query), 1);
+
+        assertEquals("cached on both segments", 2, queryCache.getCacheSize());
+        assertTrue(
+            "query bytes should be counted at least once", queryCache.ramBytesUsed() >= queryBytes);
+        assertTrue(
+            "query bytes must not be double-counted across segments: "
+                + queryCache.ramBytesUsed()
+                + " should be < 2x "
+                + queryBytes,
+            queryCache.ramBytesUsed() < 2 * queryBytes);
+        queryCache.assertConsistent();
+        queryCache.close();
+      }
+    }
+  }
+
+  public void testCanonicalQueryInstanceSharedAcrossSegments() throws IOException {
+    try (Directory dir = newDirectory()) {
+      try (IndexReader reader = twoSegmentIndex(dir, "red")) {
+        LRUQueryCache queryCache =
+            new LRUQueryCache(100, 100_000_000, _ -> true, Float.POSITIVE_INFINITY);
+
+        IndexReader.CacheHelper h0 = reader.leaves().get(0).reader().getCoreCacheHelper();
+        IndexReader.CacheHelper h1 = reader.leaves().get(1).reader().getCoreCacheHelper();
+
+        Query qA = new TermQuery(new Term("f", "red"));
+        Query qB = new TermQuery(new Term("f", "red"));
+        assertNotSame(qA, qB);
+
+        queryCache.putIfAbsent(qA, new LRUQueryCache.CacheAndCount(DocIdSet.EMPTY, 0), h0);
+        queryCache.putIfAbsent(qB, new LRUQueryCache.CacheAndCount(DocIdSet.EMPTY, 0), h1);
+
+        Map<LRUQueryCache.QueryCacheKey, LRUQueryCache.QueryMetadata> unique =
+            queryCache.getUniqueQueries();
+        assertEquals("one entry per segment", 2, unique.size());
+        Query[] queries = unique.keySet().stream().map(k -> k.query).toArray(Query[]::new);
+        assertSame(
+            "both segment entries should share one canonical Query instance despite distinct inputs",
+            queries[0],
+            queries[1]);
         queryCache.close();
       }
     }


### PR DESCRIPTION
### Description

LRUQueryCache was recently refactored (releasing in Lucene 11.0) to partition the cache, and its key structure was changed into a composite one (QueryCacheKey).

I found a bug in QueryCacheKey: it compares queries by value in equals() but hashes them with System.identityHashCode(query), breaking the hashCode/equals contract. For example, we cache new TermQuery("color","red") and then look it up with another equal new TermQuery("color","red"). The two are equal, but their identity hashes differ, so the lookup resolves to the wrong partition (or the wrong bucket within that partition's HashMap) and misses. In practice this neutered the cache.

The PR first fixes that by hashing on query.hashCode() so it matches equals(), and memoizing the composite hash to avoid recomputing it. 

As part of the PR review, we also found issues where query bytes were over-counted as we were not tracking the canonical representation of the query. So now we route each query to a single partition (by the query alone rather than (segment, query)) and canonicalizes it there to one shared Query instance, so a query cached across many segments is no longer duplicated. This in turn lets the cache account a query's RAM once per distinct query instead of once per (segment, query) entry, fixing an over-count that inflated ramBytesUsed and caused premature eviction as a result.

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
