### PR TITLE
Skip blocks without decompressing them when reading selected stored fields.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
@@ -275,6 +275,7 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
             public int readBytesUpTo(byte[] b, int offset, int len) throws IOException {
               int read = 0;
               while (len > bytes.length) {
+                // TODO: can we decompress into b directly, without copy by bytes?
                 System.arraycopy(bytes.bytes, bytes.offset, b, offset, bytes.length);
                 read += bytes.length;
                 len -= bytes.length;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
@@ -23,6 +23,8 @@ import java.util.zip.Inflater;
 import org.apache.lucene.codecs.compressing.CompressionMode;
 import org.apache.lucene.codecs.compressing.Compressor;
 import org.apache.lucene.codecs.compressing.Decompressor;
+import org.apache.lucene.codecs.lucene90.compressing.Lucene90DecompressingDataInput;
+import org.apache.lucene.codecs.lucene90.compressing.Lucene90SkippableDecompressor;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.store.ByteBuffersDataInput;
 import org.apache.lucene.store.DataInput;
@@ -65,7 +67,8 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
     return "BEST_COMPRESSION";
   }
 
-  private static final class DeflateWithPresetDictDecompressor extends Decompressor {
+  private static final class DeflateWithPresetDictDecompressor extends Decompressor
+      implements Lucene90SkippableDecompressor {
 
     byte[] compressed;
 
@@ -73,11 +76,12 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
       compressed = new byte[0];
     }
 
-    private void doDecompress(DataInput in, Inflater decompressor, BytesRef bytes)
+    private int doDecompress(
+        DataInput in, Inflater decompressor, byte[] bytes, int offset, int length)
         throws IOException {
       final int compressedLength = in.readVInt();
       if (compressedLength == 0) {
-        return;
+        return 0;
       }
       // pad with extra "dummy byte": see javadocs for using Inflater(true)
       // we do it for compliance, but it's unnecessary for years in zlib.
@@ -88,9 +92,9 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
 
       // extra "dummy byte"
       decompressor.setInput(compressed, 0, paddedLength);
+      final int decompressedLength;
       try {
-        bytes.length +=
-            decompressor.inflate(bytes.bytes, bytes.length, bytes.bytes.length - bytes.length);
+        decompressedLength = decompressor.inflate(bytes, offset, length);
       } catch (DataFormatException e) {
         throw new IOException(e);
       }
@@ -102,6 +106,14 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
                 + decompressor.needsDictionary(),
             in);
       }
+      return decompressedLength;
+    }
+
+    private void doDecompress(DataInput in, Inflater decompressor, BytesRef bytes)
+        throws IOException {
+      bytes.length +=
+          doDecompress(
+              in, decompressor, bytes.bytes, bytes.length, bytes.bytes.length - bytes.length);
     }
 
     @Override
@@ -151,6 +163,185 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
       } finally {
         decompressor.end();
       }
+    }
+
+    @Override
+    public Lucene90DecompressingDataInput decompressingDataInput(
+        DataInput in, int originalLength, int offset, int length) throws IOException {
+      assert offset + length <= originalLength;
+
+      // TODO: more simple way to handle this case?
+      if (length == 0) {
+        return new Lucene90DecompressingDataInput() {
+          @Override
+          public byte readByte() throws IOException {
+            throw new java.io.EOFException();
+          }
+
+          @Override
+          public void readBytes(byte[] b, int offset, int len) throws IOException {
+            if (len != 0) {
+              throw new java.io.EOFException();
+            }
+          }
+
+          @Override
+          public long skipBytesUpTo(long numBytes) {
+            return 0;
+          }
+        };
+      }
+
+      final int dictLength = in.readVInt();
+      final int blockLength = in.readVInt();
+      final byte[] dictionary = new byte[dictLength];
+      Inflater decompressor = new Inflater(true);
+      try {
+        final int decompressedDictLength =
+            doDecompress(in, decompressor, dictionary, 0, dictLength);
+        if (dictLength != decompressedDictLength) {
+          throw new CorruptIndexException("Unexpected dict length", in);
+        }
+      } finally {
+        decompressor.end();
+      }
+
+      final int endOffset = offset + length;
+      final BytesRef bytes = new BytesRef();
+      bytes.offset = bytes.length = 0;
+
+      int offsetInBlock = dictLength;
+      int offsetInBytesRef = offset;
+      if (offset < dictLength) {
+        bytes.bytes = ArrayUtil.growNoCopy(bytes.bytes, dictLength);
+        System.arraycopy(dictionary, 0, bytes.bytes, 0, dictLength);
+        bytes.length = dictLength;
+      } else {
+        offsetInBytesRef -= dictLength;
+        while (offsetInBlock + blockLength < offset) {
+          final int compressedLength = in.readVInt();
+          in.skipBytes(compressedLength);
+          offsetInBlock += blockLength;
+          offsetInBytesRef -= blockLength;
+        }
+      }
+
+      final int startOffsetInBlock = offsetInBlock;
+      final int startOffsetInBytesRef = offsetInBytesRef;
+
+      // This dataInput skip sub-blocks within a slice.
+      Lucene90DecompressingDataInput dataInput =
+          new Lucene90DecompressingDataInput() {
+
+            int offsetInBlock = startOffsetInBlock;
+
+            private void decompressSubBlock() throws IOException {
+              if (bytes.length != 0 || offsetInBlock >= endOffset) {
+                return;
+              }
+              final int blockBytes = Math.min(blockLength, originalLength - offsetInBlock);
+              final int bytesToExpose = Math.min(blockBytes, endOffset - offsetInBlock);
+              assert bytesToExpose > 0;
+              bytes.bytes = ArrayUtil.growNoCopy(bytes.bytes, blockBytes);
+              bytes.offset = bytes.length = 0;
+              Inflater decompressor = new Inflater(true);
+              try {
+                decompressor.setDictionary(dictionary, 0, dictLength);
+                final int decompressedLength =
+                    doDecompress(in, decompressor, bytes.bytes, 0, blockBytes);
+                if (decompressedLength != blockBytes) {
+                  throw new CorruptIndexException("Unexpected block length", in);
+                }
+                bytes.length = bytesToExpose;
+              } finally {
+                decompressor.end();
+              }
+              offsetInBlock += blockBytes;
+            }
+
+            @Override
+            public byte readByte() throws IOException {
+              if (bytes.length == 0) {
+                decompressSubBlock();
+              }
+              if (bytes.length == 0) {
+                throw new java.io.EOFException();
+              }
+              bytes.length--;
+              return bytes.bytes[bytes.offset++];
+            }
+
+            @Override
+            public int readBytesUpTo(byte[] b, int offset, int len) throws IOException {
+              int read = 0;
+              while (len > bytes.length) {
+                System.arraycopy(bytes.bytes, bytes.offset, b, offset, bytes.length);
+                read += bytes.length;
+                len -= bytes.length;
+                offset += bytes.length;
+                bytes.offset += bytes.length;
+                bytes.length = 0;
+                decompressSubBlock();
+                if (bytes.length == 0) {
+                  return read;
+                }
+              }
+              System.arraycopy(bytes.bytes, bytes.offset, b, offset, len);
+              bytes.offset += len;
+              bytes.length -= len;
+              read += len;
+              return read;
+            }
+
+            @Override
+            public long skipBytesUpTo(long numBytes) throws IOException {
+              if (numBytes < 0) {
+                throw new IllegalArgumentException("numBytes must be >= 0, got " + numBytes);
+              }
+              if (numBytes <= bytes.length) {
+                bytes.offset += numBytes;
+                bytes.length -= numBytes;
+                return numBytes;
+              }
+
+              long skipped = bytes.length;
+              bytes.offset += bytes.length;
+              bytes.length = 0;
+
+              while (skipped < numBytes && offsetInBlock < endOffset) {
+                final int currentBlockLength = Math.min(blockLength, endOffset - offsetInBlock);
+                if (currentBlockLength <= 0) {
+                  break;
+                }
+                final long remaining = numBytes - skipped;
+                if (currentBlockLength <= remaining) {
+                  // Skip the entire block without decompressing it.
+                  final int compressedLength = in.readVInt();
+                  in.skipBytes(compressedLength);
+                  //                  System.out.println(
+                  //                      "skip compressed block: "
+                  //                          + 0
+                  //                          + ", original length: "
+                  //                          + currentBlockLength
+                  //                          + ", compressed length: "
+                  //                          + compressedLength);
+                  offsetInBlock += currentBlockLength;
+                  skipped += currentBlockLength;
+                } else {
+                  // Skip finished, decompress current sub block.
+                  decompressSubBlock();
+                  final int bytesToSkip = Math.toIntExact(remaining);
+                  bytes.offset += bytesToSkip;
+                  bytes.length -= bytesToSkip;
+                  skipped += bytesToSkip;
+                }
+              }
+
+              return skipped;
+            }
+          };
+      dataInput.skipBytes(startOffsetInBytesRef);
+      return dataInput;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeflateWithPresetDictCompressionMode.java
@@ -244,6 +244,8 @@ public final class DeflateWithPresetDictCompressionMode extends CompressionMode 
               assert bytesToExpose > 0;
               bytes.bytes = ArrayUtil.growNoCopy(bytes.bytes, blockBytes);
               bytes.offset = bytes.length = 0;
+              // TODO: Reuse Inflater across sub-blocks, or even across slices. ensure to call
+              // end().
               Inflater decompressor = new Inflater(true);
               try {
                 decompressor.setDictionary(dictionary, 0, dictLength);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import org.apache.lucene.codecs.compressing.CompressionMode;
 import org.apache.lucene.codecs.compressing.Compressor;
 import org.apache.lucene.codecs.compressing.Decompressor;
+import org.apache.lucene.codecs.lucene90.compressing.Lucene90DecompressingDataInput;
+import org.apache.lucene.codecs.lucene90.compressing.Lucene90SkippableDecompressor;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.store.ByteBuffersDataInput;
 import org.apache.lucene.store.ByteBuffersDataOutput;
@@ -60,7 +62,8 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
     return "BEST_SPEED";
   }
 
-  private static final class LZ4WithPresetDictDecompressor extends Decompressor {
+  private static final class LZ4WithPresetDictDecompressor extends Decompressor
+      implements Lucene90SkippableDecompressor {
 
     private int[] compressedLengths;
     private byte[] buffer;
@@ -142,6 +145,170 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
       bytes.offset = offsetInBytesRef;
       bytes.length = length;
       assert bytes.isValid();
+    }
+
+    @Override
+    public Lucene90DecompressingDataInput decompressingDataInput(
+        DataInput in, int originalLength, int offset, int length) throws IOException {
+      assert offset + length <= originalLength;
+
+      // TODO: more simple way to handle this case?
+      if (length == 0) {
+        return new Lucene90DecompressingDataInput() {
+          @Override
+          public byte readByte() throws IOException {
+            throw new java.io.EOFException();
+          }
+
+          @Override
+          public void readBytes(byte[] b, int offset, int len) throws IOException {
+            if (len != 0) {
+              throw new java.io.EOFException();
+            }
+          }
+
+          @Override
+          public long skipBytesUpTo(long numBytes) {
+            return 0;
+          }
+        };
+      }
+
+      final int dictLength = in.readVInt();
+      final int blockLength = in.readVInt();
+      final int numBlocks = readCompressedLengths(in, originalLength, dictLength, blockLength);
+
+      buffer = ArrayUtil.growNoCopy(buffer, dictLength + blockLength);
+      final BytesRef bytes = new BytesRef();
+      bytes.length = 0;
+      if (LZ4.decompress(in, dictLength, buffer, 0) != dictLength) {
+        throw new CorruptIndexException("Illegal dict length", in);
+      }
+
+      int offsetInBlock = dictLength;
+      int offsetInBytesRef = offset;
+      int numBlocksConsumed = 0;
+      if (offset >= dictLength) {
+        offsetInBytesRef -= dictLength;
+
+        int numBytesToSkip = 0;
+        for (int i = 0; i < numBlocks && offsetInBlock + blockLength < offset; ++i) {
+          numBytesToSkip += compressedLengths[i];
+          offsetInBlock += blockLength;
+          offsetInBytesRef -= blockLength;
+          numBlocksConsumed++;
+        }
+        in.skipBytes(numBytesToSkip);
+      } else {
+        bytes.bytes = ArrayUtil.growNoCopy(bytes.bytes, dictLength);
+        System.arraycopy(buffer, 0, bytes.bytes, 0, dictLength);
+        bytes.length = dictLength;
+      }
+
+      final int endOffset = offset + length;
+      final int[] compressedLengths = this.compressedLengths;
+      final byte[] buffer = this.buffer;
+      final int startOffsetInBlock = offsetInBlock;
+      final int startOffsetInBytesRef = offsetInBytesRef;
+      final int startNumBlocksConsumed = numBlocksConsumed;
+
+      Lucene90DecompressingDataInput dataInput =
+          new Lucene90DecompressingDataInput() {
+
+            int offsetInBlock = startOffsetInBlock;
+            int numBlocksConsumed = startNumBlocksConsumed;
+
+            private void decompressSubBlock() throws IOException {
+              if (bytes.length != 0 || offsetInBlock >= endOffset) {
+                return;
+              }
+              final int bytesToDecompress = Math.min(blockLength, endOffset - offsetInBlock);
+              assert bytesToDecompress > 0;
+              LZ4.decompress(in, bytesToDecompress, buffer, dictLength);
+              bytes.bytes = ArrayUtil.growNoCopy(bytes.bytes, bytesToDecompress);
+              System.arraycopy(buffer, dictLength, bytes.bytes, 0, bytesToDecompress);
+              bytes.offset = 0;
+              bytes.length = bytesToDecompress;
+              offsetInBlock += bytesToDecompress;
+              numBlocksConsumed++;
+            }
+
+            @Override
+            public byte readByte() throws IOException {
+              if (bytes.length == 0) {
+                decompressSubBlock();
+              }
+              if (bytes.length == 0) {
+                throw new java.io.EOFException();
+              }
+              bytes.length--;
+              return bytes.bytes[bytes.offset++];
+            }
+
+            @Override
+            public int readBytesUpTo(byte[] b, int offset, int len) throws IOException {
+              int read = 0;
+              while (len > bytes.length) {
+                System.arraycopy(bytes.bytes, bytes.offset, b, offset, bytes.length);
+                read += bytes.length;
+                len -= bytes.length;
+                offset += bytes.length;
+                bytes.offset += bytes.length;
+                bytes.length = 0;
+                decompressSubBlock();
+                if (bytes.length == 0) {
+                  return read;
+                }
+              }
+              System.arraycopy(bytes.bytes, bytes.offset, b, offset, len);
+              bytes.offset += len;
+              bytes.length -= len;
+              read += len;
+              return read;
+            }
+
+            @Override
+            public long skipBytesUpTo(long numBytes) throws IOException {
+              if (numBytes < 0) {
+                throw new IllegalArgumentException("numBytes must be >= 0, got " + numBytes);
+              }
+              if (numBytes <= bytes.length) {
+                bytes.offset += numBytes;
+                bytes.length -= numBytes;
+                return numBytes;
+              }
+
+              long skipped = bytes.length;
+              bytes.offset += bytes.length;
+              bytes.length = 0;
+
+              while (skipped < numBytes && numBlocksConsumed < numBlocks) {
+                final int currentBlockLength = Math.min(blockLength, endOffset - offsetInBlock);
+                if (currentBlockLength <= 0) {
+                  break;
+                }
+                final long remaining = numBytes - skipped;
+                if (currentBlockLength <= remaining) {
+                  // Skip the entire block without decompressing it.
+                  in.skipBytes(compressedLengths[numBlocksConsumed]);
+                  offsetInBlock += currentBlockLength;
+                  numBlocksConsumed++;
+                  skipped += currentBlockLength;
+                } else {
+                  // Skip finished, decompress current sub block.
+                  decompressSubBlock();
+                  final int bytesToSkip = Math.toIntExact(remaining);
+                  bytes.offset += bytesToSkip;
+                  bytes.length -= bytesToSkip;
+                  skipped += bytesToSkip;
+                }
+              }
+
+              return skipped;
+            }
+          };
+      dataInput.skipBytes(startOffsetInBytesRef);
+      return dataInput;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -250,6 +250,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
             public int readBytesUpTo(byte[] b, int offset, int len) throws IOException {
               int read = 0;
               while (len > bytes.length) {
+                // TODO: can we decompress into b directly, without copy by bytes?
                 System.arraycopy(bytes.bytes, bytes.offset, b, offset, bytes.length);
                 read += bytes.length;
                 len -= bytes.length;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -212,6 +212,7 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
       final int startOffsetInBytesRef = offsetInBytesRef;
       final int startNumBlocksConsumed = numBlocksConsumed;
 
+      // This dataInput skip sub-blocks within a slice.
       Lucene90DecompressingDataInput dataInput =
           new Lucene90DecompressingDataInput() {
 
@@ -291,6 +292,13 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
                 if (currentBlockLength <= remaining) {
                   // Skip the entire block without decompressing it.
                   in.skipBytes(compressedLengths[numBlocksConsumed]);
+                  System.out.println(
+                      "skip compressed block: "
+                          + numBlocksConsumed
+                          + ", original length: "
+                          + currentBlockLength
+                          + ", compressed length: "
+                          + compressedLengths[numBlocksConsumed]);
                   offsetInBlock += currentBlockLength;
                   numBlocksConsumed++;
                   skipped += currentBlockLength;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4WithPresetDictCompressionMode.java
@@ -292,13 +292,13 @@ public final class LZ4WithPresetDictCompressionMode extends CompressionMode {
                 if (currentBlockLength <= remaining) {
                   // Skip the entire block without decompressing it.
                   in.skipBytes(compressedLengths[numBlocksConsumed]);
-                  System.out.println(
-                      "skip compressed block: "
-                          + numBlocksConsumed
-                          + ", original length: "
-                          + currentBlockLength
-                          + ", compressed length: "
-                          + compressedLengths[numBlocksConsumed]);
+                  //                  System.out.println(
+                  //                      "skip compressed block: "
+                  //                          + numBlocksConsumed
+                  //                          + ", original length: "
+                  //                          + currentBlockLength
+                  //                          + ", compressed length: "
+                  //                          + compressedLengths[numBlocksConsumed]);
                   offsetInBlock += currentBlockLength;
                   numBlocksConsumed++;
                   skipped += currentBlockLength;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
@@ -555,6 +555,72 @@ public final class Lucene90CompressingStoredFieldsReader extends StoredFieldsRea
       } else if (merging) {
         // already decompressed
         documentInput = new ByteArrayDataInput(bytes.bytes, bytes.offset + offset, length);
+      } else if (sliced
+          && decompressor instanceof Lucene90SkippableDecompressor skippableDecompressor) {
+        fieldsStream.seek(startPointer);
+        final int firstLength = Math.min(length, chunkSize - offset);
+        final Lucene90DecompressingDataInput firstInput =
+            skippableDecompressor.decompressingDataInput(
+                fieldsStream, chunkSize, offset, firstLength);
+        documentInput =
+            new Lucene90DecompressingDataInput() {
+
+              Lucene90DecompressingDataInput input = firstInput;
+              int decompressed = firstLength;
+
+              void loadNextSlice() throws IOException {
+                if (decompressed == length) {
+                  throw new EOFException();
+                }
+                final int toDecompress = Math.min(length - decompressed, chunkSize);
+                input =
+                    skippableDecompressor.decompressingDataInput(
+                        fieldsStream, toDecompress, 0, toDecompress);
+                decompressed += toDecompress;
+              }
+
+              @Override
+              public byte readByte() throws IOException {
+                try {
+                  return input.readByte();
+                } catch (EOFException _) {
+                  loadNextSlice();
+                  return input.readByte();
+                }
+              }
+
+              @Override
+              public void readBytes(byte[] b, int offset, int len) throws IOException {
+                while (len > 0) {
+                  final int actualRead = input.readBytesUpTo(b, offset, len);
+                  if (actualRead == len) {
+                    return;
+                  }
+                  offset += actualRead;
+                  len -= actualRead;
+                  loadNextSlice();
+                }
+              }
+
+              @Override
+              public long skipBytesUpTo(long numBytes) throws IOException {
+                if (numBytes < 0) {
+                  throw new IllegalArgumentException("numBytes must be >= 0, got " + numBytes);
+                }
+                long skipped = 0;
+                while (skipped < numBytes) {
+                  final long actualSkipped = input.skipBytesUpTo(numBytes - skipped);
+                  skipped += actualSkipped;
+                  if (skipped == numBytes || decompressed == length) {
+                    return skipped;
+                  }
+
+                  // Load next slice to skip.
+                  loadNextSlice();
+                }
+                return skipped;
+              }
+            };
       } else if (sliced) {
         fieldsStream.seek(startPointer);
         decompressor.decompress(

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
@@ -285,7 +285,7 @@ public final class Lucene90CompressingStoredFieldsReader extends StoredFieldsRea
   }
 
   private static void skipField(DataInput in, int bits) throws IOException {
-    System.out.println("skipField: bits=" + Integer.toHexString(bits));
+    //    System.out.println("skipField: bits=" + Integer.toHexString(bits));
     switch (bits & TYPE_MASK) {
       case BYTE_ARR:
       case STRING:
@@ -564,10 +564,11 @@ public final class Lucene90CompressingStoredFieldsReader extends StoredFieldsRea
               skippableDecompressor.decompressingDataInput(
                   fieldsStream, chunkSize, offset, firstLength);
 
-          // This dataInput iterate slices and skip them by slice input.
+          // This dataInput iterate slices and skip them by current slice's dataInput.
           documentInput =
               new Lucene90DecompressingDataInput() {
 
+                // Current slice's dateInput.
                 Lucene90DecompressingDataInput input = firstInput;
                 int decompressed = firstLength;
 
@@ -612,7 +613,7 @@ public final class Lucene90CompressingStoredFieldsReader extends StoredFieldsRea
                   }
                   long skipped = 0;
                   while (skipped < numBytes) {
-                    // Use slice input to skip sub-blocks.
+                    // Use current slice's dataInput to skip sub-blocks.
                     final long actualSkipped = input.skipBytesUpTo(numBytes - skipped);
                     skipped += actualSkipped;
                     if (skipped == numBytes || decompressed == length) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java
@@ -285,6 +285,7 @@ public final class Lucene90CompressingStoredFieldsReader extends StoredFieldsRea
   }
 
   private static void skipField(DataInput in, int bits) throws IOException {
+    System.out.println("skipField: bits=" + Integer.toHexString(bits));
     switch (bits & TYPE_MASK) {
       case BYTE_ARR:
       case STRING:
@@ -555,131 +556,142 @@ public final class Lucene90CompressingStoredFieldsReader extends StoredFieldsRea
       } else if (merging) {
         // already decompressed
         documentInput = new ByteArrayDataInput(bytes.bytes, bytes.offset + offset, length);
-      } else if (sliced
-          && decompressor instanceof Lucene90SkippableDecompressor skippableDecompressor) {
-        fieldsStream.seek(startPointer);
-        final int firstLength = Math.min(length, chunkSize - offset);
-        final Lucene90DecompressingDataInput firstInput =
-            skippableDecompressor.decompressingDataInput(
-                fieldsStream, chunkSize, offset, firstLength);
-        documentInput =
-            new Lucene90DecompressingDataInput() {
-
-              Lucene90DecompressingDataInput input = firstInput;
-              int decompressed = firstLength;
-
-              void loadNextSlice() throws IOException {
-                if (decompressed == length) {
-                  throw new EOFException();
-                }
-                final int toDecompress = Math.min(length - decompressed, chunkSize);
-                input =
-                    skippableDecompressor.decompressingDataInput(
-                        fieldsStream, toDecompress, 0, toDecompress);
-                decompressed += toDecompress;
-              }
-
-              @Override
-              public byte readByte() throws IOException {
-                try {
-                  return input.readByte();
-                } catch (EOFException _) {
-                  loadNextSlice();
-                  return input.readByte();
-                }
-              }
-
-              @Override
-              public void readBytes(byte[] b, int offset, int len) throws IOException {
-                while (len > 0) {
-                  final int actualRead = input.readBytesUpTo(b, offset, len);
-                  if (actualRead == len) {
-                    return;
-                  }
-                  offset += actualRead;
-                  len -= actualRead;
-                  loadNextSlice();
-                }
-              }
-
-              @Override
-              public long skipBytesUpTo(long numBytes) throws IOException {
-                if (numBytes < 0) {
-                  throw new IllegalArgumentException("numBytes must be >= 0, got " + numBytes);
-                }
-                long skipped = 0;
-                while (skipped < numBytes) {
-                  final long actualSkipped = input.skipBytesUpTo(numBytes - skipped);
-                  skipped += actualSkipped;
-                  if (skipped == numBytes || decompressed == length) {
-                    return skipped;
-                  }
-
-                  // Load next slice to skip.
-                  loadNextSlice();
-                }
-                return skipped;
-              }
-            };
       } else if (sliced) {
-        fieldsStream.seek(startPointer);
-        decompressor.decompress(
-            fieldsStream, chunkSize, offset, Math.min(length, chunkSize - offset), bytes);
-        documentInput =
-            new DataInput() {
+        if (decompressor instanceof Lucene90SkippableDecompressor skippableDecompressor) {
+          fieldsStream.seek(startPointer);
+          final int firstLength = Math.min(length, chunkSize - offset);
+          final Lucene90DecompressingDataInput firstInput =
+              skippableDecompressor.decompressingDataInput(
+                  fieldsStream, chunkSize, offset, firstLength);
 
-              int decompressed = bytes.length;
+          // This dataInput iterate slices and skip them by slice input.
+          documentInput =
+              new Lucene90DecompressingDataInput() {
 
-              void fillBuffer() throws IOException {
-                assert decompressed <= length;
-                if (decompressed == length) {
-                  throw new EOFException();
-                }
-                final int toDecompress = Math.min(length - decompressed, chunkSize);
-                decompressor.decompress(fieldsStream, toDecompress, 0, toDecompress, bytes);
-                decompressed += toDecompress;
-              }
+                Lucene90DecompressingDataInput input = firstInput;
+                int decompressed = firstLength;
 
-              @Override
-              public byte readByte() throws IOException {
-                if (bytes.length == 0) {
-                  fillBuffer();
+                void loadNextSlice() throws IOException {
+                  if (decompressed == length) {
+                    throw new EOFException();
+                  }
+                  final int toDecompress = Math.min(length - decompressed, chunkSize);
+                  input =
+                      skippableDecompressor.decompressingDataInput(
+                          fieldsStream, toDecompress, 0, toDecompress);
+                  decompressed += toDecompress;
                 }
-                --bytes.length;
-                return bytes.bytes[bytes.offset++];
-              }
 
-              @Override
-              public void readBytes(byte[] b, int offset, int len) throws IOException {
-                while (len > bytes.length) {
-                  System.arraycopy(bytes.bytes, bytes.offset, b, offset, bytes.length);
-                  len -= bytes.length;
-                  offset += bytes.length;
-                  fillBuffer();
+                @Override
+                public byte readByte() throws IOException {
+                  try {
+                    return input.readByte();
+                  } catch (EOFException _) {
+                    loadNextSlice();
+                    return input.readByte();
+                  }
                 }
-                System.arraycopy(bytes.bytes, bytes.offset, b, offset, len);
-                bytes.offset += len;
-                bytes.length -= len;
-              }
 
-              @Override
-              public void skipBytes(long numBytes) throws IOException {
-                if (numBytes < 0) {
-                  throw new IllegalArgumentException("numBytes must be >= 0, got " + numBytes);
+                @Override
+                public void readBytes(byte[] b, int offset, int len) throws IOException {
+                  while (len > 0) {
+                    final int actualRead = input.readBytesUpTo(b, offset, len);
+                    if (actualRead == len) {
+                      return;
+                    }
+                    offset += actualRead;
+                    len -= actualRead;
+                    loadNextSlice();
+                  }
                 }
-                while (numBytes > bytes.length) {
-                  numBytes -= bytes.length;
-                  fillBuffer();
+
+                @Override
+                public long skipBytesUpTo(long numBytes) throws IOException {
+                  if (numBytes < 0) {
+                    throw new IllegalArgumentException("numBytes must be >= 0, got " + numBytes);
+                  }
+                  long skipped = 0;
+                  while (skipped < numBytes) {
+                    // Use slice input to skip sub-blocks.
+                    final long actualSkipped = input.skipBytesUpTo(numBytes - skipped);
+                    skipped += actualSkipped;
+                    if (skipped == numBytes || decompressed == length) {
+                      return skipped;
+                    }
+
+                    // Load next slice to skip.
+                    loadNextSlice();
+                  }
+                  return skipped;
                 }
-                bytes.offset += numBytes;
-                bytes.length -= numBytes;
-              }
-            };
+              };
+        } else {
+          fieldsStream.seek(startPointer);
+          decompressor.decompress(
+              fieldsStream, chunkSize, offset, Math.min(length, chunkSize - offset), bytes);
+          documentInput =
+              new DataInput() {
+
+                int decompressed = bytes.length;
+
+                void fillBuffer() throws IOException {
+                  assert decompressed <= length;
+                  if (decompressed == length) {
+                    throw new EOFException();
+                  }
+                  final int toDecompress = Math.min(length - decompressed, chunkSize);
+                  decompressor.decompress(fieldsStream, toDecompress, 0, toDecompress, bytes);
+                  decompressed += toDecompress;
+                }
+
+                @Override
+                public byte readByte() throws IOException {
+                  if (bytes.length == 0) {
+                    fillBuffer();
+                  }
+                  --bytes.length;
+                  return bytes.bytes[bytes.offset++];
+                }
+
+                @Override
+                public void readBytes(byte[] b, int offset, int len) throws IOException {
+                  while (len > bytes.length) {
+                    System.arraycopy(bytes.bytes, bytes.offset, b, offset, bytes.length);
+                    len -= bytes.length;
+                    offset += bytes.length;
+                    fillBuffer();
+                  }
+                  System.arraycopy(bytes.bytes, bytes.offset, b, offset, len);
+                  bytes.offset += len;
+                  bytes.length -= len;
+                }
+
+                @Override
+                public void skipBytes(long numBytes) throws IOException {
+                  if (numBytes < 0) {
+                    throw new IllegalArgumentException("numBytes must be >= 0, got " + numBytes);
+                  }
+                  while (numBytes > bytes.length) {
+                    numBytes -= bytes.length;
+                    fillBuffer();
+                  }
+                  bytes.offset += numBytes;
+                  bytes.length -= numBytes;
+                }
+              };
+        }
       } else {
-        fieldsStream.seek(startPointer);
-        decompressor.decompress(fieldsStream, totalLength, offset, length, bytes);
-        assert bytes.length == length;
-        documentInput = new ByteArrayDataInput(bytes.bytes, bytes.offset, bytes.length);
+        if (decompressor instanceof Lucene90SkippableDecompressor skippableDecompressor) {
+          fieldsStream.seek(startPointer);
+          documentInput =
+              skippableDecompressor.decompressingDataInput(
+                  fieldsStream, totalLength, offset, length);
+        } else {
+          fieldsStream.seek(startPointer);
+          decompressor.decompress(fieldsStream, totalLength, offset, length, bytes);
+          assert bytes.length == length;
+          documentInput = new ByteArrayDataInput(bytes.bytes, bytes.offset, bytes.length);
+        }
       }
 
       return new SerializedDocument(documentInput, length, numStoredFields);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90DecompressingDataInput.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90DecompressingDataInput.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene90.compressing;
+
+import java.io.EOFException;
+import java.io.IOException;
+import org.apache.lucene.store.DataInput;
+
+/**
+ * A {@link DataInput} over decompressed data that can expose partial skip progress.
+ *
+ * @lucene.internal
+ */
+public abstract class Lucene90DecompressingDataInput extends DataInput {
+
+  /**
+   * Skip up to {@code numBytes} decompressed bytes.
+   *
+   * @return the number of bytes that were actually skipped
+   */
+  public abstract long skipBytesUpTo(long numBytes) throws IOException;
+
+  /**
+   * Read up to {@code len} decompressed bytes.
+   *
+   * @return the number of bytes that were actually read
+   */
+  public int readBytesUpTo(byte[] b, int offset, int len) throws IOException {
+    int read = 0;
+    while (read < len) {
+      try {
+        b[offset + read] = readByte();
+        ++read;
+      } catch (EOFException _) {
+        return read;
+      }
+    }
+    return read;
+  }
+
+  @Override
+  public void readBytes(byte[] b, int offset, int len) throws IOException {
+    int read = 0;
+    while (read < len) {
+      final int actualRead = readBytesUpTo(b, offset + read, len - read);
+      if (actualRead == 0) {
+        throw new EOFException();
+      }
+      read += actualRead;
+    }
+  }
+
+  @Override
+  public void skipBytes(long numBytes) throws IOException {
+    if (numBytes < 0) {
+      throw new IllegalArgumentException("numBytes must be >= 0, got " + numBytes);
+    }
+    final long skipped = skipBytesUpTo(numBytes);
+    if (skipped < numBytes) {
+      throw new EOFException();
+    }
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90SkippableDecompressor.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90SkippableDecompressor.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene90.compressing;
+
+import java.io.IOException;
+import org.apache.lucene.store.DataInput;
+
+/**
+ * Optional Lucene90 decompressor API for skipping compressed blocks without decompressing them.
+ *
+ * @lucene.internal
+ */
+public interface Lucene90SkippableDecompressor {
+
+  /**
+   * Decompress bytes that were stored between offsets {@code offset} and {@code offset + length} in
+   * the original stream into a skippable {@link DataInput}.
+   */
+  Lucene90DecompressingDataInput decompressingDataInput(
+      DataInput in, int originalLength, int offset, int length) throws IOException;
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90SkippableDecompressor.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90SkippableDecompressor.java
@@ -29,6 +29,8 @@ public interface Lucene90SkippableDecompressor {
   /**
    * Decompress bytes that were stored between offsets {@code offset} and {@code offset + length} in
    * the original stream into a skippable {@link DataInput}.
+   *
+   * <p>With this {@link DataInput}, you can skip compressed blocks without decompressing them.
    */
   Lucene90DecompressingDataInput decompressingDataInput(
       DataInput in, int originalLength, int offset, int length) throws IOException;

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/compressing/TestCompressingStoredFieldsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/compressing/TestCompressingStoredFieldsFormat.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Random;
 import java.util.Set;
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.CodecReader;
@@ -350,6 +351,88 @@ public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTes
             (Lucene90CompressingStoredFieldsReader) sr.getFieldsReader();
         assertEquals(1, reader.getNumChunks());
         assertEquals(10 * 8 * 1024, reader.getChunkSize());
+        assertTrue(payload1.length + payload2.length < 2 * reader.getChunkSize());
+
+        Document loaded = ir.storedFields().document(0, Set.of("content1", "content2", "content3"));
+        assertEquals(3, loaded.getFields().size());
+        assertEquals("content1", loaded.get("content1"));
+        assertEquals("content2", loaded.get("content2"));
+        assertEquals("content3", loaded.get("content3"));
+      }
+    }
+  }
+
+  public void testSkipDeflateWitSlicedChunk() throws IOException {
+    byte[] payload1 = new byte[atLeast(1 << 20)];
+    for (int i = 0; i < payload1.length; i++) {
+      payload1[i] = (byte) i;
+    }
+
+    byte[] payload2 = new byte[atLeast(1 << 20)];
+    for (int i = 0; i < payload2.length; i++) {
+      payload2[i] = (byte) i;
+    }
+
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwConf = newIndexWriterConfig(new MockAnalyzer(random()));
+      iwConf.setCodec(new Lucene104Codec(Lucene104Codec.Mode.BEST_COMPRESSION));
+      try (IndexWriter iw = new IndexWriter(dir, iwConf)) {
+        Document doc = new Document();
+        doc.add(new StoredField("content1", "content1"));
+        doc.add(new StoredField("payload1", payload1));
+        doc.add(new StoredField("content2", "content2"));
+        doc.add(new StoredField("payload2", payload2));
+        doc.add(new StoredField("content3", "content3"));
+        iw.addDocument(doc);
+      }
+
+      try (DirectoryReader ir = DirectoryReader.open(dir)) {
+        CodecReader sr = (CodecReader) getOnlyLeafReader(ir);
+        Lucene90CompressingStoredFieldsReader reader =
+            (Lucene90CompressingStoredFieldsReader) sr.getFieldsReader();
+        assertEquals(1, reader.getNumChunks());
+        assertEquals(10 * 48 * 1024, reader.getChunkSize());
+        assertTrue(payload1.length + payload2.length > 2 * reader.getChunkSize());
+
+        Document loaded = ir.storedFields().document(0, Set.of("content1", "content2", "content3"));
+        assertEquals(3, loaded.getFields().size());
+        assertEquals("content1", loaded.get("content1"));
+        assertEquals("content2", loaded.get("content2"));
+        assertEquals("content3", loaded.get("content3"));
+      }
+    }
+  }
+
+  public void testSkipDeflateWithUnslicedChunk() throws IOException {
+    byte[] payload1 = new byte[TestUtil.nextInt(random(), 1 << 18, 1 << 19)];
+    for (int i = 0; i < payload1.length; i++) {
+      payload1[i] = (byte) i;
+    }
+
+    byte[] payload2 = new byte[TestUtil.nextInt(random(), 1 << 18, 1 << 19)];
+    for (int i = 0; i < payload2.length; i++) {
+      payload2[i] = (byte) i;
+    }
+
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwConf = newIndexWriterConfig(new MockAnalyzer(random()));
+      iwConf.setCodec(new Lucene104Codec(Lucene104Codec.Mode.BEST_COMPRESSION));
+      try (IndexWriter iw = new IndexWriter(dir, iwConf)) {
+        Document doc = new Document();
+        doc.add(new StoredField("content1", "content1"));
+        doc.add(new StoredField("payload1", payload1));
+        doc.add(new StoredField("content2", "content2"));
+        doc.add(new StoredField("payload2", payload2));
+        doc.add(new StoredField("content3", "content3"));
+        iw.addDocument(doc);
+      }
+
+      try (DirectoryReader ir = DirectoryReader.open(dir)) {
+        CodecReader sr = (CodecReader) getOnlyLeafReader(ir);
+        Lucene90CompressingStoredFieldsReader reader =
+            (Lucene90CompressingStoredFieldsReader) sr.getFieldsReader();
+        assertEquals(1, reader.getNumChunks());
+        assertEquals(10 * 48 * 1024, reader.getChunkSize());
         assertTrue(payload1.length + payload2.length < 2 * reader.getChunkSize());
 
         Document loaded = ir.storedFields().document(0, Set.of("content1", "content2", "content3"));

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/compressing/TestCompressingStoredFieldsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/compressing/TestCompressingStoredFieldsFormat.java
@@ -18,6 +18,7 @@ package org.apache.lucene.codecs.lucene90.compressing;
 
 import java.io.IOException;
 import java.util.Random;
+import java.util.Set;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.StoredField;
@@ -33,6 +34,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.codecs.compressing.CompressingCodec;
 import org.apache.lucene.tests.index.BaseStoredFieldsFormatTestCase;
+import org.apache.lucene.tests.util.TestUtil;
 
 public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTestCase {
 
@@ -275,5 +277,46 @@ public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTes
     ir.close();
     iw.close();
     dir.close();
+  }
+
+  public void testReadFieldAcrossSlices() throws IOException {
+    byte[] payload1 = new byte[atLeast(1 << 18)];
+    for (int i = 0; i < payload1.length; i++) {
+      payload1[i] = (byte) i;
+    }
+
+    byte[] payload2 = new byte[atLeast(1 << 18)];
+    for (int i = 0; i < payload2.length; i++) {
+      payload2[i] = (byte) i;
+    }
+
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwConf = newIndexWriterConfig(new MockAnalyzer(random()));
+      iwConf.setCodec(TestUtil.getDefaultCodec());
+      try (IndexWriter iw = new IndexWriter(dir, iwConf)) {
+        Document doc = new Document();
+        doc.add(new StoredField("content1", "content1"));
+        doc.add(new StoredField("payload1", payload1));
+        doc.add(new StoredField("content2", "content2"));
+        doc.add(new StoredField("payload2", payload2));
+        doc.add(new StoredField("content3", "content3"));
+        iw.addDocument(doc);
+      }
+
+      try (DirectoryReader ir = DirectoryReader.open(dir)) {
+        CodecReader sr = (CodecReader) getOnlyLeafReader(ir);
+        Lucene90CompressingStoredFieldsReader reader =
+            (Lucene90CompressingStoredFieldsReader) sr.getFieldsReader();
+        assertEquals(1, reader.getNumChunks());
+        assertEquals(10 * 8 * 1024, reader.getChunkSize());
+        assertTrue(payload1.length + payload2.length > 2 * reader.getChunkSize());
+
+        Document loaded = ir.storedFields().document(0, Set.of("content1", "content2", "content3"));
+        assertEquals(3, loaded.getFields().size());
+        assertEquals("content1", loaded.get("content1"));
+        assertEquals("content2", loaded.get("content2"));
+        assertEquals("content3", loaded.get("content3"));
+      }
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/compressing/TestCompressingStoredFieldsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/compressing/TestCompressingStoredFieldsFormat.java
@@ -36,6 +36,7 @@ import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.codecs.compressing.CompressingCodec;
 import org.apache.lucene.tests.index.BaseStoredFieldsFormatTestCase;
 import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
 
 public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTestCase {
 
@@ -49,6 +50,15 @@ public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTes
       return CompressingCodec.randomInstance(random());
     } else {
       return CompressingCodec.reasonableInstance(random());
+    }
+  }
+
+  private static void assertStoredBytesEquals(byte[] expected, Document doc, String field) {
+    BytesRef actual = doc.getBinaryValue(field);
+    assertNotNull(actual);
+    assertEquals(expected.length, actual.length);
+    for (int i = 0; i < expected.length; i++) {
+      assertEquals(expected[i], actual.bytes[actual.offset + i]);
     }
   }
 
@@ -315,6 +325,11 @@ public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTes
         assertEquals("content1", loaded.get("content1"));
         assertEquals("content2", loaded.get("content2"));
         assertEquals("content3", loaded.get("content3"));
+
+        loaded = ir.storedFields().document(0, Set.of("payload1", "payload2"));
+        assertEquals(2, loaded.getFields().size());
+        assertStoredBytesEquals(payload1, loaded, "payload1");
+        assertStoredBytesEquals(payload2, loaded, "payload2");
       }
     }
   }
@@ -354,6 +369,11 @@ public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTes
         assertEquals("content1", loaded.get("content1"));
         assertEquals("content2", loaded.get("content2"));
         assertEquals("content3", loaded.get("content3"));
+
+        loaded = ir.storedFields().document(0, Set.of("payload1", "payload2"));
+        assertEquals(2, loaded.getFields().size());
+        assertStoredBytesEquals(payload1, loaded, "payload1");
+        assertStoredBytesEquals(payload2, loaded, "payload2");
       }
     }
   }
@@ -393,6 +413,11 @@ public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTes
         assertEquals("content1", loaded.get("content1"));
         assertEquals("content2", loaded.get("content2"));
         assertEquals("content3", loaded.get("content3"));
+
+        loaded = ir.storedFields().document(0, Set.of("payload1", "payload2"));
+        assertEquals(2, loaded.getFields().size());
+        assertStoredBytesEquals(payload1, loaded, "payload1");
+        assertStoredBytesEquals(payload2, loaded, "payload2");
       }
     }
   }
@@ -432,6 +457,11 @@ public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTes
         assertEquals("content1", loaded.get("content1"));
         assertEquals("content2", loaded.get("content2"));
         assertEquals("content3", loaded.get("content3"));
+
+        loaded = ir.storedFields().document(0, Set.of("payload1", "payload2"));
+        assertEquals(2, loaded.getFields().size());
+        assertStoredBytesEquals(payload1, loaded, "payload1");
+        assertStoredBytesEquals(payload2, loaded, "payload2");
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/compressing/TestCompressingStoredFieldsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/compressing/TestCompressingStoredFieldsFormat.java
@@ -308,8 +308,6 @@ public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTes
         CodecReader sr = (CodecReader) getOnlyLeafReader(ir);
         Lucene90CompressingStoredFieldsReader reader =
             (Lucene90CompressingStoredFieldsReader) sr.getFieldsReader();
-        assertEquals(1, reader.getNumChunks());
-        assertEquals(10 * 8 * 1024, reader.getChunkSize());
         assertTrue(payload1.length + payload2.length > 2 * reader.getChunkSize());
 
         Document loaded = ir.storedFields().document(0, Set.of("content1", "content2", "content3"));
@@ -349,8 +347,6 @@ public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTes
         CodecReader sr = (CodecReader) getOnlyLeafReader(ir);
         Lucene90CompressingStoredFieldsReader reader =
             (Lucene90CompressingStoredFieldsReader) sr.getFieldsReader();
-        assertEquals(1, reader.getNumChunks());
-        assertEquals(10 * 8 * 1024, reader.getChunkSize());
         assertTrue(payload1.length + payload2.length < 2 * reader.getChunkSize());
 
         Document loaded = ir.storedFields().document(0, Set.of("content1", "content2", "content3"));
@@ -390,8 +386,6 @@ public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTes
         CodecReader sr = (CodecReader) getOnlyLeafReader(ir);
         Lucene90CompressingStoredFieldsReader reader =
             (Lucene90CompressingStoredFieldsReader) sr.getFieldsReader();
-        assertEquals(1, reader.getNumChunks());
-        assertEquals(10 * 48 * 1024, reader.getChunkSize());
         assertTrue(payload1.length + payload2.length > 2 * reader.getChunkSize());
 
         Document loaded = ir.storedFields().document(0, Set.of("content1", "content2", "content3"));
@@ -431,8 +425,6 @@ public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTes
         CodecReader sr = (CodecReader) getOnlyLeafReader(ir);
         Lucene90CompressingStoredFieldsReader reader =
             (Lucene90CompressingStoredFieldsReader) sr.getFieldsReader();
-        assertEquals(1, reader.getNumChunks());
-        assertEquals(10 * 48 * 1024, reader.getChunkSize());
         assertTrue(payload1.length + payload2.length < 2 * reader.getChunkSize());
 
         Document loaded = ir.storedFields().document(0, Set.of("content1", "content2", "content3"));

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/compressing/TestCompressingStoredFieldsFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/compressing/TestCompressingStoredFieldsFormat.java
@@ -279,7 +279,7 @@ public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTes
     dir.close();
   }
 
-  public void testReadFieldAcrossSlices() throws IOException {
+  public void testSkipLZ4WitSlicedChunk() throws IOException {
     byte[] payload1 = new byte[atLeast(1 << 18)];
     for (int i = 0; i < payload1.length; i++) {
       payload1[i] = (byte) i;
@@ -310,6 +310,47 @@ public class TestCompressingStoredFieldsFormat extends BaseStoredFieldsFormatTes
         assertEquals(1, reader.getNumChunks());
         assertEquals(10 * 8 * 1024, reader.getChunkSize());
         assertTrue(payload1.length + payload2.length > 2 * reader.getChunkSize());
+
+        Document loaded = ir.storedFields().document(0, Set.of("content1", "content2", "content3"));
+        assertEquals(3, loaded.getFields().size());
+        assertEquals("content1", loaded.get("content1"));
+        assertEquals("content2", loaded.get("content2"));
+        assertEquals("content3", loaded.get("content3"));
+      }
+    }
+  }
+
+  public void testSkipLZ4WithUnslicedChunk() throws IOException {
+    byte[] payload1 = new byte[TestUtil.nextInt(random(), 1 << 14, 1 << 15)];
+    for (int i = 0; i < payload1.length; i++) {
+      payload1[i] = (byte) i;
+    }
+
+    byte[] payload2 = new byte[TestUtil.nextInt(random(), 1 << 14, 1 << 15)];
+    for (int i = 0; i < payload2.length; i++) {
+      payload2[i] = (byte) i;
+    }
+
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig iwConf = newIndexWriterConfig(new MockAnalyzer(random()));
+      iwConf.setCodec(TestUtil.getDefaultCodec());
+      try (IndexWriter iw = new IndexWriter(dir, iwConf)) {
+        Document doc = new Document();
+        doc.add(new StoredField("content1", "content1"));
+        doc.add(new StoredField("payload1", payload1));
+        doc.add(new StoredField("content2", "content2"));
+        doc.add(new StoredField("payload2", payload2));
+        doc.add(new StoredField("content3", "content3"));
+        iw.addDocument(doc);
+      }
+
+      try (DirectoryReader ir = DirectoryReader.open(dir)) {
+        CodecReader sr = (CodecReader) getOnlyLeafReader(ir);
+        Lucene90CompressingStoredFieldsReader reader =
+            (Lucene90CompressingStoredFieldsReader) sr.getFieldsReader();
+        assertEquals(1, reader.getNumChunks());
+        assertEquals(10 * 8 * 1024, reader.getChunkSize());
+        assertTrue(payload1.length + payload2.length < 2 * reader.getChunkSize());
 
         Document loaded = ir.storedFields().document(0, Set.of("content1", "content2", "content3"));
         assertEquals(3, loaded.getFields().size());


### PR DESCRIPTION
This change implements skip entire sub blocks without decompressing them, when these blocks only contain not requested stored fields.

Inspired by https://github.com/apache/lucene/pull/1003.
Relates to https://github.com/apache/lucene/issues/11652.